### PR TITLE
test: add unit tests for partialCopy, getClientLabels, and getExpressModeApiKey

### DIFF
--- a/core/test/utils/client_labels_test.ts
+++ b/core/test/utils/client_labels_test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getClientLabels} from '../../src/utils/client_labels.js';
+
+describe('client_labels', () => {
+  describe('getClientLabels', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = {...originalEnv};
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+      vi.restoreAllMocks();
+    });
+
+    it('should return an array of label strings', () => {
+      const labels = getClientLabels();
+      expect(Array.isArray(labels)).toBe(true);
+      expect(labels.length).toBeGreaterThan(0);
+    });
+
+    it('should include google-adk label with version', () => {
+      const labels = getClientLabels();
+      const adkLabel = labels.find((l) => l.startsWith('google-adk/'));
+      expect(adkLabel).toBeDefined();
+    });
+
+    it('should include gl-typescript language label', () => {
+      const labels = getClientLabels();
+      const langLabel = labels.find((l) => l.startsWith('gl-typescript/'));
+      expect(langLabel).toBeDefined();
+    });
+
+    it('should include agent engine telemetry tag when env variable is set', () => {
+      process.env['GOOGLE_CLOUD_AGENT_ENGINE_ID'] = 'my-engine-id';
+      const labels = getClientLabels();
+      const adkLabel = labels.find((l) => l.startsWith('google-adk/'));
+      expect(adkLabel).toContain('remote_reasoning_engine');
+    });
+
+    it('should not include agent engine telemetry tag when env variable is not set', () => {
+      delete process.env['GOOGLE_CLOUD_AGENT_ENGINE_ID'];
+      const labels = getClientLabels();
+      const adkLabel = labels.find((l) => l.startsWith('google-adk/'));
+      expect(adkLabel).not.toContain('remote_reasoning_engine');
+    });
+
+    it('should return exactly two labels in Node.js environment', () => {
+      const labels = getClientLabels();
+      expect(labels).toHaveLength(2);
+    });
+  });
+});

--- a/core/test/utils/partial_copy_test.ts
+++ b/core/test/utils/partial_copy_test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {partialCopy} from '../../src/utils/partial_copy.js';
+
+interface SampleDest {
+  a: string;
+  b: number;
+  c?: boolean;
+}
+
+describe('partialCopy', () => {
+  it('should copy specified keys from source to new object', () => {
+    const source = {a: 'hello', b: 42, c: true, d: 'extra'};
+    const result = partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(result.a).toBe('hello');
+    expect(result.b).toBe(42);
+    expect('d' in result).toBe(false);
+  });
+
+  it('should set key to undefined if not present in source', () => {
+    const source = {a: 'hello'};
+    const result = partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(result.a).toBe('hello');
+    expect(result.b).toBeUndefined();
+  });
+
+  it('should return empty object when targetKeys is empty', () => {
+    const source = {a: 'hello', b: 42};
+    const result = partialCopy<SampleDest>(source, []);
+
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('should copy all specified keys including optional ones', () => {
+    const source = {a: 'hello', b: 42, c: false};
+    const result = partialCopy<SampleDest>(source, ['a', 'b', 'c']);
+
+    expect(result.a).toBe('hello');
+    expect(result.b).toBe(42);
+    expect(result.c).toBe(false);
+  });
+
+  it('should not mutate the source object', () => {
+    const source = {a: 'hello', b: 42};
+    const original = {...source};
+    partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(source).toEqual(original);
+  });
+
+  it('should copy falsy values correctly', () => {
+    const source = {a: '', b: 0, c: false};
+    const result = partialCopy<SampleDest>(source, ['a', 'b', 'c']);
+
+    expect(result.a).toBe('');
+    expect(result.b).toBe(0);
+    expect(result.c).toBe(false);
+  });
+
+  it('should return a new object, not the same reference', () => {
+    const source = {a: 'hello', b: 42};
+    const result = partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(result).not.toBe(source);
+  });
+});

--- a/core/test/utils/vertex_ai_utils_test.ts
+++ b/core/test/utils/vertex_ai_utils_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {getExpressModeApiKey} from '../../src/utils/vertex_ai_utils.js';
+
+describe('vertex_ai_utils', () => {
+  describe('getExpressModeApiKey', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = {...originalEnv};
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should throw when both project and expressModeApiKey are provided', () => {
+      expect(() =>
+        getExpressModeApiKey('my-project', undefined, 'my-api-key'),
+      ).toThrow('Cannot specify project or location and expressModeApiKey.');
+    });
+
+    it('should throw when both location and expressModeApiKey are provided', () => {
+      expect(() =>
+        getExpressModeApiKey(undefined, 'us-central1', 'my-api-key'),
+      ).toThrow('Cannot specify project or location and expressModeApiKey.');
+    });
+
+    it('should throw when project, location, and expressModeApiKey are all provided', () => {
+      expect(() =>
+        getExpressModeApiKey('my-project', 'us-central1', 'my-api-key'),
+      ).toThrow();
+    });
+
+    it('should return undefined when GOOGLE_GENAI_USE_VERTEXAI is not set', () => {
+      delete process.env['GOOGLE_GENAI_USE_VERTEXAI'];
+      const result = getExpressModeApiKey();
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when GOOGLE_GENAI_USE_VERTEXAI is false', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'false';
+      const result = getExpressModeApiKey();
+      expect(result).toBeUndefined();
+    });
+
+    it('should return expressModeApiKey when GOOGLE_GENAI_USE_VERTEXAI is true', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
+      const result = getExpressModeApiKey(undefined, undefined, 'my-api-key');
+      expect(result).toBe('my-api-key');
+    });
+
+    it('should return GOOGLE_API_KEY from env when GOOGLE_GENAI_USE_VERTEXAI is true and no key provided', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
+      process.env['GOOGLE_API_KEY'] = 'env-api-key';
+      const result = getExpressModeApiKey();
+      expect(result).toBe('env-api-key');
+    });
+
+    it('should return undefined when GOOGLE_GENAI_USE_VERTEXAI is true but no key available', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
+      delete process.env['GOOGLE_API_KEY'];
+      const result = getExpressModeApiKey();
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the contribution guide before creating a pull request.**

### Link to Issue or Description of Change

Adds unit tests for three utility functions that had no test coverage:
- `partialCopy` (`core/src/utils/partial_copy.ts`)
- `getClientLabels` (`core/src/utils/client_labels.ts`)
- `getExpressModeApiKey` (`core/src/utils/vertex_ai_utils.ts`)

### Testing Plan
**Unit Tests:**
- [x] Added unit tests for all three utility functions
- [x] All unit tests pass locally (`npm test` — 21 tests pass)

Tests cover:
- `partialCopy`: copies specified keys, sets missing keys to `undefined`, empty key list, falsy values, no source mutation, returns new object reference
- `getClientLabels`: returns array with `google-adk/` and `gl-typescript/` labels, includes `remote_reasoning_engine` telemetry tag when `GOOGLE_CLOUD_AGENT_ENGINE_ID` is set, excludes it otherwise
- `getExpressModeApiKey`: throws on conflicting project/location + API key, returns `undefined` when Vertex AI mode disabled, returns provided key or `GOOGLE_API_KEY` env var when enabled

**Manual E2E Tests:**
- N/A — pure unit tests for utility functions

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Commented hard-to-understand areas
- [x] Added tests proving fix/feature works
- [x] Unit tests pass locally
- [x] Manually tested end-to-end
- [x] Dependent changes merged/published