### PR TITLE
fix: use progressive model streaming processing

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -62,6 +62,7 @@
     "express": "^4.22.1",
     "google-auth-library": "^10.3.0",
     "js-yaml": "^4.1.1",
+    "jsonpath-plus": "^10.4.0",
     "lodash-es": "^4.18.1",
     "winston": "^3.19.0",
     "zod": "^4.2.1",

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -235,6 +235,7 @@ export {LoadSkillTool} from './tools/skill/load_skill_tool.js';
 export {SkillToolset} from './tools/skill/skill_toolset.js';
 
 export * from './artifacts/base_artifact_service.js';
+export * from './features/feature_registry.js';
 export * from './memory/base_memory_service.js';
 export * from './sessions/base_session_service.js';
 export * from './tools/base_tool.js';

--- a/core/src/features/feature_registry.ts
+++ b/core/src/features/feature_registry.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {getBooleanEnvVar} from '../utils/env_aware_utils.js';
+import {logger} from '../utils/logger.js';
+
+/**
+ * Feature names.
+ */
+export enum FeatureName {
+  PROGRESSIVE_SSE_STREAMING = 'PROGRESSIVE_SSE_STREAMING',
+}
+
+/**
+ * Feature lifecycle stages.
+ */
+export enum FeatureStage {
+  WIP = 'wip',
+  EXPERIMENTAL = 'experimental',
+  STABLE = 'stable',
+}
+
+/**
+ * Feature configuration.
+ */
+export interface FeatureConfig {
+  stage: FeatureStage;
+  defaultOn: boolean;
+}
+
+// Central registry: FeatureName -> FeatureConfig
+const FEATURE_REGISTRY: Record<FeatureName, FeatureConfig> = {
+  [FeatureName.PROGRESSIVE_SSE_STREAMING]: {
+    stage: FeatureStage.EXPERIMENTAL,
+    defaultOn: false,
+  },
+};
+
+const WARNED_FEATURES = new Set<FeatureName>();
+const FEATURE_OVERRIDES: Partial<Record<FeatureName, boolean>> = {};
+
+/**
+ * Get the configuration of a feature from the registry.
+ *
+ * @param featureName The feature name.
+ * @returns The feature config from the registry, or undefined if not found.
+ */
+export function getFeatureConfig(
+  featureName: FeatureName,
+): FeatureConfig | undefined {
+  return FEATURE_REGISTRY[featureName];
+}
+
+/**
+ * Register a feature with a specific config.
+ *
+ * @param featureName The feature name.
+ * @param config The feature config to register.
+ */
+export function registerFeature(
+  featureName: FeatureName,
+  config: FeatureConfig,
+): void {
+  FEATURE_REGISTRY[featureName] = config;
+}
+
+/**
+ * Programmatically override a feature's enabled state.
+ *
+ * This override takes highest priority, superseding environment variables
+ * and registry defaults.
+ *
+ * @param featureName The feature name to override.
+ * @param enabled Whether the feature should be enabled.
+ */
+export function overrideFeatureEnabled(
+  featureName: FeatureName,
+  enabled: boolean | undefined,
+): void {
+  const config = getFeatureConfig(featureName);
+  if (!config) {
+    throw new Error(`Feature ${featureName} is not registered.`);
+  }
+  if (enabled === undefined) {
+    delete FEATURE_OVERRIDES[featureName];
+  } else {
+    FEATURE_OVERRIDES[featureName] = enabled;
+  }
+}
+
+/**
+ * Check if a feature is enabled at runtime.
+ *
+ * Priority order (highest to lowest):
+ * 1. Programmatic overrides
+ * 2. Environment variables (ADK_ENABLE_* / ADK_DISABLE_*)
+ * 3. Registry defaults
+ *
+ * @param featureName The feature name.
+ * @returns True if the feature is enabled, false otherwise.
+ */
+export function isFeatureEnabled(featureName: FeatureName): boolean {
+  const config = getFeatureConfig(featureName);
+  if (!config) {
+    throw new Error(`Feature ${featureName} is not registered.`);
+  }
+
+  // Check programmatic overrides first
+  if (featureName in FEATURE_OVERRIDES) {
+    const enabled = FEATURE_OVERRIDES[featureName]!;
+    if (enabled && config.stage !== FeatureStage.STABLE) {
+      emitNonStableWarningOnce(featureName, config.stage);
+    }
+    return enabled;
+  }
+
+  // Check environment variables
+  const enableVar = `ADK_ENABLE_${featureName}`;
+  const disableVar = `ADK_DISABLE_${featureName}`;
+
+  if (getBooleanEnvVar(enableVar)) {
+    if (config.stage !== FeatureStage.STABLE) {
+      emitNonStableWarningOnce(featureName, config.stage);
+    }
+    return true;
+  }
+
+  if (getBooleanEnvVar(disableVar)) {
+    return false;
+  }
+
+  // Fall back to registry config
+  if (config.stage !== FeatureStage.STABLE && config.defaultOn) {
+    emitNonStableWarningOnce(featureName, config.stage);
+  }
+  return config.defaultOn;
+}
+
+function emitNonStableWarningOnce(
+  featureName: FeatureName,
+  featureStage: FeatureStage,
+): void {
+  if (!WARNED_FEATURES.has(featureName)) {
+    WARNED_FEATURES.add(featureName);
+    logger.warn(
+      `[${featureStage.toUpperCase()}] feature ${featureName} is enabled.`,
+    );
+  }
+}
+
+/**
+ * Temporarily overrides a feature for the duration of a callback.
+ */
+export async function withTemporaryFeatureOverride<T>(
+  featureName: FeatureName,
+  enabled: boolean,
+  callback: () => Promise<T> | T,
+): Promise<T> {
+  const config = getFeatureConfig(featureName);
+  if (!config) {
+    throw new Error(`Feature ${featureName} is not registered.`);
+  }
+
+  const hadOverride = featureName in FEATURE_OVERRIDES;
+  const originalValue = FEATURE_OVERRIDES[featureName];
+
+  FEATURE_OVERRIDES[featureName] = enabled;
+
+  try {
+    return await callback();
+  } finally {
+    if (hadOverride) {
+      FEATURE_OVERRIDES[featureName] = originalValue;
+    } else {
+      delete FEATURE_OVERRIDES[featureName];
+    }
+  }
+}

--- a/core/src/models/google_llm.ts
+++ b/core/src/models/google_llm.ts
@@ -8,17 +8,15 @@ import {
   Blob,
   createPartFromText,
   FileData,
-  FinishReason,
-  GenerateContentResponse,
   GoogleGenAI,
   HttpOptions,
-  Part,
 } from '@google/genai';
 
 import {getBooleanEnvVar, isBrowser} from '../utils/env_aware_utils.js';
 import {logger} from '../utils/logger.js';
 import {GoogleLLMVariant} from '../utils/variant_utils.js';
 
