### PR TITLE
test: consolidate unit tests for plugins, runner, agents, and utils

### DIFF
--- a/core/test/agents/sequential_agent_test.ts
+++ b/core/test/agents/sequential_agent_test.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseAgentConfig,
+  createEvent,
+  createSession,
+  Event,
+  InvocationContext,
+  isSequentialAgent,
+  PluginManager,
+  SequentialAgent,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+class MockSubAgent extends BaseAgent {
+  private eventsToYield: Event[];
+
+  constructor(config: BaseAgentConfig, eventsToYield: Event[]) {
+    super(config);
+    this.eventsToYield = eventsToYield;
+  }
+
+  protected async *runAsyncImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    for (const event of this.eventsToYield) {
+      yield {
+        ...event,
+        invocationId: context.invocationId,
+        branch: context.branch,
+      };
+    }
+  }
+
+  protected async *runLiveImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {}
+}
+
+function makeContext(agent: BaseAgent): InvocationContext {
+  const session = createSession({
+    id: 'test-session',
+    appName: 'test-app',
+  });
+  return new InvocationContext({
+    invocationId: 'test-invocation',
+    agent,
+    session,
+    pluginManager: new PluginManager(),
+  });
+}
+
+describe('SequentialAgent', () => {
+  it('should be identified by isSequentialAgent', () => {
+    const agent = new SequentialAgent({name: 'seq'});
+    expect(isSequentialAgent(agent)).toBe(true);
+  });
+
+  it('should return false for non-SequentialAgent objects', () => {
+    expect(isSequentialAgent(null)).toBe(false);
+    expect(isSequentialAgent(undefined)).toBe(false);
+    expect(isSequentialAgent({})).toBe(false);
+    expect(isSequentialAgent('string')).toBe(false);
+  });
+
+  it('should run sub-agents in sequential order', async () => {
+    const event1 = createEvent({
+      author: 'sub1',
+      content: {role: 'model', parts: [{text: 'from sub1'}]},
+    });
+    const event2 = createEvent({
+      author: 'sub2',
+      content: {role: 'model', parts: [{text: 'from sub2'}]},
+    });
+
+    const sub1 = new MockSubAgent({name: 'sub1'}, [event1]);
+    const sub2 = new MockSubAgent({name: 'sub2'}, [event2]);
+
+    const seq = new SequentialAgent({
+      name: 'seq',
+      subAgents: [sub1, sub2],
+    });
+
+    const context = makeContext(seq);
+
+    const yieldedEvents: Event[] = [];
+    for await (const event of seq.runAsync(context)) {
+      yieldedEvents.push(event);
+    }
+
+    expect(yieldedEvents.length).toBe(2);
+    // sub1 must come before sub2 (sequential order)
+    expect(yieldedEvents[0].author).toBe('sub1');
+    expect(yieldedEvents[1].author).toBe('sub2');
+  });
+
+  it('should yield all events from each sub-agent before moving to the next', async () => {
+    const sub1Events = [
+      createEvent({
+        author: 'sub1',
+        content: {role: 'model', parts: [{text: 'sub1 event 1'}]},
+      }),
+      createEvent({
+        author: 'sub1',
+        content: {role: 'model', parts: [{text: 'sub1 event 2'}]},
+      }),
+    ];
+    const sub2Events = [
+      createEvent({
+        author: 'sub2',
+        content: {role: 'model', parts: [{text: 'sub2 event 1'}]},
+      }),
+    ];
+
+    const sub1 = new MockSubAgent({name: 'sub1'}, sub1Events);
+    const sub2 = new MockSubAgent({name: 'sub2'}, sub2Events);
+
+    const seq = new SequentialAgent({
+      name: 'seq',
+      subAgents: [sub1, sub2],
+    });
+
+    const context = makeContext(seq);
+
+    const authors: string[] = [];
+    for await (const event of seq.runAsync(context)) {
+      authors.push(event.author);
+    }
+
+    expect(authors).toEqual(['sub1', 'sub1', 'sub2']);
+  });
+
+  it('should yield no events when there are no sub-agents', async () => {
+    const seq = new SequentialAgent({name: 'seq', subAgents: []});
+    const context = makeContext(seq);
+
+    const yieldedEvents: Event[] = [];
+    for await (const event of seq.runAsync(context)) {
+      yieldedEvents.push(event);
+    }
+
+    expect(yieldedEvents.length).toBe(0);
+  });
+
+  it('should propagate invocationId to sub-agent events', async () => {
+    const event = createEvent({
+      author: 'sub1',
+      content: {role: 'model', parts: [{text: 'hello'}]},
+    });
+    const sub1 = new MockSubAgent({name: 'sub1'}, [event]);
+    const seq = new SequentialAgent({name: 'seq', subAgents: [sub1]});
+    const context = makeContext(seq);
+
+    const yieldedEvents: Event[] = [];
+    for await (const e of seq.runAsync(context)) {
+      yieldedEvents.push(e);
+    }
+
+    expect(yieldedEvents[0].invocationId).toBe('test-invocation');
+  });
+
+  it('should handle single sub-agent', async () => {
+    const event = createEvent({
+      author: 'only_sub',
+      content: {role: 'model', parts: [{text: 'only response'}]},
+    });
+    const sub = new MockSubAgent({name: 'only_sub'}, [event]);
+    const seq = new SequentialAgent({name: 'seq', subAgents: [sub]});
+    const context = makeContext(seq);
+
+    const yieldedEvents: Event[] = [];
+    for await (const e of seq.runAsync(context)) {
+      yieldedEvents.push(e);
+    }
+
+    expect(yieldedEvents.length).toBe(1);
+    expect(yieldedEvents[0].author).toBe('only_sub');
+  });
+});

