### PR TITLE
Remove Hard-coded check that prevents set tools and outputSchema.

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -277,13 +277,7 @@ export interface LlmAgentConfig extends BaseAgentConfig {
   /** The input schema when agent is used as a tool. */
   inputSchema?: LlmAgentSchema;
 
-  /**
-   * The output schema when agent replies.
-   *
-   * NOTE:
-   *   When this is set, agent can ONLY reply and CANNOT use any tools, such as
-   *   function tools, RAGs, agent transfer, etc.
-   */
+  /** The output schema when agent replies. */
   outputSchema?: LlmAgentSchema;
 
   /**

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -23,7 +23,7 @@ export {InvocationContext} from './agents/invocation_context.js';
 export type {InvocationContextParams} from './agents/invocation_context.js';
 export {LiveRequestQueue} from './agents/live_request_queue.js';
 export type {LiveRequest} from './agents/live_request_queue.js';
-export {LlmAgent, LlmAgentSchema, isLlmAgent} from './agents/llm_agent.js';
+export {LlmAgent, isLlmAgent} from './agents/llm_agent.js';
 export type {
   AfterModelCallback,
   AfterToolCallback,
@@ -31,6 +31,7 @@ export type {
   BeforeToolCallback,
   InstructionProvider,
   LlmAgentConfig,
+  LlmAgentSchema,
   SingleAfterModelCallback,
   SingleAfterToolCallback,
   SingleBeforeModelCallback,

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -18,10 +18,8 @@ import {
   Session,
 } from '@google/adk';
 import {Content, Schema, Type} from '@google/genai';
-import {z} from 'zod';
 import {z as z3} from 'zod/v3';
-
-import {AgentSchema} from '../../src/agents/llm_agent.js';
+import {z as z4} from 'zod/v4';
 
 class MockLlmConnection implements BaseLlmConnection {
   sendHistory(_history: Content[]): Promise<void> {
@@ -245,11 +243,11 @@ describe('LlmAgent Schema Initialization', () => {
     expect(agent.inputSchema).toEqual(inputSchema);
   });
 
-  it('should initialize inputSchema from Zod object', () => {
-    const zodSchema = z.object({foo: z.string()}) as unknown as AgentSchema;
+  it('should initialize inputSchema from Zod v4 object', () => {
+    const zodSchema = z4.object({foo: z4.string()});
     const agent = new LlmAgent({
       name: 'test',
-      inputSchema: zodSchema as unknown as Schema,
+      inputSchema: zodSchema,
     });
     expect(agent.inputSchema).toBeDefined();
     expect((agent.inputSchema as Schema).type).toBe('OBJECT');
@@ -257,10 +255,12 @@ describe('LlmAgent Schema Initialization', () => {
   });
 
   it('should initialize inputSchema from Zod v3 object', () => {
-    const zodSchema = z3.object({foo: z3.string()}) as unknown as AgentSchema;
+    const zodSchema = z3.object({
+      foo: z3.string(),
+    });
     const agent = new LlmAgent({
       name: 'test',
-      inputSchema: zodSchema as unknown as Schema,
+      inputSchema: zodSchema,
     });
     expect(agent.inputSchema).toBeDefined();
     expect((agent.inputSchema as Schema).type).toBe('OBJECT');
@@ -276,11 +276,11 @@ describe('LlmAgent Schema Initialization', () => {
     expect(agent.outputSchema).toEqual(outputSchema);
   });
 
-  it('should initialize outputSchema from Zod object', () => {
-    const zodSchema = z.object({bar: z.number()}) as unknown as AgentSchema;
+  it('should initialize outputSchema from Zod z4 object', () => {
+    const zodSchema = z4.object({bar: z4.number()});
     const agent = new LlmAgent({
       name: 'test',
-      outputSchema: zodSchema as unknown as Schema,
+      outputSchema: zodSchema,
     });
     expect(agent.outputSchema).toBeDefined();
     expect((agent.outputSchema as Schema).type).toBe('OBJECT');
@@ -288,10 +288,12 @@ describe('LlmAgent Schema Initialization', () => {
   });
 
   it('should initialize outputSchema from Zod v3 object', () => {
-    const zodSchema = z3.object({bar: z3.number()}) as unknown as AgentSchema;
+    const zodSchema = z3.object({
+      bar: z3.number(),
+    });
     const agent = new LlmAgent({
       name: 'test',
-      outputSchema: zodSchema as unknown as Schema,
+      outputSchema: zodSchema,
     });
     expect(agent.outputSchema).toBeDefined();
     expect((agent.outputSchema as Schema).type).toBe('OBJECT');


### PR DESCRIPTION
Remove Hard-coded check that prevents set tools and outputSchema.
Also support zod v3/v4 schemas for `llmAgent.inputSchema` and `llmAgent.outputSchema`.

Resolves: 
- https://github.com/google/adk-js/issues/111
- https://github.com/google/adk-js/issues/118
