### PR TITLE
fix: do not propagate skipSummarization to parent EventActions in AgentTool

### DIFF
--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -120,9 +120,13 @@ export class AgentTool extends BaseTool {
     args,
     toolContext,
   }: RunAsyncToolRequest): Promise<unknown> {
-    if (this.skipSummarization) {
-      toolContext.actions.skipSummarization = true;
-    }
+    // Note: skipSummarization is intentionally not propagated to
+    // toolContext.actions here. Setting it on the shared EventActions would
+    // leak onto the tool-response event returned to the parent agent, causing
+    // isFinalResponse() to treat that event as terminal and prematurely
+    // terminate the parent's run loop. The sub-agent's output is already
+    // returned verbatim below, which is the intended effect of
+    // skipSummarization.
 
     const hasInputSchema = isLlmAgent(this.agent) && this.agent.inputSchema;
     const content: Content = {

--- a/core/test/tools/agent_tool_test.ts
+++ b/core/test/tools/agent_tool_test.ts
@@ -249,6 +249,53 @@ describe('AgentTool', () => {
     expect(result).toBe('');
   });
 
+  it('does not set skipSummarization on toolContext actions when skipSummarization is true', async () => {
+    const mockAgent = {
+      name: 'sub-agent',
+    } as unknown as LlmAgent;
+
+    const tool = new AgentTool({agent: mockAgent, skipSummarization: true});
+
+    const session = createSession({
+      id: 'parent-session',
+      appName: 'sub-agent',
+      userId: 'parent-user',
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: mockAgent,
+      session,
+      pluginManager: new PluginManager([]),
+    });
+
+    const toolContext = new Context({
+      invocationContext,
+    });
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {role: 'model', parts: [{text: 'result'}]},
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation((config) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsync,
+      } as unknown as Runner;
+    });
+
+    await tool.runAsync({args: {request: 'hello'}, toolContext});
+
+    // skipSummarization must NOT be set on the parent's EventActions.
+    // Setting it would cause isFinalResponse() to treat the tool-response
+    // event as terminal, prematurely breaking the parent agent's run loop.
+    expect(toolContext.actions.skipSummarization).toBeFalsy();
+  });
+
   it('handles abort signal during execution', async () => {
     const mockAgent = {
       name: 'sub-agent',


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #288

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Test Files  99 passed (99)
Tests  1082 passed (1082)
```

**Manual End-to-End (E2E) Tests:**

The bug is reproducible with the minimal repro from the issue: an `LlmAgent` with an `AgentTool({ skipSummarization: true })` and an `outputSchema`. With the fix applied, the parent agent correctly continues its run loop after receiving the sub-agent's `functionResponse` and produces the schema-constrained JSON output.

Without the fix: the parent's last event is `fresp:<sub-agent>` with `skipSummarization: true`, no further generation pass occurs, and `outputSchema` output is never produced.

With the fix: the parent continues after `fresp`, makes one more generation pass, and emits the structured JSON.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Root cause:** `AgentTool.runAsync` was setting `toolContext.actions.skipSummarization = true` when `skipSummarization` config is set. Because `toolContext.actions` is the *parent* agent's shared `EventActions`, this flag leaked onto the tool-response event returned to the parent. `isFinalResponse()` treats `skipSummarization` as an unconditional terminal signal, so the parent `LlmAgent`'s run loop broke immediately on seeing the `functionResponse` event — before it could make any further generation pass.

**Fix:** Remove the `toolContext.actions.skipSummarization = true` assignment from `AgentTool.runAsync`. The sub-agent's output is already returned verbatim from `runAsync()` (the `mergedText` / parsed JSON path), which is the intended effect of `skipSummarization`. The flag does not need to propagate to the parent's `EventActions`.

**`ExitLoopTool` is unaffected:** it sets both `escalate` and `skipSummarization` on `toolContext.actions`. `LoopAgent` uses `escalate` to exit its loop; `isFinalResponse` + `skipSummarization` causes the inner `LlmAgent` to break early without an extra model round-trip. That semantics is correct and intentional for `ExitLoopTool`, and is not changed by this fix.