### PR TITLE
fix(llm_agent): add duck typing fallback for BaseLlm in bundled environments

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -781,6 +781,13 @@ export class LlmAgent extends BaseAgent {
     if (this.model instanceof BaseLlm) {
       return this.model;
     }
+    // Duck typing fallback for bundled environments where instanceof fails.
+    if (this.model && typeof this.model === 'object' &&
+        'model' in this.model &&
+        'generateContentAsync' in this.model &&
+        typeof (this.model as BaseLlm).generateContentAsync === 'function') {
+      return this.model as BaseLlm;
+    }
     if (typeof this.model === 'string' && this.model) {
       return LLMRegistry.newLlm(this.model);
     }


### PR DESCRIPTION
## Summary

This PR fixes an issue where custom `BaseLlm` subclasses fail to be recognized in bundled environments.

Fixes #36

## Problem

When packages are bundled (e.g., with `adk-devtools`, webpack, esbuild), the `BaseLlm` class identity differs between the bundled code and external packages. This causes `instanceof BaseLlm` to return `false` for valid subclasses, resulting in:

```
Error: No model found for {agent_name}
```

## Solution

Add a duck typing fallback in `canonicalModel` getter that checks for required `BaseLlm` properties when `instanceof` fails.

## Testing

- Build passes
- All 150 tests pass

## Related

- Fixes #36
- Relates to #23 (Support for other LLM Models)