### PR TITLE
Update README with TS content, quick start, and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,138 +9,109 @@
       <img src="https://raw.githubusercontent.com/google/adk-python/main/assets/agent-development-kit.png" width="256"/>
     </h2>
     <h3 align="center">
-      An open-source, code-first TypeScript toolkit for building, evaluating, and deploying sophisticated AI agents with flexibility and control.
+      An open-source, code-first TypeScript toolkit for building, evaluating,
+      and deploying sophisticated AI agents with flexibility and control.
     </h3>
     <h3 align="center">
-      Important Links:
-      <a href="https://google.github.io/adk-docs/">Docs</a>,
-      <a href="https://github.com/google/adk-samples">Samples</a>,
-      <a href="https://github.com/google/adk-python">Python ADK</a>.
-      <a href="https://github.com/google/adk-java">Java ADK</a>,
-      <a href="https://github.com/google/adk-go">Go ADK</a> &
-      <a href="https://github.com/google/adk-web">Web ADK</a>.
+      Important Links: <a href="https://adk.dev">Docs</a>, <a
+      href="https://github.com/google/adk-samples">Samples</a> & <a
+      href="https://github.com/google/adk-web">ADK Web</a>.
     </h3>
 </html>
 
-Agent Development Kit (ADK) is designed for developers seeking fine-grained
-control and flexibility when building advanced AI agents that are tightly
-integrated with services in Google Cloud. It allows you to define agent
-behavior, orchestration, and tool use directly in code, enabling robust
-debugging, versioning, and deployment anywhere – from your laptop to the
-cloud.
-
 ---
+
+Agent Development Kit (ADK) is a flexible and modular framework for building,
+deploying, and orchestrating AI agent workflows, from simple tasks to complex
+multi-agent systems. Define agent behavior, orchestration, and tool use directly
+in code, enabling robust debugging, versioning, and deployment anywhere.
+
+The TypeScript version of ADK is built for the Node.js and browser ecosystems,
+with full type safety, Zod schema validation, and support for ESM, CommonJS, and
+web runtimes.
 
 ## ✨ Key Features
 
-- **Rich Tool Ecosystem**: Utilize pre-built tools, custom functions, OpenAPI
-  specs, or integrate existing tools to give agents diverse capabilities, all
-  for tight integration with the Google ecosystem.
+- **Code-First TypeScript**: Define agent logic, tools, and orchestration with
+  full type safety. Tool parameters support Zod v3 and v4 schemas with
+  compile-time type inference.
 
-- **Code-First Development**: Define agent logic, tools, and orchestration
-  directly in TypeScript for ultimate flexibility, testability, and
-  versioning.
+- **Browser and Server**: Ships ESM, CommonJS, and web bundles. Run agents in
+  Node.js or directly in the browser.
 
-- **Modular Multi-Agent Systems**: Design scalable applications by composing
-  multiple specialized agents into flexible hierarchies.
+- **Rich Tool Ecosystem**: Built-in tools for Google Search, Google Maps, Vertex
+  AI Search, and URL context. Connect MCP servers, wrap any function as a tool,
+  or add code execution.
+
+- **Multi-Agent Orchestration**: Compose agents into sequential, parallel, loop,
+  and routed workflows. Delegate to remote agents via the A2A protocol.
+
+- **Dev Tools and CLI**: Interactive dev UI for testing and debugging. CLI
+  commands for scaffolding (`adk create`), local testing (`adk run`, `adk web`),
+  and deployment (`adk deploy cloud_run`).
 
 ## 🚀 Installation
 
-If you're using npm, add the following to your dependencies:
-
 ```bash
 npm install @google/adk
+npm install -D @google/adk-devtools
 ```
 
 Or with yarn:
 
 ```bash
 yarn add @google/adk
+yarn add -D @google/adk-devtools
 ```
 
-## 📚 Documentation
+This installs the core SDK and the dev tools (CLI and dev UI) as a dev
+dependency.
 
-For building, evaluating, and deploying agents by follow the TypeScript
-documentation & samples:
+## Quick Start
 
