### PR TITLE
A2A integration: add utils to convert A2A <-> ADK events

### DIFF
--- a/core/src/a2a/event_converter_utils.ts
+++ b/core/src/a2a/event_converter_utils.ts
@@ -1,0 +1,361 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Part as A2APart,
+  Message,
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskStatusUpdateEvent,
+} from '@a2a-js/sdk';
+import {Part} from '@google/genai';
+import {Event, createEvent} from '../events/event.js';
+import {EventActions, createEventActions} from '../events/event_actions.js';
+import {randomUUID} from '../utils/env_aware_utils.js';
+import {toA2AParts, toGenAIParts} from './part_converter_utils.js';
+
+type A2AEvent =
+  | Task
+  | Message
+  | TaskStatusUpdateEvent
+  | TaskArtifactUpdateEvent;
+
+enum A2AMetadataKeys {
+  PARTIAL = 'a2a:partial',
+  TASK_ID = 'a2a:task_id',
+  CONTEXT_ID = 'a2a:context_id',
+  ESCALATE = 'a2a:escalate',
+  TRANSFER_TO_AGENT = 'a2a:transfer_to_agent',
+  LONG_RUNNING = 'a2a:is_long_running',
+  THOUGHT = 'a2a:thought',
+}
+
+const ROLE_USER = 'user';
+const ROLE_MODEL = 'model';
+
+/**
+ * Converts a session Event to an A2A Message.
+ */
+export function toA2AMessage(event?: Event): Message | undefined {
+  if (!event) {
+    return undefined;
+  }
+
+  return {
+    kind: 'message',
+    messageId: randomUUID(),
+    role: event.author === ROLE_USER ? 'user' : 'agent',
+    parts: toA2AParts(event.content?.parts || [], event.longRunningToolIds),
+    metadata: {
+      ...toActionsMeta(event.actions),
+      ...(event.customMetadata || {}),
+    },
+  };
+}
+
+/**
+ * Converts an A2A Event to a Session Event.
+ */
+export function toAdkEvent(
+  event: A2AEvent | unknown,
+  invocationId: string,
+  agentName: string,
+): Event | undefined {
+  if (isTaskStatusUpdateEvent(event)) {
+    if (event.final) {
+      return finalTaskStatusUpdateToEvent(event, invocationId, agentName);
+    }
+    if (!event.status.message) {
+      return undefined;
+    }
+    return messageToEvent(event.status.message, invocationId, agentName, event);
+  }
+
+  if (isMessage(event)) {
+    return messageToEvent(event, invocationId, agentName);
+  }
+
+  if (isTaskArtifactUpdateEvent(event)) {
+    return artifactUpdateToEvent(event, invocationId, agentName);
+  }
+
+  if (isTask(event)) {
+    return taskToEvent(event, invocationId, agentName);
+  }
+
+  return undefined;
+}
+
+function isTaskStatusUpdateEvent(
+  event: unknown,
+): event is TaskStatusUpdateEvent {
+  return (event as TaskStatusUpdateEvent)?.kind === 'status-update';
+}
+
+function isTaskArtifactUpdateEvent(
+  event: unknown,
+): event is TaskArtifactUpdateEvent {
+  return (event as TaskArtifactUpdateEvent)?.kind === 'artifact-update';
+}
+
+function isMessage(event: unknown): event is Message {
+  return (event as Message)?.kind === 'message';
+}
+
+function isTask(event: unknown): event is Task {
+  return (event as Task)?.kind === 'task';
+}
+
+function messageToEvent(
+  msg: Message,
+  invocationId: string,
+  agentName: string,
+  parentEvent?: TaskStatusUpdateEvent,
+): Event {
+  const parts = toGenAIParts(msg.parts);
+  const event = createEvent({
+    invocationId,
+    author: msg.role === ROLE_USER ? ROLE_USER : agentName,
+  });
+
+  if (parts.length > 0) {
+    event.content = {
+      role: msg.role === ROLE_USER ? ROLE_USER : ROLE_MODEL,
+      parts,
+    };
+  }
+
+  if (parentEvent && !parentEvent.final) {
+    event.partial = true;
+
+    for (const part of event.content?.parts || []) {
+      (part as Record<string, unknown>)[A2AMetadataKeys.THOUGHT] = true;
+    }
+  }
+
+  const metaSource = parentEvent || msg;
+  processA2AMeta(metaSource, event);
+
+  event.turnComplete = !parentEvent || !!parentEvent.final;
+  if (parentEvent && !parentEvent.final) {
+    event.turnComplete = false;
+  }
+
+  if (msg.role === ROLE_USER) {
+    event.turnComplete = true;
+  }
+
+  return event;
+}
+
+function artifactUpdateToEvent(
+  event: TaskArtifactUpdateEvent,
+  invocationId: string,
+  agentName: string,
+): Event | undefined {
+  const partsToConvert = event.artifact?.parts || [];
+  if (partsToConvert.length === 0) {
+    return undefined;
+  }
+
+  const parts = toGenAIParts(partsToConvert);
+
+  const sessionEvent = createEvent({
+    invocationId,
+    author: agentName,
+    content: {role: ROLE_MODEL, parts},
+  });
+
+  sessionEvent.longRunningToolIds = getLongRunningToolIDs(
+    partsToConvert,
+    parts,
+  );
+
+  processA2AMeta(event, sessionEvent);
+
+  if (event.artifact?.metadata?.[A2AMetadataKeys.PARTIAL]) {
+    sessionEvent.partial = true;
+  } else {
+    sessionEvent.partial = true;
+  }
+
+  return sessionEvent;
+}
+
+function finalTaskStatusUpdateToEvent(
+  update: TaskStatusUpdateEvent,
+  invocationId: string,
+  agentName: string,
+): Event | undefined {
+  const event = createEvent({
+    invocationId,
+    author: agentName,
+  });
+
+  let parts: Part[] = [];
+  if (update.status.message) {
+    parts = toGenAIParts(update.status.message.parts);
+  }
+
+  if (update.status.state === 'failed' && parts.length === 1 && parts[0].text) {
+    event.errorMessage = parts[0].text;
+  } else if (parts.length > 0) {
+    event.content = {role: ROLE_MODEL, parts};
+  }
+
+  processA2AMeta(update, event);
+
+  if (update.status.message) {
+    event.longRunningToolIds = getLongRunningToolIDs(
+      update.status.message.parts,
+      parts,
+    );
+  }
+
+  event.turnComplete = true;
+
+  return event;
+}
+
+function taskToEvent(
+  task: Task,
+  invocationId: string,
+  agentName: string,
+): Event | undefined {
+  const event = createEvent({
+    invocationId,
+    author: agentName,
+  });
+
+  let parts: Part[] = [];
+  let longRunningToolIds: string[] = [];
+
+  if (task.artifacts) {
+    for (const artifact of task.artifacts) {
+      if (artifact.parts) {
+        const artifactParts = toGenAIParts(artifact.parts);
+        parts = [...parts, ...artifactParts];
+        longRunningToolIds = [
+          ...longRunningToolIds,
+          ...getLongRunningToolIDs(artifact.parts, artifactParts),
+        ];
+      }
+    }
+  }
+
+  if (task.status?.message) {
+    const msgParts = toGenAIParts(task.status.message.parts);
+
+    if (
+      task.status.state === 'failed' &&
+      msgParts.length === 1 &&
+      msgParts[0].text
+    ) {
+      event.errorMessage = msgParts[0].text;
+    } else {
+      parts = [...parts, ...msgParts];
+    }
+    longRunningToolIds = [
+      ...longRunningToolIds,
+      ...getLongRunningToolIDs(task.status.message.parts, msgParts),
+    ];
+  }
+
+  const isTerminal =
+    task.status?.state === 'completed' ||
+    task.status?.state === 'failed' ||
+    task.status?.state === 'input-required' ||
+    task.status?.state === 'canceled';
+
+  if (parts.length === 0 && !isTerminal) {
+    return undefined;
+  }
+
+  if (parts.length > 0) {
+    event.content = {role: ROLE_MODEL, parts};
+  }
+
+  if (task.status?.state === 'input-required') {
+    event.longRunningToolIds = longRunningToolIds;
+  }
+
+  processA2AMeta(task, event);
+  event.turnComplete = isTerminal;
+
+  return event;
+}
+
+function processA2AMeta(
+  source: {metadata?: Record<string, unknown>},
+  event: Event,
+) {
+  if (!source.metadata) {
+    return;
+  }
+
+  if (source.metadata[A2AMetadataKeys.ESCALATE]) {
+    if (!event.actions) {
+      event.actions = createEventActions();
+    }
+
+    event.actions.escalate = true;
+  }
+  if (source.metadata[A2AMetadataKeys.TRANSFER_TO_AGENT]) {
+    if (!event.actions) {
+      event.actions = createEventActions();
+    }
+
+    event.actions.transferToAgent = source.metadata[
+      A2AMetadataKeys.TRANSFER_TO_AGENT
+    ] as string;
+  }
+
+  const taskId = source.metadata[A2AMetadataKeys.TASK_ID] as string;
+  const contextId = source.metadata[A2AMetadataKeys.CONTEXT_ID] as string;
+
+  if (taskId || contextId) {
+    if (!event.customMetadata) {
+      event.customMetadata = {};
+    }
+
+    if (taskId) {
+      event.customMetadata[A2AMetadataKeys.TASK_ID] = taskId;
+    }
+
+    if (contextId) {
+      event.customMetadata[A2AMetadataKeys.CONTEXT_ID] = contextId;
+    }
+  }
+}
+
+function toActionsMeta(actions: EventActions): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+  if (actions.escalate) {
+    meta[A2AMetadataKeys.ESCALATE] = true;
+  }
+
+  if (actions.transferToAgent) {
+    meta[A2AMetadataKeys.TRANSFER_TO_AGENT] = actions.transferToAgent;
+  }
+
+  return meta;
+}
+
+function getLongRunningToolIDs(parts: A2APart[], converted: Part[]): string[] {
+  const ids: string[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i];
+    if (p.metadata && p.metadata[A2AMetadataKeys.LONG_RUNNING]) {
+      const fnCall = converted[i];
+      if (fnCall.functionCall && fnCall.functionCall.name) {
+        ids.push(fnCall.functionCall.name);
+      }
+    }
+  }
+
+  return ids;
+}