+import {StreamingResponseAggregator} from '../utils/streaming_utils.js';
 import {BaseLlm} from './base_llm.js';
 import {BaseLlmConnection} from './base_llm_connection.js';
 import {GeminiLlmConnection} from './gemini_llm_connection.js';
@@ -161,89 +159,16 @@ export class Gemini extends BaseLlm {
         contents: llmRequest.contents,
         config: llmRequest.config,
       });
-      let thoughtText = '';
-      let text = '';
-      let firstThoughtSignature: string | undefined;
-      let usageMetadata;
-      let lastResponse: GenerateContentResponse | undefined;
 
-      // TODO - b/425992518: verify the type of streaming response is correct.
+      const aggregator = new StreamingResponseAggregator();
       for await (const response of streamResult) {
-        lastResponse = response;
-        const llmResponse = createLlmResponse(response);
-        usageMetadata = llmResponse.usageMetadata;
-        const firstPart = llmResponse.content?.parts?.[0];
-        // Accumulates the text and thought text from the first part.
-        if (firstPart?.text) {
-          if ('thought' in firstPart && firstPart.thought) {
-            thoughtText += firstPart.text;
-          } else {
-            text += firstPart.text;
-          }
-          llmResponse.partial = true;
-        } else if (
-          (thoughtText || text) &&
-          (!firstPart || !firstPart.inlineData)
-        ) {
-          // Flushes the data if there's no more text.
-          const parts: Part[] = [];
-          if (thoughtText) {
-            parts.push({text: thoughtText, thought: true});
-          }
-          if (text) {
-            parts.push(createPartFromText(text));
-          }
-          yield {
-            content: {
-              role: 'model',
-              parts,
-            },
-            usageMetadata: llmResponse.usageMetadata,
-          };
-          thoughtText = '';
-          text = '';
+        for await (const llmResponse of aggregator.processResponse(response)) {
+          yield llmResponse;
         }
-        // Propagate thoughtSignature to all function call parts in the stream
-        // during this turn. Thinking models only provide thoughtSignature on
-        // the first function call part; subsequent concurrent function calls
-        // in the same turn omit it. The API requires matching signatures on
-        // all function response parts, so we fill them in here.
-        //
-        // https://ai.google.dev/gemini-api/docs/thought-signatures
-        const parts = llmResponse.content?.parts;
-        if (parts) {
-          for (const part of parts) {
-            if (part.functionCall) {
-              if (part.thoughtSignature) {
-                if (!firstThoughtSignature) {
-                  firstThoughtSignature = part.thoughtSignature;
-                }
-              } else if (firstThoughtSignature) {
-                part.thoughtSignature = firstThoughtSignature;
-              }
-            }
-          }
-        }
-        yield llmResponse;
       }
-      if (
-        (text || thoughtText) &&
-        lastResponse?.candidates?.[0]?.finishReason === FinishReason.STOP
-      ) {
-        const parts: Part[] = [];
-        if (thoughtText) {
-          parts.push({text: thoughtText, thought: true} as Part);
-        }
-        if (text) {
-          parts.push({text: text});
-        }
-        yield {
-          content: {
-            role: 'model',
-            parts,
-          },
-          usageMetadata,
-        };
+      const finalResponse = aggregator.close();
+      if (finalResponse) {
+        yield finalResponse;
       }
     } else {
       const response = await this.apiClient.models.generateContent({

--- a/core/src/utils/streaming_utils.ts
+++ b/core/src/utils/streaming_utils.ts
@@ -1,0 +1,403 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CitationMetadata,
+  FinishReason,
+  FunctionCall,
+  GenerateContentResponse,
+  GenerateContentResponseUsageMetadata,
+  GroundingMetadata,
+  Part,
+  PartialArg,
+} from '@google/genai';
+import {JSONPath} from 'jsonpath-plus';
+import {generateClientFunctionCallId} from '../agents/functions.js';
+import {FeatureName, isFeatureEnabled} from '../features/feature_registry.js';
+import {createLlmResponse, LlmResponse} from '../models/llm_response.js';
+
+/**
+ * Aggregates partial streaming responses.
+ *
+ * It aggregates content from partial responses, and generates LlmResponses for
+ * individual (partial) model responses, as well as for aggregated content.
+ */
+export class StreamingResponseAggregator {
+  private usageMetadata?: GenerateContentResponseUsageMetadata;
+  private groundingMetadata?: GroundingMetadata;
+  private citationMetadata?: CitationMetadata;
+  private response?: GenerateContentResponse;
+
+  // For non-progressive SSE streaming mode
+  private text = '';
+  private thoughtText = '';
+
+  // For progressive SSE streaming mode: accumulate parts in order
+  private partsSequence: Part[] = [];
+  private currentTextBuffer = '';
+  private currentTextIsThought?: boolean;
+  private finishReason?: FinishReason;
+
+  // For streaming function call arguments
+  private currentFcName?: string;
+  private currentFcArgs: Record<string, unknown> = {};
+  private currentFcId?: string;
+  private currentThoughtSignature?: string | Uint8Array;
+  private lastThoughtSignature?: string | Uint8Array;
+
+  constructor(
+    private readonly isProgressiveMode: boolean = isFeatureEnabled(
+      FeatureName.PROGRESSIVE_SSE_STREAMING,
+    ),
+  ) {}
+
+  private flushTextBufferToSequence(): void {
+    if (!this.currentTextBuffer) {
+      return;
+    }
+
+    if (this.currentTextIsThought) {
+      this.partsSequence.push({
+        text: this.currentTextBuffer,
+        thought: true,
+      });
+    } else {
+      this.partsSequence.push({
+        text: this.currentTextBuffer,
+      });
+    }
+
+    this.currentTextBuffer = '';
+    this.currentTextIsThought = undefined;
+  }
+
+  private getValueFromPartialArg(
+    partialArg: PartialArg,
+    jsonPath: string,
+  ): [unknown, boolean] {
+    let value: unknown = null;
+    let hasValue = false;
+
+    const stringValue = partialArg.stringValue;
+    const numberValue = partialArg.numberValue;
+    const boolValue = partialArg.boolValue;
+    const nullValue = partialArg.nullValue;
+
+    if (stringValue !== undefined) {
+      const stringChunk = stringValue;
+      hasValue = true;
+
+      const pathParts = JSONPath.toPathArray(jsonPath).filter(
+        (p) => p !== '$' && p !== '$[',
+      );
+
+      let existingValue: unknown = this.currentFcArgs;
+      for (const part of pathParts) {
+        if (
+          existingValue &&
+          typeof existingValue === 'object' &&
+          part in existingValue
+        ) {
+          existingValue = (existingValue as Record<string, unknown>)[part];
+        } else {
+          existingValue = undefined;
+          break;
+        }
+      }
+
+      if (typeof existingValue === 'string') {
+        value = existingValue + stringChunk;
+      } else {
+        value = stringChunk;
+      }
+    } else if (numberValue !== undefined) {
+      value = numberValue;
+      hasValue = true;
+    } else if (boolValue !== undefined) {
+      value = boolValue;
+      hasValue = true;
+    } else if (nullValue !== undefined) {
+      value = null;
+      hasValue = true;
+    }
+
+    return [value, hasValue];
+  }
+
+  private setValueByJsonPath(jsonPath: string, value: unknown): void {
+    const pathParts = JSONPath.toPathArray(jsonPath).filter(
+      (p) => p !== '$' && p !== '$[',
+    );
+
+    let current = this.currentFcArgs;
+    for (let i = 0; i < pathParts.length - 1; i++) {
+      const part = pathParts[i];
+      if (!(part in current)) {
+        current[part] = {};
+      }
+      current = current[part] as Record<string, unknown>;
+    }
+
+    if (pathParts.length > 0) {
+      current[pathParts[pathParts.length - 1]] = value;
+    }
+  }
+
+  private flushFunctionCallToSequence(): void {
+    if (this.currentFcName) {
+      const fcPart: Part = {
+        functionCall: {
+          name: this.currentFcName,
+          args: JSON.parse(JSON.stringify(this.currentFcArgs)),
+          id: this.currentFcId ?? generateClientFunctionCallId(),
+        } as FunctionCall,
+      };
+
+      if (this.currentThoughtSignature) {
+        fcPart.thoughtSignature = this.currentThoughtSignature.toString();
+      }
+
+      this.partsSequence.push(fcPart);
+
+      this.currentFcName = undefined;
+      this.currentFcArgs = {};
+      this.currentFcId = undefined;
+      this.currentThoughtSignature = undefined;
+    }
+  }
+
+  private processStreamingFunctionCall(fc: FunctionCall): void {
+    if (fc.name) {
+      this.currentFcName = fc.name;
+    }
+    if (fc.id) {
+      this.currentFcId = fc.id;
+    }
+
+    for (const partialArg of fc.partialArgs || []) {
+      const jsonPath = partialArg.jsonPath;
+      if (!jsonPath) {
+        continue;
+      }
+
+      const [value, hasValue] = this.getValueFromPartialArg(
+        partialArg,
+        jsonPath,
+      );
+
+      if (hasValue) {
+        this.setValueByJsonPath(jsonPath, value);
+      }
+    }
+
+    if (!fc.willContinue) {
+      this.flushTextBufferToSequence();
+      this.flushFunctionCallToSequence();
+    }
+  }
+
+  private processFunctionCallPart(part: Part): void {
+    const fc = part.functionCall as FunctionCall;
+    if (!fc) {
+      return;
+    }
+
+    if (part.thoughtSignature) {
+      this.lastThoughtSignature = part.thoughtSignature;
+    } else if (this.lastThoughtSignature) {
+      part.thoughtSignature = this.lastThoughtSignature.toString();
+    }
+
+    if (fc.partialArgs || fc.willContinue) {
+      if (!fc.id && !this.currentFcId) {
+        fc.id = generateClientFunctionCallId();
+      }
+
+      if (part.thoughtSignature && !this.currentThoughtSignature) {
+        this.currentThoughtSignature = part.thoughtSignature;
+      }
+      this.processStreamingFunctionCall(fc);
+    } else {
+      if (fc.name) {
+        if (!fc.id) {
+          fc.id = generateClientFunctionCallId();
+        }
+        this.flushTextBufferToSequence();
+        this.partsSequence.push(part);
+      }
+    }
+  }
+
+  async *processResponse(
+    response: GenerateContentResponse,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    this.response = response;
+    const llmResponse = createLlmResponse(response);
+    this.usageMetadata = llmResponse.usageMetadata;
+    if (llmResponse.groundingMetadata) {
+      this.groundingMetadata = llmResponse.groundingMetadata;
+    }
+    if (llmResponse.citationMetadata) {
+      this.citationMetadata = llmResponse.citationMetadata;
+    }
+
+    if (llmResponse.finishReason) {
+      this.finishReason = llmResponse.finishReason;
+    }
+    if (llmResponse.content && llmResponse.content.parts) {
+      for (const part of llmResponse.content.parts) {
+        if (part.thoughtSignature) {
+          this.lastThoughtSignature = part.thoughtSignature;
+        } else if (part.functionCall && this.lastThoughtSignature) {
+          part.thoughtSignature = this.lastThoughtSignature.toString();
+        }
+      }
+    }
+
+    if (this.isProgressiveMode) {
+      if (llmResponse.content && llmResponse.content.parts) {
+        for (const part of llmResponse.content.parts) {
+          if (part.text) {
+            const isThought = part.thought ?? false;
+            if (
+              this.currentTextBuffer &&
+              isThought !== this.currentTextIsThought
+            ) {
+              this.flushTextBufferToSequence();
+            }
+
+            if (!this.currentTextBuffer) {
+              this.currentTextIsThought = isThought;
+            }
+            this.currentTextBuffer += part.text;
+          } else if (part.functionCall) {
+            this.processFunctionCallPart(part);
+          } else {
+            this.flushTextBufferToSequence();
+            this.partsSequence.push(part);
+          }
+        }
+      }
+
+      llmResponse.partial = true;
+      yield llmResponse;
+      return;
+    }
+
+    // Non-progressive SSE streaming
+    if (
+      llmResponse.content &&
+      llmResponse.content.parts &&
+      typeof llmResponse.content.parts[0]?.text === 'string'
+    ) {
+      const part0 = llmResponse.content.parts[0];
+      const partText = part0.text || '';
+      if (part0.thought) {
+        this.thoughtText += partText;
+      } else {
+        this.text += partText;
+      }
+      llmResponse.partial = true;
+    } else if (
+      (this.thoughtText || this.text) &&
+      (!llmResponse.content ||
+        !llmResponse.content.parts ||
+        !llmResponse.content.parts[0]?.inlineData)
+    ) {
+      const parts: Part[] = [];
+      if (this.thoughtText) {
+        parts.push({text: this.thoughtText, thought: true});
+      }
+      if (this.text) {
+        parts.push({text: this.text});
+      }
+      yield {
+        content: {
+          role: 'model',
+          parts: parts,
+        },
+        usageMetadata: llmResponse.usageMetadata,
+        partial: false,
+      };
+      this.thoughtText = '';
+      this.text = '';
+    }
+    yield llmResponse;
+  }
+
+  close(): LlmResponse | undefined {
+    if (!this.response?.candidates || this.response.candidates.length === 0) {
+      return;
+    }
+
+    if (this.isProgressiveMode) {
+      this.flushTextBufferToSequence();
+      this.flushFunctionCallToSequence();
+
+      const finalParts = this.partsSequence;
+      if (finalParts.length === 0) {
+        return;
+      }
+
+      const candidate = this.response.candidates[0];
+      const finishReason = this.finishReason ?? candidate.finishReason;
+
+      return {
+        content: {
+          role: 'model',
+          parts: finalParts,
+        },
+        groundingMetadata: this.groundingMetadata,
+        citationMetadata: this.citationMetadata,
+        errorCode:
+          finishReason === FinishReason.STOP ? undefined : finishReason,
+        errorMessage:
+          finishReason === FinishReason.STOP
+            ? undefined
+            : candidate.finishMessage,
+        usageMetadata: this.usageMetadata,
+        finishReason: finishReason,
+        partial: false,
+      };
+    }
+
+    // Non-progressive SSE streaming
+    if (
+      (this.text || this.thoughtText) &&
+      this.response.candidates &&
+      this.response.candidates.length > 0
+    ) {
+      const parts: Part[] = [];
+      if (this.thoughtText) {
+        parts.push({text: this.thoughtText, thought: true});
+      }
+      if (this.text) {
+        parts.push({text: this.text});
+      }
+      const candidate = this.response.candidates[0];
+      const finishReason = candidate.finishReason;
+      return {
+        content: {
+          role: 'model',
+          parts: parts,
+        },
+        groundingMetadata: this.groundingMetadata,
+        citationMetadata: this.citationMetadata,
+        errorCode:
+          finishReason === FinishReason.STOP ? undefined : finishReason,
+        errorMessage:
+          finishReason === FinishReason.STOP
+            ? undefined
+            : candidate.finishMessage,
+        usageMetadata: this.usageMetadata,
+        finishReason: finishReason,
+        partial: false,
+      };
+    }
+
+    return undefined;
+  }
+}

--- a/core/test/features/feature_registry_test.ts
+++ b/core/test/features/feature_registry_test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  FeatureName,
+  FeatureStage,
+  getFeatureConfig,
+  isFeatureEnabled,
+  overrideFeatureEnabled,
+  registerFeature,
+  withTemporaryFeatureOverride,
+} from '@google/adk';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+describe('FeatureRegistry', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = {...originalEnv};
+    // Reset overrides
+    // We can't easily reset the internal modules without exposing a reset function,
+    // but we can override back to undefined or known state using overrideFeatureEnabled
+    // Actually withTemporaryFeatureOverride does clean up.
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should get correct config for PROGRESSIVE_SSE_STREAMING', () => {
+    const config = getFeatureConfig(FeatureName.PROGRESSIVE_SSE_STREAMING);
+    expect(config).toBeDefined();
+    expect(config?.stage).toBe(FeatureStage.EXPERIMENTAL);
+    expect(config?.defaultOn).toBe(false);
+  });
+
+  it('should return defaultOn value when no overrides or env vars', () => {
+    delete process.env.ADK_ENABLE_PROGRESSIVE_SSE_STREAMING;
+    delete process.env.ADK_DISABLE_PROGRESSIVE_SSE_STREAMING;
+
+    expect(isFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING)).toBe(false);
+  });
+
+  it('should respect ADK_DISABLE_ env var', () => {
+    process.env.ADK_DISABLE_PROGRESSIVE_SSE_STREAMING = 'true';
+
+    expect(isFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING)).toBe(false);
+  });
+
+  it('should respect ADK_ENABLE_ env var', () => {
+    // Register a dummy feature that is default off
+    const dummyName = 'DUMMY_FEATURE' as FeatureName;
+    registerFeature(dummyName, {
+      stage: FeatureStage.EXPERIMENTAL,
+      defaultOn: false,
+    });
+
+    process.env.ADK_ENABLE_DUMMY_FEATURE = 'true';
+
+    expect(isFeatureEnabled(dummyName)).toBe(true);
+  });
+
+  it('should respect programmatic overrides over env vars', () => {
+    process.env.ADK_DISABLE_PROGRESSIVE_SSE_STREAMING = 'true';
+    overrideFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING, true);
+
+    expect(isFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING)).toBe(true);
+
+    // Clean up override
+    overrideFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING, undefined);
+  });
+
+  it('should throw error when checking unregistered feature', () => {
+    expect(() => isFeatureEnabled('NON_EXISTENT' as FeatureName)).toThrowError(
+      /is not registered/,
+    );
+  });
+
+  it('should support temporary overrides', async () => {
+    // default is false
+    expect(isFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING)).toBe(false);
+
+    await withTemporaryFeatureOverride(
+      FeatureName.PROGRESSIVE_SSE_STREAMING,
+      true,
+      () => {
+        expect(isFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING)).toBe(
+          true,
+        );
+      },
+    );
+
+    // restored
+    expect(isFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING)).toBe(false);
+  });
+
+  it('should support temporary overrides with promises', async () => {
+    await withTemporaryFeatureOverride(
+      FeatureName.PROGRESSIVE_SSE_STREAMING,
+      true,
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(isFeatureEnabled(FeatureName.PROGRESSIVE_SSE_STREAMING)).toBe(
+          true,
+        );
+      },
+    );
+  });
+});

