### PR TITLE
fix: add client url to support custom url options for DB connection.

### DIFF
--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -43,28 +43,20 @@ export async function getConnectionOptionsFromUri(
     throw new Error(`Unsupported database URI: ${uri}`);
   }
 
-  if (uri === 'sqlite://:memory:') {
+  if (uri.startsWith('sqlite://')) {
     return {
       entities: ENTITIES,
-      dbName: ':memory:',
+      dbName:
+        uri === 'sqlite://:memory:'
+          ? ':memory:'
+          : uri.substring('sqlite://'.length),
       driver,
     } as MikroORMOptions;
   }
 
-  const {host, port, username, password, pathname} = new URL(uri);
-  const hostName = host.split(':')[0];
-
-  const dbName = uri.startsWith('sqlite://')
-    ? uri.substring('sqlite://'.length)
-    : pathname.slice(1);
-
   return {
     entities: ENTITIES,
-    dbName,
-    host: hostName,
-    port: port ? parseInt(port) : undefined,
-    user: username,
-    password,
+    clientUrl: uri,
     driver,
   } as MikroORMOptions;
 }

--- a/core/test/sessions/db/operations_test.ts
+++ b/core/test/sessions/db/operations_test.ts
@@ -38,20 +38,35 @@ describe('operations', () => {
       const options = await getConnectionOptionsFromUri(
         'postgres://user:pass@localhost:5432/db',
       );
-      expect(options.dbName).toBe('db');
-      expect(options.host).toBe('localhost');
-      expect(options.port).toBe(5432);
-      expect(options.user).toBe('user');
-      expect(options.password).toBe('pass');
       expect(options.driver).toBeDefined();
+      expect(options.clientUrl).toBe('postgres://user:pass@localhost:5432/db');
+    });
+
+    it('should parse postgresql URI with query params and preserve them in clientUrl', async () => {
+      const uri = 'postgres://user:pass@localhost:5432/db?sslmode=require';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.clientUrl).toBe(uri);
+    });
+
+    it('should parse postgresql Unix-socket URI with percent-encoded host', async () => {
+      const uri =
+        'postgresql://user:pass@%2Fcloudsql%2Fmy-project%3Aus-central1%3Amy-instance/mydb';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.clientUrl).toBe(uri);
+    });
+
+    it('should parse postgresql Unix-socket URI with query param host', async () => {
+      const uri =
+        'postgresql://user:pass@/mydb?host=/cloudsql/my-project:us-central1:my-instance';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.clientUrl).toBe(uri);
     });
 
     it('should parse mysql URI', async () => {
-      const options = await getConnectionOptionsFromUri(
-        'mysql://user:pass@localhost:3306/db',
-      );
+      const uri = 'mysql://user:pass@localhost:3306/db';
+      const options = await getConnectionOptionsFromUri(uri);
       expect(options.driver).toBeDefined();
-      expect(options.dbName).toBe('db');
+      expect(options.clientUrl).toBe(uri);
     });
 
     it('should parse mariadb URI', async () => {

--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -119,10 +119,12 @@ const LOG_LEVEL_OPTION = new Option(
   'Optional. The log level of the server',
 ).default('info');
 const SESSION_SERVICE_URI_OPTION = new Option(
-  '--session_service_uri <string>, Optional. The URI of the session service. Supported URIs: memory:// for in-memory session service.',
+  '--session_service_uri <string>',
+  'Optional. The URI of the session service. Supported URIs: memory:// for in-memory session service.',
 );
 const ARTIFACT_SERVICE_URI_OPTION = new Option(
-  '--artifact_service_uri <string>, Optional. The URI of the artifact service. Supported URIs: gs://<bucket name> for GCS artifact service.',
+  '--artifact_service_uri <string>',
+  'Optional. The URI of the artifact service. Supported URIs: gs://<bucket name> for GCS artifact service.',
 );
 const OTEL_TO_CLOUD_OPTION = new Option(
   '--otel_to_cloud [boolean]',


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #279
- Closes: #283

**2. Or, if no issue exists, describe the change:**

**Problem:**
When using `DatabaseSessionService` with non-SQLite database connection URIs via the `--session_service_uri` flag, the existing logic decomposed the connection string and only returned basic connection options (`host`, `port`, `user`, `password`, and `dbName`). This stripped out query parameters (such as `sslmode=require`) and broke standard Postgres Unix-domain socket URL formats containing query parameters or percent-encoded paths, making it impossible to connect to instances requiring specific driver parameters or socket-based routing.

**Solution:**
Simplified `getConnectionOptionsFromUri` to directly return the `clientUrl` option for all non-SQLite drivers, bypassing manual URI parsing completely. Passing the full, untouched connection string down to MikroORM ensures that query parameters and Unix-domain socket configurations are handled natively and correctly by the underlying database drivers.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```bash
 RUN  v3.2.4 /Users/kalenkevich/projects/adk-js

 ✓ |unit:core| core/test/sessions/db/operations_test.ts (14 tests) 46ms
 ✓ |unit:core| core/test/sessions/database_session_service_test.ts (15 tests) 193ms

 Test Files  5 passed (5)
      Tests  51 passed (51)
```

**Manual End-to-End (E2E) Tests:**
- Verified that valid Postgres URLs (with/without SSL mode parameters and Unix-socket paths) are preserved and successfully mapped to `clientUrl` in the database configuration.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.