### PR TITLE
fix: restrict stateDelta from API endpoints to session scope

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -56,6 +56,17 @@ interface ServerOptions {
   registerProcessors?: (tracerProvider: TracerProvider) => void;
 }
 
+function toSessionScopedDelta(
+  delta: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!delta) return undefined;
+  return Object.fromEntries(
+    Object.entries(delta).filter(
+      ([k]) => !k.startsWith('app:') && !k.startsWith('user:'),
+    ),
+  );
+}
+
 export class AdkApiServer {
   private readonly host: string;
   private readonly port: number;
@@ -728,7 +739,7 @@ export class AdkApiServer {
           userId,
           sessionId,
           newMessage,
-          stateDelta,
+          stateDelta: toSessionScopedDelta(stateDelta),
         })) {
           events.push(e);
         }
@@ -778,7 +789,7 @@ export class AdkApiServer {
           runConfig: {
             streamingMode: streaming ? StreamingMode.SSE : StreamingMode.NONE,
           },
-          stateDelta,
+          stateDelta: toSessionScopedDelta(stateDelta),
         })) {
           res.write(`data: ${JSON.stringify(event)}\n\n`);
         }


### PR DESCRIPTION
## What

`/run` and `/run_sse` accept a `stateDelta` field that is applied to
the session before the agent runs. The session service distinguishes
three state scopes by key prefix:

| Prefix | Scope |
|--------|-------|
| *(none)* | current session only |
| `user:` | all sessions for this user |
| `app:` | all users of this app |

There was no restriction on which prefixes callers could use. A caller
could send `{"app:some_key": "value"}` and write into the global
app-level state, which `getSession()` merges into every user's session
via `mergeStates()`. With `DatabaseSessionService` this is persisted
across server restarts.

## Fix

Added `toSessionScopedDelta()` which strips any key starting with
`app:` or `user:` before the delta reaches the runner. Session-scope
keys (no prefix) pass through unchanged, so existing behavior for
normal use is unaffected.

Applied to both `/run` and `/run_sse`.

## Why not filter in the runner or session service

The runner and session service are also used internally by agents and
tools that legitimately write cross-scope state. Filtering at the API
boundary is the right place — only user-supplied input from the HTTP
endpoints needs the restriction.

## Testing

```
# app:-prefixed key is stripped — appState stays clean
curl -X POST /run -d '{"stateDelta":{"app:ctx":"injected",...}}'
# only session-scope keys survive
```