### PR TITLE
A2A integration: Add util to convert A2A <-> GenAI parts.

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -40,6 +40,7 @@
     "prepublishOnly": "npm run build:bundle"
   },
   "dependencies": {
+    "@a2a-js/sdk": "^0.3.10",
     "@google/genai": "^1.37.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "google-auth-library": "^10.3.0",

--- a/core/src/a2a/part_converter_utils.ts
+++ b/core/src/a2a/part_converter_utils.ts
@@ -1,0 +1,257 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DataPart as A2ADataPart,
+  FilePart as A2AFilePart,
+  Part as A2APart,
+  TextPart as A2ATextPart,
+} from '@a2a-js/sdk';
+import {
+  CodeExecutionResult as GenAICodeExecutionResult,
+  ExecutableCode as GenAIExecutableCode,
+  FunctionCall as GenAIFunctionCall,
+  FunctionResponse as GenAIFunctionResponse,
+  Part as GenAIPart,
+} from '@google/genai';
+
+enum MetadataKeys {
+  TYPE = 'adk_type',
+  LONG_RUNNING = 'adk_is_long_running',
+  THOUGHT = 'adk_thought',
+}
+
+/**
+ * The types of data parts.
+ */
+enum DataPartType {
+  FUNCTION_CALL = 'function_call',
+  FUNCTION_RESPONSE = 'function_response',
+  CODE_EXEC_RESULT = 'code_execution_result',
+  CODE_EXECUTABLE_CODE = 'executable_code',
+}
+
+/**
+ * Converts GenAI Parts to A2A Parts.
+ */
+export function toA2AParts(
+  parts: GenAIPart[],
+  longRunningToolIDs: string[] = [],
+): A2APart[] {
+  return parts.map((part) => toA2APart(part, longRunningToolIDs));
+}
+
+/**
+ * Converts a GenAI Part to an A2A Part.
+ */
+export function toA2APart(
+  part: GenAIPart,
+  longRunningToolIDs?: string[],
+): A2APart {
+  if (part.text !== undefined && part.text !== null) {
+    return toA2ATextPart(part);
+  }
+
+  if (part.inlineData || part.fileData) {
+    return toA2AFilePart(part);
+  }
+
+  return toA2ADataPart(part, longRunningToolIDs);
+}
+
+/**
+ * Converts a GenAI Text Part to an A2A Text Part.
+ */
+export function toA2ATextPart(part: GenAIPart): A2APart {
+  const a2aPart: A2APart = {kind: 'text', text: part.text || ''};
+
+  if ('thought' in part && part['thought']) {
+    a2aPart.metadata = {
+      [MetadataKeys.THOUGHT]: true,
+    };
+  }
+
+  return a2aPart;
+}
+
+/**
+ * Converts a GenAI File Part to an A2A File Part.
+ */
+export function toA2AFilePart(part: GenAIPart): A2APart {
+  if (part.fileData) {
+    return {
+      kind: 'file',
+      file: {
+        uri: part.fileData.fileUri || '',
+        mimeType: part.fileData.mimeType,
+      },
+      metadata: {},
+    };
+  }
+
+  if (part.inlineData) {
+    return {
+      kind: 'file',
+      file: {
+        bytes: part.inlineData.data || '',
+        mimeType: part.inlineData.mimeType,
+      },
+      metadata: {},
+    };
+  }
+
+  throw new Error(`Not a file part: ${JSON.stringify(part)}`);
+}
+
+/**
+ * Converts a GenAI Data Part to an A2A Data Part.
+ */
+export function toA2ADataPart(
+  part: GenAIPart,
+  longRunningToolIDs: string[] = [],
+): A2APart {
+  let type: string;
+  let data:
+    | GenAIFunctionCall
+    | GenAIFunctionResponse
+    | GenAIExecutableCode
+    | GenAICodeExecutionResult;
+
+  if (part.functionCall) {
+    type = DataPartType.FUNCTION_CALL;
+    data = part.functionCall;
+  } else if (part.functionResponse) {
+    type = DataPartType.FUNCTION_RESPONSE;
+    data = part.functionResponse;
+  } else if (part.executableCode) {
+    type = DataPartType.CODE_EXECUTABLE_CODE;
+    data = part.executableCode;
+  } else if (part.codeExecutionResult) {
+    type = DataPartType.CODE_EXEC_RESULT;
+    data = part.codeExecutionResult;
+  } else {
+    throw new Error(`Unknown part type: ${JSON.stringify(part)}`);
+  }
+
+  const metadata: Record<string, unknown> = {
+    [MetadataKeys.TYPE]: type,
+  };
+
+  if (
+    part.functionCall &&
+    part.functionCall.name &&
+    longRunningToolIDs.includes(part.functionCall.name)
+  ) {
+    metadata[MetadataKeys.LONG_RUNNING] = true;
+  }
+
+  if (
+    part.functionResponse &&
+    part.functionResponse.name &&
+    longRunningToolIDs.includes(part.functionResponse.name)
+  ) {
+    metadata[MetadataKeys.LONG_RUNNING] = true;
+  }
+
+  return {
+    kind: 'data',
+    data: data as unknown as Record<string, unknown>,
+    metadata,
+  };
+}
+
+/**
+ * Converts an A2A Part to a GenAI Part.
+ */
+export function toGenAIParts(a2aParts: A2APart[]): GenAIPart[] {
+  return a2aParts.map((a2aPart) => toGenAIPart(a2aPart));
+}
+
+/**
+ * Converts an A2A Part to a GenAI Part.
+ */
+export function toGenAIPart(a2aPart: A2APart): GenAIPart {
+  if (a2aPart.kind === 'text') {
+    return toGenAIPartText(a2aPart);
+  }
+
+  if (a2aPart.kind === 'file') {
+    return toGenAIPartFile(a2aPart);
+  }
+
+  if (a2aPart.kind === 'data') {
+    return toGenAIPartData(a2aPart);
+  }
+
+  throw new Error(`Unknown part kind: ${JSON.stringify(a2aPart)}`);
+}
+
+/**
+ * Converts an A2A Text Part to a GenAI Part.
+ */
+export function toGenAIPartText(a2aPart: A2ATextPart): GenAIPart {
+  return {
+    text: a2aPart.text,
+    thought: !!a2aPart.metadata?.[MetadataKeys.THOUGHT],
+  };
+}
+
+/**
+ * Converts an A2A File Part to a GenAI Part.
+ */
+export function toGenAIPartFile(a2aPart: A2AFilePart): GenAIPart {
+  if ('bytes' in a2aPart.file) {
+    return {
+      inlineData: {
+        data: a2aPart.file.bytes,
+        mimeType: a2aPart.file.mimeType || '',
+      },
+    };
+  }
+
+  if ('uri' in a2aPart.file) {
+    return {
+      fileData: {
+        fileUri: a2aPart.file.uri,
+        mimeType: a2aPart.file.mimeType || '',
+      },
+    };
+  }
+
+  throw new Error(`Not a file part: ${JSON.stringify(a2aPart)}`);
+}
+
+/**
+ * Converts an A2A Data Part to a GenAI Part.
+ */
+export function toGenAIPartData(a2aPart: A2ADataPart): GenAIPart {
+  if (!a2aPart.data) {
+    throw new Error(`No data in part: ${JSON.stringify(a2aPart)}`);
+  }
+
+  const data = a2aPart.data as Record<string, unknown>;
+  const type = a2aPart.metadata?.[MetadataKeys.TYPE];
+
+  if (type === DataPartType.FUNCTION_CALL) {
+    return {functionCall: data};
+  }
+
+  if (type === DataPartType.FUNCTION_RESPONSE) {
+    return {functionResponse: data};
+  }
+
+  if (type === DataPartType.CODE_EXECUTABLE_CODE) {
+    return {executableCode: data};
+  }
+
+  if (type === DataPartType.CODE_EXEC_RESULT) {
+    return {codeExecutionResult: data};
+  }
+
+  return {
+    text: JSON.stringify(a2aPart.data),
+  };
+}