--- a/core/test/models/google_llm_test.ts
+++ b/core/test/models/google_llm_test.ts
@@ -4,10 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Gemini, GeminiParams, geminiInitParams, version} from '@google/adk';
+import {
+  Gemini,
+  GeminiParams,
+  LlmRequest,
+  geminiInitParams,
+  version,
+} from '@google/adk';
 import {GenerateContentResponse, GoogleGenAI, HttpOptions} from '@google/genai';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {LlmRequest} from '../../src/models/llm_request.js';
 
 vi.mock('@google/genai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@google/genai')>();

--- a/core/test/utils/streaming_utils_test.ts
+++ b/core/test/utils/streaming_utils_test.ts
@@ -1,0 +1,497 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Candidate,
+  FinishReason,
+  FunctionCall,
+  GenerateContentResponse,
+  Part,
+} from '@google/genai';
+import {describe, expect, it, vi} from 'vitest';
+import {StreamingResponseAggregator} from '../../src/utils/streaming_utils.js';
+
+// Mock generateClientFunctionCallId to return a fixed ID for testing
+vi.mock('../../src/agents/functions.js', async () => {
+  const actual = (await vi.importActual(
+    '../../src/agents/functions.js',
+  )) as typeof import('../../src/agents/functions.js');
+  return {
+    ...actual,
+    generateClientFunctionCallId: () => 'mocked-fc-id',
+  };
+});
+
+function createResponse(candidate: Candidate): GenerateContentResponse {
+  const response = new GenerateContentResponse();
+  response.candidates = [candidate];
+
+  return response;
+}
+
+describe('StreamingResponseAggregator', () => {
+  describe('Progressive Mode', () => {
+    it('should aggregate text chunks', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Hello '}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {parts: [{text: 'World!'}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const results = [];
+      for await (const res of aggregator.processResponse(response1)) {
+        results.push(res);
+      }
+      for await (const res of aggregator.processResponse(response2)) {
+        results.push(res);
+      }
+
+      expect(results.length).toBe(2);
+      expect(results[0].partial).toBe(true);
+      expect(results[1].partial).toBe(true);
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.content?.parts).toEqual([{text: 'Hello World!'}]);
+      expect(finalResponse?.partial).toBe(false);
+    });
+
+    it('should aggregate thought chunks', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Thinking ', thought: true} as Part]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {parts: [{text: 'hard...', thought: true} as Part]},
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response1)) {
+        // Consume the stream to test it
+      }
+
+      for await (const _ of aggregator.processResponse(response2)) {
+        // Consume the stream to test it
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.content?.parts).toEqual([
+        {text: 'Thinking hard...', thought: true},
+      ]);
+    });
+
+    it('should preserve order of mixed text and thought chunks', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Thinking...', thought: true} as Part]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {parts: [{text: 'Final Answer'}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response1)) {
+        // Consume the stream to test it
+      }
+      for await (const _ of aggregator.processResponse(response2)) {
+        // Consume the stream to test it
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.content?.parts).toEqual([
+        {text: 'Thinking...', thought: true},
+        {text: 'Final Answer'},
+      ]);
+    });
+
+    it('should aggregate streaming function calls', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      const response1 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                partialArgs: [
+                  {jsonPath: '$.location', stringValue: 'San Fran'},
+                ],
+                willContinue: true,
+              } as unknown as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                partialArgs: [{jsonPath: '$.location', stringValue: 'cisco'}],
+                willContinue: false,
+              } as unknown as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response1)) {
+        // Consume the stream to test it
+      }
+      for await (const _ of aggregator.processResponse(response2)) {
+        // Consume the stream to test it
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.content?.parts).toEqual([
+        {
+          functionCall: {
+            name: 'get_weather',
+            args: {location: 'San Francisco'},
+            id: 'mocked-fc-id',
+          },
+        },
+      ]);
+    });
+
+    it('should handle non-streaming function calls', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      const response = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                args: {location: 'New York'},
+              },
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response)) {
+        // Consume the stream to test it
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.content?.parts).toEqual([
+        {
+          functionCall: {
+            name: 'get_weather',
+            args: {location: 'New York'},
+            id: 'mocked-fc-id',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('Non-Progressive Mode', () => {
+    it('should aggregate text chunks in close', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Hello '}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {parts: [{text: 'World!'}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response1)) {
+        // Consume the stream to test it
+      }
+      for await (const _ of aggregator.processResponse(response2)) {
+        // Consume the stream to test it
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.content?.parts).toEqual([{text: 'Hello World!'}]);
+    });
+
+    it('should separate thought and text chunks in close', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Thinking...', thought: true} as Part]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {parts: [{text: 'Final Answer'}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response1)) {
+        // Consume the stream to test it
+      }
+      for await (const _ of aggregator.processResponse(response2)) {
+        // Consume the stream to test it
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.content?.parts).toEqual([
+        {text: 'Thinking...', thought: true},
+        {text: 'Final Answer'},
+      ]);
+    });
+
+    it('should yield partial text chunks as they arrive', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Hello '}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const results = [];
+      for await (const res of aggregator.processResponse(response1)) {
+        results.push(res);
+      }
+
+      expect(results.length).toBe(1);
+      expect(results[0].partial).toBe(true);
+      expect(results[0].content?.parts).toEqual([{text: 'Hello '}]);
+    });
+
+    it('should yield partial thought chunks as they arrive', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Thinking...', thought: true} as Part]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const results = [];
+      for await (const res of aggregator.processResponse(response1)) {
+        results.push(res);
+      }
+
+      expect(results.length).toBe(1);
+      expect(results[0].partial).toBe(true);
+      expect(results[0].content?.parts).toEqual([
+        {text: 'Thinking...', thought: true},
+      ]);
+    });
+
+    it('should handle non-text chunks and flush accumulated text', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      const response1 = createResponse({
+        content: {parts: [{text: 'Some text '}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                args: {location: 'San Francisco'},
+              },
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      const results = [];
+      for await (const res of aggregator.processResponse(response1)) {
+        results.push(res);
+      }
+      for await (const res of aggregator.processResponse(response2)) {
+        results.push(res);
+      }
+
+      expect(results.length).toBe(3);
+      expect(results[0].partial).toBe(true);
+      expect(results[0].content?.parts).toEqual([{text: 'Some text '}]);
+
+      expect(results[1].partial).toBe(false);
+      expect(results[1].content?.parts).toEqual([{text: 'Some text '}]);
+
+      expect(results[2].content?.parts).toEqual([
+        {
+          functionCall: {
+            name: 'get_weather',
+            args: {location: 'San Francisco'},
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('JSONPath Plus Integration', () => {
+    it('should support bracket notation in paths', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+      const response = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'complex_func',
+                partialArgs: [
+                  {jsonPath: "$['user']['name']", stringValue: 'Alice'},
+                ],
+                willContinue: false,
+              } as unknown as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response)) {
+        // just consume iterator
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse?.content?.parts).toEqual([
+        {
+          functionCall: {
+            name: 'complex_func',
+            args: {user: {name: 'Alice'}},
+            id: 'mocked-fc-id',
+          },
+        },
+      ]);
+    });
+
+    it('should handle deeply nested structures and mixed notation', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+      const response = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'nested_func',
+                partialArgs: [
+                  {jsonPath: "$.config['db'].port", numberValue: 5432},
+                  {jsonPath: '$.config.db.host', stringValue: 'localhost'},
+                  {jsonPath: "$.options['enableRetry']", boolValue: true},
+                  {jsonPath: '$.cache', nullValue: true},
+                ],
+                willContinue: false,
+              } as unknown as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response)) {
+        // just consume iterator
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse?.content?.parts).toEqual([
+        {
+          functionCall: {
+            name: 'nested_func',
+            args: {
+              config: {
+                db: {
+                  port: 5432,
+                  host: 'localhost',
+                },
+              },
+              options: {
+                enableRetry: true,
+              },
+              cache: null,
+            },
+            id: 'mocked-fc-id',
+          },
+        },
+      ]);
+    });
+
+    it('should accumulate string chunks across multiple partial updates at the same path', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      const response1 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'concat_func',
+                partialArgs: [
+                  {jsonPath: '$.message.text', stringValue: 'Hello '},
+                ],
+                willContinue: true,
+              } as unknown as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      const response2 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                partialArgs: [
+                  {jsonPath: '$.message.text', stringValue: 'World!'},
+                ],
+                willContinue: false,
+              } as unknown as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response1)) {
+        // just consume iterator
+      }
+      for await (const _ of aggregator.processResponse(response2)) {
+        // just consume iterator
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse?.content?.parts).toEqual([
+        {
+          functionCall: {
+            name: 'concat_func',
+            args: {
+              message: {
+                text: 'Hello World!',
+              },
+            },
+            id: 'mocked-fc-id',
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "express": "^4.22.1",
         "google-auth-library": "^10.3.0",
         "js-yaml": "^4.1.1",
+        "jsonpath-plus": "^10.4.0",
         "lodash-es": "^4.18.1",
         "winston": "^3.19.0",
         "zod": "^4.2.1",
@@ -1874,6 +1875,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@mikro-orm/core": {
@@ -9423,6 +9448,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -9489,6 +9523,24 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonwebtoken": {

--- a/tests/integration/state_dump_utils.ts
+++ b/tests/integration/state_dump_utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Event, LlmResponse} from '@google/adk';
+import type {Event, LlmResponse, RunConfig} from '@google/adk';
 import {
   BaseAgent,
   BasePlugin,
@@ -24,6 +24,7 @@ import * as path from 'node:path';
 export async function createRunner(
   agent: BaseAgent,
   plugins: BasePlugin[] = [],
+  runConfig?: RunConfig,
 ) {
   const userId = 'test_user';
   const appName = agent.name;
@@ -39,6 +40,7 @@ export async function createRunner(
         userId,
         sessionId: session.id,
         newMessage: createUserContent(prompt),
+        runConfig,
       });
     },
   };
@@ -113,9 +115,11 @@ export async function runAndCapture(
   agent: LlmAgent,
   prompts: string | string[],
   {
+    runConfig,
     events,
     modelResponses,
   }: {
+    runConfig?: RunConfig;
     events?: string | boolean;
     modelResponses?: string | boolean;
   },
@@ -127,7 +131,7 @@ export async function runAndCapture(
   if (modelResponses) {
     plugins.push(new ModelEventCapturePlugin('model_responses'));
   }
-  const runner = await createRunner(agent, plugins);
+  const runner = await createRunner(agent, plugins, runConfig);
 
   prompts = Array.isArray(prompts) ? prompts : [prompts];
 

--- a/tests/integration/streaming/agent.ts
+++ b/tests/integration/streaming/agent.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionTool, LlmAgent} from '@google/adk';
+import {ThinkingLevel} from '@google/genai';
+import {z} from 'zod';
+
+const currentTimeTool = new FunctionTool({
+  name: 'get_current_time',
+  description: 'Get the current date and time',
+  parameters: z.object({}),
+  execute: () => '2026-04-10T21:13:34.609Z',
+});
+
+export const rootAgent = new LlmAgent({
+  name: 'streaming_repro_agent',
+  model: 'gemini-3-flash-preview',
+  generateContentConfig: {
+    thinkingConfig: {
+      thinkingLevel: ThinkingLevel.HIGH,
+      includeThoughts: true,
+    },
+  },
+  instruction: 'You MUST use the get_current_time tool to answer.',
+  tools: [currentTimeTool],
+});

--- a/tests/integration/streaming/agent_test.ts
+++ b/tests/integration/streaming/agent_test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '@google/adk';
+import {describe, it} from 'vitest';
+import {RawGenerateContentResponse, runTestCase} from '../test_case_utils.js';
+import {rootAgent} from './agent.js';
+import turn1ExpectedEvents from './events_turn_1.json' with {type: 'json'};
+import modelResponses from './model_responses.json' with {type: 'json'};
+
+const testCase = {
+  agent: rootAgent,
+  turns: [
+    {
+      userPrompt: 'What time is it?',
+      expectedEvents: turn1ExpectedEvents as Event[],
+    },
+  ],
+  modelResponses: modelResponses as RawGenerateContentResponse[],
+};
+
+describe('Progressive Gemini Model response streaming', () => {
+  it('should process model response and produce events', async () => {
+    await runTestCase(testCase);
+  });
+});

--- a/tests/integration/streaming/events_turn_1.json
+++ b/tests/integration/streaming/events_turn_1.json
@@ -1,0 +1,314 @@
+[
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "id": "mW8f454h",
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "longRunningToolIds": [],
+    "timestamp": 1775855613364,
+    "content": {
+      "parts": [
+        {
+          "functionCall": {
+            "name": "get_current_time",
+            "args": {},
+            "id": "6e3po27k"
+          },
+          "thoughtSignature": "EsACCr0CAb4+9vtQQt/iesf6HKshVBd1IP4ZumKAx5pal2rDJvFa5G8OqhI20MWzgrkrwq8oLM0qKXpsmSCNfYQ6mXjrLkB4hnK5/Dx+Svgj7/iw/7AF6LnbRaTVPCvLth+3cwF1p/8F7mEGqhrOXOlHHgGF2F8DJuLtzti49bq//54gcR49MGHC0EhxWcph342bGcFq2CWtWoA1PzZt9hOaqeJtCG9UdbZZPzG/2yqnQREXgSuQnUtAPa5m6piRUL130N4Od2e1nDZORa0aH7xmflUfyICo+dvtzeZ259+q4MlDUeQuuMq3tav+4BArfx43jEWvjGISAcXAtl+HtA9+A3AmEQ1v6CSpasf8iPD8e/LW00Aun1UqrkV9i46ZaG5G5rCrUqaLnN3ztfLeCCsPMrRn2kDEFqSCuME1ftg4+gc="
+        }
+      ],
+      "role": "model"
+    },
+    "usageMetadata": {
+      "promptTokenCount": 67,
+      "candidatesTokenCount": 12,
+      "totalTokenCount": 133,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 67
+        }
+      ],
+      "thoughtsTokenCount": 54
+    }
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "content": {
+      "role": "user",
+      "parts": [
+        {
+          "functionResponse": {
+            "id": "6e3po27k",
+            "name": "get_current_time",
+            "response": {
+              "result": "2026-04-10T21:13:34.609Z"
+            }
+          }
+        }
+      ]
+    },
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "id": "ivDihJ23",
+    "longRunningToolIds": [],
+    "timestamp": 1775855614609
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "id": "db9NVV32",
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "longRunningToolIds": [],
+    "timestamp": 1775855614609,
+    "content": {
+      "parts": [
+        {
+          "text": ""
+        }
+      ],
+      "role": "model"
+    },
+    "usageMetadata": {
+      "promptTokenCount": 67,
+      "candidatesTokenCount": 12,
+      "totalTokenCount": 133,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 67
+        }
+      ],
+      "thoughtsTokenCount": 54
+    },
+    "finishReason": "STOP"
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "id": "1Jpy8oEJ",
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "longRunningToolIds": [],
+    "timestamp": 1775855615168,
+    "content": {
+      "role": "model",
+      "parts": [
+        {
+          "functionCall": {
+            "name": "get_current_time",
+            "args": {},
+            "id": "6e3po27k"
+          },
+          "thoughtSignature": "EsACCr0CAb4+9vtQQt/iesf6HKshVBd1IP4ZumKAx5pal2rDJvFa5G8OqhI20MWzgrkrwq8oLM0qKXpsmSCNfYQ6mXjrLkB4hnK5/Dx+Svgj7/iw/7AF6LnbRaTVPCvLth+3cwF1p/8F7mEGqhrOXOlHHgGF2F8DJuLtzti49bq//54gcR49MGHC0EhxWcph342bGcFq2CWtWoA1PzZt9hOaqeJtCG9UdbZZPzG/2yqnQREXgSuQnUtAPa5m6piRUL130N4Od2e1nDZORa0aH7xmflUfyICo+dvtzeZ259+q4MlDUeQuuMq3tav+4BArfx43jEWvjGISAcXAtl+HtA9+A3AmEQ1v6CSpasf8iPD8e/LW00Aun1UqrkV9i46ZaG5G5rCrUqaLnN3ztfLeCCsPMrRn2kDEFqSCuME1ftg4+gc="
+        },
+        {
+          "text": ""
+        }
+      ]
+    },
+    "usageMetadata": {
+      "promptTokenCount": 67,
+      "candidatesTokenCount": 12,
+      "totalTokenCount": 133,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 67
+        }
+      ],
+      "thoughtsTokenCount": 54
+    },
+    "finishReason": "STOP",
+    "partial": false
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "content": {
+      "role": "user",
+      "parts": [
+        {
+          "functionResponse": {
+            "id": "6e3po27k",
+            "name": "get_current_time",
+            "response": {
+              "result": "2026-04-10T21:13:35.172Z"
+            }
+          }
+        }
+      ]
+    },
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "id": "IAFGZ4FK",
+    "longRunningToolIds": [],
+    "timestamp": 1775855615172
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "id": "RUtyLfs3",
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "longRunningToolIds": [],
+    "timestamp": 1775855615173,
+    "content": {
+      "parts": [
+        {
+          "text": "The"
+        }
+      ],
+      "role": "model"
+    },
+    "usageMetadata": {
+      "promptTokenCount": 118,
+      "candidatesTokenCount": 1,
+      "totalTokenCount": 160,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 118
+        }
+      ],
+      "thoughtsTokenCount": 41
+    },
+    "partial": true
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "id": "P5DLFyF1",
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "longRunningToolIds": [],
+    "timestamp": 1775855616126,
+    "content": {
+      "parts": [
+        {
+          "text": " current time is 9:13 PM on April 10, 2026."
+        }
+      ],
+      "role": "model"
+    },
+    "usageMetadata": {
+      "promptTokenCount": 118,
+      "candidatesTokenCount": 22,
+      "totalTokenCount": 181,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 118
+        }
+      ],
+      "thoughtsTokenCount": 41
+    },
+    "partial": true
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "id": "Er0skRvM",
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "longRunningToolIds": [],
+    "timestamp": 1775855616190,
+    "content": {
+      "parts": [
+        {
+          "text": "",
+          "thoughtSignature": "EqgBCqUBAb4+9vvoVMEQ9SY/VHX0F2xXYyx5kqPjgW7HxsgEqgCjvj2x7eTBLvwZUk5/1obe42plfWKF1Hp5EZpbLbsn1ergWE3a+swaIqRnc9O/B0B3ABPEGooOtygf10lQAllEBpBpz3zs5Z7eHhQ+JcUcphWZqUWQxag1U+5r1o+CPjVrrVPZrt/NBtMWncyZeUP3TnKnzz+D7UXwVO2E0Gnh9m2hN5iA"
+        }
+      ],
+      "role": "model"
+    },
+    "usageMetadata": {
+      "promptTokenCount": 171,
+      "candidatesTokenCount": 22,
+      "totalTokenCount": 234,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 171
+        }
+      ],
+      "thoughtsTokenCount": 41
+    },
+    "finishReason": "STOP",
+    "partial": true
+  },
+  {
+    "invocationId": "e-b3db90ec-d585-422d-8b80-8fa4bf1a8018",
+    "author": "streaming_repro_agent",
+    "id": "sYgxREBF",
+    "actions": {
+      "stateDelta": {},
+      "artifactDelta": {},
+      "requestedAuthConfigs": {},
+      "requestedToolConfirmations": {}
+    },
+    "longRunningToolIds": [],
+    "timestamp": 1775855616677,
+    "content": {
+      "role": "model",
+      "parts": [
+        {
+          "text": "The current time is 9:13 PM on April 10, 2026."
+        },
+        {
+          "text": "",
+          "thoughtSignature": "EqgBCqUBAb4+9vvoVMEQ9SY/VHX0F2xXYyx5kqPjgW7HxsgEqgCjvj2x7eTBLvwZUk5/1obe42plfWKF1Hp5EZpbLbsn1ergWE3a+swaIqRnc9O/B0B3ABPEGooOtygf10lQAllEBpBpz3zs5Z7eHhQ+JcUcphWZqUWQxag1U+5r1o+CPjVrrVPZrt/NBtMWncyZeUP3TnKnzz+D7UXwVO2E0Gnh9m2hN5iA"
+        }
+      ]
+    },
+    "usageMetadata": {
+      "promptTokenCount": 171,
+      "candidatesTokenCount": 22,
+      "totalTokenCount": 234,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 171
+        }
+      ],
+      "thoughtsTokenCount": 41
+    },
+    "finishReason": "STOP",
+    "partial": false
+  }
+]

