### PR TITLE
test: add unit tests for ToolConfirmation

### DIFF
--- a/core/test/tools/tool_confirmation_test.ts
+++ b/core/test/tools/tool_confirmation_test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {ToolConfirmation} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('ToolConfirmation', () => {
+  it('stores all provided fields', () => {
+    const confirmation = new ToolConfirmation({
+      hint: 'Please confirm.',
+      confirmed: true,
+      payload: {key: 'value'},
+    });
+
+    expect(confirmation.hint).toBe('Please confirm.');
+    expect(confirmation.confirmed).toBe(true);
+    expect(confirmation.payload).toEqual({key: 'value'});
+  });
+
+  it('defaults hint to empty string when omitted', () => {
+    const confirmation = new ToolConfirmation({confirmed: false});
+
+    expect(confirmation.hint).toBe('');
+  });
+
+  it('stores confirmed as false', () => {
+    const confirmation = new ToolConfirmation({confirmed: false});
+
+    expect(confirmation.confirmed).toBe(false);
+  });
+
+  it('stores confirmed as true', () => {
+    const confirmation = new ToolConfirmation({confirmed: true});
+
+    expect(confirmation.confirmed).toBe(true);
+  });
+
+  it('leaves payload as undefined when not provided', () => {
+    const confirmation = new ToolConfirmation({confirmed: true});
+
+    expect(confirmation.payload).toBeUndefined();
+  });
+
+  it('accepts a JSON-serializable payload object', () => {
+    const payload = {userId: 123, action: 'delete', tags: ['a', 'b']};
+    const confirmation = new ToolConfirmation({
+      confirmed: true,
+      payload,
+    });
+
+    expect(() => JSON.stringify(confirmation.payload)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(confirmation.payload))).toEqual(payload);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**Problem:**
`core/src/tools/tool_confirmation.ts` is exported as part of the public API with the `@experimental` tag but had no tests. The constructor default logic and field assignments were unverified.

**Solution:**
Add `core/test/tools/tool_confirmation_test.ts` covering:
- All fields stored when provided
- `hint` defaults to `''` when omitted
- `confirmed` stores both `true` and `false`
- `payload` is `undefined` when not provided
- A JSON-serializable payload round-trips correctly through `JSON.stringify`/`JSON.parse`

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Summary of passed npm test results:_
```
✓ |unit:core| core/test/tools/tool_confirmation_test.ts (6 tests) 2ms

Test Files  1 passed (1)
     Tests  6 passed (6)
```

Full suite: 1120 passed | 21 skipped (1141)

**Manual End-to-End (E2E) Tests:**
No runtime behaviour was changed; existing E2E tests continue to pass.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.