--- a/core/test/plugins/logging_plugin_test.ts
+++ b/core/test/plugins/logging_plugin_test.ts
@@ -1,0 +1,535 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseTool,
+  Context,
+  createEvent,
+  Event,
+  InvocationContext,
+  LlmRequest,
+  LlmResponse,
+} from '@google/adk';
+import {Content} from '@google/genai';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {LoggingPlugin} from '../../src/plugins/logging_plugin.js';
+import {resetLogger, setLogger} from '../../src/utils/logger.js';
+
+function makeMockLogger() {
+  const infoCalls: string[] = [];
+  const mockLogger = {
+    setLogLevel: () => {},
+    log: () => {},
+    debug: () => {},
+    info: (...args: unknown[]) => {
+      infoCalls.push(args.map((a) => String(a)).join(' '));
+    },
+    warn: () => {},
+    error: () => {},
+  };
+  return {mockLogger, infoCalls};
+}
+
+describe('LoggingPlugin', () => {
+  const mockAgent = {name: 'test_agent'} as BaseAgent;
+  const mockSession = {
+    id: 'session-1',
+    state: new Map(),
+  } as unknown as InvocationContext['session'];
+  const mockInvocationContext = {
+    invocationId: 'inv-1',
+    session: mockSession,
+    userId: 'user-1',
+    appName: 'test-app',
+    agent: mockAgent,
+    branch: undefined,
+  } as unknown as InvocationContext;
+
+  const mockCallbackContext = {
+    agentName: 'test_agent',
+    invocationId: 'inv-1',
+    invocationContext: mockInvocationContext,
+  } as unknown as Context;
+
+  const mockTool = {name: 'my_tool'} as BaseTool;
+  const mockToolContext = {
+    agentName: 'test_agent',
+    functionCallId: 'fc-1',
+  } as unknown as Context;
+
+  const mockLlmRequest = {
+    model: 'gemini-2.0-flash',
+  } as LlmRequest;
+
+  const mockLlmResponse = {
+    content: {parts: [{text: 'response text'}]},
+  } as LlmResponse;
+
+  const mockEvent: Event = createEvent({
+    id: 'event-1',
+    author: 'test_agent',
+    content: {role: 'model', parts: [{text: 'hello'}]},
+  });
+
+  let infoCalls: string[];
+
+  beforeEach(() => {
+    const {mockLogger, infoCalls: calls} = makeMockLogger();
+    infoCalls = calls;
+    setLogger(mockLogger);
+  });
+
+  afterEach(() => {
+    resetLogger();
+  });
+
+  it('should initialize with default name "logging_plugin"', () => {
+    const plugin = new LoggingPlugin();
+    expect(plugin.name).toBe('logging_plugin');
+  });
+
+  it('should accept custom name', () => {
+    const plugin = new LoggingPlugin('custom_name');
+    expect(plugin.name).toBe('custom_name');
+  });
+
+  it('onUserMessageCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+    const userMessage: Content = {parts: [{text: 'hello world'}]};
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext: mockInvocationContext,
+      userMessage,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('USER MESSAGE RECEIVED'))).toBe(
+      true,
+    );
+    expect(infoCalls.some((m) => m.includes('inv-1'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('session-1'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('user-1'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('test-app'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('hello world'))).toBe(true);
+  });
+
+  it('onUserMessageCallback should log branch when present', async () => {
+    const plugin = new LoggingPlugin();
+    const ctxWithBranch = {
+      ...mockInvocationContext,
+      branch: 'my-branch',
+    } as unknown as InvocationContext;
+
+    await plugin.onUserMessageCallback({
+      invocationContext: ctxWithBranch,
+      userMessage: {parts: [{text: 'msg'}]},
+    });
+
+    expect(infoCalls.some((m) => m.includes('my-branch'))).toBe(true);
+  });
+
+  it('beforeRunCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.beforeRunCallback({
+      invocationContext: mockInvocationContext,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('INVOCATION STARTING'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('inv-1'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('test_agent'))).toBe(true);
+  });
+
+  it('onEventCallback should log event info and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.onEventCallback({
+      invocationContext: mockInvocationContext,
+      event: mockEvent,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('EVENT YIELDED'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('test_agent'))).toBe(true);
+  });
+
+  it('onEventCallback should log function calls when present', async () => {
+    const plugin = new LoggingPlugin();
+    const eventWithFuncCall = createEvent({
+      author: 'model',
+      content: {
+        role: 'model',
+        parts: [{functionCall: {name: 'my_func', args: {}}}],
+      },
+    });
+
+    await plugin.onEventCallback({
+      invocationContext: mockInvocationContext,
+      event: eventWithFuncCall,
+    });
+
+    expect(infoCalls.some((m) => m.includes('my_func'))).toBe(true);
+  });
+
+  it('onEventCallback should log function responses when present', async () => {
+    const plugin = new LoggingPlugin();
+    const eventWithFuncResp = createEvent({
+      author: 'tool',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'my_func',
+              response: {result: 'ok'},
+            },
+          },
+        ],
+      },
+    });
+
+    await plugin.onEventCallback({
+      invocationContext: mockInvocationContext,
+      event: eventWithFuncResp,
+    });
+
+    expect(infoCalls.some((m) => m.includes('my_func'))).toBe(true);
+  });
+
+  it('onEventCallback should log long running tool ids when present', async () => {
+    const plugin = new LoggingPlugin();
+    const eventWithLongRunning: Event = createEvent({
+      author: 'model',
+      content: {role: 'model', parts: [{text: 'running'}]},
+      longRunningToolIds: ['tool-123'],
+    });
+
+    await plugin.onEventCallback({
+      invocationContext: mockInvocationContext,
+      event: eventWithLongRunning,
+    });
+
+    expect(infoCalls.some((m) => m.includes('tool-123'))).toBe(true);
+  });
+
+  it('afterRunCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.afterRunCallback({
+      invocationContext: mockInvocationContext,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('INVOCATION COMPLETED'))).toBe(
+      true,
+    );
+    expect(infoCalls.some((m) => m.includes('inv-1'))).toBe(true);
+  });
+
+  it('beforeAgentCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.beforeAgentCallback({
+      agent: mockAgent,
+      callbackContext: mockCallbackContext,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('AGENT STARTING'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('test_agent'))).toBe(true);
+  });
+
+  it('beforeAgentCallback should log branch when present', async () => {
+    const plugin = new LoggingPlugin();
+    const ctxWithBranch = {
+      ...mockCallbackContext,
+      invocationContext: {...mockInvocationContext, branch: 'agent-branch'},
+    } as unknown as Context;
+
+    await plugin.beforeAgentCallback({
+      agent: mockAgent,
+      callbackContext: ctxWithBranch,
+    });
+
+    expect(infoCalls.some((m) => m.includes('agent-branch'))).toBe(true);
+  });
+
+  it('afterAgentCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.afterAgentCallback({
+      agent: mockAgent,
+      callbackContext: mockCallbackContext,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('AGENT COMPLETED'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('test_agent'))).toBe(true);
+  });
+
+  it('beforeModelCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: mockLlmRequest,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('LLM REQUEST'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('gemini-2.0-flash'))).toBe(true);
+  });
+
+  it('beforeModelCallback should log system instruction when present', async () => {
+    const plugin = new LoggingPlugin();
+    const reqWithInstruction: LlmRequest = {
+      ...mockLlmRequest,
+      config: {systemInstruction: 'You are a helpful assistant.'},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: reqWithInstruction,
+    });
+
+    expect(
+      infoCalls.some((m) => m.includes('You are a helpful assistant.')),
+    ).toBe(true);
+  });
+
+  it('beforeModelCallback should truncate long system instruction', async () => {
+    const plugin = new LoggingPlugin();
+    const longInstruction = 'A'.repeat(300);
+    const reqWithLongInstruction: LlmRequest = {
+      ...mockLlmRequest,
+      config: {systemInstruction: longInstruction},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: reqWithLongInstruction,
+    });
+
+    expect(infoCalls.some((m) => m.includes('...'))).toBe(true);
+  });
+
+  it('beforeModelCallback should log available tools when present', async () => {
+    const plugin = new LoggingPlugin();
+    const reqWithTools: LlmRequest = {
+      ...mockLlmRequest,
+      toolsDict: {my_tool: mockTool},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: reqWithTools,
+    });
+
+    expect(infoCalls.some((m) => m.includes('my_tool'))).toBe(true);
+  });
+
+  it('afterModelCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.afterModelCallback({
+      callbackContext: mockCallbackContext,
+      llmResponse: mockLlmResponse,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('LLM RESPONSE'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('response text'))).toBe(true);
+  });
+
+  it('afterModelCallback should log error when errorCode is present', async () => {
+    const plugin = new LoggingPlugin();
+    const errorResponse: LlmResponse = {
+      errorCode: '500',
+      errorMessage: 'Internal server error',
+    };
+
+    await plugin.afterModelCallback({
+      callbackContext: mockCallbackContext,
+      llmResponse: errorResponse,
+    });
+
+    expect(infoCalls.some((m) => m.includes('ERROR'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('500'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('Internal server error'))).toBe(
+      true,
+    );
+  });
+
+  it('afterModelCallback should log partial and turnComplete flags', async () => {
+    const plugin = new LoggingPlugin();
+    const partialResponse: LlmResponse = {
+      content: {parts: [{text: 'partial'}]},
+      partial: true,
+      turnComplete: false,
+    };
+
+    await plugin.afterModelCallback({
+      callbackContext: mockCallbackContext,
+      llmResponse: partialResponse,
+    });
+
+    expect(infoCalls.some((m) => m.includes('Partial'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('Turn Complete'))).toBe(true);
+  });
+
+  it('afterModelCallback should log usage metadata when present', async () => {
+    const plugin = new LoggingPlugin();
+    const responseWithUsage: LlmResponse = {
+      content: {parts: [{text: 'hello'}]},
+      usageMetadata: {promptTokenCount: 10, candidatesTokenCount: 20},
+    };
+
+    await plugin.afterModelCallback({
+      callbackContext: mockCallbackContext,
+      llmResponse: responseWithUsage,
+    });
+
+    expect(infoCalls.some((m) => m.includes('Token Usage'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('10'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('20'))).toBe(true);
+  });
+
+  it('beforeToolCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.beforeToolCallback({
+      tool: mockTool,
+      toolArgs: {query: 'test'},
+      toolContext: mockToolContext,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('TOOL STARTING'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('my_tool'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('fc-1'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('query'))).toBe(true);
+  });
+
+  it('afterToolCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+
+    const result = await plugin.afterToolCallback({
+      tool: mockTool,
+      toolArgs: {},
+      toolContext: mockToolContext,
+      result: {output: 'some result'},
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('TOOL COMPLETED'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('my_tool'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('some result'))).toBe(true);
+  });
+
+  it('onModelErrorCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+    const error = new Error('model failure');
+
+    const result = await plugin.onModelErrorCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: mockLlmRequest,
+      error,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('LLM ERROR'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('model failure'))).toBe(true);
+  });
+
+  it('onToolErrorCallback should log and return undefined', async () => {
+    const plugin = new LoggingPlugin();
+    const error = new Error('tool failure');
+
+    const result = await plugin.onToolErrorCallback({
+      tool: mockTool,
+      toolArgs: {key: 'val'},
+      toolContext: mockToolContext,
+      error,
+    });
+
+    expect(result).toBeUndefined();
+    expect(infoCalls.some((m) => m.includes('TOOL ERROR'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('my_tool'))).toBe(true);
+    expect(infoCalls.some((m) => m.includes('tool failure'))).toBe(true);
+  });
+
+  it('should format content with no parts as "None"', async () => {
+    const plugin = new LoggingPlugin();
+
+    await plugin.onUserMessageCallback({
+      invocationContext: mockInvocationContext,
+      userMessage: {} as Content,
+    });
+
+    expect(infoCalls.some((m) => m.includes('None'))).toBe(true);
+  });
+
+  it('should format content with functionCall part', async () => {
+    const plugin = new LoggingPlugin();
+    const eventWithFuncCall = createEvent({
+      author: 'model',
+      content: {
+        role: 'model',
+        parts: [{functionCall: {name: 'search_tool', args: {}}}],
+      },
+    });
+
+    await plugin.onEventCallback({
+      invocationContext: mockInvocationContext,
+      event: eventWithFuncCall,
+    });
+
+    expect(
+      infoCalls.some((m) => m.includes('function_call: search_tool')),
+    ).toBe(true);
+  });
+
+  it('should format content with functionResponse part', async () => {
+    const plugin = new LoggingPlugin();
+    const eventWithFuncResp = createEvent({
+      author: 'tool',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'search_tool',
+              response: {result: 'found'},
+            },
+          },
+        ],
+      },
+    });
+
+    await plugin.onEventCallback({
+      invocationContext: mockInvocationContext,
+      event: eventWithFuncResp,
+    });
+
+    expect(
+      infoCalls.some((m) => m.includes('function_response: search_tool')),
+    ).toBe(true);
+  });
+
+  it('should truncate long text content', async () => {
+    const plugin = new LoggingPlugin();
+    const longText = 'B'.repeat(300);
+
+    await plugin.onUserMessageCallback({
+      invocationContext: mockInvocationContext,
+      userMessage: {parts: [{text: longText}]},
+    });
+
+    expect(infoCalls.some((m) => m.includes('...'))).toBe(true);
+  });
+});

