### PR TITLE
fix(mcp_toolset): Implement close session method 

### DIFF
--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -31,6 +31,7 @@ import {
   runAsyncGeneratorWithOtelContext,
   tracer,
 } from '../telemetry/tracing.js';
+import {BaseToolset, isBaseToolset} from '../tools/base_toolset.js';
 import {logger} from '../utils/logger.js';
 import {isGemini2OrAbove} from '../utils/model_name.js';
 
@@ -404,6 +405,8 @@ export class Runner {
       );
     } finally {
       span.end();
+      const toolsets = getAllToolsets(this.agent);
+      await Promise.allSettled(toolsets.map((t) => t.close()));
     }
   }
 
@@ -562,4 +565,29 @@ function findEventByLastFunctionResponseId(events: Event[]): Event | null {
     }
   }
   return null;
+}
+
+function getAllToolsets(agent: BaseAgent): BaseToolset[] {
+  const toolsets: BaseToolset[] = [];
+  const visited = new Set<BaseAgent>();
+
+  function traverse(curr: BaseAgent) {
+    if (visited.has(curr)) return;
+    visited.add(curr);
+
+    if (isLlmAgent(curr)) {
+      for (const tool of curr.tools) {
+        if (isBaseToolset(tool)) {
+          toolsets.push(tool);
+        }
+      }
+    }
+
+    for (const sub of curr.subAgents) {
+      traverse(sub);
+    }
+  }
+
+  traverse(agent);
+  return toolsets;
 }

--- a/core/src/tools/mcp/mcp_session_manager.ts
+++ b/core/src/tools/mcp/mcp_session_manager.ts
@@ -72,6 +72,7 @@ export type MCPConnectionParams =
  */
 export class MCPSessionManager {
   private readonly connectionParams: MCPConnectionParams;
+  private readonly activeSessions = new Set<Client>();
 
   constructor(connectionParams: MCPConnectionParams) {
     this.connectionParams = connectionParams;
@@ -113,6 +114,18 @@ export class MCPSessionManager {
       }
     }
 
+    this.activeSessions.add(client);
     return client;
+  }
+
+  async closeSession(client: Client): Promise<void> {
+    if (this.activeSessions.has(client)) {
+      this.activeSessions.delete(client);
+      await client.close();
+    }
+  }
+
+  getActiveSessions(): Client[] {
+    return Array.from(this.activeSessions);
   }
 }

--- a/core/src/tools/mcp/mcp_tool.ts
+++ b/core/src/tools/mcp/mcp_tool.ts
@@ -65,13 +65,15 @@ export class MCPTool extends BaseTool {
   override async runAsync(request: RunAsyncToolRequest): Promise<unknown> {
     const session = await this.mcpSessionManager.createSession();
 
-    const callRequest: CallToolRequest = {} as CallToolRequest;
-    callRequest.params = {name: this.originalName, arguments: request.args};
-    const result = await session.callTool(callRequest.params, undefined, {
-      signal: request.toolContext.abortSignal,
-    });
-    await session.close();
-
-    return result as CallToolResult;
+    try {
+      const callRequest: CallToolRequest = {} as CallToolRequest;
+      callRequest.params = {name: this.originalName, arguments: request.args};
+      const result = await session.callTool(callRequest.params, undefined, {
+        signal: request.toolContext.abortSignal,
+      });
+      return result as CallToolResult;
+    } finally {
+      await this.mcpSessionManager.closeSession(session);
+    }
   }
 }

