### PR TITLE
Add integration tests & fix lodash dependency integration

### DIFF
--- a/tests/integration/build_setup/build_setup_test.ts
+++ b/tests/integration/build_setup/build_setup_test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterAll, describe, expect, it} from 'vitest';
+import { exec, spawn, ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import { promisify } from 'node:util';
+import * as fs from 'node:fs/promises';
+
+const execAsync = promisify(exec);
+const dirname = process.cwd();
+
+const TEST_EXECUTION_TIMEOUT = 15000;
+
+function sendInput(childProcess: ChildProcessWithoutNullStreams, input: string): Promise<string> {
+  childProcess.stdin.write(input);
+  childProcess.stdin.end();
+
+  return getResponse(childProcess);
+}
+
+function getResponse(childProcess: ChildProcessWithoutNullStreams): Promise<string> {
+  return new Promise<string>(resolve => {
+    let output = '';
+    let resolved = false;
+
+    const onFinish = () => {
+      if (!resolved) {
+        resolve(output);
+      }
+
+      childProcess.stdout.off('data', onData);
+      resolved = true;
+    };
+
+    const onData = (data: Buffer) => {
+      output += data.toString();
+    };
+
+    childProcess.stdout.on('data', onData);
+    childProcess.stdout.once('end', onFinish);
+    childProcess.stdout.once('close', onFinish);
+  });
+}
+
+describe('Build setup', () => {
+  describe.each(['js_commonjs', 'js_esm', 'ts_commonjs', 'ts_esm'])('%s', (buildSetup) => {
+    const projectPath = `${dirname}/tests/integration/build_setup/${buildSetup}`;
+    
+    it('should build and run agent successfully', async () => {
+      await execAsync('npm install', {cwd: projectPath});
+
+      if (buildSetup.startsWith('ts_')) {
+        const buildResult = await execAsync('npm run build', {cwd: projectPath});
+        expect(buildResult.stderr).toBe('');
+        expect(buildResult.stdout).toContain('\nBuild complete');
+      }
+
+      const childProcess = spawn('npm', ['run', 'start'], {cwd: projectPath, shell: true});
+
+      let response = await sendInput(childProcess, 'Tell me a joke.\n');
+      expect(response.toString()).toContain('test-llm-model-response');
+
+      response = await sendInput(childProcess, 'exit\n');
+      expect(response.toString()).toContain('');
+    }, TEST_EXECUTION_TIMEOUT);
+
+    afterAll(async () => {
+      await fs.rm(`${projectPath}/node_modules`, {recursive: true});
+      await fs.unlink(`${projectPath}/package-lock.json`);
+
+      if (buildSetup.startsWith('ts_')) {
+        await fs.rm(`${projectPath}/dist`, {recursive: true});
+      }
+    });
+  });
+});

--- a/tests/integration/build_setup/js_commonjs/agent.js
+++ b/tests/integration/build_setup/js_commonjs/agent.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+const { LlmAgent, setLogLevel, LogLevel, BaseLlm, LLMRegistry } = require("@google/adk");
+const { createModelContent, GenerateContentResponse } = require('@google/genai');
+
+setLogLevel(LogLevel.DEBUG);
+
+class MockLlmConnection {
+  async sendHistory() {
+    return Promise.resolve();
+  }
+  async sendContent() {
+    return Promise.resolve();
+  }
+  async sendRealtime(blob) { }
+  async * receive() { }
+  async close() { }
+}
+
+class MockLll extends BaseLlm {
+  static supportedModels = ['test-llm-model'];
+
+  async generateContentAsync(prompt) {
+    return `Mock response to: ${prompt}`;
+  }
+
+  async *
+    generateContentAsync(llmRequest) {
+    const generateContentResponse = new GenerateContentResponse();
+
+    generateContentResponse.candidates =
+      [{ content: createModelContent('test-llm-model-response') }];
+    const candidate = generateContentResponse.candidates[0];
+
+    yield {
+      content: candidate.content,
+      groundingMetadata: candidate.groundingMetadata,
+      usageMetadata: generateContentResponse.usageMetadata,
+      finishReason: candidate.finishReason,
+    };
+  }
+
+  async connect() {
+    return new MockLlmConnection();
+  }
+}
+
+LLMRegistry.register(MockLll);
+
+const rootAgent = new LlmAgent({
+  name: "root_agent",
+  model: 'test-llm-model',
+  description: "Root agent",
+  instruction: 'You are a helpful assistant that is the root agent.',
+});
+
+module.exports = { rootAgent };

--- a/tests/integration/build_setup/js_commonjs/package.json
+++ b/tests/integration/build_setup/js_commonjs/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "js_commonjs_build_setup",
+	"version": "1.0.0",
+	"description": "",
+	"main": "agent.js",
+	"type": "commonjs",
+	"scripts": {
+		"start": "npx @google/adk-devtools run agent.js"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"@google/adk": "file:../../../../core",
+		"@google/adk-devtools": "file:../../../../dev",
+		"@google/genai": "^1.37.0"
+	}
+}