--- a/core/test/plugins/security_plugin_test.ts
+++ b/core/test/plugins/security_plugin_test.ts
@@ -1,0 +1,356 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseTool, createEvent} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {Context} from '../../src/agents/context.js';
+import {
+  BasePolicyEngine,
+  getAskUserConfirmationFunctionCalls,
+  InMemoryPolicyEngine,
+  PolicyCheckResult,
+  PolicyOutcome,
+  REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+  SecurityPlugin,
+} from '../../src/plugins/security_plugin.js';
+import {ToolConfirmation} from '../../src/tools/tool_confirmation.js';
+
+function makeToolContext(
+  functionCallId: string,
+  initialState: Record<string, unknown> = {},
+): {
+  toolContext: Context;
+  stateStore: Record<string, unknown>;
+  confirmationRequests: Array<{hint: string}>;
+} {
+  const stateStore: Record<string, unknown> = {...initialState};
+  const confirmationRequests: Array<{hint: string}> = [];
+
+  const toolContext = {
+    functionCallId,
+    state: {
+      get: (key: string) => stateStore[key],
+      set: (key: string, value: unknown) => {
+        stateStore[key] = value;
+      },
+    },
+    toolConfirmation: undefined as ToolConfirmation | undefined,
+    requestConfirmation: (params: {hint: string}) => {
+      confirmationRequests.push(params);
+    },
+  } as unknown as Context;
+
+  return {toolContext, stateStore, confirmationRequests};
+}
+
+const mockTool = {name: 'dangerous_tool'} as BaseTool;
+
+describe('SecurityPlugin', () => {
+  describe('constructor', () => {
+    it('should initialize with default InMemoryPolicyEngine', () => {
+      const plugin = new SecurityPlugin();
+      expect(plugin.name).toBe('security_plugin');
+    });
+
+    it('should accept a custom policy engine', () => {
+      const customEngine: BasePolicyEngine = {
+        evaluate: async () => ({outcome: PolicyOutcome.DENY}),
+      };
+      const plugin = new SecurityPlugin({policyEngine: customEngine});
+      expect(plugin.name).toBe('security_plugin');
+    });
+  });
+
+  describe('beforeToolCallback — ALLOW outcome', () => {
+    it('should return undefined when policy allows the tool call', async () => {
+      const plugin = new SecurityPlugin();
+      const {toolContext} = makeToolContext('fc-1');
+
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {query: 'test'},
+        toolContext,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined on second call when state is ALLOW', async () => {
+      const plugin = new SecurityPlugin();
+      const {toolContext} = makeToolContext('fc-1');
+
+      // First call sets state to ALLOW
+      await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      // Second call with existing ALLOW state
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('beforeToolCallback — DENY outcome', () => {
+    it('should return error object when policy denies the tool call', async () => {
+      const denyEngine: BasePolicyEngine = {
+        evaluate: async () => ({
+          outcome: PolicyOutcome.DENY,
+          reason: 'Unauthorized operation',
+        }),
+      };
+      const plugin = new SecurityPlugin({policyEngine: denyEngine});
+      const {toolContext} = makeToolContext('fc-deny');
+
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      expect(result).toBeDefined();
+      expect((result as Record<string, unknown>)['error']).toContain(
+        'Unauthorized operation',
+      );
+    });
+  });
+
+  describe('beforeToolCallback — CONFIRM outcome', () => {
+    it('should return partial on first call and request confirmation', async () => {
+      const confirmEngine: BasePolicyEngine = {
+        evaluate: async () => ({
+          outcome: PolicyOutcome.CONFIRM,
+          reason: 'Needs approval',
+        }),
+      };
+      const plugin = new SecurityPlugin({policyEngine: confirmEngine});
+      const {toolContext, confirmationRequests} = makeToolContext('fc-confirm');
+
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      expect(result).toBeDefined();
+      expect((result as Record<string, unknown>)['partial']).toBeDefined();
+      expect(confirmationRequests).toHaveLength(1);
+      expect(confirmationRequests[0].hint).toContain('dangerous_tool');
+    });
+
+    it('should return partial on second call when no toolConfirmation set', async () => {
+      const confirmEngine: BasePolicyEngine = {
+        evaluate: async () => ({
+          outcome: PolicyOutcome.CONFIRM,
+          reason: 'Needs approval',
+        }),
+      };
+      const plugin = new SecurityPlugin({policyEngine: confirmEngine});
+      const {toolContext} = makeToolContext('fc-confirm-2');
+
+      // First call — sets state to CONFIRM
+      await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      // Second call — state is CONFIRM but no toolConfirmation provided
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      expect(result).toBeDefined();
+      expect((result as Record<string, unknown>)['partial']).toBeDefined();
+    });
+
+    it('should return error when confirmation is rejected', async () => {
+      const confirmEngine: BasePolicyEngine = {
+        evaluate: async () => ({
+          outcome: PolicyOutcome.CONFIRM,
+          reason: 'Needs approval',
+        }),
+      };
+      const plugin = new SecurityPlugin({policyEngine: confirmEngine});
+      const {toolContext} = makeToolContext('fc-confirm-3');
+
+      // First call — sets state to CONFIRM
+      await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      // Second call — user rejected
+      (toolContext as unknown as Record<string, unknown>)['toolConfirmation'] =
+        new ToolConfirmation({confirmed: false});
+
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      expect(result).toBeDefined();
+      expect((result as Record<string, unknown>)['error']).toContain(
+        'rejected',
+      );
+    });
+
+    it('should return undefined and clear confirmation when confirmed', async () => {
+      const confirmEngine: BasePolicyEngine = {
+        evaluate: async () => ({
+          outcome: PolicyOutcome.CONFIRM,
+          reason: 'Needs approval',
+        }),
+      };
+      const plugin = new SecurityPlugin({policyEngine: confirmEngine});
+      const {toolContext} = makeToolContext('fc-confirm-4');
+
+      // First call — sets state to CONFIRM
+      await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      // Second call — user confirmed
+      (toolContext as unknown as Record<string, unknown>)['toolConfirmation'] =
+        new ToolConfirmation({confirmed: true});
+
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext,
+      });
+
+      expect(result).toBeUndefined();
+      expect(toolContext.toolConfirmation).toBeUndefined();
+    });
+  });
+
+  describe('beforeToolCallback — missing functionCallId', () => {
+    it('should check policy when functionCallId is undefined', async () => {
+      const plugin = new SecurityPlugin();
+      const {toolContext} = makeToolContext('');
+      // Override to have undefined functionCallId
+      const ctxWithoutId = {
+        ...toolContext,
+        functionCallId: undefined,
+        state: toolContext.state,
+        requestConfirmation: (
+          toolContext as unknown as Record<string, unknown>
+        )['requestConfirmation'],
+        toolConfirmation: undefined,
+      } as unknown as Context;
+
+      // Should not throw — policy check proceeds but state not stored
+      const result = await plugin.beforeToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: ctxWithoutId,
+      });
+
+      // InMemoryPolicyEngine always ALLOWs, so undefined
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('InMemoryPolicyEngine', () => {
+    it('should always return ALLOW', async () => {
+      const engine = new InMemoryPolicyEngine();
+      const result: PolicyCheckResult = await engine.evaluate({
+        tool: mockTool,
+        toolArgs: {},
+      });
+
+      expect(result.outcome).toBe(PolicyOutcome.ALLOW);
+    });
+  });
+
+  describe('getAskUserConfirmationFunctionCalls', () => {
+    it('should return empty array for event with no content', () => {
+      const event = createEvent({author: 'model'});
+      const result = getAskUserConfirmationFunctionCalls(event);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array for event with no matching function calls', () => {
+      const event = createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'other_func', args: {}}}],
+        },
+      });
+      const result = getAskUserConfirmationFunctionCalls(event);
+      expect(result).toEqual([]);
+    });
+
+    it('should return confirmation function calls', () => {
+      const event = createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+                args: {hint: 'approve?'},
+              },
+            },
+          ],
+        },
+      });
+      const result = getAskUserConfirmationFunctionCalls(event);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(REQUEST_CONFIRMATION_FUNCTION_CALL_NAME);
+    });
+
+    it('should handle mixed function calls', () => {
+      const event = createEvent({
+        author: 'model',
+        content: {
+          role: 'model',
+          parts: [
+            {functionCall: {name: 'regular_func', args: {}}},
+            {
+              functionCall: {
+                name: REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+                args: {},
+              },
+            },
+            {
+              functionCall: {
+                name: REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+                args: {},
+              },
+            },
+          ],
+        },
+      });
+      const result = getAskUserConfirmationFunctionCalls(event);
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array for event with non-functionCall parts', () => {
+      const event = createEvent({
+        author: 'model',
+        content: {role: 'model', parts: [{text: 'hello'}]},
+      });
+      const result = getAskUserConfirmationFunctionCalls(event);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/core/test/runner/in_memory_runner_test.ts
+++ b/core/test/runner/in_memory_runner_test.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BasePlugin,
+  createEvent,
+  Event,
+  InMemoryRunner,
+  InvocationContext,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+const TEST_USER_ID = 'test_user_id';
+const TEST_MESSAGE = 'Hello, agent!';
+
+class MockAgent extends BaseAgent {
+  constructor(name = 'mock_agent') {
+    super({name});
+  }
+
+  protected async *runAsyncImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    yield createEvent({
+      invocationId: context.invocationId,
+      author: this.name,
+      content: {role: 'model', parts: [{text: 'Mock response'}]},
+    });
+  }
+
+  protected async *runLiveImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {}
+}
+
+describe('InMemoryRunner', () => {
+  it('should initialize with required agent parameter', () => {
+    const agent = new MockAgent();
+    const runner = new InMemoryRunner({agent});
+
+    expect(runner.agent).toBe(agent);
+    expect(runner.appName).toBe('InMemoryRunner');
+  });
+
+  it('should use custom appName when provided', () => {
+    const agent = new MockAgent();
+    const runner = new InMemoryRunner({agent, appName: 'MyApp'});
+
+    expect(runner.appName).toBe('MyApp');
+  });
+
+  it('should initialize with in-memory services', () => {
+    const agent = new MockAgent();
+    const runner = new InMemoryRunner({agent});
+
+    expect(runner.sessionService).toBeDefined();
+    expect(runner.artifactService).toBeDefined();
+    expect(runner.memoryService).toBeDefined();
+  });
+
+  it('should accept plugins', () => {
+    const agent = new MockAgent();
+    const plugin = new (class extends BasePlugin {
+      constructor() {
+        super('test_plugin');
+      }
+    })();
+
+    const runner = new InMemoryRunner({agent, plugins: [plugin]});
+    expect(runner.pluginManager).toBeDefined();
+  });
+
+  it('should default to empty plugins array', () => {
+    const agent = new MockAgent();
+    const runner = new InMemoryRunner({agent});
+
+    expect(runner.pluginManager).toBeDefined();
+  });
+
+  it('should run agent and yield events', async () => {
+    const agent = new MockAgent();
+    const runner = new InMemoryRunner({agent});
+
+    const session = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: TEST_USER_ID,
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: TEST_USER_ID,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: TEST_MESSAGE}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events.length).toBeGreaterThan(0);
+    const agentEvent = events.find((e) => e.author === 'mock_agent');
+    expect(agentEvent).toBeDefined();
+    expect(agentEvent?.content?.parts?.[0]?.text).toBe('Mock response');
+  });
+
+  it('should support multiple independent sessions', async () => {
+    const agent = new MockAgent();
+    const runner = new InMemoryRunner({agent});
+
+    const session1 = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: 'user_1',
+    });
+    const session2 = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: 'user_2',
+    });
+
+    expect(session1.id).not.toBe(session2.id);
+
+    const events1: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'user_1',
+      sessionId: session1.id,
+      newMessage: {role: 'user', parts: [{text: 'Hello from user 1'}]},
+    })) {
+      events1.push(event);
+    }
+
+    const events2: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'user_2',
+      sessionId: session2.id,
+      newMessage: {role: 'user', parts: [{text: 'Hello from user 2'}]},
+    })) {
+      events2.push(event);
+    }
+
+    expect(events1.length).toBeGreaterThan(0);
+    expect(events2.length).toBeGreaterThan(0);
+  });
+});

