### PR TITLE
fix(devtools): correct browser asset path in UI server

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -164,7 +164,7 @@ export class AdkApiServer {
       });
       app.use(
         '/dev-ui',
-        express.static(path.join(__dirname, './browser'), {
+        express.static(path.join(__dirname, '../browser'), {
           setHeaders: (res: Response, path: string) => {
             if (path.endsWith('.js')) {
               res.setHeader('Content-Type', 'text/javascript');


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #301 

**2. Or, if no issue exists, describe the change:**

**Problem:**
The devtools UI server (`AdkApiServer`) fails to serve the static browser assets for the debug UI, resulting in 404 errors when attempting to access the devtools in the browser. This happens because the static files path is configured as `./browser` relative to `adk_api_server.ts`, which incorrectly resolves to `.../server/browser`. The actual browser assets directory is located in the parent directory (`.../browser`).

**Solution:**
Update the static directory path from `path.join(__dirname, './browser')` to `path.join(__dirname, '../browser')`. This correctly points the express server to the parent directory where the `browser` assets are actually located during runtime, allowing the devtools UI to load properly.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

*Summary of passed npm test results:*
Existing tests pass successfully. The `dev` package builds without compilation errors (`npm run build` succeeds).

**Manual End-to-End (E2E) Tests:**

1. Built the `@google/adk-devtools` package locally.
2. Verified that when running the ADK agent server with `serveDebugUI: true` enabled, the browser assets load properly at the `/dev-ui` endpoint.
3. No 404 errors are present in the browser's network tab when attempting to fetch the devtools static resources (HTML, CSS, JS).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This fix is necessary for local developers trying to utilize the ADK devtools UI, as the incorrect path prevented the UI from rendering entirely.
