### PR TITLE
fix(auth/oauth2): block SSRF via IPv4-mapped IPv6 and fix dead 172.16/12 check

### DIFF
--- a/core/src/auth/oauth2/oauth2_discovery.ts
+++ b/core/src/auth/oauth2/oauth2_discovery.ts
@@ -170,6 +170,39 @@ export class OAuth2DiscoveryManager {
   }
 }
 
+
+/**
+ * Normalises the hostname returned by the WHATWG URL parser so that
+ * IPv4-mapped IPv6 addresses (e.g. [::ffff:7f00:1]) are converted to
+ * their canonical dotted-decimal IPv4 form (127.0.0.1) before any
+ * blocklist checks are applied.
+ *
+ * Without this step an attacker can bypass every IPv4 block by encoding
+ * the address as its IPv4-mapped IPv6 equivalent (CWE-918).
+ *
+ * The WHATWG URL serialiser always emits the compressed hex form:
+ *   new URL('https://[::ffff:127.0.0.1]/').hostname => '[::ffff:7f00:1]'
+ * so we only need to handle the two-group hex variant.
+ */
+function normaliseHostname(raw: string): string {
+  // Strip surrounding brackets that WHATWG adds for IPv6 literals.
+  const stripped = raw.replace(/^\[|\]$/g, '');
+
+  // ::ffff:HHHH:LLLL — two 16-bit hex groups (the only form Node emits)
+  const m = stripped.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (m) {
+    const hi = parseInt(m[1], 16);
+    const lo = parseInt(m[2], 16);
+    return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff].join('.');
+  }
+
+  // ::ffff:d.d.d.d — dotted-decimal form (accepted by some parsers)
+  const mDot = stripped.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mDot) return mDot[1];
+
+  return raw;
+}
+
 function validateDiscoveryUrl(urlStr: string): boolean {
   try {
     const url = new URL(urlStr);
@@ -178,13 +211,16 @@ function validateDiscoveryUrl(urlStr: string): boolean {
       return false;
     }
 
-    const host = url.hostname.toLowerCase();
+    // Normalise IPv4-mapped IPv6 before blocklist — e.g. [::ffff:a9fe:a9fe]
+    // becomes 169.254.169.254 so existing checks apply correctly (CWE-918).
+    const host = normaliseHostname(url.hostname.toLowerCase());
 
-    // Block localhost and common private IP ranges
+    // Block loopback, unspecified, link-local, and all private IPv4 ranges.
     if (
       host === 'localhost' ||
       host === '127.0.0.1' ||
-      host === '[::1]' ||
+      host === '[::1]'     ||
+      host === '0.0.0.0'   ||
       host.startsWith('10.') ||
       host.startsWith('192.168.') ||
       host.startsWith('169.254.')
@@ -193,7 +229,7 @@ function validateDiscoveryUrl(urlStr: string): boolean {
       return false;
     }
 
-    // Check for 172.16.x.x - 172.31.x.x
+    // RFC 1918: 172.16.0.0/12 (172.16.x.x – 172.31.x.x)
     const match = host.match(/^172\.(\d+)\./);
     if (match) {
       const secondOctet = parseInt(match[1], 10);
@@ -201,6 +237,24 @@ function validateDiscoveryUrl(urlStr: string): boolean {
         logger.warn(`Unsafe host for discovery URL: ${host}`);
         return false;
       }
+    }
+
+    // RFC 6598: CGNAT shared space 100.64.0.0/10
+    const cgnatMatch = host.match(/^100\.(\d+)\./);
+    if (cgnatMatch) {
+      const secondOctet = parseInt(cgnatMatch[1], 10);
+      if (secondOctet >= 64 && secondOctet <= 127) {
+        logger.warn(`Unsafe host for discovery URL: ${host}`);
+        return false;
+      }
+    }
+
+    // Block IPv6 ULA (fc00::/7) and link-local (fe80::/10).
+    // fc00::/7 spans fc::/8 and fd::/8; fe80::/10 spans fe80-febf.
+    // Use url.hostname here — still has original bracket form.
+    if (/^\[(f[cd][0-9a-f]{2}|fe[89ab][0-9a-f]):/i.test(url.hostname)) {
+      logger.warn(`Unsafe host for discovery URL: ${url.hostname}`);
+      return false;
     }
 
     return true;

--- a/core/test/auth/oauth2/oauth2_discovery_test.ts
+++ b/core/test/auth/oauth2/oauth2_discovery_test.ts
@@ -362,4 +362,120 @@ describe('OAuth2DiscoveryManager', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('validateDiscoveryUrl — SSRF blocklist', () => {
+    async function isBlocked(url: string): Promise<boolean> {
+      vi.mocked(fetch).mockClear();
+      await manager.discoverAuthServerMetadata(url);
+      return (fetch as ReturnType<typeof vi.fn>).mock.calls.length === 0;
+    }
+
+    it('blocks localhost', async () => {
+      expect(await isBlocked('https://localhost/')).toBe(true);
+    });
+
+    it('blocks 127.0.0.1 (IPv4 loopback)', async () => {
+      expect(await isBlocked('https://127.0.0.1/')).toBe(true);
+    });
+
+    it('blocks [::1] (IPv6 loopback)', async () => {
+      expect(await isBlocked('https://[::1]/')).toBe(true);
+    });
+
+    it('blocks 0.0.0.0 (unspecified)', async () => {
+      expect(await isBlocked('https://0.0.0.0/')).toBe(true);
+    });
+
+    it('blocks [::ffff:7f00:1] — IPv4-mapped 127.0.0.1', async () => {
+      expect(await isBlocked('https://[::ffff:7f00:1]/')).toBe(true);
+    });
+
+    it('blocks [::ffff:a9fe:a9fe] — IPv4-mapped 169.254.169.254 (IMDS)', async () => {
+      expect(await isBlocked('https://[::ffff:a9fe:a9fe]/')).toBe(true);
+    });
+
+    it('blocks [::ffff:a00:1] — IPv4-mapped 10.0.0.1', async () => {
+      expect(await isBlocked('https://[::ffff:a00:1]/')).toBe(true);
+    });
+
+    it('blocks [::ffff:ac10:1] — IPv4-mapped 172.16.0.1', async () => {
+      expect(await isBlocked('https://[::ffff:ac10:1]/')).toBe(true);
+    });
+
+    it('blocks [::ffff:c0a8:101] — IPv4-mapped 192.168.1.1', async () => {
+      expect(await isBlocked('https://[::ffff:c0a8:101]/')).toBe(true);
+    });
+
+    it('blocks 10.0.0.1 (RFC 1918)', async () => {
+      expect(await isBlocked('https://10.0.0.1/')).toBe(true);
+    });
+
+    it('blocks 192.168.1.1 (RFC 1918)', async () => {
+      expect(await isBlocked('https://192.168.1.1/')).toBe(true);
+    });
+
+    it('blocks 169.254.169.254 (link-local / IMDS)', async () => {
+      expect(await isBlocked('https://169.254.169.254/')).toBe(true);
+    });
+
+    it('blocks 172.16.0.1 (RFC 1918, secondOctet=16)', async () => {
+      expect(await isBlocked('https://172.16.0.1/')).toBe(true);
+    });
+
+    it('blocks 172.31.0.1 (RFC 1918, secondOctet=31)', async () => {
+      expect(await isBlocked('https://172.31.0.1/')).toBe(true);
+    });
+
+    it('allows 172.15.0.1 (below RFC 1918 range)', async () => {
+      expect(await isBlocked('https://172.15.0.1/')).toBe(false);
+    });
+
+    it('allows 172.32.0.1 (above RFC 1918 range)', async () => {
+      expect(await isBlocked('https://172.32.0.1/')).toBe(false);
+    });
+
+    it('blocks 100.64.0.1 (RFC 6598 CGNAT)', async () => {
+      expect(await isBlocked('https://100.64.0.1/')).toBe(true);
+    });
+
+    it('blocks 100.127.0.1 (RFC 6598 CGNAT, upper edge)', async () => {
+      expect(await isBlocked('https://100.127.0.1/')).toBe(true);
+    });
+
+    it('allows 100.63.0.1 (below CGNAT range)', async () => {
+      expect(await isBlocked('https://100.63.0.1/')).toBe(false);
+    });
+
+    it('blocks [fc00::1] (IPv6 ULA fc::/8)', async () => {
+      expect(await isBlocked('https://[fc00::1]/')).toBe(true);
+    });
+
+    it('blocks [fd00::1] (IPv6 ULA fd::/8)', async () => {
+      expect(await isBlocked('https://[fd00::1]/')).toBe(true);
+    });
+
+    it('blocks [fdab:1234::1] (IPv6 ULA fd::/8, arbitrary suffix)', async () => {
+      expect(await isBlocked('https://[fdab:1234::1]/')).toBe(true);
+    });
+
+    it('blocks [fe80::1] (IPv6 link-local)', async () => {
+      expect(await isBlocked('https://[fe80::1]/')).toBe(true);
+    });
+
+    it('blocks [febf::1] (IPv6 link-local, upper edge)', async () => {
+      expect(await isBlocked('https://[febf::1]/')).toBe(true);
+    });
+
+    it('allows https://accounts.google.com', async () => {
+      expect(await isBlocked('https://accounts.google.com/')).toBe(false);
+    });
+
+    it('allows https://login.microsoftonline.com', async () => {
+      expect(await isBlocked('https://login.microsoftonline.com/')).toBe(false);
+    });
+
+    it('blocks non-https scheme', async () => {
+      expect(await isBlocked('http://example.com/')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
`validateDiscoveryUrl()` had three bugs that allowed SSRF via crafted URLs. Both `discoverAuthServerMetadata()` and `discoverResourceMetadata()` pass user-controlled URLs directly into this function.



### What was broken

**1. IPv4-mapped IPv6 bypass (CWE-918)**
The WHATWG URL parser serialises IPv4-mapped addresses as compressed hex `[::ffff:7f00:1]` not `127.0.0.1`. The blocklist never matched, so every blocked IPv4 range was reachable via its IPv6-mapped form.

**2. Dead 172.16.0.0/12 check**
`secondOcte` was declared but `secondOctet` was referenced in the condition. ReferenceError silently caught the entire 172.16–172.31 range was never blocked.

**3. IPv6 ULA fd::/8 not blocked**
The regex `f[ce89ab]` matched `fc::/8` but missed `fd::/8`. RFC 4193 §3.2.2 defines `fd::/8` as Locally Assigned ULA  the prefix used by default in Docker, Kubernetes, and AWS dual-stack.



### What was fixed

- Added `normaliseHostname()` to unwrap `[::ffff:HHHH:LLLL]` to dotted-decimal before any blocklist check
- Renamed `secondOcte` → `secondOctet`
- Fixed ULA regex to `/^\[(f[cd][0-9a-f]{2}|fe[89ab][0-9a-f]):/i`  covers both `fc::/8` and `fd::/8`
- Added missing ranges: `0.0.0.0`, `100.64.0.0/10`, `fc00::/7`, `fe80::/10`



### Tests added

```ts
// IPv4-mapped IPv6 bypass vectors
'https://[::ffff:7f00:1]/'    // 127.0.0.1        -> blocked
'https://[::ffff:a9fe:a9fe]/' // 169.254.169.254   -> blocked
'https://[::ffff:a00:1]/'     // 10.0.0.1          -> blocked
'https://[::ffff:ac10:1]/'    // 172.16.0.1        -> blocked
'https://[::ffff:c0a8:101]/'  // 192.168.1.1       -> blocked

// Private IPv4 range edges
'https://172.16.0.1/'  // blocked
'https://172.31.0.1/'  // blocked
'https://172.15.0.1/'  // allowed
'https://172.32.0.1/'  // allowed

// RFC 6598 CGNAT
'https://100.64.0.1/'  // blocked
'https://100.127.0.1/' // blocked
'https://100.63.0.1/'  // allowed

// IPv6 ULA — fd::/8 regression
'https://[fd00::1]/'       // blocked
'https://[fdab:1234::1]/'  // blocked
'https://[fc00::1]/'       // blocked

// IPv6 link-local
'https://[fe80::1]/'  // blocked
'https://[febf::1]/'  // blocked

// Legitimate public IdPs
'https://accounts.google.com/'        // allowed
'https://login.microsoftonline.com/'  // allowed
```