### PR TITLE
fix: filter temp: state keys from sub-agent delta in AgentTool

### DIFF
--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -14,6 +14,8 @@ import {Runner} from '../runner/runner.js';
 import {InMemorySessionService} from '../sessions/in_memory_session_service.js';
 import {GoogleLLMVariant} from '../utils/variant_utils.js';
 
+import {State} from '../sessions/state.js';
+
 import {BaseTool, RunAsyncToolRequest} from './base_tool.js';
 import {ForwardingArtifactService} from './forwarding_artifact_service.js';
 
@@ -174,7 +176,14 @@ export class AgentTool extends BaseTool {
       }
 
       if (event.actions.stateDelta) {
-        toolContext.state.update(event.actions.stateDelta);
+        const filteredDelta = Object.fromEntries(
+          Object.entries(event.actions.stateDelta).filter(
+            ([key]) => !key.startsWith(State.TEMP_PREFIX),
+          ),
+        );
+        if (Object.keys(filteredDelta).length > 0) {
+          toolContext.state.update(filteredDelta);
+        }
       }
 
       lastEvent = event;

--- a/core/test/tools/agent_tool_test.ts
+++ b/core/test/tools/agent_tool_test.ts
@@ -15,6 +15,7 @@ import {
   LlmAgent,
   PluginManager,
   Runner,
+  State,
 } from '@google/adk';
 import {describe, expect, it, vi} from 'vitest';
 
@@ -304,5 +305,100 @@ describe('AgentTool', () => {
 
     // The method should return undefined (void) when aborted during loop
     expect(result).toBeUndefined();
+  });
+
+  it('does not propagate temp: keys from sub-agent state delta to parent', async () => {
+    const mockAgent = {name: 'sub-agent'} as unknown as LlmAgent;
+    const tool = new AgentTool({agent: mockAgent});
+
+    const mockSessionService = new InMemorySessionService();
+    const updateMock = vi.fn();
+
+    const toolContext = {
+      invocationContext: {
+        userId: 'parent-user',
+        session: {id: 'parent-session'},
+        sessionService: mockSessionService,
+      },
+      state: {
+        toRecord: () => ({}),
+        update: updateMock,
+      },
+    } as unknown as Context;
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {role: 'model', parts: [{text: 'done'}]},
+        actions: createEventActions({
+          stateDelta: {
+            normalKey: 'persistMe',
+            [`${State.TEMP_PREFIX}ephemeral`]: 'dropMe',
+          },
+        }),
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation(
+      (config) =>
+        ({
+          appName: config?.appName,
+          sessionService: config?.sessionService,
+          runAsync: mockRunAsync,
+        }) as unknown as Runner,
+    );
+
+    await tool.runAsync({args: {request: 'go'}, toolContext});
+
+    // Only the non-temp key must reach the parent state
+    expect(updateMock).toHaveBeenCalledWith({normalKey: 'persistMe'});
+    expect(updateMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({[`${State.TEMP_PREFIX}ephemeral`]: 'dropMe'}),
+    );
+  });
+
+  it('skips state.update entirely when all delta keys are temp:', async () => {
+    const mockAgent = {name: 'sub-agent'} as unknown as LlmAgent;
+    const tool = new AgentTool({agent: mockAgent});
+
+    const mockSessionService = new InMemorySessionService();
+    const updateMock = vi.fn();
+
+    const toolContext = {
+      invocationContext: {
+        userId: 'parent-user',
+        session: {id: 'parent-session'},
+        sessionService: mockSessionService,
+      },
+      state: {
+        toRecord: () => ({}),
+        update: updateMock,
+      },
+    } as unknown as Context;
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {role: 'model', parts: [{text: 'done'}]},
+        actions: createEventActions({
+          stateDelta: {
+            [`${State.TEMP_PREFIX}only`]: 'dropMe',
+          },
+        }),
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation(
+      (config) =>
+        ({
+          appName: config?.appName,
+          sessionService: config?.sessionService,
+          runAsync: mockRunAsync,
+        }) as unknown as Runner,
+    );
+
+    await tool.runAsync({args: {request: 'go'}, toolContext});
+
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**Problem:**
`AgentTool.runAsync()` propagates every key from a sub-agent's `stateDelta` to the parent context via `toolContext.state.update(event.actions.stateDelta)`. Keys prefixed with `State.TEMP_PREFIX` (`temp:`) are explicitly designed to be ephemeral, per-invocation state that must not be persisted or cross agent boundaries. Because no filtering was applied, any `temp:` key written by the sub-agent leaked into the parent session state, overwriting or polluting it.

**Solution:**
Before calling `toolContext.state.update()`, filter out all keys that start with `State.TEMP_PREFIX`. If the resulting delta is empty (all keys were `temp:`), skip the update entirely.

This aligns with the same filtering applied in `BaseSessionService.trimTempDeltaState()` at session-persistence time, and matches the behaviour of the Python ADK.

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Summary of passed npm test results:_
```
✓ |unit:core| core/test/tools/agent_tool_test.ts (3 tests)
✓ |integration| tests/integration/tools/agent_tool_test.ts (1 test)

Test Files  2 passed (2)
     Tests  4 passed (4)
```

Full suite: 1120 passed | 21 skipped (1141)

**Manual End-to-End (E2E) Tests:**
The filtering is applied only to keys that start with `temp:`. Non-temp state delta propagation is unchanged and verified by the existing integration test.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.