-- **[Documentation](https://google.github.io/adk-docs)**
-- **[Samples](https://github.com/google/adk-samples)**
-
-## 🏁 Feature Highlight
-
-### Same Features & Familiar Interface As Other ADKs:
+Define an agent:
 
 ```typescript
 import {LlmAgent, GOOGLE_SEARCH} from '@google/adk';
 
-const rootAgent = new LlmAgent({
+export const rootAgent = new LlmAgent({
   name: 'search_assistant',
   description: 'An assistant that can search the web.',
-  model: 'gemini-2.5-flash', // Or your preferred models
+  model: 'gemini-flash-latest',
   instruction:
     'You are a helpful assistant. Answer user questions using Google Search when needed.',
   tools: [GOOGLE_SEARCH],
 });
 ```
 
-### Development UI
+Run from your agent project directory:
 
-Same as the Python Development UI. A built-in development UI to help you test,
-evaluate, debug, and showcase your agent(s).
+```bash
+# Interactive CLI
+npx adk run agent.ts
+
+# Web UI
+npx adk web
+```
+
+The `adk web` command launches a development UI for testing and debugging
+agents:
+
 <img src="https://raw.githubusercontent.com/google/adk-python/main/assets/adk-web-dev-ui-function-call.png"/>
 
-### Evaluate Agents
+## 📚 Documentation
 
-Coming soon...
+- **Getting Started**: https://adk.dev/get-started/typescript
+- **Samples**: https://github.com/google/adk-samples
 
-## 🤖 A2A and ADK integration
-
-For remote agent-to-agent communication, ADK integrates with the
-[A2A protocol](https://github.com/google/A2A/). Examples coming soon...
-
-## 🏗️ Building the Project
-
-To set up the project and build it from source, follow these steps:
-
-1. **Install dependencies**:
-
-   ```bash
-   npm install
-   ```
-
-1. **Build the project**: This project uses `esbuild` to compile and bundle
-   the TypeScript source code. You can build the project using the following
-   npm scripts:
-   - `npm run build`: Compiles the TypeScript code into CommonJS, ESM, and Web
-     formats in the `dist` directory.
-   - `npm run build:bundle`: Creates bundled versions of the output for easier
-     distribution or use in environments that don't support tree-shaking well.
-   - `npm run build:watch`: Watches for changes in the source files and
-     automatically rebuilds the project for ESM format only.
-
-## 🤝 Contributing
+## Contributing
 
 We welcome contributions from the community! Whether it's bug reports, feature
-requests, documentation improvements, or code contributions, please see our
+requests, documentation improvements, or code contributions, please see the
+[contributing guide](https://adk.dev/community/contributing-guide/) and
+[CONTRIBUTING.md](./CONTRIBUTING.md) to get started.
 
-- [General contribution guideline and flow](https://google.github.io/adk-docs/contributing-guide/).
-- Then if you want to contribute code, please read
-  [Code Contributing Guidelines](./CONTRIBUTING.md) to get started.
-
-## 📄 License
+## License
 
 This project is licensed under the Apache 2.0 License - see the
 [LICENSE](LICENSE) file for details.
-
-## Preview
-
-This feature is subject to the "Pre-GA Offerings Terms" in the General Service
-Terms section of the
-[Service Specific Terms](https://cloud.google.com/terms/service-terms#1).
-Pre-GA features are available "as is" and might have limited support. For more
-information, see the
-[launch stage descriptions](https://cloud.google.com/products?hl=en#product-launch-stages).
-
----
-
-_Happy Agent Building!_

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ agents:
 - **Getting Started**: https://adk.dev/get-started/typescript
 - **Samples**: https://github.com/google/adk-samples
 
-## Contributing
+## 🤝 Contributing
 
 We welcome contributions from the community! Whether it's bug reports, feature
 requests, documentation improvements, or code contributions, please see the
 [contributing guide](https://adk.dev/community/contributing-guide/) and
 [CONTRIBUTING.md](./CONTRIBUTING.md) to get started.
 
-## License
+## 📄 License
 
 This project is licensed under the Apache 2.0 License - see the
 [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Updates the README with TypeScript-specific content, a tested Quick Start section, and links to adk.dev.

- New intro paragraphs highlighting TypeScript, browser support, and Zod
- Key Features rewritten with 5 TypeScript-specific bullets
- Installation now includes `@google/adk-devtools`
- New Quick Start section with tested code example and CLI commands
- Documentation links updated to adk.dev
- Removed stale "Coming soon" sections, Preview disclaimer, and "Building the Project" (covered in CONTRIBUTING.md)

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested my changes end-to-end.