### PR TITLE
A2A integration: Agent executor

### DIFF
--- a/core/src/a2a/a2a_event.ts
+++ b/core/src/a2a/a2a_event.ts
@@ -22,6 +22,19 @@ export enum MessageRole {
 }
 
 /**
+ * Task states.
+ */
+export enum TaskState {
+  SUBMITTED = 'submitted',
+  WORKING = 'working',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  CANCELED = 'canceled',
+  REJECTED = 'rejected',
+  INPUT_REQUIRED = 'input-required',
+}
+
+/**
  * A2A event.
  */
 export type A2AEvent =
@@ -83,7 +96,7 @@ export function getEventMetadata(event: A2AEvent): Record<string, unknown> {
 export function isFailedTaskStatusUpdateEvent(event: unknown): boolean {
   return (
     (isTaskStatusUpdateEvent(event) || isTask(event)) &&
-    event.status.state === 'failed'
+    event.status.state === TaskState.FAILED
   );
 }
 
@@ -93,7 +106,12 @@ export function isFailedTaskStatusUpdateEvent(event: unknown): boolean {
 export function isTerminalTaskStatusUpdateEvent(event: unknown): boolean {
   return (
     (isTaskStatusUpdateEvent(event) || isTask(event)) &&
-    ['completed', 'failed', 'canceled', 'rejected'].includes(event.status.state)
+    [
+      TaskState.COMPLETED,
+      TaskState.FAILED,
+      TaskState.CANCELED,
+      TaskState.REJECTED,
+    ].includes(event.status.state as TaskState)
   );
 }
 
@@ -103,7 +121,7 @@ export function isTerminalTaskStatusUpdateEvent(event: unknown): boolean {
 export function isInputRequiredTaskStatusUpdateEvent(event: unknown): boolean {
   return (
     (isTaskStatusUpdateEvent(event) || isTask(event)) &&
-    event.status.state === 'input-required'
+    event.status.state === TaskState.INPUT_REQUIRED
   );
 }
 
@@ -136,10 +154,12 @@ export function createTaskSubmittedEvent({
   taskId,
   contextId,
   message,
+  metadata,
 }: {
   taskId: string;
   contextId: string;
   message: Message;
+  metadata?: Record<string, unknown>;
 }): TaskStatusUpdateEvent {
   return {
     kind: 'status-update',
@@ -147,10 +167,11 @@ export function createTaskSubmittedEvent({
     contextId,
     final: false,
     status: {
-      state: 'submitted',
+      state: TaskState.SUBMITTED,
       message,
       timestamp: new Date().toISOString(),
     },
+    metadata,
   };
 }
 
@@ -161,10 +182,12 @@ export function createTask({
   contextId,
   message,
   taskId,
+  metadata,
 }: {
   taskId: string;
   contextId: string;
   message: Message;
+  metadata?: Record<string, unknown>;
 }): Task {
   return {
     kind: 'task',
@@ -172,9 +195,10 @@ export function createTask({
     contextId,
     history: [message],
     status: {
-      state: 'submitted',
+      state: TaskState.SUBMITTED,
       timestamp: new Date().toISOString(),
     },
+    metadata,
   };
 }
 
@@ -185,10 +209,12 @@ export function createTaskWorkingEvent({
   taskId,
   contextId,
   message,
+  metadata,
 }: {
   taskId: string;
   contextId: string;
-  message: Message;
+  message?: Message;
+  metadata?: Record<string, unknown>;
 }): TaskStatusUpdateEvent {
   return {
     kind: 'status-update',
@@ -196,10 +222,11 @@ export function createTaskWorkingEvent({
     contextId,
     final: false,
     status: {
-      state: 'working',
+      state: TaskState.WORKING,
       message,
       timestamp: new Date().toISOString(),
     },
+    metadata,
   };
 }
 
@@ -209,7 +236,7 @@ export function createTaskWorkingEvent({
 export function createTaskCompletedEvent({
   taskId,
   contextId,
-  metadata = {},
+  metadata,
 }: {
   taskId: string;
   contextId: string;
@@ -221,7 +248,7 @@ export function createTaskCompletedEvent({
     contextId,
     final: true,
     status: {
-      state: 'completed',
+      state: TaskState.COMPLETED,
       timestamp: new Date().toISOString(),
     },
     metadata,
@@ -257,8 +284,8 @@ export function createTaskArtifactUpdateEvent({
     artifact: {
       artifactId: artifactId || randomUUID(),
       parts,
-      metadata,
     },
+    metadata,
   };
 }
 
@@ -280,8 +307,9 @@ export function createTaskFailedEvent({
     kind: 'status-update',
     taskId,
     contextId,
+    final: true,
     status: {
-      state: 'failed',
+      state: TaskState.FAILED,
       message: {
         kind: 'message',
         messageId: randomUUID(),
@@ -298,7 +326,6 @@ export function createTaskFailedEvent({
       timestamp: new Date().toISOString(),
     },
     metadata,
-    final: true,
   };
 }
 
@@ -309,10 +336,12 @@ export function createTaskInputRequiredEvent({
   taskId,
   contextId,
   parts,
+  metadata,
 }: {
   taskId: string;
   contextId: string;
   parts: A2APart[];
+  metadata?: Record<string, unknown>;
 }): TaskStatusUpdateEvent {
   return {
     kind: 'status-update',
@@ -320,7 +349,7 @@ export function createTaskInputRequiredEvent({
     contextId,
     final: true,
     status: {
-      state: 'input-required',
+      state: TaskState.INPUT_REQUIRED,
       message: {
         kind: 'message',
         messageId: randomUUID(),
@@ -331,6 +360,7 @@ export function createTaskInputRequiredEvent({
       },
       timestamp: new Date().toISOString(),
     },
+    metadata,
   };
 }
 
@@ -341,10 +371,12 @@ export function createInputMissingErrorEvent({
   taskId,
   contextId,
   parts,
+  metadata,
 }: {
   parts: A2APart[];
   taskId: string;
   contextId: string;
+  metadata?: Record<string, unknown>;
 }): TaskStatusUpdateEvent {
   return {
     kind: 'status-update',
@@ -352,7 +384,7 @@ export function createInputMissingErrorEvent({
     contextId,
     final: true,
     status: {
-      state: 'input-required',
+      state: TaskState.INPUT_REQUIRED,
       message: {
         kind: 'message',
         messageId: randomUUID(),
@@ -363,5 +395,6 @@ export function createInputMissingErrorEvent({
       },
       timestamp: new Date().toISOString(),
     },
+    metadata,
   };
 }

--- a/core/src/a2a/agent_executor.ts
+++ b/core/src/a2a/agent_executor.ts
@@ -1,0 +1,301 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {TaskArtifactUpdateEvent, TaskStatusUpdateEvent} from '@a2a-js/sdk';
+import {
+  AgentExecutor,
+  ExecutionEventBus,
+  RequestContext,
+} from '@a2a-js/sdk/server';
+import {RunConfig} from '../agents/run_config.js';
+import {Event as AdkEvent} from '../events/event.js';
+import {isRunner, Runner, RunnerConfig} from '../runner/runner.js';
+import {BaseSessionService} from '../sessions/base_session_service.js';
+import {Session} from '../sessions/session.js';
+import {randomUUID} from '../utils/env_aware_utils.js';
+import {logger} from '../utils/logger.js';
+import {
+  createTask,
+  createTaskArtifactUpdateEvent,
+  createTaskFailedEvent,
+  createTaskWorkingEvent,
+} from './a2a_event.js';
+import {
+  getFinalTaskStatusUpdate,
+  getTaskInputRequiredEvent,
+} from './event_processor_utils.js';
+import {createExecutorContext, ExecutorContext} from './executor_context.js';
+import {
+  getA2AEventMetadata,
+  getA2ASessionMetadata,
+} from './metadata_converter_utils.js';
+import {toA2AParts, toGenAIContent} from './part_converter_utils.js';
+
+type RunnerOrRunnerConfig =
+  | Runner
+  | RunnerConfig
+  | (() => Runner | RunnerConfig)
+  | (() => Promise<Runner | RunnerConfig>);
+
+/**
+ * Callback called before execution starts.
+ */
+export type BeforeExecuteCallback = (reqCtx: RequestContext) => Promise<void>;
+
+/**
+ * Callback called after an ADK event is converted to an A2A event.
+ */
+export type AfterEventCallback = (
+  ctx: ExecutorContext,
+  adkEvent: AdkEvent,
+  a2aEvent?: TaskArtifactUpdateEvent,
+) => Promise<void>;
+
+/**
+ * Callback called after execution resolved into a completed or failed task.
+ */
+export type AfterExecuteCallback = (
+  ctx: ExecutorContext,
+  finalA2aEvent: TaskStatusUpdateEvent,
+  err?: Error,
+) => Promise<void>;
+
+/**
+ * Configuration for the Executor.
+ */
+export interface AgentExecutorConfig {
+  runner: RunnerOrRunnerConfig;
+  runConfig?: RunConfig;
+  beforeExecuteCallback?: BeforeExecuteCallback;
+  afterEventCallback?: AfterEventCallback;
+  afterExecuteCallback?: AfterExecuteCallback;
+}
+
+/**
+ * AgentExecutor invokes an ADK agent and translates session events to A2A events.
+ */
+export class A2AAgentExecutor implements AgentExecutor {
+  private agentPartialArtifactIdsMap: Record<string, string> = {};
+
+  constructor(private readonly config: AgentExecutorConfig) {}
+
+  async execute(
+    ctx: RequestContext,
+    eventBus: ExecutionEventBus,
+  ): Promise<void> {
+    const a2aUserMessage = ctx.userMessage;
+    if (!a2aUserMessage) {
+      throw new Error('message not provided');
+    }
+
+    const userId = `A2A_USER_${ctx.contextId}`;
+    const sessionId = ctx.contextId;
+    const genAIUserMessage = toGenAIContent(a2aUserMessage);
+    const adkRunner = await getAdkRunner(this.config.runner);
+    const session = await getAdkSession(
+      userId,
+      sessionId,
+      adkRunner.sessionService,
+      adkRunner.appName,
+    );
+    const executorContext = createExecutorContext({
+      session,
+      userContent: genAIUserMessage,
+      requestContext: ctx,
+    });
+
+    try {
+      if (this.config.beforeExecuteCallback) {
+        await this.config.beforeExecuteCallback(ctx);
+      }
+
+      if (ctx.task) {
+        const inputRequiredEvent = getTaskInputRequiredEvent(
+          ctx.task,
+          genAIUserMessage,
+        );
+        if (inputRequiredEvent) {
+          await this.publishFinalTaskStatus({
+            executorContext,
+            eventBus,
+            event: inputRequiredEvent,
+          });
+
+          return;
+        }
+      }
+
+      if (!ctx.task) {
+        eventBus.publish(
+          createTask({
+            taskId: ctx.taskId,
+            contextId: ctx.contextId,
+            message: a2aUserMessage,
+          }),
+        );
+      }
+
+      eventBus.publish(
+        createTaskWorkingEvent({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+        }),
+      );
+
+      const adkEvents: AdkEvent[] = [];
+      for await (const adkEvent of adkRunner.runAsync({
+        userId,
+        sessionId,
+        newMessage: genAIUserMessage,
+        runConfig: this.config.runConfig,
+      })) {
+        adkEvents.push(adkEvent);
+
+        const a2aEvent = this.convertAdkEventToA2AEvent(
+          adkEvent,
+          executorContext,
+        );
+        if (!a2aEvent) {
+          continue;
+        }
+
+        await this.config.afterEventCallback?.(
+          executorContext,
+          adkEvent,
+          a2aEvent,
+        );
+
+        eventBus.publish(a2aEvent);
+      }
+
+      await this.publishFinalTaskStatus({
+        executorContext,
+        eventBus,
+        event: getFinalTaskStatusUpdate(adkEvents, executorContext),
+      });
+    } catch (e: unknown) {
+      const error = e as Error;
+
+      await this.publishFinalTaskStatus({
+        executorContext,
+        eventBus,
+        error,
+        event: createTaskFailedEvent({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          error: new Error(`Agent run failed: ${error.message}`),
+          metadata: getA2ASessionMetadata(executorContext),
+        }),
+      });
+    }
+  }
+
+  // Task cancellation is not supported in this implementation yet.
+  async cancelTask(_taskId: string): Promise<void> {
+    throw new Error('Task cancellation is not supported yet.');
+  }
+
+  private convertAdkEventToA2AEvent(
+    adkEvent: AdkEvent,
+    executorContext: ExecutorContext,
+  ): TaskArtifactUpdateEvent | undefined {
+    const a2aParts = toA2AParts(
+      adkEvent.content?.parts,
+      adkEvent.longRunningToolIds,
+    );
+    if (a2aParts.length === 0) {
+      return undefined;
+    }
+
+    const artifactId =
+      this.agentPartialArtifactIdsMap[adkEvent.author!] || randomUUID();
+
+    const a2aEvent = createTaskArtifactUpdateEvent({
+      taskId: executorContext.requestContext.taskId,
+      contextId: executorContext.requestContext.contextId,
+      artifactId,
+      parts: a2aParts,
+      metadata: getA2AEventMetadata(adkEvent, executorContext),
+      append: adkEvent.partial,
+      lastChunk: !adkEvent.partial,
+    });
+
+    if (adkEvent.partial) {
+      this.agentPartialArtifactIdsMap[adkEvent.author!] = artifactId;
+    } else {
+      delete this.agentPartialArtifactIdsMap[adkEvent.author!];
+    }
+
+    return a2aEvent;
+  }
+
+  /**
+   * Writes the final status event to the queue.
+   */
+  private async publishFinalTaskStatus({
+    executorContext,
+    eventBus,
+    event,
+    error,
+  }: {
+    executorContext: ExecutorContext;
+    eventBus: ExecutionEventBus;
+    event: TaskStatusUpdateEvent;
+    error?: Error;
+  }): Promise<void> {
+    try {
+      await this.config.afterExecuteCallback?.(executorContext, event, error);
+    } catch (e: unknown) {
+      logger.error('Error in afterExecuteCallback:', e);
+    }
+
+    eventBus.publish(event);
+  }
+}
+
+/**
+ * Gets or creates new ADK session.
+ */
+async function getAdkSession(
+  userId: string,
+  sessionId: string,
+  sessionService: BaseSessionService,
+  appName: string,
+): Promise<Session> {
+  const session = await sessionService.getSession({
+    appName,
+    userId,
+    sessionId,
+  });
+  if (session) {
+    return session;
+  }
+
+  return sessionService.createSession({
+    appName,
+    userId,
+    sessionId,
+  });
+}
+
+/**
+ * Resolves the runner from the provided runner or runner config.
+ */
+async function getAdkRunner(
+  runnerOrConfig: RunnerOrRunnerConfig,
+): Promise<Runner> {
+  if (typeof runnerOrConfig === 'function') {
+    const result = await runnerOrConfig();
+
+    return getAdkRunner(result);
+  }
+
+  if (isRunner(runnerOrConfig)) {
+    return runnerOrConfig;
+  }
+
+  return new Runner(runnerOrConfig);
+}

--- a/core/src/a2a/event_processor_utils.ts
+++ b/core/src/a2a/event_processor_utils.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Task, TaskStatusUpdateEvent} from '@a2a-js/sdk';
+import {Content as GenAIContent, Part as GenAIPart} from '@google/genai';
+import {Event as AdkEvent} from '../events/event.js';
+import {createEventActions} from '../events/event_actions.js';
+import {
+  createInputMissingErrorEvent,
+  createTaskCompletedEvent,
+  createTaskFailedEvent,
+  createTaskInputRequiredEvent,
+  isInputRequiredTaskStatusUpdateEvent,
+} from './a2a_event.js';
+import {ExecutorContext} from './executor_context.js';
+import {
+  getA2AEventMetadata,
+  getA2AEventMetadataFromActions,
+  getA2ASessionMetadata,
+} from './metadata_converter_utils.js';
+import {toA2AParts, toGenAIParts} from './part_converter_utils.js';
+
+/**
+ * Processes a list of ADK events and determines the final task status update event.
+ * If any of the ADK events contain an error, a TaskFailedEvent is returned immediately.
+ * If there are no errors, it checks for any input required events. If found, it returns a TaskInputRequiredEvent.
+ * If there are no input required events, it returns a TaskCompletedEvent.
+ *
+ * @param adkEvents - The list of ADK events to process.
+ * @param context - The executor context containing relevant information for processing the events.
+ * @returns A TaskStatusUpdateEvent representing the final status of the task after processing the ADK events.
+ */
+export function getFinalTaskStatusUpdate(
+  adkEvents: AdkEvent[],
+  context: ExecutorContext,
+): TaskStatusUpdateEvent {
+  const finalEventActions = createEventActions();
+
+  for (const adkEvent of adkEvents) {
+    if (adkEvent.errorCode || adkEvent.errorMessage) {
+      return createTaskFailedEvent({
+        taskId: context.requestContext.taskId,
+        contextId: context.requestContext.contextId,
+        error: new Error(adkEvent.errorMessage || adkEvent.errorCode),
+        metadata: {
+          ...getA2AEventMetadata(adkEvent, context),
+          ...getA2AEventMetadataFromActions(finalEventActions),
+        },
+      });
+    }
+
+    finalEventActions.escalate =
+      finalEventActions.escalate || adkEvent.actions?.escalate;
+
+    if (adkEvent.actions?.transferToAgent) {
+      finalEventActions.transferToAgent = adkEvent.actions.transferToAgent;
+    }
+  }
+
+  const inputRequiredEvent = scanForInputRequiredEvents(adkEvents, context);
+  if (inputRequiredEvent) {
+    return {
+      ...inputRequiredEvent,
+      metadata: {
+        ...inputRequiredEvent.metadata,
+        ...getA2AEventMetadataFromActions(finalEventActions),
+      },
+    };
+  }
+
+  return createTaskCompletedEvent({
+    taskId: context.requestContext.taskId,
+    contextId: context.requestContext.contextId,
+    metadata: {
+      ...getA2ASessionMetadata(context),
+      ...getA2AEventMetadataFromActions(finalEventActions),
+    },
+  });
+}
+
+function scanForInputRequiredEvents(
+  adkEvents: AdkEvent[],
+  context: ExecutorContext,
+): TaskStatusUpdateEvent | undefined {
+  const inputRequiredParts: GenAIPart[] = [];
+  const inputRequiredFunctionCallIds = new Set<string>();
+
+  for (const adkEvent of adkEvents) {
+    if (!adkEvent.content?.parts?.length) {
+      continue;
+    }
+
+    for (const genAIPart of adkEvent.content.parts) {
+      const longRunningFunctionCallId = getLongRunnningFunctionCallId(
+        genAIPart,
+        adkEvent.longRunningToolIds,
+        inputRequiredParts,
+      );
+      if (!longRunningFunctionCallId) {
+        continue;
+      }
+
+      const isAlreadyAdded = inputRequiredFunctionCallIds.has(
+        longRunningFunctionCallId,
+      );
+      if (isAlreadyAdded) {
+        continue;
+      }
+
+      inputRequiredParts.push(genAIPart);
+      inputRequiredFunctionCallIds.add(longRunningFunctionCallId);
+    }
+  }
+
+  if (inputRequiredParts.length > 0) {
+    return createTaskInputRequiredEvent({
+      taskId: context.requestContext.taskId,
+      contextId: context.requestContext.contextId,
+      parts: toA2AParts(inputRequiredParts, [...inputRequiredFunctionCallIds]),
+      metadata: getA2ASessionMetadata(context),
+    });
+  }
+
+  return undefined;
+}
+
+function getLongRunnningFunctionCallId(
+  genAIPart: GenAIPart,
+  longRunningToolIds: string[] = [],
+  inputRequiredParts: GenAIPart[] = [],
+): string | undefined {
+  const functionCallId = genAIPart.functionCall?.id;
+  const functionResponseId = genAIPart.functionResponse?.id;
+  if (!functionCallId && !functionResponseId) {
+    return;
+  }
+
+  if (functionCallId && longRunningToolIds.includes(functionCallId)) {
+    return functionCallId;
+  }
+
+  if (functionResponseId && longRunningToolIds.includes(functionResponseId)) {
+    return functionResponseId;
+  }
+
+  for (const part of inputRequiredParts) {
+    if (part.functionCall?.id === functionResponseId) {
+      return functionResponseId;
+    }
+  }
+
+  return;
+}
+
+/**
+ * Returns input required task status update events if the provided user request does not contain responses for all function calls in the task status.
+ */
+export function getTaskInputRequiredEvent(
+  task: Task,
+  genAIContent: GenAIContent,
+): TaskStatusUpdateEvent | undefined {
+  if (
+    !task ||
+    !isInputRequiredTaskStatusUpdateEvent(task) ||
+    !task.status.message
+  ) {
+    return undefined;
+  }
+
+  const statusMsg = task.status.message;
+  const taskParts = toGenAIParts(statusMsg.parts);
+
+  for (const taskPart of taskParts) {
+    const functionCallId = taskPart.functionCall?.id;
+    if (!functionCallId) {
+      continue;
+    }
+
+    const hasMatchingResponse = (genAIContent?.parts || []).some(
+      (p) => p.functionResponse?.id === functionCallId,
+    );
+
+    if (!hasMatchingResponse) {
+      return createInputMissingErrorEvent({
+        taskId: task.id,
+        contextId: task.contextId,
+        parts: [
+          ...statusMsg.parts.filter((p) => !p.metadata?.validation_error),
+          {
+            kind: 'text',
+            text: `No input provided for function call id ${functionCallId}`,
+            metadata: {
+              validation_error: true,
+            },
+          },
+        ],
+      });
+    }
+  }
+
+  return undefined;
+}

--- a/core/src/a2a/executor_context.ts
+++ b/core/src/a2a/executor_context.ts
@@ -15,7 +15,7 @@ import {Session} from '../sessions/session.js';
 export interface ExecutorContext {
   userId: string;
   sessionId: string;
-  agentName: string;
+  appName: string;
   readonlyState: Record<string, unknown>;
   events: Event[];
   userContent: Content;
@@ -41,7 +41,7 @@ export function createExecutorContext({
   return {
     userId: session.userId,
     sessionId: session.id,
-    agentName: session.appName,
+    appName: session.appName,
     readonlyState: session.state,
     events: session.events,
     userContent,

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -138,7 +138,7 @@ export type {
   ToolCallPolicyContext,
 } from './plugins/security_plugin.js';
 export {InMemoryRunner} from './runner/in_memory_runner.js';
-export {Runner} from './runner/runner.js';
+export {Runner, isRunner} from './runner/runner.js';
 export type {RunnerConfig} from './runner/runner.js';
 export {BaseSessionService} from './sessions/base_session_service.js';
 export type {

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -54,7 +54,28 @@ export interface RunnerConfig {
   credentialService?: BaseCredentialService;
 }
 
+/**
+ * A unique symbol to identify ADK agent classes.
+ * Defined once and shared by all Runner instances.
+ */
+const RUNNER_SIGNATURE_SYMBOL = Symbol.for('google.adk.runner');
+
+/**
+ * Type guard to check if an object is an instance of Runner.
+ * @param obj The object to check.
+ * @returns True if the object is an instance of Runner, false otherwise.
+ */
+export function isRunner(obj: unknown): obj is Runner {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    RUNNER_SIGNATURE_SYMBOL in obj &&
+    obj[RUNNER_SIGNATURE_SYMBOL] === true
+  );
+}
+
 export class Runner {
+  readonly [RUNNER_SIGNATURE_SYMBOL] = true;
   readonly appName: string;
   readonly agent: BaseAgent;
   readonly pluginManager: PluginManager;

--- a/core/test/a2a/a2a_agent_test.ts
+++ b/core/test/a2a/a2a_agent_test.ts
@@ -1,0 +1,681 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {TaskArtifactUpdateEvent, TaskStatusUpdateEvent} from '@a2a-js/sdk';
+import {ExecutionEventBus, RequestContext} from '@a2a-js/sdk/server';
+import {
+  Event as AdkEvent,
+  BaseAgent,
+  BaseSessionService,
+  createEvent,
+  createEventActions,
+  InvocationContext,
+  Runner,
+  RunnerConfig,
+  Session,
+} from '@google/adk';
+import {Language, Outcome} from '@google/genai';
+import {beforeEach, describe, expect, it, Mock, vi} from 'vitest';
+import {A2AEvent} from '../../src/a2a/a2a_event.js';
+import {A2AAgentExecutor} from '../../src/a2a/agent_executor.js';
+
+class MockAgent extends BaseAgent {
+  protected runAsyncImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<AdkEvent, void, void> {
+    throw new Error('Method not implemented.');
+  }
+  protected runLiveImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<AdkEvent, void, void> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+class MockRunner extends Runner {
+  private readonly events: AdkEvent[];
+
+  constructor(config: RunnerConfig, events: AdkEvent[]) {
+    super(config);
+    this.events = events;
+  }
+
+  async *runAsync() {
+    for (const e of this.events) {
+      yield e;
+    }
+  }
+}
+
+describe('A2A Agent Executor', () => {
+  let mockSessionService: BaseSessionService;
+  let mockEventBus: ExecutionEventBus;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSessionService = {
+      getSession: vi.fn(),
+      createSession: vi.fn(),
+      getOrCreateSession: vi.fn(),
+      listSessions: vi.fn(),
+      deleteSession: vi.fn(),
+      appendEvent: vi.fn(),
+    } as unknown as BaseSessionService;
+
+    mockEventBus = {
+      publish: vi.fn(),
+    } as unknown as ExecutionEventBus;
+
+    const mockSession = {
+      id: 'session-id',
+      userId: 'test-user',
+      appName: 'test-app',
+      events: [],
+      state: {},
+    } as unknown as Session;
+    (mockSessionService.getSession as Mock).mockResolvedValue(mockSession);
+  });
+
+  const createRequestContext = (overrides = {}): RequestContext => {
+    return {
+      contextId: 'test-context',
+      taskId: 'test-task',
+      userMessage: {role: 'user', parts: [{kind: 'text', text: 'hello'}]},
+      ...overrides,
+    } as unknown as RequestContext;
+  };
+
+  const runTest = async (remoteEvents: AdkEvent[]): Promise<A2AEvent[]> => {
+    const executor = new A2AAgentExecutor({
+      // @ts-expect-error: MockRunner correctly implements Runner interface.
+      runner: new MockRunner(
+        {
+          appName: 'test-app',
+          agent: new MockAgent({name: 'test-agent'}),
+          sessionService: mockSessionService,
+        },
+        remoteEvents,
+      ),
+    });
+
+    const ctx = createRequestContext();
+    await executor.execute(ctx, mockEventBus);
+    return (mockEventBus.publish as Mock).mock.calls.map(
+      (call: unknown[]) => call[0] as A2AEvent,
+    );
+  };
+
+  it('text streaming', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'hello '}]},
+        partial: true,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'world'}]},
+        partial: true,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'hello world'}]},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+
+    const workingEvent = gotEvents.find(
+      (e: A2AEvent) =>
+        e.kind === 'status-update' && e.status?.state === 'working',
+    ) as TaskStatusUpdateEvent | undefined;
+
+    expect(workingEvent).toBeDefined();
+    expect(workingEvent!.status.message).toBeUndefined();
+    expect(artifacts).toHaveLength(3);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {kind: 'text', text: 'hello '},
+    ]);
+    expect(artifacts[0].append).toBe(true);
+    expect(artifacts[0].lastChunk).toBe(false);
+
+    expect(artifacts[1].artifact.parts).toEqual([
+      {kind: 'text', text: 'world'},
+    ]);
+    expect(artifacts[1].append).toBe(true);
+    expect(artifacts[1].lastChunk).toBe(false);
+
+    expect(artifacts[2].artifact.parts).toEqual([
+      {kind: 'text', text: 'hello world'},
+    ]);
+    expect(artifacts[2].append).toBe(false);
+    expect(artifacts[2].lastChunk).toBe(true);
+  });
+
+  it('text streaming - no streaming mode', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'hello world'}]},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {kind: 'text', text: 'hello world'},
+    ]);
+    expect(artifacts[0].append).toBe(false);
+    expect(artifacts[0].lastChunk).toBe(true);
+  });
+
+  it('code execution', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              executableCode: {
+                language: Language.PYTHON,
+                code: "print('hello')",
+              },
+            },
+          ],
+        },
+        partial: false,
+      }),
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              codeExecutionResult: {
+                outcome: Outcome.OUTCOME_OK,
+                output: 'hello',
+              },
+            },
+          ],
+        },
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {
+        kind: 'data',
+        data: {language: Language.PYTHON, code: "print('hello')"},
+        metadata: {adk_type: 'executable_code'},
+      },
+    ]);
+    expect(artifacts[1].artifact.parts).toEqual([
+      {
+        kind: 'data',
+        data: {outcome: Outcome.OUTCOME_OK, output: 'hello'},
+        metadata: {adk_type: 'code_execution_result'},
+      },
+    ]);
+  });
+
+  it('function calls', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [
+            {functionCall: {name: 'get_weather', args: {city: 'Warsaw'}}},
+          ],
+        },
+        partial: false,
+      }),
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [
+            {functionResponse: {name: 'get_weather', response: {temp: '1C'}}},
+          ],
+        },
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {
+        kind: 'data',
+        data: {name: 'get_weather', args: {city: 'Warsaw'}},
+        metadata: {adk_type: 'function_call'},
+      },
+    ]);
+    expect(artifacts[1].artifact.parts).toEqual([
+      {
+        kind: 'data',
+        data: {name: 'get_weather', response: {temp: '1C'}},
+        metadata: {adk_type: 'function_response'},
+      },
+    ]);
+  });
+
+  it('files', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [{inlineData: {data: 'hello', mimeType: 'text/plain'}}],
+        },
+        partial: false,
+      }),
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              fileData: {
+                fileUri: 'http://text.com/text.txt',
+                mimeType: 'text/plain',
+              },
+            },
+          ],
+        },
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {
+        kind: 'file',
+        file: {bytes: 'hello', mimeType: 'text/plain'},
+        metadata: {},
+      },
+    ]);
+    expect(artifacts[1].artifact.parts).toEqual([
+      {
+        kind: 'file',
+        file: {uri: 'http://text.com/text.txt', mimeType: 'text/plain'},
+        metadata: {},
+      },
+    ]);
+  });
+
+  it('escalation', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'stop'}]},
+        partial: false,
+        actions: createEventActions({escalate: true}),
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const finalEvent = gotEvents.find(
+      (e: A2AEvent) =>
+        e.kind === 'status-update' && e.status?.state === 'completed',
+    ) as TaskStatusUpdateEvent | undefined;
+
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.metadata?.adk_escalate).toBe(true);
+  });
+
+  it('transfer', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'stop'}]},
+        partial: false,
+        actions: createEventActions({transferToAgent: 'a-2'}),
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const finalEvent = gotEvents.find(
+      (e: A2AEvent) =>
+        e.kind === 'status-update' && e.status?.state === 'completed',
+    ) as TaskStatusUpdateEvent | undefined;
+
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.metadata?.adk_transfer_to_agent).toBe('a-2');
+  });
+
+  it('long-running function call', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'create_ticket', id: 'abc-123'}}],
+        },
+        partial: false,
+        longRunningToolIds: ['abc-123'],
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const inputRequiredEvent = gotEvents.find(
+      (e: A2AEvent) =>
+        e.kind === 'status-update' && e.status?.state === 'input-required',
+    ) as TaskStatusUpdateEvent | undefined;
+
+    expect(inputRequiredEvent).toBeDefined();
+    expect(inputRequiredEvent!.status.message?.parts).toEqual([
+      {
+        kind: 'data',
+        data: {name: 'create_ticket', id: 'abc-123'},
+        metadata: {adk_type: 'function_call', adk_is_long_running: true},
+      },
+    ]);
+  });
+
+  it('metadata', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'hello'}]},
+        partial: false,
+        citationMetadata: {citations: [{title: 'Title1'}, {title: 'Title2'}]},
+        usageMetadata: {
+          candidatesTokenCount: 12,
+          promptTokenCount: 42,
+          totalTokenCount: 54,
+        },
+        groundingMetadata: {searchEntryPoint: {renderedContent: 'id1'}},
+        customMetadata: {nested: {key: 'value'}},
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].metadata?.adk_citation_metadata).toEqual({
+      citations: [{title: 'Title1'}, {title: 'Title2'}],
+    });
+    expect(artifacts[0].metadata?.adk_usage_metadata).toEqual({
+      candidatesTokenCount: 12,
+      promptTokenCount: 42,
+      totalTokenCount: 54,
+    });
+    expect(artifacts[0].metadata?.adk_grounding_metadata).toEqual({
+      searchEntryPoint: {renderedContent: 'id1'},
+    });
+    expect(artifacts[0].metadata?.adk_custom_metadata).toEqual({
+      nested: {key: 'value'},
+    });
+  });
+
+  it('handles empty message', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: []},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const finalEvent = gotEvents.find(
+      (e: A2AEvent) =>
+        e.kind === 'status-update' && e.status?.state === 'completed',
+    ) as TaskStatusUpdateEvent | undefined;
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.status.message).toBeUndefined();
+  });
+
+  it('handles message with text parts', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [{text: 'hello'}, {text: 'world'}],
+        },
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {kind: 'text', text: 'hello'},
+      {kind: 'text', text: 'world'},
+    ]);
+  });
+
+  it('handles empty task', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: []},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const finalEvent = gotEvents.find(
+      (e: A2AEvent) =>
+        e.kind === 'status-update' && e.status?.state === 'completed',
+    ) as TaskStatusUpdateEvent | undefined;
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.status.message).toBeUndefined();
+  });
+
+  it('handles task with status message', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'hello'}]},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {kind: 'text', text: 'hello'},
+    ]);
+  });
+
+  it('handles task with multipart artifact', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [{text: 'hello'}, {text: 'world'}],
+        },
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {kind: 'text', text: 'hello'},
+      {kind: 'text', text: 'world'},
+    ]);
+  });
+
+  it('handles multiple tasks', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'hello'}]},
+        partial: false,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'world'}]},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0].artifact.parts).toEqual([
+      {kind: 'text', text: 'hello'},
+    ]);
+    expect(artifacts[1].artifact.parts).toEqual([
+      {kind: 'text', text: 'world'},
+    ]);
+  });
+
+  it('handles empty non-final status updates ignored', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: []},
+        partial: true,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: []},
+        partial: true,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: []},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+    expect(artifacts).toHaveLength(0);
+
+    const finalEvent = gotEvents.find(
+      (e: A2AEvent) =>
+        e.kind === 'status-update' && e.status?.state === 'completed',
+    ) as TaskStatusUpdateEvent | undefined;
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.status.message).toBeUndefined();
+  });
+
+  it('handles partial and non-partial event aggregation', async () => {
+    const remoteEvents = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: '1'}]},
+        partial: true,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: '2'}]},
+        partial: true,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: '3'}]},
+        partial: false,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: '4'}]},
+        partial: true,
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: '5'}]},
+        partial: false,
+      }),
+    ];
+
+    const gotEvents = await runTest(remoteEvents);
+
+    const artifacts = gotEvents.filter(
+      (e: A2AEvent) => e.kind === 'artifact-update',
+    ) as TaskArtifactUpdateEvent[];
+
+    // According to AgentExecutor, each adkEvent generates an artifact-update
+    // partial=true means append=true, lastChunk=false
+    // partial=false means append=false, lastChunk=true
+
+    expect(artifacts).toHaveLength(5);
+    expect(artifacts[0].artifact.parts).toEqual([{kind: 'text', text: '1'}]);
+    expect(artifacts[0].append).toBe(true);
+    expect(artifacts[0].lastChunk).toBe(false);
+
+    expect(artifacts[1].artifact.parts).toEqual([{kind: 'text', text: '2'}]);
+    expect(artifacts[1].append).toBe(true);
+    expect(artifacts[1].lastChunk).toBe(false);
+
+    expect(artifacts[2].artifact.parts).toEqual([{kind: 'text', text: '3'}]);
+    expect(artifacts[2].append).toBe(false);
+    expect(artifacts[2].lastChunk).toBe(true);
+
+    expect(artifacts[3].artifact.parts).toEqual([{kind: 'text', text: '4'}]);
+    expect(artifacts[3].append).toBe(true);
+    expect(artifacts[3].lastChunk).toBe(false);
+
+    expect(artifacts[4].artifact.parts).toEqual([{kind: 'text', text: '5'}]);
+    expect(artifacts[4].append).toBe(false);
+    expect(artifacts[4].lastChunk).toBe(true);
+  });
+});

