### PR TITLE
fix: use getOrCreateSession in AgentTool to allow reuse within same session

### DIFF
--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -151,7 +151,7 @@ export class AgentTool extends BaseTool {
       credentialService: toolContext.invocationContext.credentialService,
     });
 
-    const session = await runner.sessionService.createSession({
+    const session = await runner.sessionService.getOrCreateSession({
       appName: this.agent.name,
       userId: toolContext.invocationContext.userId,
       sessionId: toolContext.invocationContext.session.id,

--- a/core/test/tools/agent_tool_test.ts
+++ b/core/test/tools/agent_tool_test.ts
@@ -40,7 +40,7 @@ describe('AgentTool', () => {
     const tool = new AgentTool({agent: mockAgent});
 
     const mockSessionService = new InMemorySessionService();
-    vi.spyOn(mockSessionService, 'createSession');
+    vi.spyOn(mockSessionService, 'getOrCreateSession');
 
     const session = createSession({
       id: 'parent-session',
@@ -88,8 +88,8 @@ describe('AgentTool', () => {
 
     expect(result).toBe('hello');
 
-    // Verify session creation called with parent context
-    expect(mockSessionService.createSession).toHaveBeenCalledWith(
+    // Verify getOrCreateSession called with parent context
+    expect(mockSessionService.getOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
         appName: 'sub-agent',
         userId: 'parent-user',
@@ -101,6 +101,65 @@ describe('AgentTool', () => {
     expect(toolContext.state.update).toHaveBeenCalledWith({
       someKey: 'someValue',
     });
+  });
+
+  it('reuses existing session on second invocation within the same parent session', async () => {
+    const mockAgent = {
+      name: 'sub-agent',
+    } as unknown as LlmAgent;
+
+    const tool = new AgentTool({agent: mockAgent});
+
+    const mockSessionService = new InMemorySessionService();
+    vi.spyOn(mockSessionService, 'getOrCreateSession').mockResolvedValue(
+      createSession({
+        id: 'parent-session',
+        appName: 'sub-agent',
+        userId: 'parent-user',
+      }),
+    );
+
+    const session = createSession({
+      id: 'parent-session',
+      appName: 'sub-agent',
+      userId: 'parent-user',
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: mockAgent,
+      session,
+      pluginManager: new PluginManager([]),
+      sessionService: mockSessionService,
+    });
+
+    const toolContext = new Context({invocationContext});
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {role: 'model', parts: [{text: 'result'}]},
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation((config) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsync,
+      } as unknown as Runner;
+    });
+
+    // Invoke twice simulating two turns in the same parent session
+    await tool.runAsync({args: {request: 'first'}, toolContext});
+    await tool.runAsync({args: {request: 'second'}, toolContext});
+
+    // getOrCreateSession should be called twice, returning the existing
+    // session on the second call rather than throwing a duplicate-session error
+    expect(mockSessionService.getOrCreateSession).toHaveBeenCalledTimes(2);
+    expect(mockSessionService.getOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({sessionId: 'parent-session'}),
+    );
   });
 
   it('handles abort signal before execution', async () => {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #294

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Test Files  99 passed (99)
Tests  1082 passed (1082)
```

**Manual End-to-End (E2E) Tests:**

Reproduced with `DatabaseSessionService`: create a parent agent with a sub-agent wrapped in `AgentTool`. Send two messages in the same session that both trigger the tool. Without the fix, the second invocation fails with a duplicate-session error. With the fix, the second invocation reuses the existing session and completes successfully.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

`AgentTool.runAsync` called `runner.sessionService.createSession` with the parent session's ID on every invocation. Persistent session services (e.g. `DatabaseSessionService`) enforce unique session IDs, so a second call within the same parent session throws a duplicate-session error.

`BaseSessionService.getOrCreateSession` already exists and handles this correctly: it returns the existing session when one is found for the given `appName/userId/sessionId`, and only creates a new session when none exists. Switching to this method makes `AgentTool` work correctly across multiple turns in the same parent session.