--- a/core/src/tools/mcp/mcp_toolset.ts
+++ b/core/src/tools/mcp/mcp_toolset.ts
@@ -58,8 +58,12 @@ export class MCPToolset extends BaseToolset {
   async getTools(context?: ReadonlyContext): Promise<BaseTool[]> {
     const session = await this.mcpSessionManager.createSession();
 
-    const listResult = (await session.listTools()) as ListToolsResult;
-    await session.close();
+    let listResult: ListToolsResult;
+    try {
+      listResult = (await session.listTools()) as ListToolsResult;
+    } finally {
+      await this.mcpSessionManager.closeSession(session);
+    }
     logger.debug(`number of tools: ${listResult.tools.length}`);
     for (const tool of listResult.tools) {
       logger.debug(`tool: ${tool.name}`);

--- a/core/src/tools/mcp/mcp_toolset.ts
+++ b/core/src/tools/mcp/mcp_toolset.ts
@@ -100,5 +100,10 @@ export class MCPToolset extends BaseToolset {
     return tools;
   }
 
-  async close(): Promise<void> {}
+  async close(): Promise<void> {
+    const sessions = this.mcpSessionManager.getActiveSessions();
+    await Promise.allSettled(
+      sessions.map((session) => this.mcpSessionManager.closeSession(session)),
+    );
+  }
 }

--- a/core/test/runner/in_memory_runner_test.ts
+++ b/core/test/runner/in_memory_runner_test.ts
@@ -7,12 +7,15 @@
 import {
   BaseAgent,
   BasePlugin,
+  BaseTool,
+  BaseToolset,
   createEvent,
   Event,
   InMemoryRunner,
   InvocationContext,
+  LlmAgent,
 } from '@google/adk';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 const TEST_USER_ID = 'test_user_id';
 const TEST_MESSAGE = 'Hello, agent!';
@@ -140,5 +143,48 @@ describe('InMemoryRunner', () => {
 
     expect(events1.length).toBeGreaterThan(0);
     expect(events2.length).toBeGreaterThan(0);
+  });
+
+  it('automatically closes stateful toolsets at the end of runAsync', async () => {
+    const closeSpy = vi.fn().mockResolvedValue(undefined);
+
+    class CustomToolset extends BaseToolset {
+      constructor() {
+        super([]);
+      }
+      async getTools(): Promise<BaseTool[]> {
+        return [];
+      }
+      async close(): Promise<void> {
+        await closeSpy();
+      }
+    }
+
+    const toolset = new CustomToolset();
+    const agent = new LlmAgent({
+      name: 'llm_agent',
+      tools: [toolset],
+    });
+
+    const runner = new InMemoryRunner({agent});
+
+    const session = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: TEST_USER_ID,
+    });
+
+    try {
+      for await (const _ of runner.runAsync({
+        userId: TEST_USER_ID,
+        sessionId: session.id,
+        newMessage: {role: 'user', parts: [{text: TEST_MESSAGE}]},
+      })) {
+        // consume events
+      }
+    } catch (_e: unknown) {
+      // Ignore any model-related errors because we only care that finally block closes the toolset!
+    }
+
+    expect(closeSpy).toHaveBeenCalled();
   });
 });

--- a/core/test/tools/mcp/mcp_session_manager_test.ts
+++ b/core/test/tools/mcp/mcp_session_manager_test.ts
@@ -18,6 +18,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
   return {
     Client: vi.fn().mockImplementation(() => ({
       connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
     })),
   };
 });
@@ -156,5 +157,28 @@ describe('MCPSessionManager', () => {
         requestInit: {},
       },
     );
+  });
+
+  it('tracks active sessions and cleans them up', async () => {
+    const manager = new MCPSessionManager({
+      type: 'StdioConnectionParams',
+      serverParams: {
+        command: 'test-command',
+        args: ['arg1', 'arg2'],
+      },
+    });
+
+    expect(manager.getActiveSessions()).toEqual([]);
+
+    const client1 = await manager.createSession();
+    const client2 = await manager.createSession();
+
+    expect(manager.getActiveSessions()).toEqual([client1, client2]);
+
+    await manager.closeSession(client1);
+    expect(manager.getActiveSessions()).toEqual([client2]);
+
+    await manager.closeSession(client2);
+    expect(manager.getActiveSessions()).toEqual([]);
   });
 });

--- a/core/test/tools/mcp/mcp_tool_test.ts
+++ b/core/test/tools/mcp/mcp_tool_test.ts
@@ -130,4 +130,38 @@ describe('MCPTool', () => {
       'Aborted',
     );
   });
+
+  it('closes session even when callTool throws an error', async () => {
+    const mockTool: Tool = {
+      name: 'test-tool',
+      description: 'A test tool',
+      inputSchema: {type: 'object', properties: {}},
+    };
+
+    const mockClient = {
+      callTool: vi.fn().mockRejectedValue(new Error('Call failed')),
+    } as unknown as Client;
+
+    const mockSessionManager = {
+      createSession: vi.fn().mockResolvedValue(mockClient),
+      closeSession: vi.fn().mockResolvedValue(undefined),
+    } as unknown as MCPSessionManager;
+
+    const tool = new MCPTool(mockTool, mockSessionManager);
+
+    const invocationContext = {
+      abortSignal: new AbortController().signal,
+      session: {state: {}},
+    } as unknown as InvocationContext;
+
+    const toolContext = new Context({invocationContext});
+
+    // Assert that the tool still propagates the error
+    await expect(tool.runAsync({args: {}, toolContext})).rejects.toThrow(
+      'Call failed',
+    );
+
+    // Assert that closeSession was still called despite the error
+    expect(mockSessionManager.closeSession).toHaveBeenCalledWith(mockClient);
+  });
 });