--- a/tests/integration/build_setup/js_esm/agent.js
+++ b/tests/integration/build_setup/js_esm/agent.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { LlmAgent, setLogLevel, LogLevel, BaseLlm, LLMRegistry } from "@google/adk";
+import { createModelContent, GenerateContentResponse } from '@google/genai';
+
+setLogLevel(LogLevel.DEBUG);
+
+class MockLlmConnection {
+  async sendHistory() {
+    return Promise.resolve();
+  }
+
+  async sendContent() {
+    return Promise.resolve();
+  }
+
+  async sendRealtime(blob) { }
+
+  async * receive() { }
+
+  async close() { }
+}
+
+class MockLll extends BaseLlm {
+  static supportedModels = ['test-llm-model'];
+
+  async generateContentAsync(prompt) {
+    return `Mock response to: ${prompt}`;
+  }
+
+  async *
+    generateContentAsync(llmRequest) {
+    const generateContentResponse = new GenerateContentResponse();
+
+    generateContentResponse.candidates =
+      [{ content: createModelContent('test-llm-model-response') }];
+    const candidate = generateContentResponse.candidates[0];
+
+    yield {
+      content: candidate.content,
+      groundingMetadata: candidate.groundingMetadata,
+      usageMetadata: generateContentResponse.usageMetadata,
+      finishReason: candidate.finishReason,
+    };
+  }
+
+  async connect() {
+    return new MockLlmConnection();
+  }
+}
+
+LLMRegistry.register(MockLll);
+
+export const rootAgent = new LlmAgent({
+  name: "root_agent",
+  model: 'test-llm-model',
+  description: "Root agent",
+  instruction: `You are a helpful assistant that is the root agent.`,
+});

--- a/tests/integration/build_setup/js_esm/package.json
+++ b/tests/integration/build_setup/js_esm/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "js_esm_build_setup",
+	"version": "1.0.0",
+	"description": "",
+	"main": "agent.js",
+	"type": "module",
+	"scripts": {
+		"start": "npx @google/adk-devtools run agent.js"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"@google/adk": "file:../../../../core",
+		"@google/adk-devtools": "file:../../../../dev",
+		"@google/genai": "^1.37.0"
+	}
+}

--- a/tests/integration/build_setup/ts_commonjs/agent.ts
+++ b/tests/integration/build_setup/ts_commonjs/agent.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+const { BaseLlm, BaseLlmConnection, LlmAgent, LLMRegistry, LlmRequest, LlmResponse, setLogLevel, LogLevel } = require("@google/adk");
+const { createModelContent, GenerateContentResponse } = require('@google/genai');
+
+type BaseLlmConnection = typeof BaseLlmConnection;
+type LlmResponse = typeof LlmResponse;
+
+setLogLevel(LogLevel.DEBUG);
+
+class MockLlmConnection implements BaseLlmConnection {
+  async sendHistory(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async sendContent(): Promise<void> {}
+
+  async sendRealtime(): Promise<void> {}
+
+  async * receive(): AsyncGenerator<LlmResponse, void, void> {}
+
+  async close(): Promise<void> {}
+}
+
+class MockLll extends BaseLlm {
+  constructor({model}: {model: string}) {
+    super({model});
+  }
+
+  static readonly supportedModels = ['test-llm-model'];
+
+  async *
+      generateContentAsync():
+          AsyncGenerator<LlmResponse, void> {
+    const generateContentResponse = new GenerateContentResponse();
+
+    generateContentResponse.candidates =
+        [{content: createModelContent('test-llm-model-response')}];
+    const candidate = generateContentResponse.candidates[0]!;
+
+    yield {
+      content: candidate.content,
+      groundingMetadata: candidate.groundingMetadata,
+      usageMetadata: generateContentResponse.usageMetadata,
+      finishReason: candidate.finishReason,
+    };
+  }
+
+  async connect(): Promise<BaseLlmConnection> {
+    return new MockLlmConnection();
+  }
+}
+
+LLMRegistry.register(MockLll);
+
+const rootAgent = new LlmAgent({
+  name: "root_agent",
+  model: 'test-llm-model',
+  description: "Root agent",
+  instruction: 'You are a helpful assistant that is the root agent.',
+});
+
+module.exports = { rootAgent };

--- a/tests/integration/build_setup/ts_commonjs/package.json
+++ b/tests/integration/build_setup/ts_commonjs/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "ts_commonjs_build_setup",
+	"version": "1.0.0",
+	"description": "",
+	"main": "agent.ts",
+	"type": "commonjs",
+	"scripts": {
+		"build": "tsc && echo Build complete",
+		"start": "npx @google/adk-devtools run agent.ts"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"@google/adk": "file:../../../../core",
+		"@google/adk-devtools": "file:../../../../dev",
+		"@google/genai": "^1.37.0"
+	}
+}

