### PR TITLE
fix: use getter for rootAgent to match Python SDK behavior

### DIFF
--- a/core/src/agents/base_agent.ts
+++ b/core/src/agents/base_agent.ts
@@ -89,8 +89,11 @@ export abstract class BaseAgent {
 
   /**
    * Root agent of this agent.
+   * Computed dynamically by traversing up the parent chain.
    */
-  readonly rootAgent: BaseAgent;
+  get rootAgent(): BaseAgent {
+    return getRootAgent(this);
+  }
 
   /**
    * The parent agent of this agent.
@@ -143,7 +146,6 @@ export abstract class BaseAgent {
     this.description = config.description;
     this.parentAgent = config.parentAgent;
     this.subAgents = config.subAgents || [];
-    this.rootAgent = getRootAgent(this);
     this.beforeAgentCallback = getCannonicalCallback(
       config.beforeAgentCallback,
     );

--- a/core/test/agents/base_agent_test.ts
+++ b/core/test/agents/base_agent_test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LlmAgent} from '@google/adk';
+
+describe('BaseAgent', () => {
+  describe('rootAgent', () => {
+    it('should return the actual root agent for sub-agents', () => {
+      const subAgent = new LlmAgent({
+        name: 'sub_agent',
+        description: 'A sub agent',
+      });
+
+      const rootAgent = new LlmAgent({
+        name: 'root_agent',
+        description: 'The root agent',
+        subAgents: [subAgent],
+      });
+
+      expect(subAgent.rootAgent).toBe(rootAgent);
+      expect(rootAgent.rootAgent).toBe(rootAgent);
+    });
+
+    it('should traverse multiple levels of nesting', () => {
+      const leafAgent = new LlmAgent({name: 'leaf_agent'});
+      const middleAgent = new LlmAgent({
+        name: 'middle_agent',
+        subAgents: [leafAgent],
+      });
+      const rootAgent = new LlmAgent({
+        name: 'root_agent',
+        subAgents: [middleAgent],
+      });
+
+      expect(leafAgent.rootAgent).toBe(rootAgent);
+      expect(middleAgent.rootAgent).toBe(rootAgent);
+      expect(rootAgent.rootAgent).toBe(rootAgent);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Attempts to fix #82

I ran into this issue while building a TypeScript version of the [weather bot tutorial](https://google.github.io/adk-docs/tutorials/agent-team/). When a sub-agent completes and the model tries to return control to the root agent, it fails because the sub-agent's `rootAgent` property points to itself rather than the actual root.

Thanks to @santosflores for investigating this in #83, and to @ScottMansfield for pointing out that the Python SDK doesn't need recursive updates. It uses a computed property that walks up the parent chain each time.

This PR takes that same approach: replacing the cached `rootAgent` property with a getter, matching how the Python SDK handles it:

```python
@property
def root_agent(self) -> BaseAgent:
    root_agent = self
    while root_agent.parent_agent is not None:
        root_agent = root_agent.parent_agent
    return root_agent
```

## Changes

- Removed `readonly rootAgent: BaseAgent` property assignment in constructor
- Added `get rootAgent(): BaseAgent` getter that computes the root by walking up the parent chain

## Reproduction

Minimal example:

```typescript
import { FunctionTool, LlmAgent } from '@google/adk';
import { z } from 'zod';

const tellJoke = new FunctionTool({
    name: 'tell_joke',
    description: 'Tells a joke',
    parameters: z.object({}),
    execute: () => ({ joke: 'Why do programmers prefer dark mode? Because light attracts bugs!' }),
});

const subAgent = new LlmAgent({
    name: 'sub_agent',
    model: 'gemini-2.0-flash',
    description: 'Handles greetings',
    instruction: 'Greet the user.',
});

export const rootAgent = new LlmAgent({
    name: 'root_agent',
    model: 'gemini-2.0-flash',
    description: 'Main agent',
    instruction: 'Delegate greetings to sub_agent. For joke requests, use the tell_joke tool.',
    tools: [tellJoke],
    subAgents: [subAgent]
});
```

`subAgent` is created first, so its constructor sets `rootAgent = this` (pointing to itself). When it's later added to `rootAgent` via `subAgents`, the cached value is never updated.

**Before fix:**
```
[user]: hi
[sub_agent]: Hello!
[user]: tell me a joke
Error: Agent root_agent not found in the agent tree.
```

**After fix:**
```
[user]: hi
[sub_agent]: Hello!
[user]: tell me a joke
[root_agent]: Why do programmers prefer dark mode? Because light attracts bugs!
```

## Test Plan

- Run unit tests in `core/test/agents/base_agent_test.ts` to verify sub-agents correctly resolve their rootAgent
- Test locally using the repro steps above