### PR TITLE
fix: replace Unix cp with node.js fs.cp in dev/build.js for Windows compatibility

### DIFF
--- a/dev/build.js
+++ b/dev/build.js
@@ -4,14 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import esbuild from 'esbuild';
-import {exec} from 'node:child_process';
-import {writeFile} from 'node:fs/promises';
-import {promisify} from 'node:util';
+import {cp, writeFile} from 'node:fs/promises';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import {shimPlugin} from 'esbuild-shim-plugin';
-
-const execAsync = promisify(exec);
 
 const licenseHeaderText = `/**
   * @license
@@ -56,8 +52,8 @@ async function main() {
 
   // Run file operations sequentially to avoid race conditions
   await writeFile('./dist/cjs/package.json', '{"type": "commonjs"}');
-  await execAsync('cp -r ./src/browser ./dist/esm/browser');
-  await execAsync('cp -r ./src/browser ./dist/cjs/browser');
+  await cp('./src/browser', './dist/esm/browser', {recursive: true});
+  await cp('./src/browser', './dist/cjs/browser', {recursive: true});
 }
 
 main().catch((err) => {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**Problem:**
`build.js` uses Node.js `child_process.exec()` to run the Unix shell command `cp -r` when copying the browser directory into the dist output folders. This works on Unix/macOS but fails on Windows during `npm run build`:

```
Build failed: Error: Command failed: cp -r ./src/browser ./dist/esm/browser
'cp' is not recognized as an internal or external command, operable program or batch file.
```

Windows contributors following the setup steps in `CONTRIBUTING.md` are blocked from building @google/adk-devtools entirely.

**Solution:**
Replace the `exec('cp -r ...')` shell calls with Node.js's built-in `fs.cp()` from `node:fs/promises`. This is cross-platform, requires no shell and the `exec/promisify` imports are removed as they are no longer needed.

**Before:**

```js
import {exec} from 'node:child_process';
import {writeFile} from 'node:fs/promises';
import {promisify} from 'node:util';

const execAsync = promisify(exec);
// ...
await execAsync('cp -r ./src/browser ./dist/esm/browser');
await execAsync('cp -r ./src/browser ./dist/cjs/browser');
```

**After:**

```js
import {cp, writeFile} from 'node:fs/promises';
// ...
await cp('./src/browser', './dist/esm/browser', {recursive: true});
await cp('./src/browser', './dist/cjs/browser', {recursive: true});
```

`node:fs/promises` `cp` is available since Node.js 16.7.0, which is within the project's existing `target: 'node16'` baseline. perfect...

### Testing Plan

**Unit Tests:**

- No unit tests added - this is a build script fix with no runtime behavior change.
- [x] All unit tests pass locally.

```
Test Files  138 passed | 11 skipped (149)
      Tests  1350 passed | 23 skipped (1373)
```

**Manual End-to-End (E2E) Tests:**

- [x] Verified `npm run build` in `/dev` completes successfully on windows after the change.
- [x] ESM and CJS outputs are generated correctly including the browser directory.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. (n/a - build script fix)
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
