### PR TITLE
fix: skip empty text finalization chunk after function call

### DIFF
--- a/core/src/models/google_llm.ts
+++ b/core/src/models/google_llm.ts
@@ -8,6 +8,7 @@ import {
   Blob,
   createPartFromText,
   FileData,
+  FinishReason,
   GoogleGenAI,
   HttpOptions,
 } from '@google/genai';
@@ -161,7 +162,34 @@ export class Gemini extends BaseLlm {
       });
 
       const aggregator = new StreamingResponseAggregator();
+      let sawFunctionCall = false;
       for await (const response of streamResult) {
+        const parts = response.candidates?.[0]?.content?.parts ?? [];
+        if (parts.some((part) => part.functionCall)) {
+          sawFunctionCall = true;
+        }
+
+        // Gemini thinking models emit an empty text chunk with finishReason
+        // STOP after a function call. The aggregator would treat it as a
+        // final model turn and prevent the agent from making the follow-up
+        // call, so drop it before it reaches the aggregator.
+        if (
+          sawFunctionCall &&
+          response.candidates?.[0]?.finishReason === FinishReason.STOP &&
+          parts.length > 0 &&
+          parts.every(
+            (part) =>
+              !part.functionCall &&
+              !part.functionResponse &&
+              !part.inlineData &&
+              !part.executableCode &&
+              !part.codeExecutionResult &&
+              (!part.text || part.text === ''),
+          )
+        ) {
+          continue;
+        }
+
         for await (const llmResponse of aggregator.processResponse(response)) {
           yield llmResponse;
         }

--- a/core/test/models/google_llm_test.ts
+++ b/core/test/models/google_llm_test.ts
@@ -8,6 +8,7 @@ import {
   Gemini,
   GeminiParams,
   LlmRequest,
+  LlmResponse,
   geminiInitParams,
   version,
 } from '@google/adk';
@@ -370,6 +371,217 @@ describe('GoogleLlm', () => {
       abortController.abort();
 
       await expect(generator.next()).rejects.toThrow('Aborted');
+    });
+  });
+
+  describe('generateContentAsync streaming', () => {
+    /**
+     * Creates a Gemini instance with a mock apiClient whose
+     * generateContentStream yields the given raw responses as individual
+     * streaming chunks.
+     */
+    function createStreamingGemini(
+      rawChunks: Array<{
+        candidates?: Array<{
+          content?: {role?: string; parts?: Array<Record<string, unknown>>};
+          finishReason?: string;
+          finishMessage?: string;
+        }>;
+        usageMetadata?: Record<string, unknown>;
+      }>,
+    ): Gemini {
+      const gemini = new Gemini({apiKey: 'test-key'});
+
+      const chunks = rawChunks.map((raw) => {
+        const response = new GenerateContentResponse();
+        response.candidates =
+          raw.candidates as GenerateContentResponse['candidates'];
+        response.usageMetadata =
+          raw.usageMetadata as GenerateContentResponse['usageMetadata'];
+        return response;
+      });
+
+      const mockModels = {
+        async generateContentStream(
+          _req: unknown,
+        ): Promise<AsyncGenerator<GenerateContentResponse>> {
+          return (async function* () {
+            for (const chunk of chunks) {
+              yield chunk;
+            }
+          })();
+        },
+        async generateContent(_req: unknown): Promise<GenerateContentResponse> {
+          return chunks[0];
+        },
+      };
+
+      const mockClient = {
+        models: mockModels,
+        vertexai: false,
+      };
+
+      Object.defineProperty(gemini, 'apiClient', {
+        get: () => mockClient as unknown as GoogleGenAI,
+      });
+
+      return gemini;
+    }
+
+    /** Collects all yielded LlmResponses from generateContentAsync. */
+    async function collectResponses(
+      gemini: Gemini,
+      stream: boolean,
+    ): Promise<LlmResponse[]> {
+      const results: LlmResponse[] = [];
+      for await (const response of gemini.generateContentAsync(
+        {
+          contents: [{role: 'user', parts: [{text: 'hello'}]}],
+          liveConnectConfig: {},
+          toolsDict: {},
+        },
+        stream,
+      )) {
+        results.push(response);
+      }
+      return results;
+    }
+
+    it('should suppress empty finalization chunk after a function call', async () => {
+      const gemini = createStreamingGemini([
+        // Chunk 1: function call
+        {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [
+                  {
+                    functionCall: {
+                      name: 'get_weather',
+                      args: {location: 'Seattle'},
+                    },
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        // Chunk 2: empty text finalization (the bug trigger)
+        {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{text: ''}],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+      ]);
+
+      const responses = await collectResponses(gemini, true);
+
+      // Only the function call chunk should be yielded; the empty
+      // finalization chunk must be suppressed.
+      expect(responses).toHaveLength(1);
+      expect(responses[0].content?.parts?.[0]?.functionCall).toBeDefined();
+      expect(responses[0].content?.parts?.[0]?.functionCall?.name).toBe(
+        'get_weather',
+      );
+    });
+
+    it('should still yield non-empty text chunks after a function call', async () => {
+      const gemini = createStreamingGemini([
+        // Chunk 1: function call
+        {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [
+                  {
+                    functionCall: {
+                      name: 'get_weather',
+                      args: {location: 'Seattle'},
+                    },
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        // Chunk 2: real text response (should NOT be suppressed)
+        {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{text: 'The weather in Seattle is sunny.'}],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+      ]);
+
+      const responses = await collectResponses(gemini, true);
+
+      // Both the function call and the text response should be yielded.
+      // The text accumulation logic marks text chunks as partial and then
+      // flushes them, so we expect:
+      // 1. The function call chunk
+      // 2. The text chunk (marked partial)
+      // 3. A flush of accumulated text
+      expect(responses.length).toBeGreaterThanOrEqual(2);
+      expect(responses[0].content?.parts?.[0]?.functionCall?.name).toBe(
+        'get_weather',
+      );
+      // One of the later responses should contain the text
+      const textResponses = responses.filter((r) =>
+        r.content?.parts?.some(
+          (p) => p.text && p.text === 'The weather in Seattle is sunny.',
+        ),
+      );
+      expect(textResponses.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should yield empty finalization chunk when no function call preceded it', async () => {
+      const gemini = createStreamingGemini([
+        // Chunk 1: text response
+        {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{text: 'Hello there!'}],
+              },
+            },
+          ],
+        },
+        // Chunk 2: empty text finalization (no preceding function call)
+        {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{text: ''}],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+      ]);
+
+      const responses = await collectResponses(gemini, true);
+
+      // Without a preceding function call, the empty finalization should
+      // still be yielded (along with the flush of accumulated text).
+      // We expect at least the text chunk, the flush, and the finalization.
+      expect(responses.length).toBeGreaterThanOrEqual(2);
     });
   });
 });


### PR DESCRIPTION

### Link to Issue or Description of Change

- Related: https://github.com/google/adk-python/issues/3754

**Problem:**
Gemini thinking models send an empty text chunk with finishReason STOP after a function call to signal completion. The streaming loop in generateContentAsync was yielding this chunk unconditionally, causing isFinalResponse() to treat it as the agent's final response and preventing the follow-up model call that generates the actual text.

**Solution:**
Track whether a function call has been seen in the current streaming turn. When we encounter a chunk that has only empty text parts and finishReason STOP after a function call, skip it instead of yielding.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed npm test results._

**Manual End-to-End (E2E) Tests:**

The bug triggers when a thinking model makes a function call during streaming — Gemini sends the function call chunk, then an empty text chunk with finishReason: STOP. Without the fix, the agent treats that
empty chunk as the final response and never makes the second model call to generate actual text.

Setup: An agent with a tool and a thinking model:

```typescript
const getWeather = new FunctionTool({
  name: 'get_weather',
  description: 'Get current weather for a city',
  inputSchema: z.object({ city: z.string() }),
  execute: async ({ city }) => ({ city, temp: '72F', condition: 'sunny' }),
});

const agent = new LlmAgent({
  name: 'test_agent',
  model: 'gemini-3-flash-preview',
  instruction: 'You help with weather questions. Always use the get_weather tool.',
  tools: [getWeather],
});
```

A simple prompt like "What's the weather in Seattle?" is enough — you just need one tool call.

What to look for:

- Without the fix: The run ends immediately after the tool response. You get events for the function call and function response, but no final text from the model. The agent appears to silently stop mid-turn. No
 error is thrown — it just produces no answer.
- With the fix: The run completes with a final text event where the model summarizes the tool result (e.g., "The weather in Seattle is 72F and sunny").

Key conditions:
- Must use streaming (the default)
- Must use a thinking model — non-thinking models don't send the empty finalization chunk
- Only needs a single tool call to trigger, so it's more reliably reproducible than the thoughtSignature bug
- If the model decides not to use the tool (unlikely with the instruction), there's no function call and the bug doesn't apply — just retry


### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

