### PR TITLE
A2a integration: use right enum values for agent card transport types

### DIFF
--- a/core/src/a2a/agent_card.ts
+++ b/core/src/a2a/agent_card.ts
@@ -61,6 +61,7 @@ export async function getA2AAgentCard(
     version: '1.0.0',
     skills: await buildAgentSkills(agent),
     url: transports[0].url,
+    preferredTransport: transports[0].transport,
     capabilities: {
       extensions: [],
       stateTransitionHistory: false,

--- a/core/src/a2a/agent_to_a2a.ts
+++ b/core/src/a2a/agent_to_a2a.ts
@@ -69,12 +69,12 @@ export async function toA2a(
     ? await resolveAgentCard(options.agentCard)
     : await getA2AAgentCard(agent, [
         {
-          url: `${rpcUrl}/rest`,
-          transport: 'rest',
+          url: `${rpcUrl}/jsonrpc`,
+          transport: 'JSONRPC',
         },
         {
-          url: `${rpcUrl}/jsonrpc`,
-          transport: 'jsonrpc',
+          url: `${rpcUrl}/rest`,
+          transport: 'HTTP+JSON',
         },
       ]);
 

--- a/core/test/a2a/agent_to_a2a_test.ts
+++ b/core/test/a2a/agent_to_a2a_test.ts
@@ -99,8 +99,8 @@ describe('toA2a', () => {
     expect(app.use).toHaveBeenCalledWith('json_middleware');
 
     expect(getA2AAgentCard).toHaveBeenCalledWith(agent, [
-      {url: 'http://localhost:8000/rest', transport: 'rest'},
-      {url: 'http://localhost:8000/jsonrpc', transport: 'jsonrpc'},
+      {url: 'http://localhost:8000/jsonrpc', transport: 'JSONRPC'},
+      {url: 'http://localhost:8000/rest', transport: 'HTTP+JSON'},
     ]);
 
     expect(A2AAgentExecutor).toHaveBeenCalledWith(
@@ -146,8 +146,8 @@ describe('toA2a', () => {
 
     expect(express).not.toHaveBeenCalled();
     expect(getA2AAgentCard).toHaveBeenCalledWith(agent, [
-      {url: 'https://custom-host:9000api/v1/rest', transport: 'rest'},
-      {url: 'https://custom-host:9000api/v1/jsonrpc', transport: 'jsonrpc'},
+      {url: 'https://custom-host:9000api/v1/jsonrpc', transport: 'JSONRPC'},
+      {url: 'https://custom-host:9000api/v1/rest', transport: 'HTTP+JSON'},
     ]);
 
     expect(A2AAgentExecutor).toHaveBeenCalledWith(


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
- Related: https://github.com/google/adk-js/issues/189

**Problem:**
The A2A agent card previously omitted the `preferredTransport` field. Furthermore, the transport protocols being advertised (`rest` and `jsonrpc`) were incorrectly mapped and did not match the standardized enum values expected by the A2A specification (`HTTP+JSON` and `JSONRPC`, respectively).

**Solution:**
- Added the missing `preferredTransport` property to the generated `AgentCard` in `getA2AAgentCard`.
- Updated transport definitions in `toA2a` to use the correct standard transport values (`JSONRPC` and `HTTP+JSON`).
- Updated the associated unit and integration tests to assert the corrected transport names and behavior.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

*Passed `npm run test` successfully locally. Output confirms that all tests in `agent_to_a2a_test.ts` pass with the updated transport strings.*

**Manual End-to-End (E2E) Tests:**

Manually verified via local A2A integration usage that the generated agent card properly reports `JSONRPC` and `HTTP+JSON` protocols, enabling correctly routed remote agent communication.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