--- a/core/test/utils/client_labels_test.ts
+++ b/core/test/utils/client_labels_test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {getClientLabels} from '../../src/utils/client_labels.js';
+
+describe('client_labels', () => {
+  describe('getClientLabels', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = {...originalEnv};
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+      vi.restoreAllMocks();
+    });
+
+    it('should return an array of label strings', () => {
+      const labels = getClientLabels();
+      expect(Array.isArray(labels)).toBe(true);
+      expect(labels.length).toBeGreaterThan(0);
+    });
+
+    it('should include google-adk label with version', () => {
+      const labels = getClientLabels();
+      const adkLabel = labels.find((l) => l.startsWith('google-adk/'));
+      expect(adkLabel).toBeDefined();
+    });
+
+    it('should include gl-typescript language label', () => {
+      const labels = getClientLabels();
+      const langLabel = labels.find((l) => l.startsWith('gl-typescript/'));
+      expect(langLabel).toBeDefined();
+    });
+
+    it('should include agent engine telemetry tag when env variable is set', () => {
+      process.env['GOOGLE_CLOUD_AGENT_ENGINE_ID'] = 'my-engine-id';
+      const labels = getClientLabels();
+      const adkLabel = labels.find((l) => l.startsWith('google-adk/'));
+      expect(adkLabel).toContain('remote_reasoning_engine');
+    });
+
+    it('should not include agent engine telemetry tag when env variable is not set', () => {
+      delete process.env['GOOGLE_CLOUD_AGENT_ENGINE_ID'];
+      const labels = getClientLabels();
+      const adkLabel = labels.find((l) => l.startsWith('google-adk/'));
+      expect(adkLabel).not.toContain('remote_reasoning_engine');
+    });
+
+    it('should return exactly two labels in Node.js environment', () => {
+      const labels = getClientLabels();
+      expect(labels).toHaveLength(2);
+    });
+  });
+});

