### PR TITLE
feat: skills: define skills interface (part 1)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -225,6 +225,8 @@ export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 
+export type {Frontmatter, Resources, Script, Skill} from './skills/skill.js';
+
 export * from './artifacts/base_artifact_service.js';
 export * from './memory/base_memory_service.js';
 export * from './sessions/base_session_service.js';

--- a/core/src/skills/prompt.ts
+++ b/core/src/skills/prompt.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Frontmatter, Skill} from './skill.js';
+
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Formats available skills into a standard XML string.
+ *
+ * @param skills A list of skill frontmatter or full skill objects.
+ * @returns XML string with <available_skills> block.
+ */
+export function formatSkillsAsXml(skills: Array<Skill | Frontmatter>): string {
+  if (!skills || skills.length === 0) {
+    return '<available_skills>\n</available_skills>';
+  }
+
+  const lines = ['<available_skills>'];
+
+  for (const item of skills) {
+    const frontmatter =
+      'frontmatter' in item ? (item.frontmatter as Frontmatter) : item;
+
+    lines.push('  <skill>');
+    lines.push(`    <name>${escapeHtml(frontmatter.name)}</name>`);
+    lines.push(
+      `    <description>${escapeHtml(frontmatter.description)}</description>`,
+    );
+    lines.push('  </skill>');
+  }
+
+  lines.push('</available_skills>');
+
+  return lines.join('\n');
+}

