### PR TITLE
Mute @google/adk logs while running tests

### DIFF
--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -186,7 +186,6 @@ describe('Runner.determineAgentForResumption', () => {
   }
 
   it('should find agent when last event is function response', async () => {
-    console.log('should find agent when last event is function response');
     const functionCall: FunctionCall = {
       id: 'func_123',
       name: 'test_func',
@@ -216,8 +215,6 @@ describe('Runner.determineAgentForResumption', () => {
   });
 
   it('should return root agent when session has no non-user events', async () => {
-    console.log('should return root agent when session has no non-user events');
-
     const nonUserEvent = createEvent({
       invocationId: 'inv1',
       author: 'user',
@@ -230,8 +227,6 @@ describe('Runner.determineAgentForResumption', () => {
   });
 
   it('should return root agent when it is found in session events', async () => {
-    console.log('should return root agent when it is found in session events');
-
     const rootEvent = createEvent({
       invocationId: 'inv1',
       author: 'root_agent',
@@ -244,8 +239,6 @@ describe('Runner.determineAgentForResumption', () => {
   });
 
   it('should return transferable sub agent when found', async () => {
-    console.log('should return transferable sub agent when found');
-
     const subAgent1Event = createEvent({
       invocationId: 'inv1',
       author: 'sub_agent1',
@@ -258,8 +251,6 @@ describe('Runner.determineAgentForResumption', () => {
   });
 
   it('should skip non-transferable agent and return root agent', async () => {
-    console.log('should skip non-transferable agent and return root agent');
-
     const nonTransferableResponse = createEvent({
       invocationId: 'inv1',
       author: 'non_transferable',
@@ -275,8 +266,6 @@ describe('Runner.determineAgentForResumption', () => {
   });
 
   it('should skip unknown agent and return root agent', async () => {
-    console.log('should skip unknown agent and return root agent');
-
     const unknownEvent = createEvent({
       invocationId: 'inv1',
       author: 'unknown_agent',
@@ -298,7 +287,6 @@ describe('Runner.determineAgentForResumption', () => {
   });
 
   it('should prioritize function response scenario', async () => {
-    console.log('should prioritize function response scenario');
     const functionCall: FunctionCall = {
       id: 'func_456',
       name: 'test_func',

--- a/core/test/telemetry/google_cloud_test.ts
+++ b/core/test/telemetry/google_cloud_test.ts
@@ -12,6 +12,9 @@ import {
 } from '../../src/telemetry/google_cloud.js';
 import type {OtelExportersConfig} from '../../src/telemetry/setup.js';
 
+vi.hoisted(() => {
+  vi.resetModules();
+});
 // Mock Google Cloud modules
 vi.mock('google-auth-library');
 vi.mock('@google-cloud/opentelemetry-cloud-trace-exporter');

--- a/core/test/telemetry/setup_test.ts
+++ b/core/test/telemetry/setup_test.ts
@@ -11,6 +11,9 @@ import {MetricReader} from '@opentelemetry/sdk-metrics';
 import type {OTelHooks} from '../../src/telemetry/setup.js';
 import {maybeSetOtelProviders} from '../../src/telemetry/setup.js';
 
+vi.hoisted(() => {
+  vi.resetModules();
+});
 // Mock OpenTelemetry modules
 vi.mock('@opentelemetry/exporter-trace-otlp-http');
 vi.mock('@opentelemetry/exporter-metrics-otlp-http');

--- a/core/test/telemetry/tracing_test.ts
+++ b/core/test/telemetry/tracing_test.ts
@@ -21,6 +21,9 @@ import {
 } from '../../src/telemetry/tracing.js';
 import {BaseTool} from '../../src/tools/base_tool.js';
 
+vi.hoisted(() => {
+  vi.resetModules();
+});
 // Mock OpenTelemetry API
 vi.mock('@opentelemetry/api');
 

--- a/core/test/tools/mcp/mcp_session_manager_test.ts
+++ b/core/test/tools/mcp/mcp_session_manager_test.ts
@@ -10,6 +10,10 @@ import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/st
 import {describe, expect, it, vi} from 'vitest';
 import {MCPSessionManager} from '../../../src/tools/mcp/mcp_session_manager.js';
 
+vi.hoisted(() => {
+  vi.resetModules();
+});
+
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
   return {
     Client: vi.fn().mockImplementation(() => ({

--- a/tests/global_setup.ts
+++ b/tests/global_setup.ts
@@ -1,0 +1,9 @@
+import {LogLevel, setLogLevel} from '@google/adk';
+
+export function setup() {
+  setLogLevel(LogLevel.ERROR);
+}
+
+export function teardown() {
+  setLogLevel(LogLevel.INFO);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         lines: 53,
       },
     },
+    globalSetup: ['./tests/global_setup.ts'],
   },
   resolve: {alias: {'@google/adk': path.resolve(__dirname, './core/src')}},
 });


### PR DESCRIPTION
Mute @google/adk logs while running tests.

- Used vitest global setup hook to set ADK log level to be error only.
- Removed console logs in tests
- Some of the tests required mock reset before making module mocks
