### PR TITLE
Feat: Plugin callbacks for context compaction and tool selection

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -744,7 +744,8 @@ export class LlmAgent extends BaseAgent {
         // tools that are in the allowedTools set.
         // The allowedTools set is populated by request processors.
         return (
-          !llmRequest.allowedTools || llmRequest.allowedTools.has(tool.name)
+          !llmRequest.allowedTools ||
+          llmRequest.allowedTools.includes(tool.name)
         );
       });
 

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -63,6 +63,7 @@ import {ContextCompactorRequestProcessor} from './processors/context_compactor_r
 import {IDENTITY_LLM_REQUEST_PROCESSOR} from './processors/identity_llm_request_processor.js';
 import {INSTRUCTIONS_LLM_REQUEST_PROCESSOR} from './processors/instructions_llm_request_processor.js';
 import {REQUEST_CONFIRMATION_LLM_REQUEST_PROCESSOR} from './processors/request_confirmation_llm_request_processor.js';
+import {TOOL_FILTER_REQUEST_PROCESSOR} from './processors/tool_filter_request_processor.js';
 import {ReadonlyContext} from './readonly_context.js';
 import {StreamingMode} from './run_config.js';
 
@@ -396,6 +397,7 @@ export class LlmAgent extends BaseAgent {
       REQUEST_CONFIRMATION_LLM_REQUEST_PROCESSOR,
       CONTENT_REQUEST_PROCESSOR,
       CODE_EXECUTION_REQUEST_PROCESSOR,
+      TOOL_FILTER_REQUEST_PROCESSOR,
     ];
 
     if (
@@ -732,10 +734,20 @@ export class LlmAgent extends BaseAgent {
       const toolContext = new Context({invocationContext});
 
       // process all tools from this tool union
-      const tools = await convertToolUnionToTools(
-        toolUnion,
-        new ReadonlyContext(invocationContext),
-      );
+      const tools = (
+        await convertToolUnionToTools(
+          toolUnion,
+          new ReadonlyContext(invocationContext),
+        )
+      ).filter((tool) => {
+        // If allowedTools is not set, allow all tools. Otherwise, only allow
+        // tools that are in the allowedTools set.
+        // The allowedTools set is populated by request processors.
+        return (
+          !llmRequest.allowedTools || llmRequest.allowedTools.has(tool.name)
+        );
+      });
+
       for (const tool of tools) {
         await tool.processLlmRequest({toolContext, llmRequest});
       }

--- a/core/src/agents/processors/context_compactor_request_processor.ts
+++ b/core/src/agents/processors/context_compactor_request_processor.ts
@@ -7,6 +7,7 @@
 import {BaseContextCompactor} from '../../context/base_context_compactor.js';
 import {Event} from '../../events/event.js';
 import {LlmRequest} from '../../models/llm_request.js';
+import {ContextCompactionTrigger} from '../../plugins/base_plugin.js';
 import {InvocationContext} from '../invocation_context.js';
 import {BaseLlmRequestProcessor} from './base_llm_processor.js';
 
@@ -33,8 +34,19 @@ export class ContextCompactorRequestProcessor implements BaseLlmRequestProcessor
         compactor.shouldCompact(invocationContext),
       );
       if (shouldCompact) {
+        await invocationContext.pluginManager.runBeforeContextCompaction({
+          invocationContext,
+          trigger: ContextCompactionTrigger.Auto,
+        });
+
         const oldEvents = new Set(invocationContext.session.events);
         await Promise.resolve(compactor.compact(invocationContext));
+
+        await invocationContext.pluginManager.runAfterContextCompaction({
+          invocationContext,
+          trigger: ContextCompactionTrigger.Auto,
+        });
+
         const newEvents = invocationContext.session.events.filter(
           (e) => !oldEvents.has(e),
         );

--- a/core/src/agents/processors/tool_filter_request_processor.ts
+++ b/core/src/agents/processors/tool_filter_request_processor.ts
@@ -50,7 +50,7 @@ export class ToolFilterRequestProcessor extends BaseLlmRequestProcessor {
 
     // If plugins returned a filtered set, update allowedTools
     if (filteredTools !== undefined) {
-      llmRequest.allowedTools = new Set(Object.keys(filteredTools));
+      llmRequest.allowedTools = Object.keys(filteredTools);
     }
   }
 }

--- a/core/src/agents/processors/tool_filter_request_processor.ts
+++ b/core/src/agents/processors/tool_filter_request_processor.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../../events/event.js';
+import {LlmRequest} from '../../models/llm_request.js';
+import {BaseTool} from '../../tools/base_tool.js';
+import {Context} from '../context.js';
+import {InvocationContext} from '../invocation_context.js';
+import {isLlmAgent} from '../llm_agent.js';
+import {ReadonlyContext} from '../readonly_context.js';
+import {BaseLlmRequestProcessor} from './base_llm_processor.js';
+
+export class ToolFilterRequestProcessor extends BaseLlmRequestProcessor {
+  /** Filters the set of tools on the request based on plugins. */
+  // eslint-disable-next-line require-yield
+  override async *runAsync(
+    invocationContext: InvocationContext,
+    llmRequest: LlmRequest,
+  ): AsyncGenerator<Event, void, void> {
+    const agent = invocationContext.agent;
+    if (!isLlmAgent(agent)) {
+      return;
+    }
+
+    // Get all tools resolved to BaseTool
+    const toolsList = await agent.canonicalTools(
+      new ReadonlyContext(invocationContext),
+    );
+
+    if (toolsList.length === 0) {
+      return;
+    }
+
+    const toolsDict: Record<string, BaseTool> = {};
+    for (const tool of toolsList) {
+      toolsDict[tool.name] = tool;
+    }
+
+    const callbackContext = new Context({invocationContext});
+
+    // Call plugins to filter tools
+    const filteredTools =
+      await invocationContext.pluginManager.runBeforeToolSelection({
+        callbackContext,
+        tools: toolsDict,
+      });
+
+    // If plugins returned a filtered set, update allowedTools
+    if (filteredTools !== undefined) {
+      llmRequest.allowedTools = new Set(Object.keys(filteredTools));
+    }
+  }
+}
+
+export const TOOL_FILTER_REQUEST_PROCESSOR = new ToolFilterRequestProcessor();

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -156,7 +156,7 @@ export {LLMRegistry} from './models/registry.js';
 export type {BaseLlmType} from './models/registry.js';
 export {RoutedLlm} from './models/routed_llm.js';
 export type {LlmRouter} from './models/routed_llm.js';
-export {BasePlugin} from './plugins/base_plugin.js';
+export {BasePlugin, ContextCompactionTrigger} from './plugins/base_plugin.js';
 export {LoggingPlugin} from './plugins/logging_plugin.js';
 export {PluginManager} from './plugins/plugin_manager.js';
 export {

--- a/core/src/models/llm_request.ts
+++ b/core/src/models/llm_request.ts
@@ -41,6 +41,11 @@ export interface LlmRequest {
    * The tools dictionary. Excluded from JSON serialization.
    */
   toolsDict: {[key: string]: BaseTool};
+
+  /**
+   * The set of allowed tools, populated by request processors.
+   */
+  allowedTools?: Set<string>;
 }
 
 /**

--- a/core/src/models/llm_request.ts
+++ b/core/src/models/llm_request.ts
@@ -45,7 +45,7 @@ export interface LlmRequest {
   /**
    * The set of allowed tools, populated by request processors.
    */
-  allowedTools?: Set<string>;
+  allowedTools?: string[];
 }
 
 /**

--- a/core/src/plugins/base_plugin.ts
+++ b/core/src/plugins/base_plugin.ts
@@ -13,6 +13,7 @@ import {Event} from '../events/event.js';
 import {LlmRequest} from '../models/llm_request.js';
 import {LlmResponse} from '../models/llm_response.js';
 import {BaseTool} from '../tools/base_tool.js';
+import {experimental} from '../utils/experimental.js';
 
 /**
  * Base class for creating plugins.
@@ -286,6 +287,27 @@ export abstract class BasePlugin {
     llmRequest: LlmRequest;
     error: Error;
   }): Promise<LlmResponse | undefined> {
+    return;
+  }
+
+  /**
+   * Callback executed before a tool is selected.
+   *
+   * This callback provides an opportunity to inspect, log, or modify the
+   * available tools before they are selected.
+   *
+   * @param params.callbackContext The context for the current agent call.
+   * @param params.tools The available tools.
+   * @returns An optional value. A non-`undefined` return may be used by the
+   *     framework to modify or replace the available tools. Returning
+   *     `undefined` allows the original tools to be used.
+   */
+  @experimental
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async beforeToolSelection(params: {
+    callbackContext: Context;
+    tools: Readonly<Record<string, BaseTool>>;
+  }): Promise<Readonly<Record<string, BaseTool>> | undefined> {
     return;
   }
 

--- a/core/src/plugins/base_plugin.ts
+++ b/core/src/plugins/base_plugin.ts
@@ -16,6 +16,14 @@ import {BaseTool} from '../tools/base_tool.js';
 import {experimental} from '../utils/experimental.js';
 
 /**
+ * Trigger for context compaction.
+ */
+export enum ContextCompactionTrigger {
+  Manual = 'Manual',
+  Auto = 'Auto',
+}
+
+/**
  * Base class for creating plugins.
  *
  * Plugins provide a structured way to intercept and modify agent, tool, and
@@ -308,6 +316,42 @@ export abstract class BasePlugin {
     callbackContext: Context;
     tools: Readonly<Record<string, BaseTool>>;
   }): Promise<Readonly<Record<string, BaseTool>> | undefined> {
+    return;
+  }
+
+  /**
+   * Callback executed before context compaction.
+   *
+   * This callback provides an opportunity to inspect or modify the context
+   * before it is compacted.
+   *
+   * @param params.invocationContext The context for the entire invocation.
+   * @param params.trigger The trigger for the context compaction.
+   */
+  @experimental
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async beforeContextCompaction(params: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }): Promise<void> {
+    return;
+  }
+
+  /**
+   * Callback executed after context compaction.
+   *
+   * This callback provides an opportunity to inspect the context
+   * after it has been compacted.
+   *
+   * @param params.invocationContext The context for the entire invocation.
+   * @param params.trigger The trigger for the context compaction.
+   */
+  @experimental
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async afterContextCompaction(params: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }): Promise<void> {
     return;
   }
 

