### PR TITLE
fix(#37): add proper type inference to functional tool parameters t…

### DIFF
--- a/core/test/tools/function_tool_test.ts
+++ b/core/test/tools/function_tool_test.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {FunctionTool, ToolContext} from '@google/adk';
-import {Type} from '@google/genai';
-import {z} from 'zod';
+import { FunctionTool, ToolContext } from '@google/adk'
+import { Type } from '@google/genai'
+import { z } from 'zod'
 
 describe('FunctionTool', () => {
   let emptyContext: ToolContext;
@@ -178,5 +178,25 @@ describe('FunctionTool', () => {
     const result = await concatStringTool.runAsync(
         {args: {strings: ['a', 'b', 'c']}, toolContext: emptyContext});
     expect(result).toEqual('a,b,c');
+  });
+
+  it('infers types from zod schema without explicit annotations', async () => {
+    const addTool = new FunctionTool({
+      name: 'add',
+      description: 'Adds two numbers.',
+      parameters: z.object({
+        a: z.number(),
+        b: z.number(),
+      }),
+      execute: async ({a, b}) => {
+        return a + b;
+      },
+    });
+
+    const result = await addTool.runAsync({
+      args: {a: 1, b: 2},
+      toolContext: emptyContext,
+    });
+    expect(result).toEqual(3);
   });
 });


### PR DESCRIPTION
**Summary:**

This PR replaces `any` types in `FunctionTool` with proper Zod generics, enabling automatic type inference from schemas to execute functions.

## Changes

- Replaced `ZodObject<any>` with `ZodObject<ZodRawShape>` in `ToolInputParameters`
- Updated `ToolExecuteArgument` to properly infer types using `infer T, U, V`
- Removed unnecessary `any` cast in constructor

## Impact
```typescript
const tool = new FunctionTool({
  parameters: z.object({ 
    studentId: z.number(),
    name: z.string()
  }),
  execute: async ({ studentId, name }) => {
    // studentId and name are now automatically typed from schema
    return { studentId, name };
  },
});
```

## Testing

Added test to verify type inference works without explicit type annotations. All existing tests continue to pass.

## Benefits
- Automatic type inference from Zod schemas
- Full autocomplete/IntelliSense support
- Compile-time type checking

Fixes #37 