### PR TITLE
fix: remove hardcoded ACAO wildcard that overrides configured CORS policy in run_sse

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -767,7 +767,6 @@ export class AdkApiServer {
 
         res.setHeader('Cache-Control', 'no-cache');
         res.setHeader('Content-Type', 'text/event-stream');
-        res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Connection', 'keep-alive');
         res.flushHeaders();
 


### PR DESCRIPTION
## What

When `allowOrigins` is configured, the `cors()` middleware sets
`Access-Control-Allow-Origin` to the configured value for all routes.
The `/run_sse` handler then called:

```ts
res.setHeader('Access-Control-Allow-Origin', '*');
```

This runs after the middleware, so it replaces the restricted origin
with a wildcard. Any cross-origin page could read the full SSE
response stream, ignoring whatever `allowOrigins` was set to.

`/run` had no such override and was behaving correctly already.

## Fix

Remove the explicit `setHeader` call. The `cors()` middleware handles
the header. If `allowOrigins` is not configured, no CORS header is
sent at all — the same behavior as every other endpoint in the server.

## Before / After

**Before** (with `allowOrigins: 'https://app.example.com'`):
```
< Access-Control-Allow-Origin: *   ← ignores config
```

**After**:
```
< Access-Control-Allow-Origin: https://app.example.com   ← respects config
```

## No behavior change for the common case

If `allowOrigins` is not set, the middleware adds nothing and the
handler previously added `*`. After this fix, nothing is added —
which matches the browser's default-deny behavior and is more secure
for local development too.