--- a/core/src/plugins/plugin_manager.ts
+++ b/core/src/plugins/plugin_manager.ts
@@ -15,7 +15,7 @@ import {LlmResponse} from '../models/llm_response.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {logger} from '../utils/logger.js';
 
-import {BasePlugin} from './base_plugin.js';
+import {BasePlugin, ContextCompactionTrigger} from './base_plugin.js';
 
 /**
  * Manages the registration and execution of plugins.
@@ -232,6 +232,42 @@ export class PluginManager {
         plugin.beforeToolSelection({callbackContext, tools}),
       'beforeToolSelection',
     )) as Readonly<Record<string, BaseTool>> | undefined;
+  }
+
+  /**
+   * Runs the `beforeContextCompaction` for all plugins.
+   */
+  async runBeforeContextCompaction({
+    invocationContext,
+    trigger,
+  }: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }): Promise<void> {
+    await this.runCallbacks(
+      this.plugins,
+      (plugin: BasePlugin) =>
+        plugin.beforeContextCompaction({invocationContext, trigger}),
+      'beforeContextCompaction',
+    );
+  }
+
+  /**
+   * Runs the `afterContextCompaction` for all plugins.
+   */
+  async runAfterContextCompaction({
+    invocationContext,
+    trigger,
+  }: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }): Promise<void> {
+    await this.runCallbacks(
+      this.plugins,
+      (plugin: BasePlugin) =>
+        plugin.afterContextCompaction({invocationContext, trigger}),
+      'afterContextCompaction',
+    );
   }
 
   /**

--- a/core/src/plugins/plugin_manager.ts
+++ b/core/src/plugins/plugin_manager.ts
@@ -217,6 +217,24 @@ export class PluginManager {
   }
 
   /**
+   * Runs the `beforeToolSelection` for all plugins.
+   */
+  async runBeforeToolSelection({
+    callbackContext,
+    tools,
+  }: {
+    callbackContext: Context;
+    tools: Readonly<Record<string, BaseTool>>;
+  }): Promise<Readonly<Record<string, BaseTool>> | undefined> {
+    return (await this.runCallbacks(
+      this.plugins,
+      (plugin: BasePlugin) =>
+        plugin.beforeToolSelection({callbackContext, tools}),
+      'beforeToolSelection',
+    )) as Readonly<Record<string, BaseTool>> | undefined;
+  }
+
+  /**
    * Runs the `beforeToolCallback` for all plugins.
    */
   async runBeforeToolCallback({

--- a/core/test/agents/processors/context_compactor_request_processor_test.ts
+++ b/core/test/agents/processors/context_compactor_request_processor_test.ts
@@ -11,13 +11,19 @@ import {
   LlmRequest,
 } from '@google/adk';
 import {describe, expect, it, vi} from 'vitest';
+import {ContextCompactionTrigger} from '../../../src/plugins/base_plugin.js';
 
 describe('ContextCompactorRequestProcessor', () => {
   it('should run compactors in order and stop after first compaction', async () => {
+    const mockPluginManager = {
+      runBeforeContextCompaction: vi.fn().mockResolvedValue(undefined),
+      runAfterContextCompaction: vi.fn().mockResolvedValue(undefined),
+    };
     const mockCtx = {
       session: {
         events: [],
       },
+      pluginManager: mockPluginManager,
     } as unknown as InvocationContext;
     const mockReq = {} as LlmRequest;
 
@@ -55,5 +61,15 @@ describe('ContextCompactorRequestProcessor', () => {
 
     expect(compactor3.shouldCompact).not.toHaveBeenCalled();
     expect(compactor3.compact).not.toHaveBeenCalled();
+
+    expect(mockPluginManager.runBeforeContextCompaction).toHaveBeenCalledWith({
+      invocationContext: mockCtx,
+      trigger: ContextCompactionTrigger.Auto,
+    });
+
+    expect(mockPluginManager.runAfterContextCompaction).toHaveBeenCalledWith({
+      invocationContext: mockCtx,
+      trigger: ContextCompactionTrigger.Auto,
+    });
   });
 });

--- a/core/test/agents/processors/tool_filter_request_processor_test.ts
+++ b/core/test/agents/processors/tool_filter_request_processor_test.ts
@@ -135,8 +135,8 @@ describe('ToolFilterRequestProcessor', () => {
     }
 
     expect(llmRequest.allowedTools).toBeDefined();
-    expect(llmRequest.allowedTools?.has('tool1')).toBe(true);
-    expect(llmRequest.allowedTools?.has('tool2')).toBe(false);
+    expect(llmRequest.allowedTools?.includes('tool1')).toBe(true);
+    expect(llmRequest.allowedTools?.includes('tool2')).toBe(false);
   });
 
   it('should not populate allowedTools if plugins return undefined', async () => {
@@ -194,7 +194,10 @@ describe('ToolFilterRequestProcessor', () => {
       new ReadonlyContext(invocationContext),
     );
     for (const tool of tools) {
-      if (llmRequest.allowedTools && !llmRequest.allowedTools.has(tool.name)) {
+      if (
+        llmRequest.allowedTools &&
+        !llmRequest.allowedTools.includes(tool.name)
+      ) {
         continue;
       }
       await tool.processLlmRequest({toolContext, llmRequest});

--- a/core/test/agents/processors/tool_filter_request_processor_test.ts
+++ b/core/test/agents/processors/tool_filter_request_processor_test.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BasePlugin,
+  BaseTool,
+  Context,
+  InvocationContext,
+  LlmAgent,
+  LlmRequest,
+  PluginManager,
+  ReadonlyContext,
+  createSession,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {handleFunctionCallsAsync} from '../../../src/agents/functions.js';
+import {TOOL_FILTER_REQUEST_PROCESSOR} from '../../../src/agents/processors/tool_filter_request_processor.js';
+import {createEvent} from '../../../src/events/event.js';
+
+class MockTool extends BaseTool {
+  constructor(name: string) {
+    super({name, description: 'Mock tool'});
+  }
+  async runAsync() {
+    return {};
+  }
+}
+
+class MockPlugin extends BasePlugin {
+  filteredTools: Record<string, BaseTool> | undefined;
+
+  constructor(filteredTools?: Record<string, BaseTool>) {
+    super('mock_plugin');
+    this.filteredTools = filteredTools;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override async beforeToolSelection(params: {
+    callbackContext: Context;
+    tools: Readonly<Record<string, BaseTool>>;
+  }) {
+    return this.filteredTools;
+  }
+}
+
+function createMockInvocationContext(
+  agent: BaseAgent,
+  plugins: BasePlugin[] = [],
+): InvocationContext {
+  return new InvocationContext({
+    invocationId: 'test-invocation',
+    agent,
+    session: createSession({
+      id: 'test-session',
+      events: [],
+      appName: 'test-app',
+      userId: 'test-user',
+    }),
+    pluginManager: new PluginManager(plugins),
+  });
+}
+
+describe('ToolFilterRequestProcessor', () => {
+  it('should do nothing if agent is not LlmAgent', async () => {
+    class NonLlmAgent extends BaseAgent {
+      protected async *runAsyncImpl() {}
+      protected async *runLiveImpl() {}
+    }
+    const agent = new NonLlmAgent({name: 'non_llm'});
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+
+    for await (const _ of TOOL_FILTER_REQUEST_PROCESSOR.runAsync(
+      invocationContext,
+      llmRequest,
+    )) {
+      // intentionally empty
+    }
+
+    expect(llmRequest.allowedTools).toBeUndefined();
+  });
+
+  it('should do nothing if agent has no tools', async () => {
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: 'gemini-2.5-flash',
+    });
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+
+    for await (const _ of TOOL_FILTER_REQUEST_PROCESSOR.runAsync(
+      invocationContext,
+      llmRequest,
+    )) {
+      // intentionally empty
+    }
+
+    expect(llmRequest.allowedTools).toBeUndefined();
+  });
+
+  it('should populate allowedTools if plugins return filtered tools', async () => {
+    const tool1 = new MockTool('tool1');
+    const tool2 = new MockTool('tool2');
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: 'gemini-2.5-flash',
+      tools: [tool1, tool2],
+    });
+
+    const mockPlugin = new MockPlugin({'tool1': tool1});
+    const invocationContext = createMockInvocationContext(agent, [mockPlugin]);
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+
+    for await (const _ of TOOL_FILTER_REQUEST_PROCESSOR.runAsync(
+      invocationContext,
+      llmRequest,
+    )) {
+      // intentionally empty
+    }
+
+    expect(llmRequest.allowedTools).toBeDefined();
+    expect(llmRequest.allowedTools?.has('tool1')).toBe(true);
+    expect(llmRequest.allowedTools?.has('tool2')).toBe(false);
+  });
+
+  it('should not populate allowedTools if plugins return undefined', async () => {
+    const tool1 = new MockTool('tool1');
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: 'gemini-2.5-flash',
+      tools: [tool1],
+    });
+
+    const mockPlugin = new MockPlugin(undefined);
+    const invocationContext = createMockInvocationContext(agent, [mockPlugin]);
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+
+    for await (const _ of TOOL_FILTER_REQUEST_PROCESSOR.runAsync(
+      invocationContext,
+      llmRequest,
+    )) {
+      // intentionally empty
+    }
+
+    expect(llmRequest.allowedTools).toBeUndefined();
+  });
+
+  it('should fail if model tries to call a filtered tool', async () => {
+    const tool1 = new MockTool('tool1');
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: 'gemini-2.5-flash',
+      tools: [tool1],
+    });
+
+    const mockPlugin = new MockPlugin({});
+    const invocationContext = createMockInvocationContext(agent, [mockPlugin]);
+
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+
+    for await (const _ of TOOL_FILTER_REQUEST_PROCESSOR.runAsync(
+      invocationContext,
+      llmRequest,
+    )) {
+      // intentionally empty
+    }
+
+    const toolContext = new Context({invocationContext});
+    const tools = await agent.canonicalTools(
+      new ReadonlyContext(invocationContext),
+    );
+    for (const tool of tools) {
+      if (llmRequest.allowedTools && !llmRequest.allowedTools.has(tool.name)) {
+        continue;
+      }
+      await tool.processLlmRequest({toolContext, llmRequest});
+    }
+
+    const functionCallEvent = createEvent({
+      invocationId: 'test-invocation',
+      author: 'test_agent',
+      content: {
+        role: 'model',
+        parts: [{functionCall: {name: 'tool1', id: '1'}}],
+      },
+    });
+
+    await expect(
+      handleFunctionCallsAsync({
+        invocationContext,
+        functionCallEvent,
+        toolsDict: llmRequest.toolsDict,
+        beforeToolCallbacks: [],
+        afterToolCallbacks: [],
+      }),
+    ).rejects.toThrow('Function tool1 is not found in the toolsDict.');
+  });
+});

--- a/core/test/plugins/base_plugin_test.ts
+++ b/core/test/plugins/base_plugin_test.ts
@@ -17,6 +17,7 @@ import {
 } from '@google/adk';
 import {Content} from '@google/genai';
 import {describe, expect, it} from 'vitest';
+import {ContextCompactionTrigger} from '../../src/plugins/base_plugin.js';
 import {resetLogger, setLogger} from '../../src/utils/logger.js';
 
 class TestablePlugin extends BasePlugin {
@@ -347,6 +348,64 @@ describe('BasePlugin', () => {
       expect(warnCalls).toHaveLength(1);
       expect(warnCalls[0]).toContain(
         'Method BasePlugin.beforeToolSelection is experimental',
+      );
+    } finally {
+      resetLogger();
+    }
+  });
+
+  it('should warn that beforeContextCompaction is experimental', async () => {
+    const warnCalls: string[] = [];
+    const mockLogger = {
+      setLogLevel: () => {},
+      log: () => {},
+      debug: () => {},
+      info: () => {},
+      warn: (...args: unknown[]) => {
+        warnCalls.push(args.map((a) => String(a)).join(' '));
+      },
+      error: () => {},
+    };
+
+    setLogger(mockLogger);
+    try {
+      const plugin = new TestablePlugin('test_plugin');
+      await plugin.beforeContextCompaction({
+        invocationContext: mockInvocationContext,
+        trigger: ContextCompactionTrigger.Auto,
+      });
+      expect(warnCalls).toHaveLength(1);
+      expect(warnCalls[0]).toContain(
+        'Method BasePlugin.beforeContextCompaction is experimental',
+      );
+    } finally {
+      resetLogger();
+    }
+  });
+
+  it('should warn that afterContextCompaction is experimental', async () => {
+    const warnCalls: string[] = [];
+    const mockLogger = {
+      setLogLevel: () => {},
+      log: () => {},
+      debug: () => {},
+      info: () => {},
+      warn: (...args: unknown[]) => {
+        warnCalls.push(args.map((a) => String(a)).join(' '));
+      },
+      error: () => {},
+    };
+
+    setLogger(mockLogger);
+    try {
+      const plugin = new TestablePlugin('test_plugin');
+      await plugin.afterContextCompaction({
+        invocationContext: mockInvocationContext,
+        trigger: ContextCompactionTrigger.Auto,
+      });
+      expect(warnCalls).toHaveLength(1);
+      expect(warnCalls[0]).toContain(
+        'Method BasePlugin.afterContextCompaction is experimental',
       );
     } finally {
       resetLogger();

--- a/core/test/plugins/base_plugin_test.ts
+++ b/core/test/plugins/base_plugin_test.ts
@@ -17,6 +17,7 @@ import {
 } from '@google/adk';
 import {Content} from '@google/genai';
 import {describe, expect, it} from 'vitest';
+import {resetLogger, setLogger} from '../../src/utils/logger.js';
 
 class TestablePlugin extends BasePlugin {
   constructor(name = 'testable_plugin') {
@@ -321,5 +322,34 @@ describe('BasePlugin', () => {
     ).toEqual({
       content: {parts: [{text: 'overridden_on_model_error'}]},
     });
+  });
+
+  it('should warn that beforeToolSelection is experimental', async () => {
+    const warnCalls: string[] = [];
+    const mockLogger = {
+      setLogLevel: () => {},
+      log: () => {},
+      debug: () => {},
+      info: () => {},
+      warn: (...args: unknown[]) => {
+        warnCalls.push(args.map((a) => String(a)).join(' '));
+      },
+      error: () => {},
+    };
+
+    setLogger(mockLogger);
+    try {
+      const plugin = new TestablePlugin('test_plugin');
+      await plugin.beforeToolSelection({
+        callbackContext: mockCallbackContext,
+        tools: {},
+      });
+      expect(warnCalls).toHaveLength(1);
+      expect(warnCalls[0]).toContain(
+        'Method BasePlugin.beforeToolSelection is experimental',
+      );
+    } finally {
+      resetLogger();
+    }
   });
 });

--- a/core/test/plugins/plugin_manager_test.ts
+++ b/core/test/plugins/plugin_manager_test.ts
@@ -17,6 +17,7 @@ import {
 } from '@google/adk';
 import {Content} from '@google/genai';
 import {beforeEach, describe, expect, it} from 'vitest';
+import {ContextCompactionTrigger} from '../../src/plugins/base_plugin.js';
 
 type PluginCallbackName = keyof BasePlugin;
 
@@ -145,6 +146,20 @@ class TestPlugin extends BasePlugin {
     return (await this.handleCallback('onModelErrorCallback')) as
       | LlmResponse
       | undefined;
+  }
+
+  override async beforeContextCompaction(_params: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }): Promise<void> {
+    await this.handleCallback('beforeContextCompaction');
+  }
+
+  override async afterContextCompaction(_params: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }): Promise<void> {
+    await this.handleCallback('afterContextCompaction');
   }
 }
 