--- a/core/test/a2a/a2a_event_test.ts
+++ b/core/test/a2a/a2a_event_test.ts
@@ -13,9 +13,11 @@ import {
 import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 import {
   createInputMissingErrorEvent,
+  createTask,
   createTaskArtifactUpdateEvent,
   createTaskCompletedEvent,
   createTaskFailedEvent,
+  createTaskInputRequiredEvent,
   createTaskSubmittedEvent,
   createTaskWorkingEvent,
   getEventMetadata,
@@ -319,6 +321,54 @@ describe('a2a_event', () => {
       });
     });
 
+    it('createTaskWorkingEvent without message', () => {
+      expect(createTaskWorkingEvent({taskId: 't1', contextId: 'c1'})).toEqual({
+        kind: 'status-update',
+        taskId: 't1',
+        contextId: 'c1',
+        final: false,
+        status: {
+          state: 'working',
+          message: undefined,
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      });
+    });
+
+    it('createTask', () => {
+      expect(createTask({taskId: 't1', contextId: 'c1', message})).toEqual({
+        kind: 'task',
+        id: 't1',
+        contextId: 'c1',
+        history: [message],
+        status: {
+          state: 'submitted',
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      });
+    });
+
+    it('createTask with random UUID if taskId not provided', () => {
+      expect(
+        createTask({
+          taskId: '',
+          contextId: 'c1',
+          message,
+          metadata: {foo: 'bar'},
+        }),
+      ).toEqual({
+        kind: 'task',
+        id: 'mock-uuid',
+        contextId: 'c1',
+        history: [message],
+        status: {
+          state: 'submitted',
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+        metadata: {foo: 'bar'},
+      });
+    });
+
     it('createTaskCompletedEvent', () => {
       expect(createTaskCompletedEvent({taskId: 't1', contextId: 'c1'})).toEqual(
         {
@@ -330,7 +380,7 @@ describe('a2a_event', () => {
             state: 'completed',
             timestamp: '2024-01-01T00:00:00.000Z',
           },
-          metadata: {},
+          metadata: undefined,
         },
       );
     });
@@ -354,8 +404,8 @@ describe('a2a_event', () => {
         artifact: {
           artifactId: 'mock-uuid',
           parts: [{kind: 'text', text: 'part'}],
-          metadata: {m: 1},
         },
+        metadata: {m: 1},
       });
     });
 
@@ -404,6 +454,35 @@ describe('a2a_event', () => {
           },
           timestamp: '2024-01-01T00:00:00.000Z',
         },
+      });
+    });
+
+    it('createTaskInputRequiredEvent', () => {
+      expect(
+        createTaskInputRequiredEvent({
+          taskId: 't1',
+          contextId: 'c1',
+          parts: [{kind: 'text', text: 'input required'}],
+          metadata: {m: 1},
+        }),
+      ).toEqual({
+        kind: 'status-update',
+        taskId: 't1',
+        contextId: 'c1',
+        final: true,
+        status: {
+          state: 'input-required',
+          message: {
+            kind: 'message',
+            messageId: 'mock-uuid',
+            role: 'agent',
+            taskId: 't1',
+            contextId: 'c1',
+            parts: [{kind: 'text', text: 'input required'}],
+          },
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+        metadata: {m: 1},
       });
     });
 

--- a/core/test/a2a/agent_executor_test.ts
+++ b/core/test/a2a/agent_executor_test.ts
@@ -1,0 +1,278 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {TaskStatusUpdateEvent, TextPart} from '@a2a-js/sdk';
+import {ExecutionEventBus, RequestContext} from '@a2a-js/sdk/server';
+import {beforeEach, describe, expect, it, Mocked, vi} from 'vitest';
+import {A2AAgentExecutor} from '../../src/a2a/agent_executor.js';
+import {Event as AdkEvent, createEvent} from '../../src/events/event.js';
+import {createEventActions} from '../../src/events/event_actions.js';
+import {Runner, RunnerConfig} from '../../src/runner/runner.js';
+import {BaseSessionService} from '../../src/sessions/base_session_service.js';
+import {Session} from '../../src/sessions/session.js';
+
+// Mock the Runner to control its async generator
+vi.mock('../../src/runner/runner.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/runner/runner.js')>();
+  return {
+    ...actual,
+    Runner: vi.fn().mockImplementation((config: RunnerConfig) => ({
+      appName: config?.appName,
+      sessionService: config?.sessionService,
+      runAsync: vi.fn(),
+    })),
+  };
+});
+
+describe('A2AAgentExecutor', () => {
+  let mockSessionService: Mocked<BaseSessionService>;
+  let mockEventBus: Mocked<ExecutionEventBus>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSessionService = {
+      getSession: vi.fn(),
+      createSession: vi.fn(),
+      getOrCreateSession: vi.fn(),
+      listSessions: vi.fn(),
+      deleteSession: vi.fn(),
+      appendEvent: vi.fn(),
+    } as unknown as Mocked<BaseSessionService>;
+
+    mockEventBus = {
+      publish: vi.fn(),
+    } as unknown as Mocked<ExecutionEventBus>;
+  });
+
+  const createRequestContext = (overrides = {}): RequestContext => {
+    return {
+      contextId: 'test-context',
+      taskId: 'test-task',
+      userMessage: {role: 'user', parts: [{kind: 'text', text: 'hello'}]}, // a2a UserMessage
+      ...overrides,
+    } as unknown as RequestContext;
+  };
+
+  it('should throw an error if no message is provided', async () => {
+    const executor = new A2AAgentExecutor({
+      runner: {
+        appName: 'test-app',
+        sessionService: mockSessionService,
+      } as unknown as RunnerConfig,
+    });
+
+    const ctx = createRequestContext({userMessage: undefined});
+    await expect(executor.execute(ctx, mockEventBus)).rejects.toThrow(
+      'message not provided',
+    );
+  });
+
+  it('should get or create a session, run the agent, and publish working and final status events', async () => {
+    // Setup Session
+    const mockSession = {
+      id: 'session-id',
+      userId: 'test-user',
+      appName: 'test-app',
+      events: [],
+      state: {},
+    } as unknown as Session;
+    mockSessionService.getSession.mockResolvedValue(mockSession);
+
+    // Setup Runner
+    const adkEvents: AdkEvent[] = [
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'response part 1'}]},
+        partial: true,
+        actions: createEventActions(),
+      }),
+      createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'response part 2'}]},
+        partial: false,
+        actions: createEventActions(),
+      }),
+    ];
+
+    async function* mockRunAsync() {
+      for (const e of adkEvents) {
+        yield e;
+      }
+    }
+
+    vi.mocked(Runner).mockImplementation(((config: RunnerConfig) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsync,
+      } as unknown as Runner;
+    }) as unknown as () => Runner);
+
+    let beforeExecutedCalled = false;
+    let afterEventCount = 0;
+    let afterExecuteCalled = false;
+
+    const executor = new A2AAgentExecutor({
+      runner: {
+        appName: 'test-app',
+        sessionService: mockSessionService,
+      } as unknown as RunnerConfig,
+      beforeExecuteCallback: async () => {
+        beforeExecutedCalled = true;
+      },
+      afterEventCallback: async () => {
+        afterEventCount++;
+      },
+      afterExecuteCallback: async () => {
+        afterExecuteCalled = true;
+      },
+    });
+
+    const ctx = createRequestContext();
+    await executor.execute(ctx, mockEventBus);
+
+    if (afterEventCount !== 2) {
+      console.error(
+        'PUBLISHED EVENTS:',
+        JSON.stringify(mockEventBus.publish.mock.calls, null, 2),
+      );
+    }
+
+    expect(beforeExecutedCalled).toBe(true);
+    expect(afterEventCount).toBe(2);
+    expect(afterExecuteCalled).toBe(true);
+
+    // Verify event bus payload counts
+    // Task + Working + 2 task artifact updates + 1 final task status
+    expect(mockEventBus.publish).toHaveBeenCalledTimes(5);
+
+    // Assert that the second published event is the "Working" event
+    expect(mockEventBus.publish).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        kind: 'status-update',
+      }),
+    );
+  });
+
+  it('should return early with input required event if task needs input', async () => {
+    const mockSession = {
+      id: 'session-id',
+      userId: 'test-user',
+      appName: 'test-app',
+      events: [],
+      state: {},
+    } as unknown as Session;
+    mockSessionService.getSession.mockResolvedValue(mockSession);
+
+    const executor = new A2AAgentExecutor({
+      runner: {
+        appName: 'test-app',
+        sessionService: mockSessionService,
+      } as unknown as RunnerConfig,
+    });
+
+    const ctx = createRequestContext({
+      task: {
+        kind: 'task',
+        id: 'test-task',
+        contextId: 'test-context',
+        status: {
+          state: 'input-required',
+          message: {
+            role: 'agent',
+            parts: [
+              {
+                kind: 'data',
+                metadata: {'adk_type': 'function_call'},
+                data: {id: 'fc-123', name: 'mockFunction'},
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    await executor.execute(ctx, mockEventBus);
+
+    // No runner execution should happen, just publish input required event
+    expect(mockEventBus.publish).toHaveBeenCalledTimes(1);
+    const event = mockEventBus.publish.mock
+      .calls[0][0] as TaskStatusUpdateEvent;
+    expect(event.kind).toBe('status-update');
+    expect(event.status.state).toBe('input-required');
+  });
+
+  it('should handle unrecoverable runner errors properly', async () => {
+    const mockSession = {
+      id: 'session-id',
+      userId: 'test-user',
+      appName: 'test-app',
+      events: [],
+      state: {},
+    } as unknown as Session;
+    mockSessionService.getSession.mockResolvedValue(mockSession);
+
+    async function* mockRunAsyncWithError() {
+      yield createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'some part'}]},
+        partial: false,
+        actions: createEventActions(),
+      });
+      throw new Error('LLM failed');
+    }
+
+    vi.mocked(Runner).mockImplementation(((config: RunnerConfig) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsyncWithError,
+      } as unknown as Runner;
+    }) as unknown as () => Runner);
+
+    const executor = new A2AAgentExecutor({
+      runner: {
+        appName: 'test-app',
+        sessionService: mockSessionService,
+      } as unknown as RunnerConfig,
+    });
+
+    const ctx = createRequestContext();
+    await executor.execute(ctx, mockEventBus);
+
+    // Task + Working + Artifact update (1) + Failed TaskStatusUpdate (1) = 4 calls
+    if (mockEventBus.publish.mock.calls.length < 4) {
+      console.error(
+        'PUBLISHED EVENTS in error test:',
+        JSON.stringify(mockEventBus.publish.mock.calls, null, 2),
+      );
+    }
+    expect(mockEventBus.publish).toHaveBeenCalledTimes(4);
+
+    const lastCallArg = mockEventBus.publish.mock
+      .calls[3][0] as TaskStatusUpdateEvent;
+    expect(lastCallArg.kind).toBe('status-update');
+    expect(lastCallArg.status.state).toBe('failed');
+    const firstPart = lastCallArg.status.message!.parts[0] as TextPart;
+    expect(firstPart.text).toContain('LLM failed');
+  });
+
+  it('should fail cancelTask because it is not implemented', async () => {
+    const executor = new A2AAgentExecutor({
+      runner: {
+        appName: 'test-app',
+        sessionService: mockSessionService,
+      } as unknown as RunnerConfig,
+    });
+
+    await expect(executor.cancelTask('any-task-id')).rejects.toThrow(
+      'Task cancellation is not supported yet.',
+    );
+  });
+});