--- a/tests/integration/build_setup/ts_commonjs/tsconfig.json
+++ b/tests/integration/build_setup/ts_commonjs/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "rootDir": "./",
+    "outDir": "dist",
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "pretty": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/build_setup/ts_esm/agent.ts
+++ b/tests/integration/build_setup/ts_esm/agent.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { BaseLlm, BaseLlmConnection, LlmAgent, LLMRegistry, LlmResponse, setLogLevel, LogLevel } from "@google/adk";
+import { createModelContent, GenerateContentResponse } from '@google/genai';
+
+setLogLevel(LogLevel.DEBUG);
+
+class MockLlmConnection implements BaseLlmConnection {
+  async sendHistory(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async sendContent(): Promise<void> {}
+
+  async sendRealtime(): Promise<void> {}
+
+  async * receive(): AsyncGenerator<LlmResponse, void, void> {}
+
+  async close(): Promise<void> {}
+}
+
+class MockLll extends BaseLlm {
+  constructor({model}: {model: string}) {
+    super({model});
+  }
+
+  static override readonly supportedModels = ['test-llm-model'];
+
+  async *
+      generateContentAsync():
+          AsyncGenerator<LlmResponse, void> {
+    const generateContentResponse = new GenerateContentResponse();
+
+    generateContentResponse.candidates =
+        [{content: createModelContent('test-llm-model-response')}];
+    const candidate = generateContentResponse.candidates[0]!;
+
+    yield {
+      content: candidate.content,
+      groundingMetadata: candidate.groundingMetadata,
+      usageMetadata: generateContentResponse.usageMetadata,
+      finishReason: candidate.finishReason,
+    };
+  }
+
+  async connect(): Promise<BaseLlmConnection> {
+    return new MockLlmConnection();
+  }
+}
+
+LLMRegistry.register(MockLll);
+
+export const rootAgent = new LlmAgent({
+  name: "root_agent",
+  model: 'test-llm-model',
+  description: "Root agent",
+  instruction: 'You are a helpful assistant that is the root agent.',
+});

--- a/tests/integration/build_setup/ts_esm/package.json
+++ b/tests/integration/build_setup/ts_esm/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "ts_esm_build_setup",
+	"version": "1.0.0",
+	"description": "",
+	"main": "agent.ts",
+	"type": "module",
+	"scripts": {
+		"build": "tsc && echo Build complete",
+		"start": "npx @google/adk-devtools run agent.ts"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"@google/adk": "file:../../../../core",
+		"@google/adk-devtools": "file:../../../../dev",
+		"@google/genai": "^1.37.0"
+	}
+}

--- a/tests/integration/build_setup/ts_esm/tsconfig.json
+++ b/tests/integration/build_setup/ts_esm/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "rootDir": "./",
+    "outDir": "dist",
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "pretty": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
feature: Add integration tests for different build setups

Changed how lodash utils are being imported.
Added integration tests that are verifies that adk can be compiled and executed without errors for different build setups:
- js commonjs
- js esm
- ts common js
- ts esm