@@ -290,6 +305,14 @@ describe('PluginManager', () => {
       llmRequest: mockLlmRequest,
       error: mockError,
     });
+    await service.runBeforeContextCompaction({
+      invocationContext: mockInvocationContext,
+      trigger: ContextCompactionTrigger.Auto,
+    });
+    await service.runAfterContextCompaction({
+      invocationContext: mockInvocationContext,
+      trigger: ContextCompactionTrigger.Auto,
+    });
 
     const expectedCallbacks: PluginCallbackName[] = [
       'onUserMessageCallback',
@@ -304,6 +327,8 @@ describe('PluginManager', () => {
       'beforeModelCallback',
       'afterModelCallback',
       'onModelErrorCallback',
+      'beforeContextCompaction',
+      'afterContextCompaction',
     ];
     expect(plugin1.callLog.sort()).toEqual(expectedCallbacks.sort());
   });

--- a/tests/e2e/context_compaction/e2e_compaction_test.ts
+++ b/tests/e2e/context_compaction/e2e_compaction_test.ts
@@ -4,13 +4,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {InMemoryRunner, isCompactedEvent} from '@google/adk';
+import {
+  BasePlugin,
+  ContextCompactionTrigger,
+  InMemoryRunner,
+  InvocationContext,
+  isCompactedEvent,
+} from '@google/adk';
 import {createUserContent} from '@google/genai';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import * as path from 'path';
 import {describe, expect, it} from 'vitest';
 import {createCompactionAgent} from './agent.js';
