### PR TITLE
chore: increase timeouts for server start up in cross language tests.

### DIFF
--- a/tests/cross_language/a2a/go_ts/go_a2a_ts_test.ts
+++ b/tests/cross_language/a2a/go_ts/go_a2a_ts_test.ts
@@ -21,6 +21,7 @@ describe(
       tsServer = new AdkTsApiServer({
         agentsDir: path.resolve(__dirname, 'ts_backend'),
         a2a: true,
+        startFailureTimeout: TIMEOUT,
       });
       await tsServer.start();
     }, TIMEOUT);

--- a/tests/cross_language/a2a/ts_go/ts_a2a_go_test.ts
+++ b/tests/cross_language/a2a/ts_go/ts_a2a_go_test.ts
@@ -20,6 +20,7 @@ describe(
     beforeAll(async () => {
       goServer = new AdkGoServer({
         serverDir: path.resolve(__dirname, 'go_backend'),
+        startFailureTimeout: TIMEOUT,
       });
       await goServer.start();
     }, TIMEOUT);


### PR DESCRIPTION

**Problem:** Cross-language A2A tests were experiencing flakes or failures due to the default server startup timeout being too short in some slow environments.

**Solution:**
Explicitly set `startFailureTimeout` to the standard `TIMEOUT` (60000ms) for both `AdkTsApiServer` (in `go_ts` tests) and `AdkGoServer` (in `ts_go` tests) to allow sufficient boot time.
