### PR TITLE
Cleaning up parsing logic for "foreign events"

### DIFF
--- a/core/src/agents/content_processor_utils.ts
+++ b/core/src/agents/content_processor_utils.ts
@@ -156,7 +156,7 @@ function isEventFromAnotherAgent(agentName: string, event: Event): boolean {
  * @returns The converted event.
  */
 function convertForeignEvent(event: Event): Event {
-  if (!event.content?.parts) {
+  if (!event.content?.parts?.length) {
     return event;
   }
 
@@ -175,16 +175,16 @@ function convertForeignEvent(event: Event): Event {
         text: `[${event.author}] said: ${part.text}`,
       });
     } else if (part.functionCall) {
+      const argsText = safeStringify(part.functionCall.args);
       content.parts?.push({
         text: `[${event.author}] called tool \`${
-            part.functionCall.name}\` with parameters: ${
-            part.functionCall.args}`,
+          part.functionCall.name}\` with parameters: ${argsText}`,
       });
     } else if (part.functionResponse) {
+      const responseText = safeStringify(part.functionResponse.response);
       content.parts?.push({
         text: `[${event.author}] tool \`${
-            part.functionResponse.name}\` returned result: ${
-            part.functionResponse.response}`,
+          part.functionResponse.name}\` returned result: ${responseText}`,
       });
     } else {
       content.parts?.push(part);
@@ -455,3 +455,18 @@ function rearrangeEventsForAsyncFunctionResponsesInHistory(
 
   return resultEvents;
 }
+
+/**
+ * Safely stringifies an object, handling circular references.
+ */
+function safeStringify(obj: unknown): string {
+  if (typeof obj === 'string') {
+    return obj;
+  }
+  try {
+    return JSON.stringify(obj);
+  } catch (e) {
+    return String(obj);
+  }
+}
+

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -418,6 +418,7 @@ class AgentTransferLlmRequestProcessor extends BaseLlmRequestProcessor {
             throw new Error('toolContext is required.');
           }
           toolContext.actions.transferToAgent = args.agentName;
+          return 'Transfer queued';
         },
   });
 

--- a/core/test/agents/content_processor_utils_test.ts
+++ b/core/test/agents/content_processor_utils_test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getContents } from '../../src/agents/content_processor_utils.js';
+import { createEvent } from '../../src/events/event.js';
+
+describe('getContents', () => {
+  it('should handle object responses in convertForeignEvent', () => {
+    const event = createEvent({
+      author: 'other_agent',
+      content: {
+        role: 'model',
+        parts: [{
+          functionResponse: {
+            name: 'transfer_to_agent',
+            response: {
+              result: 'success',
+              details: {
+                foo: 'bar'
+              }
+            }
+          }
+        }]
+      }
+    });
+
+    const contents = getContents([event], 'current_agent');
+
+    // We expect the content to contain a string representation of the object, not [object Object]
+    const textPart = contents[0].parts?.find(p => p.text?.includes('transfer_to_agent'));
+    expect(textPart).toBeDefined();
+    expect(textPart?.text).not.toContain('[object Object]');
+    expect(textPart?.text).toContain('{"result":"success"');
+  });
+
+  it('should handle object parameters in convertForeignEvent', () => {
+    const event = createEvent({
+      author: 'other_agent',
+      content: {
+        role: 'model',
+        parts: [{
+          functionCall: {
+            name: 'transfer_to_agent',
+            args: {
+              target_agent: 'foo',
+              reason: 'bar'
+            }
+          }
+        }]
+      }
+    });
+
+    const contents = getContents([event], 'current_agent');
+
+    const textPart = contents[0].parts?.find(p => p.text?.includes('transfer_to_agent'));
+    expect(textPart).toBeDefined();
+    expect(textPart?.text).not.toContain('[object Object]');
+    expect(textPart?.text).toContain('{"target_agent":"foo"');
+  });
+
+  it('should handle circular objects in convertForeignEvent', () => {
+    const circular: any = { a: 1 };
+    circular.self = circular;
+
+    const event = createEvent({
+      author: 'other_agent',
+      content: {
+        role: 'model',
+        parts: [{
+          functionCall: {
+            name: 'circular_tool',
+            args: circular
+          }
+        }]
+      }
+    });
+
+    const contents = getContents([event], 'current_agent');
+
+    const textPart = contents[0].parts?.find(p => p.text?.includes('circular_tool'));
+    expect(textPart).toBeDefined();
+    // It should fall back to String(obj) which is usually [object Object] for plain objects.
+    expect(textPart?.text).toContain('[object Object]');
+  });
+});


### PR DESCRIPTION
Current output for a typical "transfer_to_agent" call:

```
[
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      },
      {
        "text": "[undefined] said: This is the Gemini CLI. We are setting up the context for our chat.\\nToday's date is Wednesday, November 19, 2025 (formatted according to the user's locale).\\nMy operating system is: darwin\\nThe project's temporary directory is: <omitted for clarity>Reminder: Do not return an empty response when a tool call is required.\\n\\nMy setup is complete. I will provide my first command in the next turn."
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "Use the codebase investigator agent to summarize the structure of this codebase"
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      },
      {
        "thought": true,
        "text": "**Analyzing the Request: Codebase Investigation**\\n\\nOkay, so the user wants me to get the \`codebase_investigator\` agent to give a high-level summary of the codebase structure. Straightforward enough. My job here is to route this request appropriately. The prompt, \\"Use the codebase investigator agent to summarize the structure of this codebase,\\" is explicit - it's a clear directive for me to transfer the task.  No need for any further interpretation on my end. I'll get this over to the correct agent using \`transfer_to_agent\`. \`agentName\` will be set to \`codebase_investigator\`, and I'll keep the original query intact. Time to put this into motion.\\n"
      },
      {
        "text": "[GeminiCLI] called tool \`transfer_to_agent\` with parameters: [object Object]"
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      },
      {
        "text": "[GeminiCLI] tool \`transfer_to_agent\` returned result: {}"
      }
    ]
  }
]
```

This PR cleans up the extra "for context" blocks and properly textifies the objects:

```
[
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      },
      {
        "text": "[undefined] said: This is the Gemini CLI. We are setting up the context for our chat.\\nToday's date is Friday, November 21, 2025 (formatted according to the user's locale).\\nMy operating system is: darwin\\nThe project's temporary directory is: <omitted for clarity> Reminder: Do not return an empty response when a tool call is required.\\n\\nMy setup is complete. I will provide my first command in the next turn."
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "Use the codebase investigator agent to summarize the structure of this codebase"
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      },
      {
        "text": "[GeminiCLI] called tool \`transfer_to_agent\` with parameters: {\\"agentName\\":\\"codebase_investigator\\"}"
      }
    ]
  },
  {
    "parts": [],
    "role": "user"
  },
  {
    "parts": [],
    "role": "user"
  },
  {
    "role": "user",
    "parts": [
      {
        "text": "For context:"
      },
      {
        "text": "[GeminiCLI] tool \`transfer_to_agent\` returned result: { Transfer queued }"
      }
    ]
  }
]
```

This still leaves the problem of "[undefined] said...", and I think we should have a discussion about the semantics of transfer_to_agent & how to best handle that.