+
+class TestCompactionPlugin extends BasePlugin {
+  beforeCalled = false;
+  afterCalled = false;
+
+  constructor() {
+    super('TestCompactionPlugin');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override async beforeContextCompaction(params: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }) {
+    this.beforeCalled = true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override async afterContextCompaction(params: {
+    invocationContext: InvocationContext;
+    trigger: ContextCompactionTrigger;
+  }) {
+    this.afterCalled = true;
+  }
+}
 
 describe('E2e Context Compaction', () => {
   const envPath = path.resolve(__dirname, '.env');
@@ -30,8 +61,12 @@ describe('E2e Context Compaction', () => {
     async () => {
       // Instantiate agent inside the test so it relies on the loaded env variations
       const agent = createCompactionAgent();
-
-      const runner = new InMemoryRunner({agent, appName: 'e2e_test'});
+      const plugin = new TestCompactionPlugin();
+      const runner = new InMemoryRunner({
+        agent,
+        appName: 'e2e_test',
+        plugins: [plugin],
+      });
       const session = await runner.sessionService.createSession({
         appName: 'e2e_test',
         userId: 'test_user',
@@ -69,6 +104,10 @@ describe('E2e Context Compaction', () => {
       const latestCompacted = compactedEvents[compactedEvents.length - 1];
       expect(latestCompacted.compactedContent).toBeTruthy();
       expect(latestCompacted.compactedContent.length).toBeGreaterThan(0);
+
+      // Verify that the plugin callbacks were called
+      expect(plugin.beforeCalled).toBe(true);
+      expect(plugin.afterCalled).toBe(true);
     },
     30000,
   ); // 30 sec timeout for e2e LLM tests

--- a/tests/e2e/tools/before_tool_selection_test.ts
+++ b/tests/e2e/tools/before_tool_selection_test.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BasePlugin,
+  BaseTool,
+  Context,
+  InMemoryRunner,
+  LlmAgent,
+  LOAD_ARTIFACTS,
+} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+import {describe, expect, it} from 'vitest';
+
+class FilterPlugin extends BasePlugin {
+  constructor() {
+    super('filter_plugin');
+  }
+
+  override async beforeToolSelection(params: {
+    callbackContext: Context;
+    tools: Readonly<Record<string, BaseTool>>;
+  }) {
+    const filtered: Record<string, BaseTool> = {};
+    for (const [name, tool] of Object.entries(params.tools)) {
+      if (name !== LOAD_ARTIFACTS.name) {
+        filtered[name] = tool;
+      }
+    }
+    return filtered;
+  }
+}
+
+describe('E2E beforeToolSelection', () => {
+  const envPath = path.resolve(__dirname, '.env');
+  const envExists = fs.existsSync(envPath);
+
+  if (envExists) {
+    dotenv.config({path: envPath});
+  }
+
+  const hasAKey =
+    !!process.env.GEMINI_API_KEY ||
+    !!process.env.GOOGLE_GENAI_API_KEY ||
+    !!process.env.GOOGLE_CLOUD_PROJECT;
+
+  it.skipIf(!hasAKey)(
+    'should filter out LOAD_ARTIFACTS tool and fail to answer',
+    async () => {
+      const filterPlugin = new FilterPlugin();
+      const agent = new LlmAgent({
+        name: 'e2e_filter_agent',
+        description: 'An agent that reads artifacts.',
+        instruction:
+          'You have tools to load artifacts. Use them to read artifacts if the user asks about them, and give a short answer based solely on the artifact content.',
+        model: 'gemini-2.5-flash',
+        tools: [LOAD_ARTIFACTS],
+      });
+
+      const runner = new InMemoryRunner({
+        agent,
+        appName: 'e2e_tool_test',
+        plugins: [filterPlugin],
+      });
+      const session = await runner.sessionService.createSession({
+        appName: 'e2e_tool_test',
+        userId: 'test_user',
+      });
+
+      // Provide an artifact
+      const csvBytes = Buffer.from(
+        'name,age\nAlice,12345\nBob,25\n',
+        'utf8',
+      ).toString('base64');
+      await runner.artifactService!.saveArtifact({
+        appName: 'e2e_tool_test',
+        userId: 'test_user',
+        sessionId: session.id,
+        filename: 'people.csv',
+        artifact: {
+          inlineData: {
+            data: csvBytes,
+            mimeType: 'application/csv',
+          },
+        },
+      });
+
+      let finalResponse = '';
+      for await (const event of runner.runAsync({
+        userId: 'test_user',
+        sessionId: session.id,
+        newMessage: createUserContent(
+          'What is the age of Alice in people.csv?',
+        ),
+      })) {
+        if (
+          event.author === 'e2e_filter_agent' &&
+          event.content?.parts?.[0]?.text
+        ) {
+          finalResponse += event.content.parts[0].text;
+        }
+      }
+
+      // Check the output
+      // Since the tool was filtered out, the agent should NOT be able to answer '12345'.
+      expect(finalResponse.toLowerCase()).not.toContain('12345');
+    },
+    30000,
+  );
+
+  it.skipIf(!hasAKey)(
+    'should NOT filter out LOAD_ARTIFACTS tool when plugin returns undefined',
+    async () => {
+      class NoOpPlugin extends BasePlugin {
+        constructor() {
+          super('noop_plugin');
+        }
+        override async beforeToolSelection() {
+          return undefined;
+        }
+      }
+
+      const agent = new LlmAgent({
+        name: 'e2e_noop_agent',
+        description: 'An agent that reads artifacts.',
+        instruction:
+          'You have tools to load artifacts. Use them to read artifacts if the user asks about them, and give a short answer based solely on the artifact content.',
+        model: 'gemini-2.5-flash',
+        tools: [LOAD_ARTIFACTS],
+      });
+
+      const runner = new InMemoryRunner({
+        agent,
+        appName: 'e2e_tool_test',
+        plugins: [new NoOpPlugin()],
+      });
+      const session = await runner.sessionService.createSession({
+        appName: 'e2e_tool_test',
+        userId: 'test_user',
+      });
+
+      // Provide an artifact
+      const csvBytes = Buffer.from(
+        'name,age\nAlice,12345\nBob,25\n',
+        'utf8',
+      ).toString('base64');
+      await runner.artifactService!.saveArtifact({
+        appName: 'e2e_tool_test',
+        userId: 'test_user',
+        sessionId: session.id,
+        filename: 'people.csv',
+        artifact: {
+          inlineData: {
+            data: csvBytes,
+            mimeType: 'application/csv',
+          },
+        },
+      });
+
+      let finalResponse = '';
+      for await (const event of runner.runAsync({
+        userId: 'test_user',
+        sessionId: session.id,
+        newMessage: createUserContent(
+          'What is the age of Alice in people.csv?',
+        ),
+      })) {
+        if (
+          event.author === 'e2e_noop_agent' &&
+          event.content?.parts?.[0]?.text
+        ) {
+          finalResponse += event.content.parts[0].text;
+        }
+      }
+
+      // Check the output
+      expect(finalResponse.toLowerCase()).toContain('12345');
+    },
+    30000,
+  );
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

This is in direct support of https://github.com/google-gemini/gemini-cli/issues/20995

**Problem:**
Gemini CLI has a couple hooks that do not yet exist in ADK: PreCompress and BeforeToolSelection. 

**Solution:**
These hooks require direct support within ADK. To support these, this PR creates three new plugin callbacks:

* BeforeToolSelection
* BeforeContextCompaction
* AfterContextCompaction

Only the first two are required to support Gemini CLI, but the third is a symmetric callback to allow more functionality around monitoring context compaction. For example, a user can collect statistics about the effectiveness of the context compaction.

These three callbacks are marked experimental for now since this is not agreed upon for all ADK languages.

### Testing Plan
New unit and e2e tests were added for all three callbacks:

```
##################
# Unit tests
##################

$ npm run test run -- core/test/agents/processors/context_compactor_request_processor_test.ts core/test/agents/processors/tool_filter_request_processor_test.ts core/test/plugins/base_plugin_test.ts core/test/plugins/plugin_manager_test.ts

> adk@0.6.1 test
> vitest --project unit:core --project unit:dev --project integration --project e2e run core/test/agents/processors/context_compactor_request_processor_test.ts core/test/agents/processors/tool_filter_request_processor_test.ts core/test/plugins/base_plugin_test.ts core/test/plugins/plugin_manager_test.ts


 RUN  v3.2.4 /Users/scottmansfield/projects/adk-js

 ✓  unit:core  core/test/agents/processors/context_compactor_request_processor_test.ts (1 test) 2ms
stdout | core/test/agents/processors/tool_filter_request_processor_test.ts > ToolFilterRequestProcessor > should populate allowedTools if plugins return filtered tools
INFO: [ADK] 2026-04-09T00:06:09.892Z Plugin 'mock_plugin' registered.

stdout | core/test/agents/processors/tool_filter_request_processor_test.ts > ToolFilterRequestProcessor > should not populate allowedTools if plugins return undefined
INFO: [ADK] 2026-04-09T00:06:09.893Z Plugin 'mock_plugin' registered.

stdout | core/test/agents/processors/tool_filter_request_processor_test.ts > ToolFilterRequestProcessor > should fail if model tries to call a filtered tool
INFO: [ADK] 2026-04-09T00:06:09.893Z Plugin 'mock_plugin' registered.

stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should register and get a plugin
INFO: [ADK] 2026-04-09T00:06:09.892Z Plugin 'plugin1' registered.

stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should throw an error when registering a duplicate plugin object
INFO: [ADK] 2026-04-09T00:06:09.893Z Plugin 'plugin1' registered.

stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should throw an error when registering a duplicate plugin name
INFO: [ADK] 2026-04-09T00:06:09.894Z Plugin 'plugin1' registered.

 ✓  unit:core  core/test/plugins/base_plugin_test.ts (6 tests) 2ms
stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should stop subsequent plugins if early exit occurs
INFO: [ADK] 2026-04-09T00:06:09.894Z Plugin 'plugin1' registered.
INFO: [ADK] 2026-04-09T00:06:09.894Z Plugin 'plugin2' registered.

stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should call all plugins if no plugin returns a value
INFO: [ADK] 2026-04-09T00:06:09.894Z Plugin 'plugin1' registered.
INFO: [ADK] 2026-04-09T00:06:09.894Z Plugin 'plugin2' registered.

 ✓  unit:core  core/test/agents/processors/tool_filter_request_processor_test.ts (5 tests) 3ms
stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should wrap plugin exception in a runtime error
INFO: [ADK] 2026-04-09T00:06:09.894Z Plugin 'plugin1' registered.

stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should wrap plugin exception in a runtime error
ERROR: [ADK] 2026-04-09T00:06:09.895Z Error in plugin 'plugin1' during 'beforeRunCallback' callback: Error: Something went wrong inside the plugin!

stdout | core/test/plugins/plugin_manager_test.ts > PluginManager > should support all callbacks
INFO: [ADK] 2026-04-09T00:06:09.895Z Plugin 'plugin1' registered.

 ✓  unit:core  core/test/plugins/plugin_manager_test.ts (7 tests) 4ms

 Test Files  4 passed (4)
      Tests  19 passed (19)
   Start at  17:06:07
   Duration  2.31s (transform 259ms, setup 0ms, collect 3.80s, tests 11ms, environment 0ms, prepare 189ms)


##################
# All tests
##################

$ npm run test run
 Test Files  106 passed | 6 skipped (112)
      Tests  1037 passed | 11 skipped (1048)
   Start at  17:09:21
   Duration  41.53s (transform 3.40s, setup 0ms, collect 156.55s, tests 95.08s, environment 14ms, prepare 6.45s)


##################
# E2e tests
##################

$ npm run test run -- tests/e2e/context_compaction/e2e_compaction_test.ts tests/e2e/tools/before_tool_selection_test.ts

> adk@0.6.1 test
> vitest --project unit:core --project unit:dev --project integration --project e2e run tests/e2e/context_compaction/e2e_compaction_test.ts tests/e2e/tools/before_tool_selection_test.ts


 RUN  v3.2.4 /Users/scottmansfield/projects/adk-js

stdout | tests/e2e/tools/before_tool_selection_test.ts
[dotenv@17.3.1] injecting env (1) from tests/e2e/tools/.env -- tip: ⚙️  load multiple .env files with { path: ['.env.local', '.env'] }

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts
[dotenv@17.3.1] injecting env (1) from tests/e2e/context_compaction/.env -- tip: 🔐 encrypt with Dotenvx: https://dotenvx.com

stdout | tests/e2e/tools/before_tool_selection_test.ts > E2E beforeToolSelection > should filter out LOAD_ARTIFACTS tool and fail to answer
INFO: [ADK] 2026-04-09T00:07:22.028Z Plugin 'filter_plugin' registered.

stdout | tests/e2e/tools/before_tool_selection_test.ts > E2E beforeToolSelection > should filter out LOAD_ARTIFACTS tool and fail to answer
INFO: [ADK] 2026-04-09T00:07:22.029Z event: {"invocationId":"e-9709f05d-e555-40f1-a888-8ba869fdcdf6","author":"user","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"content":{"role":"user","parts":[{"text":"What is the age of Alice in people.csv?"}]},"id":"BEItCXhn","longRunningToolIds":[],"timestamp":1775693242029}

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:22.029Z Plugin 'TestCompactionPlugin' registered.

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:22.031Z event: {"invocationId":"e-4046eff8-11a2-4584-950e-7bef28cedcd5","author":"user","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"content":{"role":"user","parts":[{"text":"Tell me a long story about a brave knight named Sir Galahad exploring a dragon-infested cave."}]},"id":"dg6Acaog","longRunningToolIds":[],"timestamp":1775693242031}

stdout | tests/e2e/tools/before_tool_selection_test.ts > E2E beforeToolSelection > should filter out LOAD_ARTIFACTS tool and fail to answer
INFO: [ADK] 2026-04-09T00:07:22.031Z Sending out request, model: gemini-2.5-flash, backend: GEMINI_API, stream: false

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:22.032Z Sending out request, model: gemini-2.5-flash, backend: GEMINI_API, stream: false

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:23.175Z event: {"invocationId":"e-71b6e880-ad95-4ea5-bbf2-5a506a7f88cc","author":"user","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"content":{"role":"user","parts":[{"text":"What happens after he finds the treasure?"}]},"id":"RTj2WFd0","longRunningToolIds":[],"timestamp":1775693243174}
INFO: [ADK] 2026-04-09T00:07:23.176Z event: {"invocationId":"e-4046eff8-11a2-4584-950e-7bef28cedcd5","author":"compaction_agent","id":"nRhyX7Ga","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"longRunningToolIds":[],"timestamp":1775693242031,"content":{"parts":[{"text":"I am sorry, but I am unable to tell long stories; I can only provide short, single-sentence answers."}],"role":"model"},"usageMetadata":{"promptTokenCount":71,"candidatesTokenCount":24,"totalTokenCount":166,"promptTokensDetails":[{"modality":"TEXT","tokenCount":71}],"thoughtsTokenCount":71},"finishReason":"STOP"}

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:23.179Z Sending out request, model: gemini-2.5-flash, backend: GEMINI_API, stream: false

stdout | tests/e2e/tools/before_tool_selection_test.ts > E2E beforeToolSelection > should NOT filter out LOAD_ARTIFACTS tool when plugin returns undefined
INFO: [ADK] 2026-04-09T00:07:23.344Z Plugin 'noop_plugin' registered.

stdout | tests/e2e/tools/before_tool_selection_test.ts > E2E beforeToolSelection > should NOT filter out LOAD_ARTIFACTS tool when plugin returns undefined
INFO: [ADK] 2026-04-09T00:07:23.345Z event: {"invocationId":"e-e9904701-c894-4562-bd47-f05ded7f7945","author":"user","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"content":{"role":"user","parts":[{"text":"What is the age of Alice in people.csv?"}]},"id":"DLLTtrsJ","longRunningToolIds":[],"timestamp":1775693243345}

stdout | tests/e2e/tools/before_tool_selection_test.ts > E2E beforeToolSelection > should NOT filter out LOAD_ARTIFACTS tool when plugin returns undefined
INFO: [ADK] 2026-04-09T00:07:23.346Z Sending out request, model: gemini-2.5-flash, backend: GEMINI_API, stream: false

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:24.226Z event: {"invocationId":"e-78b63188-84f1-48d9-8a2b-ae99b2c858ba","author":"user","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"content":{"role":"user","parts":[{"text":"Can you summarize his entire adventure in 3 sentences?"}]},"id":"0ZdvrTwm","longRunningToolIds":[],"timestamp":1775693244226}
INFO: [ADK] 2026-04-09T00:07:24.226Z event: {"invocationId":"e-71b6e880-ad95-4ea5-bbf2-5a506a7f88cc","author":"compaction_agent","id":"bXtePWOf","actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{},"requestedToolConfirmations":{}},"longRunningToolIds":[],"timestamp":1775693243178,"content":{"parts":[{"text":"I cannot answer that question as I am unable to tell stories."}],"role":"model"},"usageMetadata":{"promptTokenCount":105,"candidatesTokenCount":13,"totalTokenCount":171,"promptTokensDetails":[{"modality":"TEXT","tokenCount":105}],"thoughtsTokenCount":53},"finishReason":"STOP"}

stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:24.228Z Sending out request, model: gemini-2.5-flash, backend: GEMINI_API, stream: false

stdout | tests/e2e/tools/before_tool_selection_test.ts > E2E beforeToolSelection > should NOT filter out LOAD_ARTIFACTS tool when plugin returns undefined
INFO: [ADK] 2026-04-09T00:07:24.373Z Sending out request, model: gemini-2.5-flash, backend: GEMINI_API, stream: false

 ✓  e2e  tests/e2e/tools/before_tool_selection_test.ts (2 tests) 3375ms
   ✓ E2E beforeToolSelection > should filter out LOAD_ARTIFACTS tool and fail to answer  1316ms
   ✓ E2E beforeToolSelection > should NOT filter out LOAD_ARTIFACTS tool when plugin returns undefined  2057ms
stdout | tests/e2e/context_compaction/e2e_compaction_test.ts > E2e Context Compaction > should hit token threshold and compact history using Gemini API
INFO: [ADK] 2026-04-09T00:07:28.200Z Sending out request, model: gemini-2.5-flash, backend: GEMINI_API, stream: false

 ✓  e2e  tests/e2e/context_compaction/e2e_compaction_test.ts (1 test) 7426ms
   ✓ E2e Context Compaction > should hit token threshold and compact history using Gemini API  7424ms

 Test Files  2 passed (2)
      Tests  3 passed (3)
   Start at  17:07:19
   Duration  9.71s (transform 261ms, setup 0ms, collect 2.05s, tests 10.80s, environment 0ms, prepare 97ms)
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.