--- a/core/test/a2a/event_processor_utils_test.ts
+++ b/core/test/a2a/event_processor_utils_test.ts
@@ -1,0 +1,278 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {DataPart, Task, TextPart} from '@a2a-js/sdk';
+import {Content as GenAIContent} from '@google/genai';
+import {describe, expect, it, vi} from 'vitest';
+import {
+  getFinalTaskStatusUpdate,
+  getTaskInputRequiredEvent,
+} from '../../src/a2a/event_processor_utils.js';
+import {ExecutorContext} from '../../src/a2a/executor_context.js';
+import {toA2AParts} from '../../src/a2a/part_converter_utils.js';
+import {Event as AdkEvent, createEvent} from '../../src/events/event.js';
+import {createEventActions} from '../../src/events/event_actions.js';
+
+vi.mock('../../src/utils/env_aware_utils.js', () => ({
+  randomUUID: () => 'mock-uuid',
+}));
+
+describe('event_processor_utils', () => {
+  describe('getFinalTaskStatusUpdate', () => {
+    const mockContext = {
+      requestContext: {
+        taskId: 'test-task-id',
+        contextId: 'test-context-id',
+      },
+      appName: 'test-app',
+      sessionId: 'test-session',
+      userId: 'test-user',
+    } as ExecutorContext;
+
+    it('returns TaskCompletedEvent for empty adkEvents', () => {
+      const result = getFinalTaskStatusUpdate([], mockContext);
+
+      expect(result.kind).toBe('status-update');
+      expect(result.status?.state).toBe('completed');
+      expect(result.taskId).toBe('test-task-id');
+      expect(result.contextId).toBe('test-context-id');
+      expect(result.metadata).toEqual(
+        expect.objectContaining({
+          adk_session_id: 'test-session',
+          adk_app_name: 'test-app',
+          adk_user_id: 'test-user',
+        }),
+      );
+    });
+
+    it('returns TaskFailedEvent if any adkEvent has an errorCode', () => {
+      const events: AdkEvent[] = [
+        createEvent({
+          errorCode: 'ERROR_1',
+          errorMessage: 'Something went wrong',
+        }),
+      ];
+      const result = getFinalTaskStatusUpdate(events, mockContext);
+
+      expect(result.kind).toBe('status-update');
+      expect(result.status?.state).toBe('failed');
+      const parts = result.status?.message?.parts;
+      expect((parts?.[0] as TextPart)?.text).toContain('Something went wrong');
+    });
+
+    it('returns TaskFailedEvent if any adkEvent has an errorMessage', () => {
+      const events: AdkEvent[] = [
+        createEvent({
+          errorMessage: 'Just a message',
+        }),
+      ];
+      const result = getFinalTaskStatusUpdate(events, mockContext);
+
+      expect(result.kind).toBe('status-update');
+      expect(result.status?.state).toBe('failed');
+      const parts = result.status?.message?.parts;
+      expect((parts?.[0] as TextPart)?.text).toContain('Just a message');
+    });
+
+    it('merges escalate and transferToAgent from actions and returns TaskCompletedEvent', () => {
+      const events: AdkEvent[] = [
+        createEvent({
+          actions: createEventActions({escalate: true}),
+        }),
+        createEvent({
+          actions: createEventActions({transferToAgent: 'agent-x'}),
+        }),
+      ];
+      const result = getFinalTaskStatusUpdate(events, mockContext);
+
+      expect(result.kind).toBe('status-update');
+      expect(result.status?.state).toBe('completed');
+      expect(result.metadata).toEqual(
+        expect.objectContaining({
+          adk_session_id: 'test-session',
+          adk_app_name: 'test-app',
+          adk_user_id: 'test-user',
+          'adk_escalate': true,
+          'adk_transfer_to_agent': 'agent-x',
+        }),
+      );
+    });
+
+    it('returns TaskInputRequiredEvent if there are longRunningToolIds that match functionCall', () => {
+      const events: AdkEvent[] = [
+        createEvent({
+          longRunningToolIds: ['call_1'],
+          content: {
+            parts: [{functionCall: {id: 'call_1', name: 'myFunc', args: {}}}],
+          },
+        }),
+      ];
+      const result = getFinalTaskStatusUpdate(events, mockContext);
+
+      expect(result.kind).toBe('status-update');
+      expect(result.status?.state).toBe('input-required');
+
+      // Converted to A2AParts by toA2AParts
+      const parts = result.status?.message?.parts;
+      expect((parts?.[0] as DataPart)?.data?.id).toBe('call_1');
+    });
+
+    it('returns TaskInputRequiredEvent if there are longRunningToolIds that match functionResponse', () => {
+      const events: AdkEvent[] = [
+        createEvent({
+          longRunningToolIds: ['call_2'],
+          content: {
+            parts: [
+              {
+                functionResponse: {
+                  id: 'call_2',
+                  name: 'myFunc',
+                  response: {},
+                },
+              },
+            ],
+          },
+        }),
+      ];
+      const result = getFinalTaskStatusUpdate(events, mockContext);
+
+      expect(result.kind).toBe('status-update');
+      expect(result.status?.state).toBe('input-required');
+
+      const parts = result.status?.message?.parts;
+      expect((parts?.[0] as DataPart)?.data?.id).toBe('call_2');
+    });
+
+    it('does not duplicate required inputs for the same functionCall id', () => {
+      const events: AdkEvent[] = [
+        createEvent({
+          longRunningToolIds: ['call_1'],
+          content: {
+            parts: [{functionCall: {id: 'call_1', name: 'myFunc1'}}],
+          },
+        }),
+        createEvent({
+          content: {
+            parts: [{functionCall: {id: 'call_1', name: 'myFunc1'}}],
+          },
+        }),
+      ];
+      const result = getFinalTaskStatusUpdate(events, mockContext);
+
+      expect(result.kind).toBe('status-update');
+      expect(result.status?.state).toBe('input-required');
+      const parts = result.status?.message?.parts;
+      expect(parts?.length).toBe(1);
+      expect((parts?.[0] as DataPart)?.data?.id).toBe('call_1');
+    });
+  });
+
+  describe('getTaskInputRequiredEvent', () => {
+    it('returns undefined if task is falsy', () => {
+      expect(
+        getTaskInputRequiredEvent(null as unknown as Task, {} as GenAIContent),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined if task is not input required', () => {
+      const task = {
+        kind: 'task',
+        status: {state: 'working'},
+      } as Task;
+      expect(
+        getTaskInputRequiredEvent(task, {} as GenAIContent),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined if task does not have a status message', () => {
+      const task = {
+        kind: 'task',
+        status: {state: 'input-required'},
+      } as Task;
+      expect(
+        getTaskInputRequiredEvent(task, {} as GenAIContent),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined if matching response exists in genAIContent', () => {
+      const taskParts = toA2AParts([
+        {functionCall: {id: 'call_1', name: 'myFunc', args: {}}},
+      ]);
+      const task = {
+        id: 't1',
+        contextId: 'c1',
+        kind: 'task',
+        status: {
+          state: 'input-required',
+          message: {
+            parts: taskParts,
+          },
+        },
+      } as Task;
+      const genAIContent = {
+        parts: [
+          {functionResponse: {id: 'call_1', name: 'myFunc', response: {}}},
+        ],
+      } as GenAIContent;
+
+      expect(getTaskInputRequiredEvent(task, genAIContent)).toBeUndefined();
+    });
+
+    it('returns Error event if matching response does NOT exist in genAIContent', () => {
+      const taskParts = toA2AParts([
+        {functionCall: {id: 'call_1', name: 'myFunc', args: {}}},
+      ]);
+      const task = {
+        id: 'taskId1',
+        contextId: 'contextId1',
+        kind: 'task',
+        status: {
+          state: 'input-required',
+          message: {
+            parts: taskParts,
+          },
+        },
+      } as Task;
+      const genAIContent = {
+        parts: [{text: 'I can not do that.'}],
+      } as GenAIContent;
+
+      const result = getTaskInputRequiredEvent(task, genAIContent);
+      expect(result).toBeDefined();
+      expect(result!.kind).toBe('status-update');
+      expect(result!.status?.state).toBe('input-required');
+
+      const parts = result!.status?.message?.parts;
+      expect(parts).toBeDefined();
+      expect(parts!.length).toBe(2);
+      expect((parts![0] as DataPart)?.data?.id).toBe('call_1');
+      expect((parts![1] as TextPart)?.text).toContain(
+        'No input provided for function call id call_1',
+      );
+      expect(parts![1].metadata?.validation_error).toBe(true);
+    });
+
+    it('returns undefined if status message has no functionCall parts', () => {
+      const taskParts = toA2AParts([{text: 'Please answer'}]);
+      const task = {
+        id: 'taskId1',
+        contextId: 'contextId1',
+        kind: 'task',
+        status: {
+          state: 'input-required',
+          message: {
+            parts: taskParts,
+          },
+        },
+      } as Task;
+      const genAIContent = {
+        parts: [{text: 'Sure!'}],
+      } as GenAIContent;
+
+      expect(getTaskInputRequiredEvent(task, genAIContent)).toBeUndefined();
+    });
+  });
+});

--- a/core/test/a2a/executor_context_test.ts
+++ b/core/test/a2a/executor_context_test.ts
@@ -34,7 +34,7 @@ describe('createExecutorContext', () => {
     expect(context).toEqual({
       userId: 'user-1',
       sessionId: 'session-123',
-      agentName: 'agent-1',
+      appName: 'agent-1',
       readonlyState: {key: 'value'},
       events: mockSession.events,
       userContent: mockUserContent,


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**
The core infrastructure lacked a dedicated execution mechanism and event processing utilities specifically for managing Agent-to-Agent (A2A) interactions and their task event loops.

**Solution:**
- Added `A2AAgentExecutor` to encapsulate the core execution loop and state management for A2A tasks.
- Introduced `event_processor_utils.ts` with utility functions (e.g., `getFinalTaskStatusUpdate`, `getTaskInputRequiredEvent`) to correctly handle and synthesize A2A task status updates and input requests.
- Updated `a2a_event.ts` and `executor_context.ts` to align with the new executor abstractions (e.g., replacing `agentName` with `appName` in context).
- Added comprehensive unit test suites for the new `agent_executor` and `event_processor_utils`, and updated existing tests to match the new implementations.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added new unit testing for `agent_executor.ts` and `event_processor_utils.ts`. Updated existing tests for `a2a_event.ts` and `executor_context_test.ts`. All test suites run successfully.

**Manual End-to-End (E2E) Tests:**

N/A - This change primarily introduces internal core A2A infrastructure and associated unit tests, and does not require manual E2E user-facing verification at this stage.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

N/A