--- a/core/src/skills/skill.ts
+++ b/core/src/skills/skill.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {z} from 'zod';
+
+export const SNAKE_OR_KEBAB_NAME_PATTERN =
+  /^([a-z0-9]+(-[a-z0-9]+)*|[a-z0-9]+(_[a-z0-9]+)*)$/;
+
+/**
+ * Schema and Type for Skill Frontmatter metadata.
+ */
+export const FrontmatterSchema = z.preprocess(
+  (data) => {
+    if (typeof data === 'object' && data !== null) {
+      const obj = data as Record<string, unknown>;
+      if ('allowed-tools' in obj && !('allowedTools' in obj)) {
+        return {
+          ...obj,
+          allowedTools: obj['allowed-tools'],
+        };
+      }
+    }
+    return data;
+  },
+  z
+    .object({
+      name: z
+        .string()
+        .regex(SNAKE_OR_KEBAB_NAME_PATTERN, {
+          message:
+            'name must be lowercase kebab-case (a-z, 0-9, hyphens) or snake_case (a-z, 0-9, underscores), with no leading, trailing, or consecutive delimiters. Mixing hyphens and underscores is not allowed.',
+        })
+        .max(64),
+      description: z.string().min(1).max(1024),
+      license: z.string().optional(),
+      compatibility: z.string().max(500).optional(),
+      'allowed-tools': z.string().optional(),
+      metadata: z
+        .record(z.string(), z.any())
+        .default({})
+        .refine(
+          (data) => {
+            if ('adk_additional_tools' in data) {
+              return (
+                Array.isArray(data.adk_additional_tools) &&
+                data.adk_additional_tools.every(
+                  (item) => typeof item === 'string',
+                )
+              );
+            }
+            return true;
+          },
+          {
+            message: 'adk_additional_tools must be a list of strings',
+          },
+        ),
+    })
+    .loose(),
+);
+
+export interface Frontmatter {
+  name: string;
+  description: string;
+  license?: string;
+  compatibility?: string;
+  allowedTools?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Wrapper for script content.
+ */
+export interface Script {
+  src: string;
+}
+
+/**
+ * L3 skill content: additional instructions, assets, and scripts.
+ */
+export interface Resources {
+  references?: Record<string, string | Buffer>;
+  assets?: Record<string, string | Buffer>;
+  scripts?: Record<string, Script>;
+}
+
+/**
+ * Complete skill representation including frontmatter, instructions, and resources.
+ */
+export interface Skill {
+  frontmatter: Frontmatter;
+  instructions: string;
+  resources?: Resources;
+}

--- a/core/test/skills/prompt_test.ts
+++ b/core/test/skills/prompt_test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {formatSkillsAsXml} from '../../src/skills/prompt.js';
+import {Frontmatter, Skill} from '../../src/skills/skill.js';
+
+describe('prompt', () => {
+  describe('formatSkillsAsXml', () => {
+    it('returns empty tags for empty skills list', () => {
+      expect(formatSkillsAsXml([])).toBe(
+        '<available_skills>\n</available_skills>',
+      );
+    });
+
+    it('formats a single skill from frontmatter', () => {
+      const skills: Frontmatter[] = [
+        {name: 'test-skill', description: 'A test skill'},
+      ];
+      const expected = `<available_skills>
+  <skill>
+    <name>test-skill</name>
+    <description>A test skill</description>
+  </skill>
+</available_skills>`;
+      expect(formatSkillsAsXml(skills)).toBe(expected);
+    });
+
+    it('formats multiple skills', () => {
+      const skills: Frontmatter[] = [
+        {name: 'skill-1', description: 'Desc 1'},
+        {name: 'skill-2', description: 'Desc 2'},
+      ];
+      const expected = `<available_skills>
+  <skill>
+    <name>skill-1</name>
+    <description>Desc 1</description>
+  </skill>
+  <skill>
+    <name>skill-2</name>
+    <description>Desc 2</description>
+  </skill>
+</available_skills>`;
+      expect(formatSkillsAsXml(skills)).toBe(expected);
+    });
+
+    it('formats skills passed as Skill objects', () => {
+      const skills = [
+        {
+          frontmatter: {name: 'skill-1', description: 'Desc 1'},
+          instructions: 'Instructions 1',
+          resources: {},
+        } as Skill,
+      ];
+      const expected = `<available_skills>
+  <skill>
+    <name>skill-1</name>
+    <description>Desc 1</description>
+  </skill>
+</available_skills>`;
+      expect(formatSkillsAsXml(skills)).toBe(expected);
+    });
+
+    it('escapes HTML entities in name and description', () => {
+      const skills: Frontmatter[] = [
+        {
+          name: 'dangerous<name>',
+          description: 'dangerous&description"with\'quotes',
+        },
+      ];
+      const expected = `<available_skills>
+  <skill>
+    <name>dangerous&lt;name&gt;</name>
+    <description>dangerous&amp;description&quot;with&#039;quotes</description>
+  </skill>
+</available_skills>`;
+      expect(formatSkillsAsXml(skills)).toBe(expected);
+    });
+  });
+});

--- a/core/test/skills/skill_test.ts
+++ b/core/test/skills/skill_test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {
+  FrontmatterSchema,
+  SNAKE_OR_KEBAB_NAME_PATTERN,
+} from '../../src/skills/skill.js';
+
+describe('skill', () => {
+  describe('SNAKE_OR_KEBAB_NAME_PATTERN', () => {
+    it('matches valid kebab-case names', () => {
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('valid-kebab-name')).toBe(true);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('valid123-name')).toBe(true);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('name')).toBe(true);
+    });
+
+    it('matches valid snake_case names', () => {
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('valid_snake_name')).toBe(true);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('valid123_name')).toBe(true);
+    });
+
+    it('does not match mixed case or invalid characters', () => {
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('Invalid-Name')).toBe(false);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid_Name')).toBe(false);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid.name')).toBe(false);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid name')).toBe(false);
+    });
+
+    it('does not match mixed hyphens and underscores', () => {
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid-snake_name')).toBe(
+        false,
+      );
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid_kebab-name')).toBe(
+        false,
+      );
+    });
+
+    it('does not match consecutive delimiters', () => {
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid--name')).toBe(false);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid__name')).toBe(false);
+    });
+
+    it('does not match leading or trailing delimiters', () => {
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('-invalid-name')).toBe(false);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid-name-')).toBe(false);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('_invalid_name')).toBe(false);
+      expect(SNAKE_OR_KEBAB_NAME_PATTERN.test('invalid_name_')).toBe(false);
+    });
+  });
+
+  describe('FrontmatterSchema', () => {
+    const validFrontmatter = {
+      name: 'valid-skill-name',
+      description: 'A valid description',
+    };
+
+    it('validates valid frontmatter', () => {
+      const result = FrontmatterSchema.safeParse(validFrontmatter);
+      expect(result.success).toBe(true);
+    });
+
+    it('validates frontmatter with optional fields', () => {
+      const result = FrontmatterSchema.safeParse({
+        ...validFrontmatter,
+        license: 'Apache-2.0',
+        compatibility: '>=1.0.0',
+        'allowed-tools': 'tool1,tool2',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('maps allowed-tools to allowedTools', () => {
+      const result = FrontmatterSchema.safeParse({
+        ...validFrontmatter,
+        'allowed-tools': 'tool1,tool2',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.allowedTools).toBe('tool1,tool2');
+      }
+    });
+
+    it('preserves allowedTools if provided directly', () => {
+      const result = FrontmatterSchema.safeParse({
+        ...validFrontmatter,
+        allowedTools: 'tool1,tool2',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.allowedTools).toBe('tool1,tool2');
+      }
+    });
+
+    it('fails on invalid name', () => {
+      const result = FrontmatterSchema.safeParse({
+        ...validFrontmatter,
+        name: 'Invalid Name',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('fails on too long name', () => {
+      const result = FrontmatterSchema.safeParse({
+        ...validFrontmatter,
+        name: 'a'.repeat(65),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('fails on empty description', () => {
+      const result = FrontmatterSchema.safeParse({
+        ...validFrontmatter,
+        description: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('fails on too long description', () => {
+      const result = FrontmatterSchema.safeParse({
+        ...validFrontmatter,
+        description: 'a'.repeat(1025),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    describe('metadata refinement', () => {
+      it('allows metadata without adk_additional_tools', () => {
+        const result = FrontmatterSchema.safeParse({
+          ...validFrontmatter,
+          metadata: {
+            foo: 'bar',
+          },
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('allows metadata with valid adk_additional_tools', () => {
+        const result = FrontmatterSchema.safeParse({
+          ...validFrontmatter,
+          metadata: {
+            adk_additional_tools: ['tool1', 'tool2'],
+          },
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('fails when adk_additional_tools is not an array', () => {
+        const result = FrontmatterSchema.safeParse({
+          ...validFrontmatter,
+          metadata: {
+            adk_additional_tools: 'tool1',
+          },
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('fails when adk_additional_tools contains non-strings', () => {
+        const result = FrontmatterSchema.safeParse({
+          ...validFrontmatter,
+          metadata: {
+            adk_additional_tools: ['tool1', 123],
+          },
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
- Related: https://github.com/google/adk-js/issues/155

**2. Or, if no issue exists, describe the change:**

**Problem:**
The ADK JS implementation lacked support for ["Agent Skills"](https://agentskills.io/home). Skills are structured directories containing instructions, references, assets, and scripts that extend an agent's capabilities for specialized tasks.

**Solution:**
This PR introduces the foundational interfaces and schemas for the Skills feature:
- Defined `Skill`, `Frontmatter`, `Resources`, and `Script` interfaces in `core/src/skills/skill.ts`.
- Implemented `FrontmatterSchema` using Zod to validate skill metadata, supporting both snake_case and kebab-case names, and handling aliases like mapping `allowed-tools` to `allowedTools`.
- Added `formatSkillsAsXml` in `core/src/skills/prompt.ts` to format a list of skills into an XML block for the prompt, ensuring proper HTML escaping.
- Exported the new types in `core/src/common.ts`.

This is part 1 of the skills implementation, focusing on the data structures and prompt generation.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.



### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR lays the groundwork for loading skills from files and attaching them to agents, which will be addressed in subsequent PRs.
