### PR TITLE
fix(): uses js-yaml instead of yaml for parsing

### DIFF
--- a/dev/src/conformance/yaml_test_loader.ts
+++ b/dev/src/conformance/yaml_test_loader.ts
@@ -44,7 +44,6 @@ export async function batchLoadYamlTestDefs(
     const specFile = path.posix.join(baseDir, 'spec.yaml');
     const filePath = specFile;
     const content = await fs.readFile(filePath, 'utf-8');
-
     const testSpec = camelcaseKeys(load(content) as object, {
       deep: true,
     }) as unknown as TestSpec;

--- a/dev/src/conformance/yaml_test_loader.ts
+++ b/dev/src/conformance/yaml_test_loader.ts
@@ -7,9 +7,9 @@
 import {Session} from '@google/adk';
 import camelcaseKeys from 'camelcase-keys';
 import fg from 'fast-glob';
+import {load} from 'js-yaml';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import {parse} from 'yaml';
 import {Recordings, TestInfo, TestSpec} from '../integration/test_types.js';
 
 /**
@@ -44,16 +44,17 @@ export async function batchLoadYamlTestDefs(
     const specFile = path.posix.join(baseDir, 'spec.yaml');
     const filePath = specFile;
     const content = await fs.readFile(filePath, 'utf-8');
-    const testSpec = camelcaseKeys(parse(content), {
+
+    const testSpec = camelcaseKeys(load(content) as object, {
       deep: true,
-    }) as TestSpec;
+    }) as unknown as TestSpec;
 
     // Session file
     const sessionFile = path.posix.join(baseDir, 'generated-session.yaml');
     const sessionContent = await fs.readFile(sessionFile, 'utf-8');
-    const session = camelcaseKeys(parse(sessionContent), {
+    const session = camelcaseKeys(load(sessionContent) as object, {
       deep: true,
-    }) as Session;
+    }) as unknown as Session;
 
     // Recordings file
     const recordingsFile = path.posix.join(
@@ -61,9 +62,9 @@ export async function batchLoadYamlTestDefs(
       'generated-recordings.yaml',
     );
     const recordingsContent = await fs.readFile(recordingsFile, 'utf-8');
-    const recordings = camelcaseKeys(parse(recordingsContent), {
+    const recordings = camelcaseKeys(load(recordingsContent) as object, {
       deep: true,
-    }) as Recordings;
+    }) as unknown as Recordings;
 
     // Make test names unique by including relative file path from given root dir
     const normalizedDir = directory.replaceAll('\\', '/');

--- a/dev/src/conformance/yaml_test_loader.ts
+++ b/dev/src/conformance/yaml_test_loader.ts
@@ -7,7 +7,7 @@
 import {Session} from '@google/adk';
 import camelcaseKeys from 'camelcase-keys';
 import fg from 'fast-glob';
-import {load} from 'js-yaml';
+import yaml from 'js-yaml';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import {Recordings, TestInfo, TestSpec} from '../integration/test_types.js';
@@ -44,16 +44,24 @@ export async function batchLoadYamlTestDefs(
     const specFile = path.posix.join(baseDir, 'spec.yaml');
     const filePath = specFile;
     const content = await fs.readFile(filePath, 'utf-8');
-    const testSpec = camelcaseKeys(load(content) as object, {
+    const parsedSpec = yaml.load(content);
+    if (typeof parsedSpec !== 'object' || parsedSpec === null) {
+      throw new Error('Spec file must be a YAML mapping');
+    }
+    const testSpec = camelcaseKeys(parsedSpec, {
       deep: true,
-    }) as unknown as TestSpec;
+    }) as TestSpec;
 
     // Session file
     const sessionFile = path.posix.join(baseDir, 'generated-session.yaml');
     const sessionContent = await fs.readFile(sessionFile, 'utf-8');
-    const session = camelcaseKeys(load(sessionContent) as object, {
+    const parsedSession = yaml.load(sessionContent);
+    if (typeof parsedSession !== 'object' || parsedSession === null) {
+      throw new Error('Session file must be a YAML mapping');
+    }
+    const session = camelcaseKeys(parsedSession, {
       deep: true,
-    }) as unknown as Session;
+    }) as Session;
 
     // Recordings file
     const recordingsFile = path.posix.join(
@@ -61,9 +69,13 @@ export async function batchLoadYamlTestDefs(
       'generated-recordings.yaml',
     );
     const recordingsContent = await fs.readFile(recordingsFile, 'utf-8');
-    const recordings = camelcaseKeys(load(recordingsContent) as object, {
+    const parsedRecordings = yaml.load(recordingsContent);
+    if (typeof parsedRecordings !== 'object' || parsedRecordings === null) {
+      throw new Error('Recording file must be a YAML mapping');
+    }
+    const recordings = camelcaseKeys(parsedRecordings, {
       deep: true,
-    }) as unknown as Recordings;
+    }) as Recordings;
 
     // Make test names unique by including relative file path from given root dir
     const normalizedDir = directory.replaceAll('\\', '/');


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #290

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [X] I have added or updated unit tests for my change.
- [X] All unit tests pass locally.

<img width="917" height="114" alt="image" src="https://github.com/user-attachments/assets/237bfbde-2041-41e9-8f39-6770f4917165" />

### Checklist

- [X] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.

### Additional context

Issue is related to `yaml` package not installed in the project, as it was replaced with `js-yaml`. Affected file is `dev/src/conformance/yaml_test_loader.ts`