### PR TITLE
Deprecate MCP Session Manager header option in favor of new transportOptions

### DIFF
--- a/core/test/tools/mcp/mcp_session_manager_test.ts
+++ b/core/test/tools/mcp/mcp_session_manager_test.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {describe, expect, it, vi} from 'vitest';
+import {MCPSessionManager} from '../../../src/tools/mcp/mcp_session_manager.js';
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  return {
+    Client: vi.fn().mockImplementation(() => ({
+      connect: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => {
+  return {
+    StdioClientTransport: vi.fn(),
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => {
+  return {
+    StreamableHTTPClientTransport: vi.fn(),
+  };
+});
+
+describe('MCPSessionManager', () => {
+  it('creates an stdio client', async () => {
+    const manager = new MCPSessionManager({
+      type: 'StdioConnectionParams',
+      serverParams: {
+        command: 'test-command',
+        args: ['arg1', 'arg2'],
+      },
+    });
+
+    const client = await manager.createSession();
+
+    expect(Client).toHaveBeenCalledWith({
+      name: 'MCPClient',
+      version: '1.0.0',
+    });
+    expect(StdioClientTransport).toHaveBeenCalledWith({
+      command: 'test-command',
+      args: ['arg1', 'arg2'],
+    });
+    expect(client.connect).toHaveBeenCalled();
+  });
+
+  it('creates an http client with transport options headers', async () => {
+    const manager = new MCPSessionManager({
+      type: 'StreamableHTTPConnectionParams',
+      url: 'http://test-url',
+      transportOptions: {
+        requestInit: {
+          headers: {
+            'x-test-header': 'test-value',
+          },
+        },
+      },
+    });
+
+    const client = await manager.createSession();
+
+    expect(Client).toHaveBeenCalledWith({
+      name: 'MCPClient',
+      version: '1.0.0',
+    });
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+      new URL('http://test-url'),
+      {
+        requestInit: {
+          headers: {'x-test-header': 'test-value'},
+        },
+      },
+    );
+    expect(client.connect).toHaveBeenCalled();
+  });
+
+  it('creates an http client with deprecated header param', async () => {
+    const manager = new MCPSessionManager({
+      type: 'StreamableHTTPConnectionParams',
+      url: 'http://test-url',
+      header: {
+        'x-test-header': 'test-value',
+      },
+    });
+
+    await manager.createSession();
+
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+      new URL('http://test-url'),
+      {
+        requestInit: {
+          headers: {'x-test-header': 'test-value'},
+        },
+      },
+    );
+  });
+
+  it('prioritizes transportOptions headers over header', async () => {
+    const manager = new MCPSessionManager({
+      type: 'StreamableHTTPConnectionParams',
+      url: 'http://test-url',
+      transportOptions: {
+        requestInit: {
+          headers: {
+            'x-priority': 'headers',
+          },
+        },
+      },
+      header: {
+        'x-priority': 'header',
+      },
+    });
+
+    await manager.createSession();
+
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+      expect.any(URL),
+      {
+        requestInit: {
+          headers: {'x-priority': 'headers'},
+        },
+      },
+    );
+  });
+
+  it('prioritizes transportOptions over header', async () => {
+    const manager = new MCPSessionManager({
+      type: 'StreamableHTTPConnectionParams',
+      url: 'http://test-url',
+      transportOptions: {
+        requestInit: {},
+      },
+      header: {
+        'x-priority': 'header',
+      },
+    });
+
+    await manager.createSession();
+
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+      expect.any(URL),
+      {
+        requestInit: {},
+      },
+    );
+  });
+});


### PR DESCRIPTION
Deprecate MCP Session Manager header option in favor of new transportOptions.
Add new transportOptions which are StreamableHTTPClientTransportOptions from MCP.

Resolving https://github.com/google/adk-js/issues/32 by carrying config where you can handle auth setup for MCP.