--- a/core/test/a2a/event_converter_utils_test.ts
+++ b/core/test/a2a/event_converter_utils_test.ts
@@ -1,0 +1,435 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Message,
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskStatusUpdateEvent,
+} from '@a2a-js/sdk';
+import {describe, expect, it, vi} from 'vitest';
+import {toA2AMessage, toAdkEvent} from '../../src/a2a/event_converter_utils.js';
+import {createEvent} from '../../src/events/event.js';
+import {createEventActions} from '../../src/events/event_actions.js';
+import * as envAwareUtils from '../../src/utils/env_aware_utils.js';
+
+vi.mock('../../src/utils/env_aware_utils.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/utils/env_aware_utils.js')>();
+  return {
+    ...actual,
+    randomUUID: vi.fn(),
+  };
+});
+
+describe('event_converter_utils', () => {
+  describe('toA2AMessage', () => {
+    it('returns undefined if no event is provided', () => {
+      expect(toA2AMessage()).toBeUndefined();
+    });
+
+    it('converts a simple user event to an A2A message', () => {
+      vi.mocked(envAwareUtils.randomUUID).mockReturnValue('test-uuid-1');
+      const event = createEvent({
+        invocationId: 'inv1',
+        author: 'user',
+        content: {
+          role: 'user',
+          parts: [{text: 'hello'}],
+        },
+      });
+
+      const message = toA2AMessage(event);
+      expect(message).toBeDefined();
+      expect(message).toEqual({
+        kind: 'message',
+        messageId: 'test-uuid-1',
+        role: 'user',
+        parts: [{kind: 'text', text: 'hello'}],
+        metadata: {},
+      });
+    });
+
+    it('converts agent event with actions and custom metadata', () => {
+      vi.mocked(envAwareUtils.randomUUID).mockReturnValue('test-uuid-2');
+      const actions = createEventActions();
+      actions.escalate = true;
+      actions.transferToAgent = 'human';
+
+      const event = createEvent({
+        invocationId: 'inv2',
+        author: 'agent_1',
+        content: {
+          role: 'model',
+          parts: [{text: 'response'}],
+        },
+        actions,
+        customMetadata: {
+          'custom_key': 'custom_value',
+        },
+      });
+
+      const message = toA2AMessage(event);
+      expect(message).toBeDefined();
+      expect(message).toEqual({
+        kind: 'message',
+        messageId: 'test-uuid-2',
+        role: 'agent',
+        parts: [{kind: 'text', text: 'response'}],
+        metadata: {
+          'a2a:escalate': true,
+          'a2a:transfer_to_agent': 'human',
+          'custom_key': 'custom_value',
+        },
+      });
+    });
+  });
+
+  describe('toAdkEvent', () => {
+    it('returns undefined for unknown event type', () => {
+      expect(toAdkEvent({kind: 'unknown'}, 'inv', 'agent')).toBeUndefined();
+    });
+
+    describe('Message', () => {
+      it('converts user message to AdkEvent', () => {
+        const message: Message = {
+          kind: 'message',
+          messageId: 'msg1',
+          role: 'user',
+          parts: [{kind: 'text', text: 'hello from user'}],
+        };
+
+        const event = toAdkEvent(message, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.author).toBe('user');
+        expect(event.content?.role).toBe('user');
+        expect(event.content?.parts).toEqual([
+          {text: 'hello from user', thought: false},
+        ]);
+        expect(event.turnComplete).toBe(true);
+      });
+
+      it('converts agent message to AdkEvent', () => {
+        const message: Message = {
+          kind: 'message',
+          messageId: 'msg2',
+          role: 'agent',
+          parts: [{kind: 'text', text: 'hello from agent'}],
+          metadata: {
+            'a2a:escalate': true,
+            'a2a:transfer_to_agent': 'agent2',
+            'a2a:task_id': 'task1',
+            'a2a:context_id': 'context1',
+          },
+        };
+
+        const event = toAdkEvent(message, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.author).toBe('agent1');
+        expect(event.content?.role).toBe('model');
+        expect(event.content?.parts).toEqual([
+          {text: 'hello from agent', thought: false},
+        ]);
+        expect(event.turnComplete).toBe(true);
+        expect(event.actions?.escalate).toBe(true);
+        expect(event.actions?.transferToAgent).toBe('agent2');
+        expect(event.customMetadata).toEqual({
+          'a2a:task_id': 'task1',
+          'a2a:context_id': 'context1',
+        });
+      });
+    });
+
+    describe('TaskStatusUpdateEvent', () => {
+      it('converts final status update', () => {
+        const finalUpdate: TaskStatusUpdateEvent = {
+          kind: 'status-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'completed',
+            message: {
+              kind: 'message',
+              messageId: 'msg1',
+              role: 'agent',
+              parts: [{kind: 'text', text: 'done'}],
+            },
+          },
+          final: true,
+        };
+
+        const event = toAdkEvent(finalUpdate, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.author).toBe('agent1');
+        expect(event.content?.role).toBe('model');
+        expect(event.content?.parts).toEqual([{text: 'done', thought: false}]);
+        expect(event.turnComplete).toBe(true);
+      });
+
+      it('converts final status update (failed without message parts)', () => {
+        const finalUpdate: TaskStatusUpdateEvent = {
+          kind: 'status-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'failed',
+          },
+          final: true,
+        };
+
+        const event = toAdkEvent(finalUpdate, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.author).toBe('agent1');
+        expect(event.content).toBeUndefined();
+        expect(event.turnComplete).toBe(true);
+      });
+
+      it('converts final status update (failed with text part)', () => {
+        const finalUpdate: TaskStatusUpdateEvent = {
+          kind: 'status-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'failed',
+            message: {
+              kind: 'message',
+              messageId: 'msg1',
+              role: 'agent',
+              parts: [{kind: 'text', text: 'error occurred'}],
+            },
+          },
+          final: true,
+        };
+
+        const event = toAdkEvent(finalUpdate, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.errorMessage).toBe('error occurred');
+        expect(event.content).toBeUndefined();
+        expect(event.turnComplete).toBe(true);
+      });
+
+      it('converts non-final status update with partial message', () => {
+        const nonFinalUpdate: TaskStatusUpdateEvent = {
+          kind: 'status-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'working',
+            message: {
+              kind: 'message',
+              messageId: 'msg1',
+              role: 'agent',
+              parts: [{kind: 'text', text: 'thinking loudly...'}],
+            },
+          },
+          final: false,
+        };
+
+        const event = toAdkEvent(nonFinalUpdate, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.partial).toBe(true);
+        expect(event.turnComplete).toBe(false);
+        // Thought metadata is added to partial message parts internally
+        expect(event.content?.parts).toEqual([
+          {text: 'thinking loudly...', thought: false, 'a2a:thought': true},
+        ]);
+      });
+
+      it('returns undefined if non-final status update has no message', () => {
+        const nonFinalUpdate: TaskStatusUpdateEvent = {
+          kind: 'status-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'working',
+          },
+          final: false,
+        };
+
+        expect(toAdkEvent(nonFinalUpdate, 'inv1', 'agent1')).toBeUndefined();
+      });
+    });
+
+    describe('TaskArtifactUpdateEvent', () => {
+      it('converts artifact update with no parts to undefined', () => {
+        const artifactUpdate: TaskArtifactUpdateEvent = {
+          kind: 'artifact-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          artifact: {
+            artifactId: 'art1',
+            parts: [],
+          },
+        };
+
+        expect(toAdkEvent(artifactUpdate, 'inv1', 'agent1')).toBeUndefined();
+      });
+
+      it('converts artifact update', () => {
+        const artifactUpdate: TaskArtifactUpdateEvent = {
+          kind: 'artifact-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          metadata: {
+            'a2a:task_id': 'task2',
+          },
+          artifact: {
+            artifactId: 'art1',
+            parts: [
+              {
+                kind: 'data',
+                data: {name: 'testTool', args: {}},
+                metadata: {
+                  'a2a:is_long_running': true,
+                  'adk_type': 'function_call',
+                },
+              },
+            ],
+            metadata: {
+              'a2a:partial': true,
+              'a2a:task_id': 'task2',
+              'adk_type': 'function_call',
+            },
+          },
+        };
+
+        const event = toAdkEvent(artifactUpdate, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.partial).toBe(true);
+        expect(event.longRunningToolIds).toEqual(['testTool']);
+        expect(event.customMetadata).toEqual({'a2a:task_id': 'task2'});
+        expect(event.content?.parts).toEqual([
+          {functionCall: {name: 'testTool', args: {}}},
+        ]);
+      });
+    });
+
+    describe('Task', () => {
+      it('returns undefined for task with no parts and non-terminal state', () => {
+        const task: Task = {
+          kind: 'task',
+          id: 'task1',
+          contextId: 'context1',
+          status: {state: 'working'},
+        };
+        expect(toAdkEvent(task, 'inv1', 'agent1')).toBeUndefined();
+      });
+
+      it('converts completed task with artifacts and status message', () => {
+        const task: Task = {
+          kind: 'task',
+          id: 'task1',
+          contextId: 'context1',
+          artifacts: [
+            {
+              artifactId: 'art1',
+              parts: [
+                {
+                  kind: 'data',
+                  data: {name: 'artTool', args: {}},
+                  metadata: {
+                    'a2a:is_long_running': true,
+                    'adk_type': 'function_call',
+                  },
+                },
+              ],
+            },
+          ],
+          status: {
+            state: 'completed',
+            message: {
+              kind: 'message',
+              messageId: 'msg1',
+              role: 'agent',
+              parts: [{kind: 'text', text: 'task complete'}],
+            },
+          },
+          metadata: {
+            'a2a:task_id': 't1',
+            'a2a:context_id': 'c1',
+          },
+        };
+
+        const event = toAdkEvent(task, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.turnComplete).toBe(true);
+        expect(event.longRunningToolIds).toEqual([]); // No long running for non-input-required
+        expect(event.content?.parts).toEqual([
+          {functionCall: {name: 'artTool', args: {}}},
+          {text: 'task complete', thought: false},
+        ]);
+        expect(event.customMetadata).toEqual({
+          'a2a:task_id': 't1',
+          'a2a:context_id': 'c1',
+        });
+      });
+
+      it('converts failed task with text error message', () => {
+        const task: Task = {
+          kind: 'task',
+          id: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'failed',
+            message: {
+              kind: 'message',
+              messageId: 'msg1',
+              role: 'agent',
+              parts: [{kind: 'text', text: 'task failed miserably'}],
+            },
+          },
+        };
+
+        const event = toAdkEvent(task, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.turnComplete).toBe(true);
+        expect(event.errorMessage).toBe('task failed miserably');
+        expect(event.content).toBeUndefined(); // parts is ignored
+      });
+
+      it('converts input-required task and extracts longRunningToolIds', () => {
+        const task: Task = {
+          kind: 'task',
+          id: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'input-required',
+            message: {
+              kind: 'message',
+              messageId: 'msg1',
+              role: 'agent',
+              parts: [
+                {
+                  kind: 'data',
+                  data: {name: 'inputTool', args: {}},
+                  metadata: {
+                    'a2a:is_long_running': true,
+                    'adk_type': 'function_call',
+                  },
+                },
+              ],
+            },
+          },
+        };
+
+        const event = toAdkEvent(task, 'inv1', 'agent1');
+        expect(event).toBeDefined();
+        if (!event) return;
+        expect(event.turnComplete).toBe(true);
+        expect(event.longRunningToolIds).toEqual(['inputTool']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### **Description:**

This PR introduces utility functions to facilitate the conversion of events and messages between the Agent-to-Agent (A2A) protocol and the ADK format. These utilities act as a bridge ensuring that various event types and their specific payloads are seamlessly transformed back and forth.

### **Changes:**

- **`core/src/a2a/event_converter_utils.ts`**: Added core conversion logic:
  - `toA2AMessage` - Converts ADK formats to A2A counterparts.
  - `toAdkEvent` - Converts A2A formats back to ADK events.
  - Handled mapping for multiple event structures such as `TaskStatusUpdateEvent`, `TaskArtifactUpdateEvent`, and `Task`.
  - Added support for accurately parsing event metadata, task boundaries, final/partial states, error messages, long-running tool indicators, and standard role assignments.
- **`core/test/a2a/event_converter_utils_test.ts`**: Added comprehensive unit test coverage to ensure full stability. Validated various conversion scenarios across inputs, outputs, and intermediate updates to guarantee the correctness of the utility functions.