--- a/core/test/a2a/part_converter_utils_test.ts
+++ b/core/test/a2a/part_converter_utils_test.ts
@@ -1,0 +1,470 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DataPart as A2ADataPart,
+  FilePart as A2AFilePart,
+  Part as A2APart,
+  TextPart as A2ATextPart,
+} from '@a2a-js/sdk';
+import {Part as GenAIPart, Language, Outcome} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {
+  toA2ADataPart,
+  toA2AFilePart,
+  toA2APart,
+  toA2AParts,
+  toA2ATextPart,
+  toGenAIPart,
+  toGenAIPartData,
+  toGenAIPartFile,
+  toGenAIParts,
+  toGenAIPartText,
+} from '../../src/a2a/part_converter_utils.js';
+
+describe('part_converter_utils', () => {
+  describe('toA2ATextPart', () => {
+    it('converts basic text part', () => {
+      const genAiPart: GenAIPart = {text: 'hello world'};
+      const expected: A2APart = {kind: 'text', text: 'hello world'};
+      expect(toA2ATextPart(genAiPart)).toEqual(expected);
+    });
+
+    it('converts thought text part', () => {
+      const genAiPart = {text: 'thinking...', thought: true};
+      const expected: A2APart = {
+        kind: 'text',
+        text: 'thinking...',
+        metadata: {'adk_thought': true},
+      };
+      expect(toA2ATextPart(genAiPart)).toEqual(expected);
+    });
+  });
+
+  describe('toA2AFilePart', () => {
+    it('converts fileData part', () => {
+      const genAiPart: GenAIPart = {
+        fileData: {mimeType: 'image/jpeg', fileUri: 'gs://bucket/image.jpg'},
+      };
+      const expected: A2APart = {
+        kind: 'file',
+        file: {uri: 'gs://bucket/image.jpg', mimeType: 'image/jpeg'},
+        metadata: {},
+      };
+      expect(toA2AFilePart(genAiPart)).toEqual(expected);
+    });
+
+    it('converts inlineData part', () => {
+      const genAiPart: GenAIPart = {
+        inlineData: {mimeType: 'image/png', data: 'base64data'},
+      };
+      const expected: A2APart = {
+        kind: 'file',
+        file: {bytes: 'base64data', mimeType: 'image/png'},
+        metadata: {},
+      };
+      expect(toA2AFilePart(genAiPart)).toEqual(expected);
+    });
+
+    it('throws on invalid file part', () => {
+      expect(() => toA2AFilePart({text: 'not file'})).toThrow(
+        'Not a file part',
+      );
+    });
+  });
+
+  describe('toA2ADataPart', () => {
+    it('converts functionCall', () => {
+      const genAiPart: GenAIPart = {
+        functionCall: {name: 'getWeather', args: {location: 'London'}},
+      };
+      const expected: A2APart = {
+        kind: 'data',
+        data: {name: 'getWeather', args: {location: 'London'}},
+        metadata: {'adk_type': 'function_call'},
+      };
+      expect(toA2ADataPart(genAiPart)).toEqual(expected);
+    });
+
+    it('adds long_running metadata to functionCall if ID matches', () => {
+      const genAiPart: GenAIPart = {
+        functionCall: {name: 'getWeather', args: {location: 'London'}},
+      };
+      const expected: A2APart = {
+        kind: 'data',
+        data: {name: 'getWeather', args: {location: 'London'}},
+        metadata: {'adk_type': 'function_call', 'adk_is_long_running': true},
+      };
+      expect(toA2ADataPart(genAiPart, ['getWeather'])).toEqual(expected);
+    });
+
+    it('converts functionResponse', () => {
+      const genAiPart: GenAIPart = {
+        functionResponse: {name: 'getWeather', response: {temp: 20}},
+      };
+      const expected: A2APart = {
+        kind: 'data',
+        data: {name: 'getWeather', response: {temp: 20}},
+        metadata: {'adk_type': 'function_response'},
+      };
+      expect(toA2ADataPart(genAiPart)).toEqual(expected);
+    });
+
+    it('adds long_running metadata to functionResponse if ID matches', () => {
+      const genAiPart: GenAIPart = {
+        functionResponse: {name: 'getWeather', response: {temp: 20}},
+      };
+      const expected: A2APart = {
+        kind: 'data',
+        data: {name: 'getWeather', response: {temp: 20}},
+        metadata: {
+          'adk_type': 'function_response',
+          'adk_is_long_running': true,
+        },
+      };
+      expect(toA2ADataPart(genAiPart, ['getWeather'])).toEqual(expected);
+    });
+
+    it('converts executableCode', () => {
+      const genAiPart: GenAIPart = {
+        executableCode: {code: 'print("hello")', language: Language.PYTHON},
+      };
+      const expected: A2APart = {
+        kind: 'data',
+        data: {
+          code: 'print("hello")',
+          language: Language.PYTHON,
+        },
+        metadata: {'adk_type': 'executable_code'},
+      };
+      expect(toA2ADataPart(genAiPart)).toEqual(expected);
+    });
+
+    it('converts codeExecutionResult', () => {
+      const genAiPart: GenAIPart = {
+        codeExecutionResult: {outcome: Outcome.OUTCOME_OK, output: 'hello'},
+      };
+      const expected: A2APart = {
+        kind: 'data',
+        data: {
+          outcome: Outcome.OUTCOME_OK,
+          output: 'hello',
+        },
+        metadata: {'adk_type': 'code_execution_result'},
+      };
+      expect(toA2ADataPart(genAiPart)).toEqual(expected);
+    });
+
+    it('throws on unknown data part type', () => {
+      expect(() => toA2ADataPart({text: 'text'})).toThrow('Unknown part type');
+    });
+  });
+
+  describe('toA2APart', () => {
+    it('delegates text part', () => {
+      const genAiPart: GenAIPart = {text: 'hello'};
+      expect(toA2APart(genAiPart)).toEqual({kind: 'text', text: 'hello'});
+    });
+
+    it('delegates fileData part', () => {
+      const genAiPart: GenAIPart = {
+        fileData: {mimeType: 'image/jpeg', fileUri: 'gs://foo'},
+      };
+      expect(toA2APart(genAiPart)).toEqual({
+        kind: 'file',
+        file: {uri: 'gs://foo', mimeType: 'image/jpeg'},
+        metadata: {},
+      });
+    });
+
+    it('delegates inlineData part', () => {
+      const genAiPart: GenAIPart = {
+        inlineData: {mimeType: 'image/jpeg', data: 'xyz'},
+      };
+      expect(toA2APart(genAiPart)).toEqual({
+        kind: 'file',
+        file: {bytes: 'xyz', mimeType: 'image/jpeg'},
+        metadata: {},
+      });
+    });
+
+    it('delegates data part', () => {
+      const genAiPart: GenAIPart = {functionCall: {name: 'foo', args: {}}};
+      expect(toA2APart(genAiPart)).toEqual({
+        kind: 'data',
+        data: {name: 'foo', args: {}},
+        metadata: {'adk_type': 'function_call'},
+      });
+    });
+  });
+
+  describe('toA2AParts', () => {
+    it('maps an array of parts', () => {
+      const genAiParts: GenAIPart[] = [
+        {text: 'hello'},
+        {functionCall: {name: 'longFoo', args: {}}},
+      ];
+      const expected: A2APart[] = [
+        {kind: 'text', text: 'hello'},
+        {
+          kind: 'data',
+          data: {name: 'longFoo', args: {}},
+          metadata: {'adk_type': 'function_call', 'adk_is_long_running': true},
+        },
+      ];
+      expect(toA2AParts(genAiParts, ['longFoo'])).toEqual(expected);
+    });
+  });
+
+  // Now the backward conversions
+  describe('toGenAIPartText', () => {
+    it('converts to text part', () => {
+      const a2aPart: A2ATextPart = {kind: 'text', text: 'hello'};
+      const expected: GenAIPart = {text: 'hello', thought: false};
+      expect(toGenAIPartText(a2aPart)).toEqual(expected);
+    });
+
+    it('converts thought text part', () => {
+      const a2aPart: A2ATextPart = {
+        kind: 'text',
+        text: 'thinking...',
+        metadata: {'adk_thought': true},
+      };
+      const expected: GenAIPart = {text: 'thinking...', thought: true};
+      expect(toGenAIPartText(a2aPart)).toEqual(expected);
+    });
+  });
+
+  describe('toGenAIPartFile', () => {
+    it('converts from file with bytes', () => {
+      const a2aPart: A2AFilePart = {
+        kind: 'file',
+        file: {bytes: 'data', mimeType: 'image/png'},
+      };
+      const expected: GenAIPart = {
+        inlineData: {mimeType: 'image/png', data: 'data'},
+      };
+      expect(toGenAIPartFile(a2aPart)).toEqual(expected);
+    });
+
+    it('converts from file with uri', () => {
+      const a2aPart: A2AFilePart = {
+        kind: 'file',
+        file: {uri: 'gs://bucket/file', mimeType: 'image/png'},
+      };
+      const expected: GenAIPart = {
+        fileData: {mimeType: 'image/png', fileUri: 'gs://bucket/file'},
+      };
+      expect(toGenAIPartFile(a2aPart)).toEqual(expected);
+    });
+
+    it('throws if neither uri nor bytes', () => {
+      const a2aPart = {kind: 'file', file: {}} as unknown as A2AFilePart;
+      expect(() => toGenAIPartFile(a2aPart)).toThrow(
+        'Not a file part: {"kind":"file","file":{}}',
+      );
+    });
+  });
+
+  describe('toGenAIPartData', () => {
+    it('converts functionCall', () => {
+      const a2aPart: A2ADataPart = {
+        kind: 'data',
+        data: {name: 'foo', args: {}},
+        metadata: {'adk_type': 'function_call'},
+      };
+      const expected: GenAIPart = {functionCall: {name: 'foo', args: {}}};
+      expect(toGenAIPartData(a2aPart)).toEqual(expected);
+    });
+
+    it('converts functionResponse', () => {
+      const a2aPart: A2ADataPart = {
+        kind: 'data',
+        data: {name: 'foo', response: {ok: true}},
+        metadata: {'adk_type': 'function_response'},
+      };
+      const expected: GenAIPart = {
+        functionResponse: {name: 'foo', response: {ok: true}},
+      };
+      expect(toGenAIPartData(a2aPart)).toEqual(expected);
+    });
+
+    it('converts executableCode', () => {
+      const a2aPart: A2ADataPart = {
+        kind: 'data',
+        data: {
+          code: 'print("hi")',
+          language: Language.PYTHON,
+        },
+        metadata: {'adk_type': 'executable_code'},
+      };
+      const expected: GenAIPart = {
+        executableCode: {code: 'print("hi")', language: Language.PYTHON},
+      };
+      expect(toGenAIPartData(a2aPart)).toEqual(expected);
+    });
+
+    it('converts codeExecutionResult', () => {
+      const a2aPart: A2ADataPart = {
+        kind: 'data',
+        data: {
+          outcome: Outcome.OUTCOME_OK,
+          output: 'hi',
+        },
+        metadata: {'adk_type': 'code_execution_result'},
+      };
+      const expected: GenAIPart = {
+        codeExecutionResult: {outcome: Outcome.OUTCOME_OK, output: 'hi'},
+      };
+      expect(toGenAIPartData(a2aPart)).toEqual(expected);
+    });
+
+    it('throws if no data in part', () => {
+      const a2aPart = {
+        kind: 'data',
+      } as unknown as A2ADataPart;
+      expect(() => toGenAIPartData(a2aPart)).toThrow('No data in part');
+    });
+
+    it('falls back to stringified text if type is unknown', () => {
+      const a2aPart: A2ADataPart = {
+        kind: 'data',
+        data: {customData: 123},
+      };
+      const expected: GenAIPart = {
+        text: '{"customData":123}',
+      };
+      expect(toGenAIPartData(a2aPart)).toEqual(expected);
+    });
+  });
+
+  describe('toGenAIPart', () => {
+    it('delegates text', () => {
+      const a2aPart: A2APart = {kind: 'text', text: 'hi'};
+      expect(toGenAIPart(a2aPart)).toEqual({text: 'hi', thought: false});
+    });
+
+    it('delegates file', () => {
+      const a2aPart: A2APart = {
+        kind: 'file',
+        file: {uri: 'gs://hi', mimeType: 'text/plain'},
+      };
+      expect(toGenAIPart(a2aPart)).toEqual({
+        fileData: {fileUri: 'gs://hi', mimeType: 'text/plain'},
+      });
+    });
+
+    it('delegates data', () => {
+      const a2aPart: A2APart = {
+        kind: 'data',
+        data: {name: 'foo', args: {}},
+        metadata: {'adk_type': 'function_call'},
+      };
+      expect(toGenAIPart(a2aPart)).toEqual({
+        functionCall: {name: 'foo', args: {}},
+      });
+    });
+
+    it('throws on unknown kind', () => {
+      const a2aPart = {kind: 'unknown'} as unknown as A2APart;
+      expect(() => toGenAIPart(a2aPart)).toThrow('Unknown part kind');
+    });
+  });
+
+  describe('toGenAIParts', () => {
+    it('maps array of parts', () => {
+      const a2aParts: A2APart[] = [
+        {kind: 'text', text: 'hi'},
+        {
+          kind: 'data',
+          data: {name: 'foo', args: {}},
+          metadata: {'adk_type': 'function_call'},
+        },
+      ];
+      const expected: GenAIPart[] = [
+        {text: 'hi', thought: false},
+        {functionCall: {name: 'foo', args: {}}},
+      ];
+      expect(toGenAIParts(a2aParts)).toEqual(expected);
+    });
+  });
+
+  describe('end-to-end conversion', () => {
+    it('toA2APart(toGenAIPart(part)) equals part for text', () => {
+      const a2aPart: A2APart = {kind: 'text', text: 'hello'};
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+
+    it('toA2APart(toGenAIPart(part)) equals part for thought text', () => {
+      const a2aPart: A2APart = {
+        kind: 'text',
+        text: 'thinking...',
+        metadata: {'adk_thought': true},
+      };
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+
+    it('toA2APart(toGenAIPart(part)) equals part for file base64', () => {
+      const a2aPart: A2APart = {
+        kind: 'file',
+        file: {bytes: 'base64data', mimeType: 'image/png'},
+        metadata: {},
+      };
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+
+    it('toA2APart(toGenAIPart(part)) equals part for file uri', () => {
+      const a2aPart: A2APart = {
+        kind: 'file',
+        file: {uri: 'gs://bucket/image.jpg', mimeType: 'image/jpeg'},
+        metadata: {},
+      };
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+
+    it('toA2APart(toGenAIPart(part)) equals part for functionCall', () => {
+      const a2aPart: A2APart = {
+        kind: 'data',
+        data: {name: 'getWeather', args: {location: 'London'}},
+        metadata: {'adk_type': 'function_call'},
+      };
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+
+    it('toA2APart(toGenAIPart(part)) equals part for functionResponse', () => {
+      const a2aPart: A2APart = {
+        kind: 'data',
+        data: {name: 'getWeather', response: {temp: 20}},
+        metadata: {'adk_type': 'function_response'},
+      };
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+
+    it('toA2APart(toGenAIPart(part)) equals part for executableCode', () => {
+      const a2aPart: A2APart = {
+        kind: 'data',
+        data: {
+          code: 'print("hello")',
+          language: Language.PYTHON,
+        },
+        metadata: {'adk_type': 'executable_code'},
+      };
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+
+    it('toA2APart(toGenAIPart(part)) equals part for codeExecutionResult', () => {
+      const a2aPart: A2APart = {
+        kind: 'data',
+        data: {
+          outcome: Outcome.OUTCOME_OK,
+          output: 'hello',
+        },
+        metadata: {'adk_type': 'code_execution_result'},
+      };
+      expect(toA2APart(toGenAIPart(a2aPart))).toEqual(a2aPart);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@a2a-js/sdk": "^0.3.10",
         "@google/genai": "^1.37.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "google-auth-library": "^10.3.0",
@@ -297,6 +298,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@a2a-js/sdk": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.10.tgz",
+      "integrity": "sha512-t6w5ctnwJkSOMRl6M9rn95C1FTHCPqixxMR0yWXtzhZXEnF6mF1NAK0CfKlG3cz+tcwTxkmn287QZC3t9XPgrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1050,20 +1079,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter/node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@google-cloud/opentelemetry-cloud-trace-exporter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-trace-exporter/-/opentelemetry-cloud-trace-exporter-3.0.0.tgz",
@@ -1102,20 +1117,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/opentelemetry-cloud-trace-exporter/node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/opentelemetry-resource-util": {
@@ -1235,20 +1236,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@google-cloud/storage/node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -1260,6 +1247,16 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@google/adk": {
@@ -1571,9 +1568,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.0.tgz",
-      "integrity": "sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -3122,40 +3119,40 @@
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz",
-      "integrity": "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0",
+        "@shikijs/types": "3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.22.0.tgz",
-      "integrity": "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0"
+        "@shikijs/types": "3.23.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.22.0.tgz",
-      "integrity": "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0"
+        "@shikijs/types": "3.23.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.22.0.tgz",
-      "integrity": "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3769,9 +3766,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3990,9 +3987,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4085,9 +4082,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4239,9 +4236,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6360,10 +6357,23 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.7.tgz",
-      "integrity": "sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
       "funding": [
         {
           "type": "github",
@@ -6373,6 +6383,7 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -6852,17 +6863,16 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+      "integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^8.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
@@ -6950,9 +6960,9 @@
       }
     },
     "node_modules/google-auth-library/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -7057,20 +7067,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/googleapis-common/node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/googleapis-common/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -7103,20 +7099,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/googleapis/node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7137,121 +7119,17 @@
       "license": "MIT"
     },
     "node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "gaxios": "^7.0.0",
+        "gaxios": "^6.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gtoken/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/gtoken/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/gtoken/node_modules/gaxios": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2",
-        "rimraf": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gtoken/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/gtoken/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/gtoken/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/gtoken/node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/gts": {
@@ -8938,9 +8816,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11152,9 +11030,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11168,9 +11046,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -11523,9 +11401,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11673,9 +11551,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -11789,13 +11667,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
-      "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {


### PR DESCRIPTION
## Description

This PR introduces robust utilities for bidirectionally converting specialized Parts between the internal adk-js representation (A2A) and the `@google/genai` SDK format. It provides seamless translation between `A2APart` types (Text, File, Data) and standard GenAI `Part` types.

### Key Changes

- Added `@a2a-js/sdk` to dependencies in `core/package.json`.
- Implemented `part_converter_utils.ts` containing core logic to convert part types:
  - `text` <-> `text`.
  - `fileData`/`inlineData` <-> `A2AFilePart` (supports both embedded bytes and direct URIs).
  - `data` <-> `functionCall`, `functionResponse`, `executableCode`, and `codeExecutionResult`.
- Added logic to attach specialized `metadata` (e.g., `'a2a/type': 'function_call'` and `'a2a/is_long_running': true`) within translated `A2ADataPart` objects, providing necessary downstream execution context.
- Added a comprehensive test suite in `part_converter_utils_test.ts` covering success handling and expected runtime errors for unknown part types.

## Motivation and Context

Converting these structures natively simplifies the agent's core code by abstracting A2A-specific part metadata away from the `genai` models. This prevents boilerplate format translation logic from spreading into system execution modules, leading to cleaner and more maintainable components.

## How Has This Been Tested?

- Automated coverage added in `core/test/a2a/part_converter_utils_test.ts` to test all bidirectional flows. Exhaustively verifies mapping logic (Text, File, and Data permutations) and safety bounds through error assertions.