--- a/tests/integration/streaming/model_responses.json
+++ b/tests/integration/streaming/model_responses.json
@@ -1,0 +1,206 @@
+[
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "functionCall": {
+                "name": "get_current_time",
+                "args": {},
+                "id": "6e3po27k"
+              },
+              "thoughtSignature": "EsACCr0CAb4+9vtQQt/iesf6HKshVBd1IP4ZumKAx5pal2rDJvFa5G8OqhI20MWzgrkrwq8oLM0qKXpsmSCNfYQ6mXjrLkB4hnK5/Dx+Svgj7/iw/7AF6LnbRaTVPCvLth+3cwF1p/8F7mEGqhrOXOlHHgGF2F8DJuLtzti49bq//54gcR49MGHC0EhxWcph342bGcFq2CWtWoA1PzZt9hOaqeJtCG9UdbZZPzG/2yqnQREXgSuQnUtAPa5m6piRUL130N4Od2e1nDZORa0aH7xmflUfyICo+dvtzeZ259+q4MlDUeQuuMq3tav+4BArfx43jEWvjGISAcXAtl+HtA9+A3AmEQ1v6CSpasf8iPD8e/LW00Aun1UqrkV9i46ZaG5G5rCrUqaLnN3ztfLeCCsPMrRn2kDEFqSCuME1ftg4+gc="
+            }
+          ],
+          "role": "model"
+        }
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 67,
+      "candidatesTokenCount": 12,
+      "totalTokenCount": 133,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 67
+        }
+      ],
+      "thoughtsTokenCount": 54
+    }
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": ""
+            }
+          ],
+          "role": "model"
+        },
+        "finishReason": "STOP"
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 67,
+      "candidatesTokenCount": 12,
+      "totalTokenCount": 133,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 67
+        }
+      ],
+      "thoughtsTokenCount": 54
+    }
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "functionCall": {
+                "name": "get_current_time",
+                "args": {},
+                "id": "6e3po27k"
+              },
+              "thoughtSignature": "EsACCr0CAb4+9vtQQt/iesf6HKshVBd1IP4ZumKAx5pal2rDJvFa5G8OqhI20MWzgrkrwq8oLM0qKXpsmSCNfYQ6mXjrLkB4hnK5/Dx+Svgj7/iw/7AF6LnbRaTVPCvLth+3cwF1p/8F7mEGqhrOXOlHHgGF2F8DJuLtzti49bq//54gcR49MGHC0EhxWcph342bGcFq2CWtWoA1PzZt9hOaqeJtCG9UdbZZPzG/2yqnQREXgSuQnUtAPa5m6piRUL130N4Od2e1nDZORa0aH7xmflUfyICo+dvtzeZ259+q4MlDUeQuuMq3tav+4BArfx43jEWvjGISAcXAtl+HtA9+A3AmEQ1v6CSpasf8iPD8e/LW00Aun1UqrkV9i46ZaG5G5rCrUqaLnN3ztfLeCCsPMrRn2kDEFqSCuME1ftg4+gc="
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "finishReason": "STOP"
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 67,
+      "candidatesTokenCount": 12,
+      "totalTokenCount": 133,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 67
+        }
+      ],
+      "thoughtsTokenCount": 54
+    }
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "The"
+            }
+          ],
+          "role": "model"
+        }
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 118,
+      "candidatesTokenCount": 1,
+      "totalTokenCount": 160,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 118
+        }
+      ],
+      "thoughtsTokenCount": 41
+    }
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": " current time is 9:13 PM on April 10, 2026."
+            }
+          ],
+          "role": "model"
+        }
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 118,
+      "candidatesTokenCount": 22,
+      "totalTokenCount": 181,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 118
+        }
+      ],
+      "thoughtsTokenCount": 41
+    }
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "",
+              "thoughtSignature": "EqgBCqUBAb4+9vvoVMEQ9SY/VHX0F2xXYyx5kqPjgW7HxsgEqgCjvj2x7eTBLvwZUk5/1obe42plfWKF1Hp5EZpbLbsn1ergWE3a+swaIqRnc9O/B0B3ABPEGooOtygf10lQAllEBpBpz3zs5Z7eHhQ+JcUcphWZqUWQxag1U+5r1o+CPjVrrVPZrt/NBtMWncyZeUP3TnKnzz+D7UXwVO2E0Gnh9m2hN5iA"
+            }
+          ],
+          "role": "model"
+        },
+        "finishReason": "STOP"
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 171,
+      "candidatesTokenCount": 22,
+      "totalTokenCount": 234,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 171
+        }
+      ],
+      "thoughtsTokenCount": 41
+    }
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "The current time is 9:13 PM on April 10, 2026."
+            },
+            {
+              "text": "",
+              "thoughtSignature": "EqgBCqUBAb4+9vvoVMEQ9SY/VHX0F2xXYyx5kqPjgW7HxsgEqgCjvj2x7eTBLvwZUk5/1obe42plfWKF1Hp5EZpbLbsn1ergWE3a+swaIqRnc9O/B0B3ABPEGooOtygf10lQAllEBpBpz3zs5Z7eHhQ+JcUcphWZqUWQxag1U+5r1o+CPjVrrVPZrt/NBtMWncyZeUP3TnKnzz+D7UXwVO2E0Gnh9m2hN5iA"
+            }
+          ]
+        },
+        "finishReason": "STOP"
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 171,
+      "candidatesTokenCount": 22,
+      "totalTokenCount": 234,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 171
+        }
+      ],
+      "thoughtsTokenCount": 41
+    }
+  }
+]


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: 
  - https://github.com/google/adk-js/issues/48
  - https://github.com/google/adk-js/issues/149
  - https://github.com/google/adk-js/issues/261
