### PR TITLE
feat: Google maps tool

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -209,6 +209,10 @@ export type {
   ToolInputParameters,
   ToolOptions,
 } from './tools/function_tool.js';
+export {
+  GOOGLE_MAPS_GROUNDING,
+  GoogleMapsGroundingTool,
+} from './tools/google_maps_grounding_tool.js';
 export {GOOGLE_SEARCH, GoogleSearchTool} from './tools/google_search_tool.js';
 export {
   LOAD_ARTIFACTS,
@@ -221,7 +225,6 @@ export {
   PreloadMemoryTool,
 } from './tools/preload_memory_tool.js';
 export {ToolConfirmation} from './tools/tool_confirmation.js';
-export {VertexRagRetrievalTool} from './tools/vertex_rag_retrieval_tool.js';
 export {URL_CONTEXT, UrlContextTool} from './tools/url_context_tool.js';
 export {VertexAiSearchTool} from './tools/vertex_ai_search_tool.js';
 export type {
@@ -231,6 +234,7 @@ export type {
   VertexAISearchDataStoreSpec,
   VertexAiSearchToolParams,
 } from './tools/vertex_ai_search_tool.js';
+export {VertexRagRetrievalTool} from './tools/vertex_rag_retrieval_tool.js';
 export {LogLevel, getLogger, setLogLevel, setLogger} from './utils/logger.js';
 export type {Logger} from './utils/logger.js';
 export {isGemini2OrAbove} from './utils/model_name.js';

--- a/core/src/tools/google_maps_grounding_tool.ts
+++ b/core/src/tools/google_maps_grounding_tool.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {GenerateContentConfig} from '@google/genai';
+
+import {LlmRequest} from '../models/llm_request.js';
+import {
+  isGemini1Model,
+  isGeminiModel,
+  isGeminiModelIdCheckDisabled,
+} from '../utils/model_name.js';
+
+import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+
+/**
+ * Applies Google Maps grounding to the LLM request if supported.
+ */
+export function applyGoogleMapsGrounding(llmRequest: LlmRequest): void {
+  if (!llmRequest.model) {
+    return;
+  }
+
+  const modelCheckDisabled = isGeminiModelIdCheckDisabled();
+  llmRequest.config = llmRequest.config || ({} as GenerateContentConfig);
+  llmRequest.config.tools = llmRequest.config.tools || [];
+
+  if (isGemini1Model(llmRequest.model)) {
+    throw new Error(
+      'Google Maps grounding tool cannot be used with Gemini 1.x models.',
+    );
+  }
+
+  if (isGeminiModel(llmRequest.model) || modelCheckDisabled) {
+    llmRequest.config.tools.push({
+      googleMaps: {},
+    });
+
+    return;
+  }
+
+  throw new Error(
+    `Google maps tool is not supported for model ${llmRequest.model}`,
+  );
+}
+
+/**
+ * A built-in tool that is automatically invoked by Gemini 2 models to ground
+ * query results with Google Maps.
+ *
+ * This tool operates internally within the model and does not require or
+ * perform local code execution.
+ */
+export class GoogleMapsGroundingTool extends BaseTool {
+  constructor() {
+    super({name: 'google_maps', description: 'Google Maps Grounding Tool'});
+  }
+
+  runAsync(): Promise<unknown> {
+    // This is a built-in tool on server side, it's triggered by setting the
+    // corresponding request parameters.
+    return Promise.resolve();
+  }
+
+  override async processLlmRequest({
+    llmRequest,
+  }: ToolProcessLlmRequest): Promise<void> {
+    applyGoogleMapsGrounding(llmRequest);
+  }
+}
+
+/**
+ * A global instance of {@link GoogleMapsGroundingTool}.
+ */
+export const GOOGLE_MAPS_GROUNDING = new GoogleMapsGroundingTool();

--- a/core/test/tools/google_maps_grounding_tool_test.ts
+++ b/core/test/tools/google_maps_grounding_tool_test.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  GOOGLE_MAPS_GROUNDING,
+  GoogleMapsGroundingTool,
+  LlmRequest,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+function makeRequest(model?: string, tools = []): LlmRequest {
+  return {
+    model,
+    config: {tools},
+    contents: [],
+    toolsDict: {},
+    liveConnectConfig: {},
+  } as unknown as LlmRequest;
+}
+
+describe('GoogleMapsGroundingTool', () => {
+  describe('processLlmRequest', () => {
+    it('returns early when model is not set', async () => {
+      const tool = new GoogleMapsGroundingTool();
+      const req = makeRequest(undefined);
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config?.tools).toEqual([]);
+    });
+
+    it('throws for Gemini 1.x model', async () => {
+      const tool = new GoogleMapsGroundingTool();
+      const req = makeRequest('gemini-1.5-pro');
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow(
+        'Google Maps grounding tool cannot be used with Gemini 1.x models.',
+      );
+    });
+
+    it('adds googleMaps for Gemini 2+ model', async () => {
+      const tool = new GoogleMapsGroundingTool();
+      const req = makeRequest('gemini-2.0-flash');
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{googleMaps: {}}]);
+    });
+
+    it('throws for unsupported (non-Gemini) model', async () => {
+      const tool = new GoogleMapsGroundingTool();
+      const req = makeRequest('gpt-4');
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow('Google maps tool is not supported for model gpt-4');
+    });
+
+    it('initializes config.tools when config is absent', async () => {
+      const tool = new GoogleMapsGroundingTool();
+      const req: LlmRequest = {
+        model: 'gemini-2.0-flash',
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      } as unknown as LlmRequest;
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{googleMaps: {}}]);
+    });
+
+    it('adds googleMaps for non-Gemini model when check is disabled', async () => {
+      const tool = new GoogleMapsGroundingTool();
+      const req = makeRequest('gpt-4');
+
+      const originalValue = process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK;
+      process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK = 'true';
+
+      try {
+        await tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        });
+        expect(req.config!.tools).toEqual([{googleMaps: {}}]);
+      } finally {
+        if (originalValue === undefined) {
+          delete process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK;
+        } else {
+          process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK = originalValue;
+        }
+      }
+    });
+
+    it('runAsync returns resolved promise', async () => {
+      const tool = new GoogleMapsGroundingTool();
+      await expect(tool.runAsync()).resolves.toBeUndefined();
+    });
+  });
+
+  it('has a global instance GOOGLE_MAPS_GROUNDING', () => {
+    expect(GOOGLE_MAPS_GROUNDING).toBeInstanceOf(GoogleMapsGroundingTool);
+  });
+});