--- a/core/test/utils/partial_copy_test.ts
+++ b/core/test/utils/partial_copy_test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {partialCopy} from '../../src/utils/partial_copy.js';
+
+interface SampleDest {
+  a: string;
+  b: number;
+  c?: boolean;
+}
+
+describe('partialCopy', () => {
+  it('should copy specified keys from source to new object', () => {
+    const source = {a: 'hello', b: 42, c: true, d: 'extra'};
+    const result = partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(result.a).toBe('hello');
+    expect(result.b).toBe(42);
+    expect('d' in result).toBe(false);
+  });
+
+  it('should set key to undefined if not present in source', () => {
+    const source = {a: 'hello'};
+    const result = partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(result.a).toBe('hello');
+    expect(result.b).toBeUndefined();
+  });
+
+  it('should return empty object when targetKeys is empty', () => {
+    const source = {a: 'hello', b: 42};
+    const result = partialCopy<SampleDest>(source, []);
+
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('should copy all specified keys including optional ones', () => {
+    const source = {a: 'hello', b: 42, c: false};
+    const result = partialCopy<SampleDest>(source, ['a', 'b', 'c']);
+
+    expect(result.a).toBe('hello');
+    expect(result.b).toBe(42);
+    expect(result.c).toBe(false);
+  });
+
+  it('should not mutate the source object', () => {
+    const source = {a: 'hello', b: 42};
+    const original = {...source};
+    partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(source).toEqual(original);
+  });
+
+  it('should copy falsy values correctly', () => {
+    const source = {a: '', b: 0, c: false};
+    const result = partialCopy<SampleDest>(source, ['a', 'b', 'c']);
+
+    expect(result.a).toBe('');
+    expect(result.b).toBe(0);
+    expect(result.c).toBe(false);
+  });
+
+  it('should return a new object, not the same reference', () => {
+    const source = {a: 'hello', b: 42};
+    const result = partialCopy<SampleDest>(source, ['a', 'b']);
+
+    expect(result).not.toBe(source);
+  });
+});

--- a/core/test/utils/vertex_ai_utils_test.ts
+++ b/core/test/utils/vertex_ai_utils_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {getExpressModeApiKey} from '../../src/utils/vertex_ai_utils.js';
+
+describe('vertex_ai_utils', () => {
+  describe('getExpressModeApiKey', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = {...originalEnv};
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should throw when both project and expressModeApiKey are provided', () => {
+      expect(() =>
+        getExpressModeApiKey('my-project', undefined, 'my-api-key'),
+      ).toThrow('Cannot specify project or location and expressModeApiKey.');
+    });
+
+    it('should throw when both location and expressModeApiKey are provided', () => {
+      expect(() =>
+        getExpressModeApiKey(undefined, 'us-central1', 'my-api-key'),
+      ).toThrow('Cannot specify project or location and expressModeApiKey.');
+    });
+
+    it('should throw when project, location, and expressModeApiKey are all provided', () => {
+      expect(() =>
+        getExpressModeApiKey('my-project', 'us-central1', 'my-api-key'),
+      ).toThrow();
+    });
+
+    it('should return undefined when GOOGLE_GENAI_USE_VERTEXAI is not set', () => {
+      delete process.env['GOOGLE_GENAI_USE_VERTEXAI'];
+      const result = getExpressModeApiKey();
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when GOOGLE_GENAI_USE_VERTEXAI is false', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'false';
+      const result = getExpressModeApiKey();
+      expect(result).toBeUndefined();
+    });
+
+    it('should return expressModeApiKey when GOOGLE_GENAI_USE_VERTEXAI is true', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
+      const result = getExpressModeApiKey(undefined, undefined, 'my-api-key');
+      expect(result).toBe('my-api-key');
+    });
+
+    it('should return GOOGLE_API_KEY from env when GOOGLE_GENAI_USE_VERTEXAI is true and no key provided', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
+      process.env['GOOGLE_API_KEY'] = 'env-api-key';
+      const result = getExpressModeApiKey();
+      expect(result).toBe('env-api-key');
+    });
+
+    it('should return undefined when GOOGLE_GENAI_USE_VERTEXAI is true but no key available', () => {
+      process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
+      delete process.env['GOOGLE_API_KEY'];
+      const result = getExpressModeApiKey();
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates the following 5 PRs into one as requested by @ScottMansfield in #348:

- #348 — LoggingPlugin unit tests
- #349 — SecurityPlugin unit tests
- #350 — partialCopy, getClientLabels, getExpressModeApiKey utils tests
- #351 — InMemoryRunner unit tests
- #352 — SequentialAgent unit tests

## Files added

- `core/test/plugins/logging_plugin_test.ts`
- `core/test/plugins/security_plugin_test.ts`
- `core/test/utils/client_labels_test.ts`
- `core/test/utils/partial_copy_test.ts`
- `core/test/utils/vertex_ai_utils_test.ts`
- `core/test/runner/in_memory_runner_test.ts`
- `core/test/agents/sequential_agent_test.ts`

Closes #348, #349, #350, #351, #352