### PR TITLE
Fix release please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
   "packages": {
     ".": {
       "component": "main",
-      "skip-changelog": true,
-      "skip-github-release": true
+      "skip-changelog": true
     },
     "core": {
       "changelog-path": "CHANGELOG.md",
@@ -39,11 +38,7 @@
     {
       "type": "linked-versions",
       "groupName": "adk",
-      "components": [
-        "main",
-        "adk",
-        "devtools"
-      ]
+      "components": ["main", "adk", "devtools"]
     }
   ],
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Fix release please config.

We should allow to create github releases and tags for main (root) component because release please tracks new releases based on github tags.