### PR TITLE
fix(mcp): strip prefix during tool execution

### DIFF
--- a/core/src/tools/mcp/mcp_tool.ts
+++ b/core/src/tools/mcp/mcp_tool.ts
@@ -29,15 +29,26 @@ import {MCPSessionManager} from './mcp_session_manager.js';
  * invoked, which in turn establishes an MCP session, sends a `callTool`
  * request with the provided arguments, and returns the result from the
  * remote tool.
+ *
+ * The originalName parameter allows the tool to track the native tool name
+ * exposed by the MCP server. This is critical when the toolset applies a
+ * prefix to tool names (e.g., for LLM namespace disambiguation), ensuring
+ * the correct original name is used when executing on the server.
  */
 export class MCPTool extends BaseTool {
   private readonly mcpTool: Tool;
   private readonly mcpSessionManager: MCPSessionManager;
+  private readonly originalName: string;
 
-  constructor(mcpTool: Tool, mcpSessionManager: MCPSessionManager) {
+  constructor(
+    mcpTool: Tool,
+    mcpSessionManager: MCPSessionManager,
+    originalName?: string,
+  ) {
     super({name: mcpTool.name, description: mcpTool.description || ''});
     this.mcpTool = mcpTool;
     this.mcpSessionManager = mcpSessionManager;
+    this.originalName = originalName || mcpTool.name;
   }
 
   override _getDeclaration(): FunctionDeclaration {
@@ -55,7 +66,7 @@ export class MCPTool extends BaseTool {
     const session = await this.mcpSessionManager.createSession();
 
     const callRequest: CallToolRequest = {} as CallToolRequest;
-    callRequest.params = {name: this.mcpTool.name, arguments: request.args};
+    callRequest.params = {name: this.originalName, arguments: request.args};
     const result = await session.callTool(callRequest.params, undefined, {
       signal: request.toolContext.abortSignal,
     });

--- a/core/src/tools/mcp/mcp_toolset.ts
+++ b/core/src/tools/mcp/mcp_toolset.ts
@@ -24,6 +24,11 @@ import {MCPTool} from './mcp_tool.js';
  * The toolset can be configured with a filter to selectively expose a subset
  * of the tools provided by the MCP server.
  *
+ * It can also be configured with a prefix. If provided, all tools discovered
+ * from the MCP server will have their names prefixed with `${prefix}_`. When the
+ * LLM invokes the prefixed tool, this toolset transparently strips the prefix
+ * before sending the request to the underlying MCP server.
+ *
  * Usage:
  *   import { MCPToolset } from '@google/adk';
  *   import { StreamableHTTPConnectionParamsSchema } from '@google/adk';
@@ -65,7 +70,7 @@ export class MCPToolset extends BaseToolset {
         ...tool,
         name: this.prefix ? `${this.prefix}_${tool.name}` : tool.name,
       };
-      return new MCPTool(toolWithPrefix, this.mcpSessionManager);
+      return new MCPTool(toolWithPrefix, this.mcpSessionManager, tool.name);
     });
   }
 

--- a/core/test/tools/mcp/mcp_tool_test.ts
+++ b/core/test/tools/mcp/mcp_tool_test.ts
@@ -51,6 +51,43 @@ describe('MCPTool', () => {
     );
   });
 
