### PR TITLE
Add auto-assignment script for PRs and Issues

### DIFF
--- a/.github/workflows/auto-assignment.yml
+++ b/.github/workflows/auto-assignment.yml
@@ -1,0 +1,25 @@
+name: auto-assignment
+on:
+  issues:
+    types:
+      - opened
+      
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./scripts/auto-assignment.js')
+            script({github, context})

--- a/scripts/auto-assignment.js
+++ b/scripts/auto-assignment.js
@@ -1,0 +1,41 @@
+module.exports = async ({github, context}) => {
+  let issueNumber;
+  let activeAssigneesList;
+  
+  const issueAssigneesList = ['Varun-S10'];
+  const prAssigneesList = ['Varun-S10'];
+
+  if (context.payload.issue) {                     // For issue
+    issueNumber = context.payload.issue.number;
+    activeAssigneesList = issueAssigneesList;
+    console.log('Event Type: Issue');
+  } else if (context.payload.pull_request) {       // For PR
+    issueNumber = context.payload.pull_request.number;
+    activeAssigneesList = prAssigneesList;
+    console.log('Event Type: Pull Request');
+  } else {
+    console.log('Not an issue or PR');
+    return;
+  }
+
+  console.log('Target Assignee list:', activeAssigneesList);
+  console.log('Entered auto assignment for number:', issueNumber);
+
+  if (!activeAssigneesList || activeAssigneesList.length === 0) {
+    console.log('No assignees found for this type.');
+    return;
+  }
+
+  const noOfAssignees = activeAssigneesList.length;
+  const selection = issueNumber % noOfAssignees;
+  const assigneeToAssign = activeAssigneesList[selection];
+
+  console.log(`Assigning #${issueNumber} to: ${assigneeToAssign}`);
+
+  return github.rest.issues.addAssignees({
+    issue_number: issueNumber,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    assignees: [assigneeToAssign],
+  });
+};


### PR DESCRIPTION
Added the script to automatically assign team members whenever a new issue or pull request is raised. The script uses a round-robin system to rotate through the list of names, which ensures that everyone shares the work fairly. By assigning someone right away, GitHub will send them an email notification so the team knows the moment something new is created. This list of names is easy to update, so in the future if we require, we can add more assignees to the script as the team grows. Note: The code has been refactored as per the reviewer comments.