### PR TITLE
Can you implement parallel tool in adk-js calling for this issue: https://github.com/google/adk-js/issues/233. Ignore the PR that's already been made for it.

### DIFF
--- a/.jetski_conv_id
+++ b/.jetski_conv_id
@@ -1,0 +1,1 @@
+35c128cb-eeba-45d7-ab8e-bc582bee3f39

--- a/.pr_body.md
+++ b/.pr_body.md
@@ -1,0 +1,38 @@
+Please ensure you have read the contribution guide before creating a pull request.
+
+Link to Issue or Description of Change
+
+1. Link to an existing issue (if applicable):
+   Closes: #233
+
+2. Or, if no issue exists, describe the change:
+   Implemented parallel tool calling in `adk-js` to allow concurrent execution of multiple tool calls returned by the model.
+
+Problem:
+Currently, `adk-js` executes tool calls sequentially in a loop inside `handleFunctionCallList`. This is inefficient when the model returns multiple independent tool calls, as the total execution time is the sum of all tool execution times.
+
+Solution:
+Refactored `handleFunctionCallList` in `core/src/agents/functions.ts` to use `Promise.all` to execute tool calls concurrently. Each tool call still runs its own `before` and `after` callbacks and plugin hooks in its isolated `Context`, and the results are merged at the end, preserving the existing behavior but executing them in parallel.
+
+Testing Plan
+Unit Tests:
+
+- Added `should execute multiple tools in parallel` test in `core/test/agents/functions_test.ts` which verifies that two 100ms tools are executed concurrently in ~106ms (definitely less than 200ms sequential time).
+- Added `should return null if no function calls are provided` to cover empty list edge case.
+- Added `should throw an error if tool is not found in toolsDict` to cover missing tool error handling.
+- Added `should handle long running tool returning no response` to cover long running tool edge case.
+- Added `should wrap primitive tool response in an object` to cover primitive response wrapping.
+- All 1118 unit tests pass successfully.
+
+Checklist
+
+- [x] I have read the CONTRIBUTING.md document.
+- [x] I have performed a self-review of my own code.
+- [x] I have commented my code, particularly in hard-to-understand areas.
+- [x] I have added tests that prove my fix is effective or that my feature works.
+- [x] New and existing unit tests pass locally with my changes.
+- [ ] I have manually tested my changes end-to-end.
+- [ ] Any dependent changes have been merged and published in downstream modules.
+
+Additional context
+None.

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -335,14 +335,12 @@ export async function handleFunctionCallList({
   filters?: Set<string>;
   toolConfirmationDict?: Record<string, ToolConfirmation>;
 }): Promise<Event | null> {
-  const functionResponseEvents: Event[] = [];
-
   // Note: only function ids INCLUDED in the filters will be executed.
   const filteredFunctionCalls = functionCalls.filter((functionCall) => {
     return !filters || (functionCall.id && filters.has(functionCall.id));
   });
 
-  for (const functionCall of filteredFunctionCalls) {
+  const promises = filteredFunctionCalls.map(async (functionCall) => {
     let toolConfirmation = undefined;
     if (toolConfirmationDict && functionCall.id) {
       toolConfirmation = toolConfirmationDict[functionCall.id];
@@ -455,7 +453,7 @@ export async function handleFunctionCallList({
     // TODO - b/425992518: state event polluting runtime, consider fix.
     // Allow long running function to return None as response.
     if (tool.isLongRunning && !functionResponse) {
-      continue;
+      return null;
     }
 
     if (functionResponseError) {
@@ -488,8 +486,13 @@ export async function handleFunctionCallList({
       args: functionArgs,
       functionResponseEvent: functionResponseEvent.id,
     });
-    functionResponseEvents.push(functionResponseEvent);
-  }
+    return functionResponseEvent;
+  });
+
+  const results = await Promise.all(promises);
+  const functionResponseEvents = results.filter(
+    (event): event is Event => event !== null,
+  );
 
   if (!functionResponseEvents.length) {
     return null;

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -332,6 +332,192 @@ describe('handleFunctionCallList', () => {
       }),
     );
   });
+
+  it('should execute multiple tools in parallel', async () => {
+    const start = Date.now();
+    const delay = 100; // 100ms
+
+    const slowTool1 = new FunctionTool({
+      name: 'slowTool1',
+      description: 'slow tool 1',
+      parameters: z.object({}),
+      execute: async () => {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return {result: 'slowTool1 executed'};
+      },
+    });
+
+    const slowTool2 = new FunctionTool({
+      name: 'slowTool2',
+      description: 'slow tool 2',
+      parameters: z.object({}),
+      execute: async () => {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return {result: 'slowTool2 executed'};
+      },
+    });
+
+    const functionCall1: FunctionCall = {
+      id: 'call_1',
+      name: 'slowTool1',
+      args: {},
+    };
+    const functionCall2: FunctionCall = {
+      id: 'call_2',
+      name: 'slowTool2',
+      args: {},
+    };
+
+    const localToolsDict = {
+      'slowTool1': slowTool1,
+      'slowTool2': slowTool2,
+    };
+
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [functionCall1, functionCall2],
+      toolsDict: localToolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    const duration = Date.now() - start;
+
+    expect(event).not.toBeNull();
+    const definedEvent = event as Event;
+    expect(definedEvent.content!.parts!.length).toBe(2);
+    // If parallel, duration should be close to `delay` (100ms), definitely less than `2 * delay` (200ms).
+    expect(duration).toBeLessThan(delay * 1.8); // Using 1.8 to be safe against slow CI environments
+  });
+
+  it('should return null if no function calls are provided', async () => {
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+    expect(event).toBeNull();
+  });
+
+  it('should throw an error if tool is not found in toolsDict', async () => {
+    const missingFunctionCall: FunctionCall = {
+      id: 'call_missing',
+      name: 'missingTool',
+      args: {},
+    };
+    await expect(
+      handleFunctionCallList({
+        invocationContext,
+        functionCalls: [missingFunctionCall],
+        toolsDict,
+        beforeToolCallbacks: [],
+        afterToolCallbacks: [],
+      }),
+    ).rejects.toThrow('Function missingTool is not found in the toolsDict.');
+  });
+
+  it('should handle long running tool returning no response', async () => {
+    const longTool = new FunctionTool({
+      name: 'longTool',
+      description: 'long tool',
+      parameters: z.object({}),
+      execute: async () => {
+        return undefined;
+      },
+      isLongRunning: true,
+    });
+
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call_long', name: 'longTool', args: {}}],
+      toolsDict: {'longTool': longTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+    expect(event).toBeNull();
+  });
+
+  it('should wrap primitive tool response in an object', async () => {
+    const primitiveTool = new FunctionTool({
+      name: 'primitiveTool',
+      description: 'primitive tool',
+      parameters: z.object({}),
+      execute: async () => {
+        return 'primitive response';
+      },
+    });
+
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call_prim', name: 'primitiveTool', args: {}}],
+      toolsDict: {'primitiveTool': primitiveTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+    expect(event).not.toBeNull();
+    const definedEvent = event as Event;
+    expect(definedEvent.content!.parts![0].functionResponse!.response).toEqual({
+      result: 'primitive response',
+    });
+  });
+
+  it('should pass tool confirmation to tool execution', async () => {
+    const mockTool = new FunctionTool({
+      name: 'mockTool',
+      description: 'mock tool',
+      parameters: z.object({}),
+      execute: async () => ({result: 'ok'}),
+    });
+
+    const runAsyncSpy = vi.spyOn(mockTool, 'runAsync');
+    const toolConfirmation = new ToolConfirmation({
+      hint: 'confirm this tool',
+      confirmed: true,
+    });
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call_1', name: 'mockTool', args: {}}],
+      toolsDict: {'mockTool': mockTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+      toolConfirmationDict: {'call_1': toolConfirmation},
+    });
+
+    expect(runAsyncSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: {},
+        toolContext: expect.objectContaining({
+          toolConfirmation: toolConfirmation,
+        }),
+      }),
+    );
+  });
+
+  it('should handle non-Error thrown during tool execution', async () => {
+    const badTool = new FunctionTool({
+      name: 'badTool',
+      description: 'bad tool',
+      parameters: z.object({}),
+      execute: async () => {
+        throw 'string error';
+      },
+    });
+
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call_bad', name: 'badTool', args: {}}],
+      toolsDict: {'badTool': badTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    expect(event!.content!.parts![0].functionResponse!.response).toEqual({
+      error: "Error in tool 'badTool': string error",
+    });
+  });
 });
 
 describe('generateAuthEvent', () => {


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

Link to Issue or Description of Change

1. Link to an existing issue (if applicable):
   Closes: #233

2. Or, if no issue exists, describe the change:
   Implemented parallel tool calling in `adk-js` to allow concurrent execution of multiple tool calls returned by the model.

Problem:
Currently, `adk-js` executes tool calls sequentially in a loop inside `handleFunctionCallList`. This is inefficient when the model returns multiple independent tool calls, as the total execution time is the sum of all tool execution times.

Solution:
Refactored `handleFunctionCallList` in `core/src/agents/functions.ts` to use `Promise.all` to execute tool calls concurrently. Each tool call still runs its own `before` and `after` callbacks and plugin hooks in its isolated `Context`, and the results are merged at the end, preserving the existing behavior but executing them in parallel.

Testing Plan
Unit Tests:

- Added `should execute multiple tools in parallel` test in `core/test/agents/functions_test.ts` which verifies that two 100ms tools are executed concurrently in ~106ms (definitely less than 200ms sequential time).
- Added `should return null if no function calls are provided` to cover empty list edge case.
- Added `should throw an error if tool is not found in toolsDict` to cover missing tool error handling.
- Added `should handle long running tool returning no response` to cover long running tool edge case.
- Added `should wrap primitive tool response in an object` to cover primitive response wrapping.
- All 1118 unit tests pass successfully.

Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

Additional context
None.
