### PR TITLE
Add support for MCP type array instead of string only in gemini_schema_util

### DIFF
--- a/core/src/utils/gemini_schema_util.ts
+++ b/core/src/utils/gemini_schema_util.ts
@@ -14,6 +14,7 @@ const MCPToolSchemaObject = z.object({
   required: z.string().array().optional(),
 });
 type MCPToolSchema = z.infer<typeof MCPToolSchemaObject>;
+type MCPTypeArrayItem = string | {type: string};
 
 function toGeminiType(mcpType: string): Type {
   if (!mcpType) return Type.TYPE_UNSPECIFIED;
@@ -32,10 +33,21 @@ function toGeminiType(mcpType: string): Type {
       return Type.ARRAY;
     case 'object':
       return Type.OBJECT;
+    case 'null':
+      return Type.NULL;
     default:
       return Type.TYPE_UNSPECIFIED;
   }
 }
+
+const getTypeFromArrayItem = (
+  mcpType: MCPTypeArrayItem,
+): string | undefined => {
+  if (typeof mcpType === 'string') {
+    return mcpType.toLowerCase();
+  }
+  return mcpType?.type?.toLowerCase?.();
+};
 
 export function toGeminiSchema(mcpSchema?: MCPToolSchema): Schema | undefined {
   if (!mcpSchema) {
@@ -44,15 +56,23 @@ export function toGeminiSchema(mcpSchema?: MCPToolSchema): Schema | undefined {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function recursiveConvert(mcp: any): Schema {
-    // Handle nullable types
-    if (!mcp.type && mcp.anyOf && Array.isArray(mcp.anyOf)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const nonNullOption = mcp.anyOf.find((opt: any) => {
-        const t = opt.type;
-        return t !== 'null' && t !== 'NULL';
-      });
-      if (nonNullOption) {
-        mcp = nonNullOption;
+    const sourceType = mcp.anyOf ?? mcp.type;
+    let isNullable = false;
+    if (Array.isArray(sourceType)) {
+      const nonNullType = sourceType.find(
+        (t: MCPTypeArrayItem) => getTypeFromArrayItem(t) !== 'null',
+      );
+      isNullable = sourceType.some(
+        (t: MCPTypeArrayItem) => getTypeFromArrayItem(t) === 'null',
+      );
+
+      if (nonNullType && typeof nonNullType === 'object') {
+        mcp = nonNullType;
+      } else {
+        mcp = {
+          ...mcp,
+          type: nonNullType,
+        };
       }
     }
 
@@ -62,6 +82,8 @@ export function toGeminiSchema(mcpSchema?: MCPToolSchema): Schema | undefined {
         mcp.type = 'object';
       } else if (mcp.items) {
         mcp.type = 'array';
+      } else if (isNullable) {
+        mcp.type = 'null';
       }
     }
 
@@ -70,6 +92,10 @@ export function toGeminiSchema(mcpSchema?: MCPToolSchema): Schema | undefined {
       type: geminiType,
       description: mcp.description,
     };
+
+    if (isNullable && mcp.type !== 'null') {
+      geminiSchema.nullable = true;
+    }
 
     if (geminiType === Type.OBJECT) {
       geminiSchema.properties = {};

--- a/core/test/utils/gemini_schema_util_test.ts
+++ b/core/test/utils/gemini_schema_util_test.ts
@@ -77,6 +77,7 @@ describe('toGeminiSchema', () => {
     // Should resolve to STRING
     expect(schema).toEqual({
       type: Type.STRING,
+      nullable: true,
     });
   });
 
@@ -89,6 +90,19 @@ describe('toGeminiSchema', () => {
 
     expect(schema).toEqual({
       type: Type.STRING,
+      nullable: true,
+    });
+  });
+
+  it('handles anyOf with null only', () => {
+    const input = {
+      anyOf: [{type: 'null'}],
+    };
+
+    const schema = toGeminiSchema(input as unknown as MCPToolSchema);
+
+    expect(schema).toEqual({
+      type: Type.NULL,
     });
   });
 
@@ -126,6 +140,7 @@ describe('toGeminiSchema', () => {
           properties: {
             created: {type: Type.STRING},
           },
+          nullable: true,
         },
       },
     });
@@ -141,6 +156,88 @@ describe('toGeminiSchema', () => {
     expect(schema).toEqual({
       type: Type.OBJECT,
       properties: {},
+    });
+  });
+
+  it('handles array-typed type field with null - picks non-null type', () => {
+    const input = {
+      type: ['string', 'null'],
+      description: 'an optional string',
+    };
+
+    const schema = toGeminiSchema(input as unknown as MCPToolSchema);
+
+    expect(schema).toEqual({
+      type: Type.STRING,
+      description: 'an optional string',
+      nullable: true,
+    });
+  });
+
+  it('handles array-typed type field without null - picks the single non-null type', () => {
+    const input = {
+      type: ['integer'],
+    };
+
+    const schema = toGeminiSchema(input as unknown as MCPToolSchema);
+
+    expect(schema).toEqual({
+      type: Type.INTEGER,
+      description: undefined,
+    });
+  });
+
+  it('handles array-typed type field with case-insensitive NULL', () => {
+    const input = {
+      type: ['boolean', 'NULL'],
+    };
+
+    const schema = toGeminiSchema(input as unknown as MCPToolSchema);
+
+    expect(schema).toEqual({
+      type: Type.BOOLEAN,
+      description: undefined,
+      nullable: true,
+    });
+  });
+
+  it('handles array-typed type field with reverse order', () => {
+    const input = {
+      type: ['null', 'boolean'],
+    };
+
+    const schema = toGeminiSchema(input as unknown as MCPToolSchema);
+
+    expect(schema).toEqual({
+      type: Type.BOOLEAN,
+      description: undefined,
+      nullable: true,
+    });
+  });
+
+  it('handles array-typed type field with only null', () => {
+    const input = {
+      type: ['null'],
+    };
+
+    const schema = toGeminiSchema(input as unknown as MCPToolSchema);
+
+    expect(schema).toEqual({
+      type: Type.NULL,
+      description: undefined,
+    });
+  });
+
+  it('handles type null', () => {
+    const input = {
+      type: 'null',
+    };
+
+    const schema = toGeminiSchema(input as unknown as MCPToolSchema);
+
+    expect(schema).toEqual({
+      type: Type.NULL,
+      description: undefined,
     });
   });
 


### PR DESCRIPTION
Copy of https://github.com/google/adk-js/pull/199 but with additional fixes

# PR Description:

The gemini_schema_util.ts file converts MCP tool schemas to the Gemini API schema format.

However, it crashes when MCP properly uses an array in the `type` field, e.g. `['string', 'null']`, instead of using `anyOf`.
In such cases, `gemini_schema_util` crashes when trying to call `toLowerCase()` on `mcpType`, because this method does not exist on arrays.

## Why This Is Needed:

This PR adds proper handling of arrays in the `type` field.

The issue exists in v5.0.0.

### Example agent code:

```
import { LlmAgent, MCPToolset } from '@google/adk';

const MCP_URL = "https://...";
const MCP_HEADER = { "Authorization": "Bearer AABBCC" };

const mcpTools = new MCPToolset({
    type: "StreamableHTTPConnectionParams",
    url: MCP_URL,
    transportOptions: {
        requestInit: {
            headers: {
                ...MCP_HEADER,
            }
        }
    }
});

export const rootAgent = new LlmAgent({
    name: 'custom_mcp_agent',
    model: 'gemini-2.5-flash',
    instruction: 'You are a helpful assistant that can answer questions and help with MCP server tasks.',
    tools: [mcpTools],
});
```

### Logs in the console when the crash occurs:

```
ksndev@mac my-agent1 % npx adk run agent.ts
Running agent custom_mcp_agent, type exit to exit.
[user]: list available mcp tools
INFO: [ADK] 2026-03-15T19:44:18.314Z event: {"invocationId":"e-995fa988-a3e6-4d73-ab7b-a09ade8862dc","author":"user","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"content":{"role":"user","parts":[{"text":"list available mcp tools"}]},"id":"dcuVFs4v","longRunningToolIds":[],"timestamp":1773603858313}
TypeError: r.toLowerCase is not a function
    at PUr (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:486:3773)
    at e (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:486:4261)
    at e (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:486:4402)
    at e (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:486:4402)
    at Kmt (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:486:4508)
    at OUr._getDeclaration (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:486:4742)
    at OUr.processLlmRequest (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:406:39303)
    at gP.runOneStepAsync (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:483:12684)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async gP.runAsyncImpl (file:///private/var/folders/cx/kjlq7mq54v34j8l3k1m6n3sr0000gn/T/adk_agent_loader/1773603850371/agent.mjs:483:12026)
```