### PR TITLE
test: add unit tests for GoogleSearchTool

### DIFF
--- a/core/test/tools/google_search_tool_test.ts
+++ b/core/test/tools/google_search_tool_test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {GOOGLE_SEARCH, GoogleSearchTool, LlmRequest} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+function makeRequest(model?: string, tools = []): LlmRequest {
+  return {
+    model,
+    config: {tools},
+    contents: [],
+    toolsDict: {},
+    liveConnectConfig: {},
+  } as unknown as LlmRequest;
+}
+
+describe('GoogleSearchTool', () => {
+  describe('processLlmRequest', () => {
+    it('returns early when model is not set', async () => {
+      const tool = new GoogleSearchTool();
+      const req = makeRequest(undefined);
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config?.tools).toEqual([]);
+    });
+
+    it('adds googleSearchRetrieval for Gemini 1.x model', async () => {
+      const tool = new GoogleSearchTool();
+      const req = makeRequest('gemini-1.5-pro');
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{googleSearchRetrieval: {}}]);
+    });
+
+    it('throws when Gemini 1.x model already has other tools', async () => {
+      const tool = new GoogleSearchTool();
+      const req = makeRequest('gemini-1.5-pro', [{functionDeclarations: []}]);
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow(
+        'Google search tool can not be used with other tools in Gemini 1.x.',
+      );
+    });
+
+    it('adds googleSearch for Gemini 2+ model', async () => {
+      const tool = new GoogleSearchTool();
+      const req = makeRequest('gemini-2.0-flash');
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{googleSearch: {}}]);
+    });
+
+    it('throws for unsupported (non-Gemini) model', async () => {
+      const tool = new GoogleSearchTool();
+      const req = makeRequest('gpt-4');
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow('Google search tool is not supported for model gpt-4');
+    });
+
+    it('initializes config.tools when config is absent', async () => {
+      const tool = new GoogleSearchTool();
+      const req: LlmRequest = {
+        model: 'gemini-2.0-flash',
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      } as unknown as LlmRequest;
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{googleSearch: {}}]);
+    });
+  });
+
+  it('has a global instance GOOGLE_SEARCH', () => {
+    expect(GOOGLE_SEARCH).toBeInstanceOf(GoogleSearchTool);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**Problem:**
`core/src/tools/google_search_tool.ts` had no tests. The branching logic in `processLlmRequest` — Gemini 1.x vs 2+, error on conflicting tools, error on unsupported model — was entirely untested.

**Solution:**
Add `core/test/tools/google_search_tool_test.ts` covering:
- Early return when `model` is not set
- `googleSearchRetrieval` pushed for Gemini 1.x
- Error thrown when Gemini 1.x already has other tools
- `googleSearch` pushed for Gemini 2+ models
- Error thrown for non-Gemini models (includes model name in message)
- `config.tools` initialized when `config` is absent
- `GOOGLE_SEARCH` singleton is an instance of `GoogleSearchTool`

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Summary of passed npm test results:_
```
✓ |unit:core| core/test/tools/google_search_tool_test.ts (7 tests) 4ms

Test Files  1 passed (1)
     Tests  7 passed (7)
```

Full suite: 1120 passed | 21 skipped (1141)

**Manual End-to-End (E2E) Tests:**
No runtime behaviour was changed; existing E2E tests continue to pass.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.