- Related: 
  - https://github.com/google/adk-js/pull/49

**Problem:**
The previous implementation of streaming response processing in `google_llm.ts` was complex and handled inline. It did not robustly handle all edge cases of progressive streaming, such as reconstructing streaming function calls with `partialArgs` or properly ordering, mixed text and thought parts.

**Solution:**
1. **Feature Registry Implementation (`core/src/features/feature_registry.ts`)**: 
   - Introduced a centralized `FEATURE_REGISTRY` modeled after the Python ADK to safely manage feature toggles (`PROGRESSIVE_SSE_STREAMING`). 
  - Added support for feature activation via programmatic overrides, environment variables (`ADK_ENABLE_<FEATURE>`, `ADK_DISABLE_<FEATURE>`), and configured defaults across different developmental stages (`WIP`, `EXPERIMENTAL`, `STABLE`).
  
2. Moved the streaming response aggregation logic out of `google_llm.ts` into a new dedicated `StreamingResponseAggregator` class in `core/src/utils/streaming_utils.ts`. This class handles:
- Accumulating text and thought parts in sequence.
- Reconstructing streaming function calls by aggregating `partialArgs` and handling `willContinue`.
- Generating proper `LlmResponse` objects for both partial chunks and the final aggregated result.

3. **Non-Progressive Streaming Fallback (`core/src/utils/streaming_utils.ts`)**: 
   - `StreamingResponseAggregator` will respect the `PROGRESSIVE_SSE_STREAMING` feature flag. 
   - Added support for accumulating non-progressive chunks internally and yielding state appropriately when progressive processing is toggled off, maintaining complete consistency. 

**Note:** `PROGRESSIVE_SSE_STREAMING` is off by default in ADK TS. This is intended and different from ADK Python.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

*Added localized tests verifying feature registry configuration updates (`feature_registry_test.ts`) and legacy non-progressive aggregation state tests (`streaming_utils_test.ts`).*

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.