### PR TITLE
fix: recursively update the rootAgent of all subAgents

### DIFF
--- a/core/src/agents/base_agent.ts
+++ b/core/src/agents/base_agent.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Content} from '@google/genai';
-import {trace} from '@opentelemetry/api';
+import { Content } from '@google/genai';
+import { trace } from '@opentelemetry/api';
 
-import {createEvent, Event} from '../events/event.js';
+import { createEvent, Event } from '../events/event.js';
 
-import {CallbackContext} from './callback_context.js';
-import {InvocationContext} from './invocation_context.js';
+import { CallbackContext } from './callback_context.js';
+import { InvocationContext } from './invocation_context.js';
 
 /**
  * A single callback function for an agent.
@@ -299,7 +299,7 @@ export abstract class BaseAgent {
       return undefined;
     }
 
-    const callbackContext = new CallbackContext({invocationContext});
+    const callbackContext = new CallbackContext({ invocationContext });
     for (const callback of this.beforeAgentCallback) {
       const content = await callback(callbackContext);
 
@@ -342,7 +342,7 @@ export abstract class BaseAgent {
       return undefined;
     }
 
-    const callbackContext = new CallbackContext({invocationContext});
+    const callbackContext = new CallbackContext({ invocationContext });
     for (const callback of this.afterAgentCallback) {
       const content = await callback(callbackContext);
 
@@ -373,15 +373,23 @@ export abstract class BaseAgent {
     for (const subAgent of this.subAgents) {
       if (subAgent.parentAgent) {
         throw new Error(
-          `Agent "${
-            subAgent.name
-          }" already has a parent agent, current parent: "${
-            subAgent.parentAgent.name
+          `Agent "${subAgent.name
+          }" already has a parent agent, current parent: "${subAgent.parentAgent.name
           }", trying to add: "${this.name}"`,
         );
       }
 
       subAgent.parentAgent = this;
+      subAgent.updateRootAgent(this.rootAgent);
+    }
+  }
+
+  protected updateRootAgent(rootAgent: BaseAgent): void {
+    // @ts-ignore: constrained by readonly in strict TS, but valid in JS runtime logic
+    this.rootAgent = rootAgent;
+
+    for (const subAgent of this.subAgents) {
+      subAgent.updateRootAgent(rootAgent);
     }
   }
 }
@@ -395,8 +403,7 @@ export abstract class BaseAgent {
 function validateAgentName(name: string): string {
   if (!isIdentifier(name)) {
     throw new Error(
-      `Found invalid agent name: "${
-        name
+      `Found invalid agent name: "${name
       }". Agent name must be a valid identifier. It should start with a letter (a-z, A-Z) or an underscore (_), and can only contain letters, digits (0-9), and underscores.`,
     );
   }


### PR DESCRIPTION
Passing `this.rootAgent` (from the parent) to updateRootAgent is the correct approach to ensure the sub-agent becomes part of the existing tree structure, rather than creating a new one or pointing incorrectly.

Here is why:

* Inheritance of Context: When a sub-agent is added to a parent, it effectively becomes a child node in that parent's tree. The parent already knows who its root is (stored in this.rootAgent).
* Consistency: By using this.rootAgent, we guarantee that every node in the tree points to the same root object. This single source of truth is crucial for tree-wide operations like getAgentByName to work correctly.
* Handling Nested Structures: If we were adding Orchestrator -> MiddleManager -> Worker, when MiddleManager adds Worker, MiddleManager.rootAgent would already point to Orchestrator. Passing this.rootAgent ensures Worker also points to Orchestrator, maintaining the hierarchy correctly across multiple levels.