### PR TITLE
Fix: lodash esm import crashes via default import utility

### DIFF
--- a/core/src/agents/content_processor_utils.ts
+++ b/core/src/agents/content_processor_utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {Content} from '@google/genai';
-import {cloneDeep} from 'lodash';
+import {cloneDeep} from '../utils/lodash.js';
 
 import {createEvent, Event, getFunctionCalls, getFunctionResponses} from '../events/event.js';
 

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -6,7 +6,7 @@
 
 // TODO - b/436079721: implement traceMergedToolCalls, traceToolCall, tracer.
 import {Content, createUserContent, FunctionCall, Part} from '@google/genai';
-import {isEmpty} from 'lodash';
+import {isEmpty} from '../utils/lodash.js';
 
 import {InvocationContext} from '../agents/invocation_context.js';
 import {createEvent, Event, getFunctionCalls} from '../events/event.js';

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -5,7 +5,7 @@
  */
 
 import {Content, FunctionCall, GenerateContentConfig, Part, Schema} from '@google/genai';
-import {cloneDeep} from 'lodash';
+import {cloneDeep} from '../utils/lodash.js';
 import {z} from 'zod';
 
 import {BaseCodeExecutor} from '../code_executors/base_code_executor.js';

--- a/core/src/code_executors/code_execution_utils.ts
+++ b/core/src/code_executors/code_execution_utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {Content, Language, Outcome, Part} from '@google/genai';
-import {cloneDeep} from 'lodash';
+import {cloneDeep} from '../utils/lodash.js';
 
 import {base64Encode, isBase64Encoded} from '../utils/env_aware_utils.js';
 

--- a/core/src/code_executors/code_executor_context.ts
+++ b/core/src/code_executors/code_executor_context.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import {cloneDeep} from 'lodash';
+import {cloneDeep} from '../utils/lodash.js';
 
 import {State} from '../sessions/state.js';
 

--- a/core/src/sessions/in_memory_session_service.ts
+++ b/core/src/sessions/in_memory_session_service.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import {cloneDeep} from 'lodash';
+import {cloneDeep} from '../utils/lodash.js';
 
 import {Event} from '../events/event.js';
 import {randomUUID} from '../utils/env_aware_utils.js';

--- a/core/src/utils/lodash.ts
+++ b/core/src/utils/lodash.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import pkg from 'lodash';
+
+export const {cloneDeep, isEmpty} = pkg;
+export default pkg;


### PR DESCRIPTION
### Solves #59 

- Created a centralized ```src/utils/lodash.ts``` to handle the ```import pkg from 'lodash'``` + destructuring logic in one place.
- Refactored all direct lodash imports to use this new utility.