### PR TITLE
Fix: Correct compiler options in build setup integration tests

### DIFF
--- a/tests/integration/build_setup/build_setup_test.ts
+++ b/tests/integration/build_setup/build_setup_test.ts
@@ -61,9 +61,17 @@ describe('Build setup', () => {
           await execAsync('npm install', {cwd: projectPath});
 
           if (buildSetup.startsWith('ts_')) {
-            const buildResult = await execAsync('npm run build', {
-              cwd: projectPath,
-            });
+            let buildResult;
+            try {
+              buildResult = await execAsync('npm run build', {
+                cwd: projectPath,
+              });
+            } catch (error: unknown) {
+              console.error(`Build failed for ${buildSetup}:`);
+              console.error(`stdout:\n${(error as {stdout: string}).stdout}`);
+              console.error(`stderr:\n${(error as {stderr: string}).stderr}`);
+              throw error;
+            }
             expect(buildResult.stderr).toBe('');
             expect(buildResult.stdout).toContain('\nBuild complete');
           }
@@ -83,11 +91,15 @@ describe('Build setup', () => {
       );
 
       afterAll(async () => {
-        await fs.rm(`${projectPath}/node_modules`, {recursive: true});
-        await fs.unlink(`${projectPath}/package-lock.json`);
+        await fs
+          .rm(`${projectPath}/node_modules`, {recursive: true, force: true})
+          .catch(() => {});
+        await fs.unlink(`${projectPath}/package-lock.json`).catch(() => {});
 
         if (buildSetup.startsWith('ts_')) {
-          await fs.rm(`${projectPath}/dist`, {recursive: true});
+          await fs
+            .rm(`${projectPath}/dist`, {recursive: true, force: true})
+            .catch(() => {});
         }
       });
     },

--- a/tests/integration/build_setup/ts_commonjs/package.json
+++ b/tests/integration/build_setup/ts_commonjs/package.json
@@ -1,19 +1,19 @@
 {
-	"name": "ts_commonjs_build_setup",
-	"version": "1.0.0",
-	"description": "",
-	"main": "agent.ts",
-	"type": "commonjs",
-	"scripts": {
-		"build": "tsc && echo Build complete",
-		"start": "npx @google/adk-devtools run agent.ts"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
-	"dependencies": {
-		"@google/adk": "file:../../../../core",
-		"@google/adk-devtools": "file:../../../../dev",
-		"@google/genai": "^1.37.0"
-	}
+  "name": "ts_commonjs_build_setup",
+  "version": "1.0.0",
+  "description": "",
+  "main": "agent.ts",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc && echo Build complete",
+    "start": "npx @google/adk-devtools run agent.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@google/adk": "file:../../../../core",
+    "@google/adk-devtools": "file:../../../../dev",
+    "@google/genai": "^1.37.0"
+  }
 }

--- a/tests/integration/build_setup/ts_commonjs/tsconfig.json
+++ b/tests/integration/build_setup/ts_commonjs/tsconfig.json
@@ -16,6 +16,7 @@
     "pretty": true,
     "skipLibCheck": true,
     "sourceMap": true,
+    "preserveSymlinks": true,
     "strict": true
   },
   "exclude": ["node_modules", "dist"]

--- a/tests/integration/build_setup/ts_esm/package.json
+++ b/tests/integration/build_setup/ts_esm/package.json
@@ -1,19 +1,19 @@
 {
-	"name": "ts_esm_build_setup",
-	"version": "1.0.0",
-	"description": "",
-	"main": "agent.ts",
-	"type": "module",
-	"scripts": {
-		"build": "tsc && echo Build complete",
-		"start": "npx @google/adk-devtools run agent.ts"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
-	"dependencies": {
-		"@google/adk": "file:../../../../core",
-		"@google/adk-devtools": "file:../../../../dev",
-		"@google/genai": "^1.37.0"
-	}
+  "name": "ts_esm_build_setup",
+  "version": "1.0.0",
+  "description": "",
+  "main": "agent.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc && echo Build complete",
+    "start": "npx @google/adk-devtools run agent.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@google/adk": "file:../../../../core",
+    "@google/adk-devtools": "file:../../../../dev",
+    "@google/genai": "^1.37.0"
+  }
 }

--- a/tests/integration/build_setup/ts_esm/tsconfig.json
+++ b/tests/integration/build_setup/ts_esm/tsconfig.json
@@ -16,6 +16,7 @@
     "pretty": true,
     "skipLibCheck": true,
     "sourceMap": true,
+    "preserveSymlinks": true,
     "strict": true
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
### Link to Issue or Description of Change

The build setup integration tests keep failing (e.g. #179) and blocking PRs. This PR should fix the build setup tests.

I also edited the test runner to correctly output build failures in the future if any problems arise.

### Testing Plan

```
> npm run test:integration
 [...]
Test Files  2 passed (2)
      Tests  5 passed (5)
   Start at  17:13:01
   Duration  14.97s (transform 184ms, setup 0ms, collect 624ms, tests 13.59s, environment 0ms, prepare 59ms)
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