--- a/core/test/tools/mcp/mcp_tool_test.ts
+++ b/core/test/tools/mcp/mcp_tool_test.ts
@@ -29,6 +29,7 @@ describe('MCPTool', () => {
 
     const mockSessionManager = {
       createSession: vi.fn().mockResolvedValue(mockClient),
+      closeSession: vi.fn().mockResolvedValue(undefined),
     } as unknown as MCPSessionManager;
 
     const tool = new MCPTool(mockTool, mockSessionManager);
@@ -66,6 +67,7 @@ describe('MCPTool', () => {
 
     const mockSessionManager = {
       createSession: vi.fn().mockResolvedValue(mockClient),
+      closeSession: vi.fn().mockResolvedValue(undefined),
     } as unknown as MCPSessionManager;
 
     // Pass 'test-tool' as originalName
@@ -108,6 +110,7 @@ describe('MCPTool', () => {
 
     const mockSessionManager = {
       createSession: vi.fn().mockResolvedValue(mockClient),
+      closeSession: vi.fn().mockResolvedValue(undefined),
     } as unknown as MCPSessionManager;
 
     const tool = new MCPTool(mockTool, mockSessionManager);

--- a/core/test/tools/mcp/mcp_toolset_test.ts
+++ b/core/test/tools/mcp/mcp_toolset_test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {describe, expect, it, vi} from 'vitest';
 import {ReadonlyContext} from '../../../src/agents/readonly_context.js';
 import {MCPConnectionParams} from '../../../src/tools/mcp/mcp_session_manager.js';
@@ -113,6 +114,39 @@ describe('MCPToolset', () => {
       const tools = await toolset.getTools();
 
       expect(tools).toHaveLength(2);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('closes the session and leaves activeSessions empty after getTools success', async () => {
+      const toolset = new MCPToolset(stdioParams);
+      const spy = vi.spyOn(toolset['mcpSessionManager'], 'closeSession');
+      const tools = await toolset.getTools();
+
+      expect(tools).toHaveLength(2);
+      expect(spy).toHaveBeenCalledOnce();
+      expect(toolset['mcpSessionManager'].getActiveSessions()).toHaveLength(0);
+    });
+
+    it('closes the session and leaves activeSessions empty even if listTools throws an error', async () => {
+      const toolset = new MCPToolset(stdioParams);
+
+      const {Client} =
+        await import('@modelcontextprotocol/sdk/client/index.js');
+      const mockClientInstance = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockRejectedValue(new Error('List tools failed')),
+      };
+      vi.mocked(Client).mockImplementationOnce(
+        () => mockClientInstance as unknown as Client,
+      );
+
+      const spy = vi.spyOn(toolset['mcpSessionManager'], 'closeSession');
+
+      await expect(toolset.getTools()).rejects.toThrow('List tools failed');
+      expect(spy).toHaveBeenCalledOnce();
+      expect(toolset['mcpSessionManager'].getActiveSessions()).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #377

**2. Or, if no issue exists, describe the change:**

**Problem:**
When executing an ADK agent inside command-line or short-lived/ephemeral contexts, the parent Node/Bun process hangs indefinitely upon completion. This is caused by:
1. `MCPToolset.close()` being a compiled empty no-op that does not terminate any client connection sessions spawned by `MCPSessionManager`.
2. The base `Runner` class (and its subclasses like `InMemoryRunner`) not automatically invoking the `.close()` lifecycle hook on its agent's stateful toolsets when `runEphemeral` or `runAsync` generators complete.
3. Connection transport resources (Stdio child processes or SSE keep-alive handles) leaked in the event loop, preventing clean process termination.

**Solution:**
1. **Session Tracking**: Enhanced `MCPSessionManager` to track active client connection sessions in a `Set<Client>` and added a `closeSession()` method to safely terminate specific sessions and remove them from tracking.
2. **Try-Finally Guard**: Refactored `MCPTool.runAsync` to call the remote tool within a `try-finally` block, ensuring that the connection session is closed even if the tool call throws an exception or is aborted.
3. **Clean close() Implementation**: Implemented `MCPToolset.close()` to retrieve all active sessions from the session manager and safely close them using `Promise.allSettled`.
4. **Automated Runner Cleanup**: Added recursive traversal (`getAllToolsets`) in `Runner.runAsync` to search the agent's tree for stateful toolsets (subclasses of `BaseToolset`) and automatically call `close()` on them within the runner's `finally` block.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Specific test files updated/added:
- `core/test/tools/mcp/mcp_session_manager_test.ts`: Added test case asserting that `MCPSessionManager` tracks active sessions and correctly removes them upon `closeSession()`.
- `core/test/runner/in_memory_runner_test.ts`: Added test case asserting that stateful toolsets in the agent tree are automatically closed at the end of `runAsync()`.
- `core/test/tools/mcp/mcp_tool_test.ts`: Updated mocked session managers to support the new `closeSession` method signature.
**Manual End-to-End (E2E) Tests:**

Verification can be performed by invoking an agent with a stdio-based MCP connection inside a Node script:
```typescript
const runner = new InMemoryRunner({ agent });
for await (const event of runner.runEphemeral({
  userId: 'user',
  newMessage: { role: 'user', parts: [{ text: 'my task' }] }
})) {
  console.log(event);
}
```

Checklist:
- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

Additional context
None.
