### PR TITLE
fix: StreamingResponseAggregator.close() drops final event when last chunk has no candidates

### DIFF
--- a/core/src/utils/streaming_utils.ts
+++ b/core/src/utils/streaming_utils.ts
@@ -329,10 +329,6 @@ export class StreamingResponseAggregator {
   }
 
   close(): LlmResponse | undefined {
-    if (!this.response?.candidates || this.response.candidates.length === 0) {
-      return;
-    }
-
     if (this.isProgressiveMode) {
       this.flushTextBufferToSequence();
       this.flushFunctionCallToSequence();
@@ -342,8 +338,11 @@ export class StreamingResponseAggregator {
         return;
       }
 
-      const candidate = this.response.candidates[0];
-      const finishReason = this.finishReason ?? candidate.finishReason;
+      // Use the candidate from the last response that carried one. Gemini may
+      // send a trailing empty chunk (no candidates) to signal stream end; we
+      // must not discard accumulated parts in that case.
+      const candidate = this.response?.candidates?.[0];
+      const finishReason = this.finishReason ?? candidate?.finishReason;
 
       return {
         content: {
@@ -357,19 +356,17 @@ export class StreamingResponseAggregator {
         errorMessage:
           finishReason === FinishReason.STOP
             ? undefined
-            : candidate.finishMessage,
+            : candidate?.finishMessage,
         usageMetadata: this.usageMetadata,
         finishReason: finishReason,
         partial: false,
       };
     }
 
-    // Non-progressive SSE streaming
-    if (
-      (this.text || this.thoughtText) &&
-      this.response.candidates &&
-      this.response.candidates.length > 0
-    ) {
+    // Non-progressive SSE streaming: use this.finishReason which is accumulated
+    // across all chunks, falling back to the last candidate when available.
+    // This handles the case where the final Gemini chunk carries no candidates.
+    if (this.text || this.thoughtText) {
       const parts: Part[] = [];
       if (this.thoughtText) {
         parts.push({text: this.thoughtText, thought: true});
@@ -377,8 +374,8 @@ export class StreamingResponseAggregator {
       if (this.text) {
         parts.push({text: this.text});
       }
-      const candidate = this.response.candidates[0];
-      const finishReason = candidate.finishReason;
+      const candidate = this.response?.candidates?.[0];
+      const finishReason = this.finishReason ?? candidate?.finishReason;
       return {
         content: {
           role: 'model',
@@ -391,7 +388,7 @@ export class StreamingResponseAggregator {
         errorMessage:
           finishReason === FinishReason.STOP
             ? undefined
-            : candidate.finishMessage,
+            : candidate?.finishMessage,
         usageMetadata: this.usageMetadata,
         finishReason: finishReason,
         partial: false,

--- a/core/test/utils/streaming_utils_test.ts
+++ b/core/test/utils/streaming_utils_test.ts
@@ -493,5 +493,59 @@ describe('StreamingResponseAggregator', () => {
         },
       ]);
     });
+
+    it('should yield final response when last chunk has no candidates (progressive mode)', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      // First chunk: function call with candidates
+      const chunkWithCandidate = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                args: {city: 'Seattle'},
+              } as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      // Final chunk: no candidates (Gemini stream termination signal)
+      const emptyChunk = new GenerateContentResponse();
+      emptyChunk.candidates = [];
+
+      for await (const _ of aggregator.processResponse(chunkWithCandidate)) {
+        // consume
+      }
+      for await (const _ of aggregator.processResponse(emptyChunk)) {
+        // consume
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.partial).toBe(false);
+      expect(finalResponse?.content?.parts).toHaveLength(1);
+      expect(finalResponse?.content?.parts?.[0]?.functionCall?.name).toBe(
+        'get_weather',
+      );
+    });
+  });
+
+  describe('Non-Progressive Mode', () => {
+    it('should return undefined from close() when no data accumulated and last chunk has no candidates', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      const emptyChunk = new GenerateContentResponse();
+      emptyChunk.candidates = [];
+
+      for await (const _ of aggregator.processResponse(emptyChunk)) {
+        // consume
+      }
+
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #289

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Test Files  134 passed (134)
Tests  1332 passed (1332)
```

**Manual End-to-End (E2E) Tests:**

The bug triggers in progressive SSE streaming mode when Gemini sends a final empty chunk (no `candidates` array) to signal stream end after a function call. Without the fix, `close()` returns `undefined` because the early guard exits before the accumulated `partsSequence` is returned — the agent loop receives no final event and the tool call is never executed.

With the fix, `close()` correctly returns the accumulated `partsSequence` (containing the function call) as a `partial: false` event regardless of whether the last chunk carried candidates.

Setup: agent with a tool using any model that sends a trailing empty termination chunk in streaming mode. Send a prompt that triggers the tool. Without the fix, the agent silently stops after the function call event with no tool execution. With the fix, the tool executes and the agent produces a final text response.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Root cause:** `StreamingResponseAggregator.close()` had an early guard:

```ts
if (!this.response?.candidates || this.response.candidates.length === 0) {
  return;
}
```

When Gemini sends a trailing empty chunk (no `candidates`) as a stream termination signal, `this.response` gets set to that empty chunk in `processResponse()`. On the subsequent `close()` call, the guard fires and returns `undefined` — discarding all data accumulated in `partsSequence` (progressive mode) or `text`/`thoughtText` (non-progressive mode).

**Fix:** Remove the early guard. In progressive mode, `partsSequence.length === 0` already provides a safe early-exit when there is genuinely nothing to return. Candidate access is updated to use optional chaining (`this.response?.candidates?.[0]`) so the code is safe when the last chunk had no candidates. `this.finishReason`, which is accumulated from whichever chunk last carried it, serves as the primary source of the finish reason in both paths.