+  it('uses originalName for callTool when provided', async () => {
+    const mockTool: Tool = {
+      name: 'prefixed_test-tool',
+      description: 'A test tool',
+      inputSchema: {type: 'object', properties: {}},
+    };
+
+    const mockClient = {
+      callTool: vi.fn().mockResolvedValue({content: []}),
+    } as unknown as Client;
+
+    const mockSessionManager = {
+      createSession: vi.fn().mockResolvedValue(mockClient),
+    } as unknown as MCPSessionManager;
+
+    // Pass 'test-tool' as originalName
+    const tool = new MCPTool(mockTool, mockSessionManager, 'test-tool');
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const invocationContext = {
+      abortSignal: signal,
+      session: {state: {}},
+    } as unknown as InvocationContext;
+
+    const toolContext = new Context({invocationContext});
+
+    await tool.runAsync({args: {}, toolContext});
+
+    expect(mockClient.callTool).toHaveBeenCalledWith(
+      {name: 'test-tool', arguments: {}},
+      undefined,
+      {signal: signal},
+    );
+  });
+
   it('respects abort signal when callTool rejects', async () => {
     const mockTool: Tool = {
       name: 'test-tool',

--- a/core/test/tools/mcp/mcp_toolset_test.ts
+++ b/core/test/tools/mcp/mcp_toolset_test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {MCPConnectionParams} from '../../../src/tools/mcp/mcp_session_manager.js';
+import {MCPToolset} from '../../../src/tools/mcp/mcp_toolset.js';
+
+vi.hoisted(() => {
+  vi.resetModules();
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  return {
+    Client: vi.fn().mockImplementation(() => ({
+      connect: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {name: 'test-tool', description: 'A test tool', inputSchema: {}},
+          {name: 'other-tool', description: 'Another tool', inputSchema: {}},
+        ],
+      }),
+    })),
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => {
+  return {
+    StdioClientTransport: vi.fn(),
+  };
+});
+
+describe('MCPToolset', () => {
+  it('discovers tools without prefix', async () => {
+    const connectionParams = {
+      type: 'StdioConnectionParams',
+      serverParams: {command: 'test'},
+    } as unknown as MCPConnectionParams;
+    const toolset = new MCPToolset(connectionParams);
+
+    const tools = await toolset.getTools();
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0].name).toBe('test-tool');
+    expect(tools[1].name).toBe('other-tool');
+  });
+
+  it('discovers tools with prefix applied', async () => {
+    const connectionParams = {
+      type: 'StdioConnectionParams',
+      serverParams: {command: 'test'},
+    } as unknown as MCPConnectionParams;
+    const toolset = new MCPToolset(connectionParams, [], 'myprefix');
+
+    const tools = await toolset.getTools();
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0].name).toBe('myprefix_test-tool');
+    expect(tools[1].name).toBe('myprefix_other-tool');
+  });
+});


### PR DESCRIPTION
Closes #300 

**Problem:**
When a `prefix` is provided to the `MCPToolset` constructor, the prefix is prepended to the tool names exposed to the LLM (e.g. `myprefix_list-databases`). However, when the LLM attempts to execute the tool, `MCPTool.runAsync()` uses this permanently modified name to call the underlying MCP server. Because the underlying MCP server has no knowledge of the prefix, it responds with a `Tool not found` (code `-32602`) error.

**Solution:**
The `MCPTool` class needs to keep track of both the native tool name (for server communication) and the prefixed tool name (for LLM routing). 

The solution is to modify `MCPTool` to accept and store the original native name during construction. Then, in `runAsync()`, the tool should use this native name when executing `session.callTool(callRequest.params, ...)` instead of the prefixed `this.mcpTool.name`. This ensures the LLM interacts with the prefixed name while the MCP server receives the correct, unmodified name.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed npm test results._

**Manual End-to-End (E2E) Tests:**

1. Start a local MCP server (e.g., `mongodb-mcp-server`).
2. Initialize an `MCPToolset` with a custom prefix pointing to this server.
3. Start an agent using this toolset.
4. Prompt the agent to use one of the prefixed tools (e.g., `myprefix_list-databases`).
5. Verify that the agent successfully executes the tool and receives a valid response instead of a `-32602 Tool not found` error.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Root cause detail:**
In `core/src/tools/mcp/mcp_toolset.ts` (inside `getTools()`):
```typescript
return listResult.tools.map((tool) => {
    const toolWithPrefix = {
        ...tool,
        name: this.prefix ? `${this.prefix}_${tool.name}` : tool.name
    };
    return new MCPTool(toolWithPrefix, this.mcpSessionManager);
});
```
The `name` is overwritten permanently. When `MCPTool` later calls the tool in `runAsync`:
```typescript
callRequest.params = { name: this.mcpTool.name, arguments: request.args };
```
It sends the prefixed name to the MCP server.
