### PR TITLE
fix: filter thought parts in stringifyContent and AgentTool merged text

### DIFF
--- a/core/src/events/event.ts
+++ b/core/src/events/event.ts
@@ -157,7 +157,11 @@ export function stringifyContent(event: Event): string {
     return '';
   }
 
-  return event.content.parts.map((part) => part.text ?? '').join('');
+  // Exclude thoughts from the context.
+  return event.content.parts
+    .filter((part) => !part.thought)
+    .map((part) => part.text ?? '')
+    .join('');
 }
 
 const ASCII_LETTERS_AND_NUMBERS =

--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -185,7 +185,9 @@ export class AgentTool extends BaseTool {
     }
 
     const hasOutputSchema = isLlmAgent(this.agent) && this.agent.outputSchema;
+    // Exclude thoughts from the merged text.
     const mergedText = lastEvent.content.parts
+      .filter((part) => !part.thought)
       .map((part) => part.text)
       .filter((text) => text)
       .join('\n');

--- a/core/test/events/event_test.ts
+++ b/core/test/events/event_test.ts
@@ -209,6 +209,31 @@ describe('Event Utils', () => {
       });
       expect(stringifyContent(event)).toBe('HelloWorld');
     });
+
+    it('ignores parts marked as thought', () => {
+      const event = createEvent({
+        content: {
+          parts: [
+            {text: 'reasoning about the user request', thought: true},
+            {text: 'Hello'},
+            {text: 'World'},
+          ],
+        },
+      });
+      expect(stringifyContent(event)).toBe('HelloWorld');
+    });
+
+    it('returns empty string when all parts are thoughts', () => {
+      const event = createEvent({
+        content: {
+          parts: [
+            {text: 'first thought', thought: true},
+            {text: 'second thought', thought: true},
+          ],
+        },
+      });
+      expect(stringifyContent(event)).toBe('');
+    });
   });
 
   describe('createNewEventId', () => {

--- a/core/test/tools/agent_tool_test.ts
+++ b/core/test/tools/agent_tool_test.ts
@@ -162,6 +162,57 @@ describe('AgentTool', () => {
     );
   });
 
+  it('strips thought parts from the merged result', async () => {
+    const mockAgent = {
+      name: 'sub-agent',
+    } as unknown as LlmAgent;
+
+    const tool = new AgentTool({agent: mockAgent});
+
+    const session = createSession({
+      id: 'parent-session',
+      appName: 'sub-agent',
+      userId: 'parent-user',
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: mockAgent,
+      session,
+      pluginManager: new PluginManager([]),
+    });
+
+    const toolContext = new Context({invocationContext});
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {
+          role: 'model',
+          parts: [
+            {text: 'reasoning about the user request', thought: true},
+            {text: 'final answer'},
+          ],
+        },
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation((config) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsync,
+      } as unknown as Runner;
+    });
+
+    const result = await tool.runAsync({
+      args: {request: 'hello'},
+      toolContext,
+    });
+
+    expect(result).toBe('final answer');
+  });
+
   it('handles abort signal before execution', async () => {
     const mockAgent = {
       name: 'sub-agent',


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #322

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Test Files  115 passed (115)
     Tests  1275 passed (1275)
```

Added cases:

- `core/test/events/event_test.ts` — `stringifyContent` skips parts marked `thought: true`.
- `core/test/tools/agent_tool_test.ts` — `AgentTool.runAsync` returns only the non-thought text from the sub-agent's last event.

**Manual End-to-End (E2E) Tests:**

Verified against a live `LlmAgent` configured with `thinkingConfig.includeThoughts: true`. Before the fix, the sub-agent's reasoning was concatenated into the parent's tool response and persisted to the message store. After the fix, only the final answer is returned, while the original `thought: true` parts are still preserved on the `Event` (visible in OpenTelemetry traces).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Root cause:** `AgentTool.runAsync` and `stringifyContent` merged every part's `text` without checking `part.thought`. When `thinkingConfig.includeThoughts: true` is enabled, the model returns reasoning as parts with `thought: true`; those leaked into the parent agent's input (via `AgentTool`) and into persisted/displayed messages (via `stringifyContent`).

**Fix:** Add `.filter((part) => !part.thought)` in both locations, matching the existing behavior in `adk-python`:

https://github.com/google/adk-python/blob/main/src/google/adk/tools/agent_tool.py

```python
merged_text = '\n'.join(
    p.text for p in last_content.parts if p.text and not p.thought
)
```