--- a/tests/integration/tools/google_maps_grounding_tool_test.ts
+++ b/tests/integration/tools/google_maps_grounding_tool_test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Gemini,
+  GoogleMapsGroundingTool,
+  LlmAgent,
+  LlmRequest,
+} from '@google/adk';
+import {GenerateContentResponse, GoogleGenAI} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {createRunner} from '../test_case_utils.js';
+
+class SpyMockModels {
+  lastRequest?: LlmRequest;
+  private response: GenerateContentResponse;
+
+  constructor(response: GenerateContentResponse) {
+    this.response = response;
+  }
+
+  async generateContent(req: LlmRequest): Promise<GenerateContentResponse> {
+    this.lastRequest = req;
+    return this.response;
+  }
+}
+
+class SpyMockGenAIClient {
+  public models: SpyMockModels;
+  public vertexai = false;
+
+  constructor(response: GenerateContentResponse) {
+    this.models = new SpyMockModels(response);
+  }
+}
+
+class SpyGemini extends Gemini {
+  public spyClient: SpyMockGenAIClient;
+
+  constructor(response: GenerateContentResponse) {
+    super({apiKey: 'test-key'});
+    this.spyClient = new SpyMockGenAIClient(response);
+  }
+
+  override get apiClient(): GoogleGenAI {
+    return this.spyClient as unknown as GoogleGenAI;
+  }
+}
+
+describe('GoogleMapsGroundingTool Integration', () => {
+  it('adds googleMaps config to the LLM request during execution', async () => {
+    const mockResponse = new GenerateContentResponse();
+    mockResponse.candidates = [
+      {
+        content: {
+          parts: [{text: 'Mock response'}],
+          role: 'model',
+        },
+      },
+    ];
+
+    const spyModel = new SpyGemini(mockResponse);
+    const mapsTool = new GoogleMapsGroundingTool();
+
+    const agent = new LlmAgent({
+      model: spyModel,
+      name: 'mapsAgent',
+      description: 'Agent with maps tool',
+      instruction: 'Search for something on maps',
+      tools: [mapsTool],
+    });
+
+    const {run} = await createRunner(agent);
+
+    // Run the agent
+    for await (const _event of run('Find info about X')) {
+      // Consume events
+    }
+
+    // Verify the request captured by the spy model
+    expect(spyModel.spyClient.models.lastRequest).toBeDefined();
+    expect(spyModel.spyClient.models.lastRequest!.config?.tools).toHaveLength(
+      1,
+    );
+    expect(spyModel.spyClient.models.lastRequest!.config?.tools?.[0]).toEqual({
+      googleMaps: {},
+    });
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

if no issue exists, describe the change:

Problem: The Google Maps tool was available in `adk-python` but missing in `adk-js`.

Solution: Ported `GoogleMapsGroundingTool` from Python to TypeScript in `adk-js`. The implementation adds the `googleMaps` tool to the request config for Gemini 2 and above models (including Gemini 3).

Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- Added unit tests for `GoogleMapsGroundingTool` covering model validation and config modification.
- Verified that tests pass.

Summary of passed npm test results:
```
✓ |unit:core| core/test/tools/google_maps_grounding_tool_test.ts (8 tests)
✓ |integration| tests/integration/tools/google_maps_grounding_tool_test.ts (1 test)
```
Coverage for `google_maps_grounding_tool.ts` is 100% (verified via vitest coverage report). 

Manual End-to-End (E2E) Tests:
This is a built-in tool that operates server-side by passing parameters to the Gemini API. Unit and integration tests verify that the request is correctly modified.

Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes. (One pre-existing test failure observed in large test suite, unrelated to this change; global coverage thresholds failed due to running single test file).
