### PR TITLE
test: add unit tests for file_extension_utils

### DIFF
--- a/core/test/utils/file_extension_utils_test.ts
+++ b/core/test/utils/file_extension_utils_test.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {
+  CodeExecutionLanguage,
+  FileContentEncoding,
+} from '../../src/code_executors/code_execution_utils.js';
+import {
+  getMimeTypeAndEncoding,
+  getScriptLanguageByExtension,
+} from '../../src/utils/file_extension_utils.js';
+
+describe('getMimeTypeAndEncoding', () => {
+  describe('text extensions (UTF-8)', () => {
+    it.each([
+      ['.js', 'text/javascript'],
+      ['.py', 'text/x-python'],
+      ['.md', 'text/markdown'],
+      ['.txt', 'text/plain'],
+      ['.html', 'text/html'],
+      ['.css', 'text/css'],
+      ['.json', 'application/json'],
+      ['.csv', 'text/csv'],
+      ['.svg', 'image/svg+xml'],
+      ['.xml', 'application/xml'],
+      ['.yaml', 'text/yaml'],
+      ['.yml', 'text/yaml'],
+    ])('returns correct MIME type for %s', (ext, expectedMime) => {
+      const result = getMimeTypeAndEncoding(ext);
+      expect(result.mimeType).toBe(expectedMime);
+      expect(result.encoding).toBe(FileContentEncoding.UTF8);
+    });
+  });
+
+  describe('binary extensions (BASE64)', () => {
+    it.each([
+      ['.png', 'image/png'],
+      ['.jpg', 'image/jpeg'],
+      ['.jpeg', 'image/jpeg'],
+      ['.pdf', 'application/pdf'],
+    ])('returns correct MIME type for %s', (ext, expectedMime) => {
+      const result = getMimeTypeAndEncoding(ext);
+      expect(result.mimeType).toBe(expectedMime);
+      expect(result.encoding).toBe(FileContentEncoding.BASE64);
+    });
+  });
+
+  describe('unknown extension', () => {
+    it('returns application/octet-stream with BASE64 for unknown extension', () => {
+      const result = getMimeTypeAndEncoding('.unknown');
+      expect(result.mimeType).toBe('application/octet-stream');
+      expect(result.encoding).toBe(FileContentEncoding.BASE64);
+    });
+
+    it('returns fallback for empty string extension', () => {
+      const result = getMimeTypeAndEncoding('');
+      expect(result.mimeType).toBe('application/octet-stream');
+      expect(result.encoding).toBe(FileContentEncoding.BASE64);
+    });
+  });
+
+  describe('case-insensitivity', () => {
+    it('treats .JS the same as .js', () => {
+      expect(getMimeTypeAndEncoding('.JS')).toEqual(
+        getMimeTypeAndEncoding('.js'),
+      );
+    });
+
+    it('treats .PNG the same as .png', () => {
+      expect(getMimeTypeAndEncoding('.PNG')).toEqual(
+        getMimeTypeAndEncoding('.png'),
+      );
+    });
+
+    it('treats .JSON the same as .json', () => {
+      expect(getMimeTypeAndEncoding('.JSON')).toEqual(
+        getMimeTypeAndEncoding('.json'),
+      );
+    });
+  });
+});
+
+describe('getScriptLanguageByExtension', () => {
+  describe('known language extensions', () => {
+    it.each([
+      ['.js', CodeExecutionLanguage.JAVASCRIPT],
+      ['.ts', CodeExecutionLanguage.TYPESCRIPT],
+      ['.py', CodeExecutionLanguage.PYTHON],
+      ['.bat', CodeExecutionLanguage.WINDOWS_CMD],
+      ['.cmd', CodeExecutionLanguage.WINDOWS_CMD],
+      ['.ps1', CodeExecutionLanguage.POWERSHELL],
+      ['.sh', CodeExecutionLanguage.SHELL],
+    ])('returns correct language for %s', (ext, expectedLang) => {
+      expect(getScriptLanguageByExtension(ext)).toBe(expectedLang);
+    });
+  });
+
+  describe('unknown extension', () => {
+    it('returns UNSPECIFIED for unknown extension', () => {
+      expect(getScriptLanguageByExtension('.rb')).toBe(
+        CodeExecutionLanguage.UNSPECIFIED,
+      );
+    });
+
+    it('returns UNSPECIFIED for empty string', () => {
+      expect(getScriptLanguageByExtension('')).toBe(
+        CodeExecutionLanguage.UNSPECIFIED,
+      );
+    });
+  });
+
+  describe('case-insensitivity', () => {
+    it('treats .PY the same as .py', () => {
+      expect(getScriptLanguageByExtension('.PY')).toBe(
+        getScriptLanguageByExtension('.py'),
+      );
+    });
+
+    it('treats .SH the same as .sh', () => {
+      expect(getScriptLanguageByExtension('.SH')).toBe(
+        getScriptLanguageByExtension('.sh'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**Problem:** `core/src/utils/file_extension_utils.ts` exports `getMimeTypeAndEncoding` and `getScriptLanguageByExtension` — pure deterministic lookup functions used when loading files into code execution context — but had zero unit tests.

**Solution:** Add `core/test/utils/file_extension_utils_test.ts` with 32 tests covering:
- All 12 text MIME types returning correct `mimeType` + `UTF8` encoding
- All 4 binary MIME types returning correct `mimeType` + `BASE64` encoding
- Fallback to `application/octet-stream` / `BASE64` for unknown and empty extensions
- Case-insensitivity for both functions (`.JS` == `.js`, `.PNG` == `.png`)
- All 7 script language mappings
- `UNSPECIFIED` fallback for unknown and empty extensions

### Testing Plan

**Unit Tests:**
- [x] Added unit tests for `getMimeTypeAndEncoding` and `getScriptLanguageByExtension`
- [x] All unit tests pass locally

```
Test Files  1 passed (1)
     Tests  32 passed (32)
```

**Manual E2E Tests:**
No runtime behaviour changed — test-only addition.

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Commented hard-to-understand areas
- [x] Added tests proving fix/feature works
- [x] Unit tests pass locally
- [x] Manually tested end-to-end
- [x] Dependent changes merged/published