### PR TITLE
test: add unit tests for LongRunningFunctionTool

### DIFF
--- a/core/test/tools/long_running_tool_test.ts
+++ b/core/test/tools/long_running_tool_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LongRunningFunctionTool} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+const LONG_RUNNING_INSTRUCTION = `\n\nNOTE: This is a long-running operation. Do not call this tool again if it has already returned some intermediate or pending status.`;
+
+describe('LongRunningFunctionTool', () => {
+  it('sets isLongRunning to true', () => {
+    const tool = new LongRunningFunctionTool({
+      name: 'my_tool',
+      description: 'Does something.',
+      execute: async () => 'done',
+    });
+
+    expect(tool.isLongRunning).toBe(true);
+  });
+
+  it('appends long-running instruction to existing description', () => {
+    const tool = new LongRunningFunctionTool({
+      name: 'my_tool',
+      description: 'Does something.',
+      execute: async () => 'done',
+    });
+
+    const declaration = tool._getDeclaration();
+    expect(declaration.description).toBe(
+      'Does something.' + LONG_RUNNING_INSTRUCTION,
+    );
+  });
+
+  it('sets long-running instruction as description when none provided', () => {
+    const tool = new LongRunningFunctionTool({
+      name: 'my_tool',
+      description: '',
+      execute: async () => 'done',
+    });
+
+    const declaration = tool._getDeclaration();
+    expect(declaration.description).toBe(LONG_RUNNING_INSTRUCTION.trimStart());
+  });
+
+  it('preserves the tool name in declaration', () => {
+    const tool = new LongRunningFunctionTool({
+      name: 'background_task',
+      description: 'Runs a background task.',
+      execute: async () => null,
+    });
+
+    const declaration = tool._getDeclaration();
+    expect(declaration.name).toBe('background_task');
+  });
+
+  it('executes the underlying function via runAsync', async () => {
+    const tool = new LongRunningFunctionTool({
+      name: 'compute',
+      description: 'Computes a value.',
+      execute: async () => 42,
+    });
+
+    const result = await tool.runAsync({
+      args: {},
+      toolContext: {} as never,
+    });
+
+    expect(result).toBe(42);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**Problem:**
`core/src/tools/long_running_tool.ts` had no tests. The key behaviour — `_getDeclaration()` appending `LONG_RUNNING_INSTRUCTION` to the description — was untested and a silent regression risk.

**Solution:**
Add `core/test/tools/long_running_tool_test.ts` covering:
- `isLongRunning` is `true` after construction
- `_getDeclaration()` appends instruction to an existing description
- `_getDeclaration()` sets the instruction as description when none provided (trimmed)
- Tool name is preserved in the declaration
- Underlying `FunctionTool.runAsync` executes correctly

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Summary of passed npm test results:_
```
✓ |unit:core| core/test/tools/long_running_tool_test.ts (5 tests) 1ms

Test Files  1 passed (1)
     Tests  5 passed (5)
```

Full suite: 1120 passed | 21 skipped (1141)

**Manual End-to-End (E2E) Tests:**
No runtime behaviour was changed; existing E2E tests continue to pass.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.