### PR TITLE
fix: apply toolFilter in MCPToolset.getTools()

### DIFF
--- a/core/src/tools/mcp/mcp_toolset.ts
+++ b/core/src/tools/mcp/mcp_toolset.ts
@@ -6,6 +6,7 @@
 
 import {ListToolsResult} from '@modelcontextprotocol/sdk/types.js';
 
+import {ReadonlyContext} from '../../agents/readonly_context.js';
 import {logger} from '../../utils/logger.js';
 import {BaseTool} from '../base_tool.js';
 import {BaseToolset, ToolPredicate} from '../base_toolset.js';
@@ -54,7 +55,7 @@ export class MCPToolset extends BaseToolset {
     this.mcpSessionManager = new MCPSessionManager(connectionParams);
   }
 
-  async getTools(): Promise<BaseTool[]> {
+  async getTools(context?: ReadonlyContext): Promise<BaseTool[]> {
     const session = await this.mcpSessionManager.createSession();
 
     const listResult = (await session.listTools()) as ListToolsResult;
@@ -63,8 +64,7 @@ export class MCPToolset extends BaseToolset {
       logger.debug(`tool: ${tool.name}`);
     }
 
-    // TODO: respect context (e.g. tool filter)
-    return listResult.tools.map((tool) => {
+    const tools = listResult.tools.map((tool) => {
       // Create a cloned tool definition with the prefixed name
       const toolWithPrefix = {
         ...tool,
@@ -72,6 +72,31 @@ export class MCPToolset extends BaseToolset {
       };
       return new MCPTool(toolWithPrefix, this.mcpSessionManager, tool.name);
     });
+
+    // Apply toolFilter when specified.
+    // An empty array (the default) means no filter — all tools are returned.
+    const filter = this.toolFilter;
+    if (!filter || (Array.isArray(filter) && filter.length === 0)) {
+      return tools;
+    }
+
+    if (Array.isArray(filter)) {
+      // String-array filter: match against the (possibly-prefixed) tool name.
+      return tools.filter((tool) => (filter as string[]).includes(tool.name));
+    }
+
+    if (context) {
+      // Predicate filter: requires a ReadonlyContext to evaluate.
+      return tools.filter((tool) => filter(tool, context));
+    }
+
+    // Predicate filter requested but no context provided — return all tools
+    // and log a warning so callers are aware the filter was not applied.
+    logger.warn(
+      'MCPToolset: a ToolPredicate toolFilter was provided but getTools() ' +
+        'was called without a ReadonlyContext. The filter will not be applied.',
+    );
+    return tools;
   }
 
   async close(): Promise<void> {}

--- a/core/test/tools/mcp/mcp_toolset_test.ts
+++ b/core/test/tools/mcp/mcp_toolset_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {describe, expect, it, vi} from 'vitest';
+import {ReadonlyContext} from '../../../src/agents/readonly_context.js';
 import {MCPConnectionParams} from '../../../src/tools/mcp/mcp_session_manager.js';
 import {MCPToolset} from '../../../src/tools/mcp/mcp_toolset.js';
 
@@ -32,14 +33,14 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => {
   };
 });
 
+const stdioParams = {
+  type: 'StdioConnectionParams',
+  serverParams: {command: 'test'},
+} as unknown as MCPConnectionParams;
+
 describe('MCPToolset', () => {
   it('discovers tools without prefix', async () => {
-    const connectionParams = {
-      type: 'StdioConnectionParams',
-      serverParams: {command: 'test'},
-    } as unknown as MCPConnectionParams;
-    const toolset = new MCPToolset(connectionParams);
-
+    const toolset = new MCPToolset(stdioParams);
     const tools = await toolset.getTools();
 
     expect(tools).toHaveLength(2);
@@ -48,16 +49,69 @@ describe('MCPToolset', () => {
   });
 
   it('discovers tools with prefix applied', async () => {
-    const connectionParams = {
-      type: 'StdioConnectionParams',
-      serverParams: {command: 'test'},
-    } as unknown as MCPConnectionParams;
-    const toolset = new MCPToolset(connectionParams, [], 'myprefix');
-
+    const toolset = new MCPToolset(stdioParams, [], 'myprefix');
     const tools = await toolset.getTools();
 
     expect(tools).toHaveLength(2);
     expect(tools[0].name).toBe('myprefix_test-tool');
     expect(tools[1].name).toBe('myprefix_other-tool');
+  });
+
+  describe('toolFilter', () => {
+    it('empty array (default) returns all tools', async () => {
+      const toolset = new MCPToolset(stdioParams, []);
+      const tools = await toolset.getTools();
+
+      expect(tools).toHaveLength(2);
+    });
+
+    it('string array filter returns only matching tools', async () => {
+      const toolset = new MCPToolset(stdioParams, ['test-tool']);
+      const tools = await toolset.getTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('test-tool');
+    });
+
+    it('string array filter with prefix matches prefixed names', async () => {
+      const toolset = new MCPToolset(
+        stdioParams,
+        ['myprefix_test-tool'],
+        'myprefix',
+      );
+      const tools = await toolset.getTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('myprefix_test-tool');
+    });
+
+    it('string array filter returns empty when no tools match', async () => {
+      const toolset = new MCPToolset(stdioParams, ['nonexistent-tool']);
+      const tools = await toolset.getTools();
+
+      expect(tools).toHaveLength(0);
+    });
+
+    it('predicate filter applies when context is provided', async () => {
+      const toolset = new MCPToolset(
+        stdioParams,
+        (tool) => tool.name === 'other-tool',
+      );
+      const tools = await toolset.getTools({} as ReadonlyContext);
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('other-tool');
+    });
+
+    it('predicate filter returns all tools when no context is provided', async () => {
+      const toolset = new MCPToolset(
+        stdioParams,
+        (tool) => tool.name === 'other-tool',
+      );
+      // No context passed — filter cannot be applied, returns all tools
+      const tools = await toolset.getTools();
+
+      expect(tools).toHaveLength(2);
+    });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #312

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Test Files  134 passed (134)
Tests  1341 passed (1341)
```

**Manual End-to-End (E2E) Tests:**

Created an `MCPToolset` with a string-array `toolFilter` pointing at a stdio MCP server. Without the fix, all tools are returned regardless of the filter. With the fix, only the named tools are returned.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Root cause:** `MCPToolset` accepts `toolFilter: ToolPredicate | string[]` (inherited from `BaseToolset`) but `getTools()` never consulted the filter — there was a `// TODO: respect context (e.g. tool filter)` comment acknowledging this gap. All tools from the MCP server were always returned, making the `toolFilter` parameter a no-op.

**Fix:** `getTools(context?: ReadonlyContext)` now applies the filter after building the tool list:

- `toolFilter: []` (default) — empty array is treated as "no filter"; all tools returned. This preserves the existing default behaviour.
- `toolFilter: string[]` — tools are filtered by (possibly-prefixed) name; no `ReadonlyContext` needed.
- `toolFilter: ToolPredicate` — predicate is evaluated against each tool when a `ReadonlyContext` is supplied. If called without a context, all tools are returned and a warning is logged.
