### PR TITLE
feat: add UrlContextTool for Gemini 2+ URL context grounding

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -221,6 +221,7 @@ export {
   PreloadMemoryTool,
 } from './tools/preload_memory_tool.js';
 export {ToolConfirmation} from './tools/tool_confirmation.js';
+export {URL_CONTEXT, UrlContextTool} from './tools/url_context_tool.js';
 export {VertexAiSearchTool} from './tools/vertex_ai_search_tool.js';
 export type {
   DataStoreParams,

--- a/core/src/tools/url_context_tool.ts
+++ b/core/src/tools/url_context_tool.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {GenerateContentConfig} from '@google/genai';
+
+import {isGemini2OrAbove, isGeminiModel} from '../utils/model_name.js';
+
+import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+
+/**
+ * A built-in tool that allows Gemini 2+ models to retrieve content from URLs
+ * provided in the conversation.
+ *
+ * This tool operates internally within the model and does not require or
+ * perform local code execution.
+ */
+export class UrlContextTool extends BaseTool {
+  constructor() {
+    super({name: 'url_context', description: 'URL Context Tool'});
+  }
+
+  runAsync(): Promise<unknown> {
+    // This is a built-in tool on server side, it's triggered by setting the
+    // corresponding request parameters.
+    return Promise.resolve();
+  }
+
+  override async processLlmRequest({
+    llmRequest,
+  }: ToolProcessLlmRequest): Promise<void> {
+    if (!llmRequest.model) {
+      return;
+    }
+
+    if (!isGeminiModel(llmRequest.model)) {
+      throw new Error(
+        `URL context tool is not supported for model ${llmRequest.model}`,
+      );
+    }
+
+    if (!isGemini2OrAbove(llmRequest.model)) {
+      throw new Error(
+        `URL context tool requires Gemini 2 or above, but got ${llmRequest.model}`,
+      );
+    }
+
+    llmRequest.config = llmRequest.config || ({} as GenerateContentConfig);
+    llmRequest.config.tools = llmRequest.config.tools || [];
+    llmRequest.config.tools.push({
+      urlContext: {},
+    });
+  }
+}
+
+/**
+ * A global instance of {@link UrlContextTool}.
+ */
+export const URL_CONTEXT = new UrlContextTool();

--- a/core/test/tools/url_context_tool_test.ts
+++ b/core/test/tools/url_context_tool_test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LlmRequest, URL_CONTEXT, UrlContextTool} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+function makeRequest(model?: string, tools = []): LlmRequest {
+  return {
+    model,
+    config: {tools},
+    contents: [],
+    toolsDict: {},
+    liveConnectConfig: {},
+  } as unknown as LlmRequest;
+}
+
+describe('UrlContextTool', () => {
+  describe('processLlmRequest', () => {
+    it('returns early when model is not set', async () => {
+      const tool = new UrlContextTool();
+      const req = makeRequest(undefined);
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config?.tools).toEqual([]);
+    });
+
+    it('adds urlContext for Gemini 2+ model', async () => {
+      const tool = new UrlContextTool();
+      const req = makeRequest('gemini-2.0-flash');
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{urlContext: {}}]);
+    });
+
+    it('adds urlContext for Gemini 2.5 model', async () => {
+      const tool = new UrlContextTool();
+      const req = makeRequest('gemini-2.5-pro');
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{urlContext: {}}]);
+    });
+
+    it('throws for Gemini 1.x model', async () => {
+      const tool = new UrlContextTool();
+      const req = makeRequest('gemini-1.5-pro');
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow(
+        'URL context tool requires Gemini 2 or above, but got gemini-1.5-pro',
+      );
+    });
+
+    it('throws for unsupported (non-Gemini) model', async () => {
+      const tool = new UrlContextTool();
+      const req = makeRequest('gpt-4');
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow('URL context tool is not supported for model gpt-4');
+    });
+
+    it('initializes config.tools when config is absent', async () => {
+      const tool = new UrlContextTool();
+      const req: LlmRequest = {
+        model: 'gemini-2.0-flash',
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      } as unknown as LlmRequest;
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{urlContext: {}}]);
+    });
+  });
+
+  it('has a global instance URL_CONTEXT', () => {
+    expect(URL_CONTEXT).toBeInstanceOf(UrlContextTool);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #282

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Test Files  100 passed (100)
Tests  1088 passed (1088)
```

**Manual End-to-End (E2E) Tests:**

Verified that an `LlmAgent` configured with `URL_CONTEXT` and a Gemini 2.x model correctly adds `{urlContext: {}}` to the request config. Confirmed that passing a Gemini 1.x or non-Gemini model throws the expected error.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Adds `UrlContextTool` — a built-in server-side tool that enables Gemini 2+ models to fetch and use content from URLs provided in the conversation. This brings `adk-js` to parity with the [Python ADK `UrlContextTool`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/url_context_tool.py).

The implementation follows the same pattern as `GoogleSearchTool`:
- `processLlmRequest` injects `{urlContext: {}}` into the Gemini request config.
- Validated against Gemini 2+ only — throws for Gemini 1.x and non-Gemini models.
- `URL_CONTEXT` singleton exported from the public API alongside `GOOGLE_SEARCH`.