### PR TITLE
test: add unit tests for CodeExecutionRequestProcessor and CodeExecutionResponseProcessor

### DIFF
--- a/core/test/agents/processors/code_execution_request_processor_test.ts
+++ b/core/test/agents/processors/code_execution_request_processor_test.ts
@@ -1,0 +1,221 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  InvocationContext,
+  LlmAgent,
+  LlmRequest,
+  PluginManager,
+  createSession,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {
+  CODE_EXECUTION_REQUEST_PROCESSOR,
+  CodeExecutionResponseProcessor,
+} from '../../../src/agents/processors/code_execution_request_processor.js';
+import {
+  BaseCodeExecutor,
+  ExecuteCodeParams,
+} from '../../../src/code_executors/base_code_executor.js';
+import {CodeExecutionResult} from '../../../src/code_executors/code_execution_utils.js';
+
+class MockBaseAgent extends BaseAgent {
+  constructor(name: string) {
+    super({name});
+  }
+  protected async *runAsyncImpl(_context: InvocationContext) {}
+  protected async *runLiveImpl(_context: InvocationContext) {}
+}
+
+class TestCodeExecutor extends BaseCodeExecutor {
+  async executeCode(_params: ExecuteCodeParams): Promise<CodeExecutionResult> {
+    return {stdout: '', stderr: '', outputFiles: []};
+  }
+}
+
+function createMockInvocationContext(agent: BaseAgent): InvocationContext {
+  return new InvocationContext({
+    invocationId: 'test-invocation',
+    agent,
+    session: createSession({
+      id: 'test-session',
+      events: [],
+      appName: 'test-app',
+      userId: 'test-user',
+    }),
+    pluginManager: new PluginManager([]),
+  });
+}
+
+function createLlmRequest(overrides: Partial<LlmRequest> = {}): LlmRequest {
+  return {
+    contents: [],
+    toolsDict: {},
+    liveConnectConfig: {},
+    ...overrides,
+  };
+}
+
+async function collectEvents<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const event of gen) {
+    results.push(event);
+  }
+  return results;
+}
+
+describe('CodeExecutionRequestProcessor', () => {
+  describe('early-exit paths', () => {
+    it('yields no events and leaves request unchanged for a non-LlmAgent', async () => {
+      const agent = new MockBaseAgent('non-llm-agent');
+      const ctx = createMockInvocationContext(agent);
+      const llmRequest = createLlmRequest({
+        contents: [{role: 'user', parts: [{text: 'hello'}]}],
+      });
+
+      const events = await collectEvents(
+        CODE_EXECUTION_REQUEST_PROCESSOR.runAsync(ctx, llmRequest),
+      );
+
+      expect(events).toHaveLength(0);
+      expect(llmRequest.contents).toHaveLength(1);
+    });
+
+    it('yields no events when LlmAgent has no codeExecutor', async () => {
+      const agent = new LlmAgent({
+        name: 'agent-no-executor',
+        model: 'gemini-2.5-flash',
+      });
+      const ctx = createMockInvocationContext(agent);
+      const llmRequest = createLlmRequest({
+        contents: [{role: 'user', parts: [{text: 'hello'}]}],
+      });
+
+      const events = await collectEvents(
+        CODE_EXECUTION_REQUEST_PROCESSOR.runAsync(ctx, llmRequest),
+      );
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('calls runPreProcessor and proceeds to convertCodeExecutionParts when codeExecutor is BaseCodeExecutor', async () => {
+      const executor = new TestCodeExecutor();
+      const agent = new LlmAgent({
+        name: 'agent-with-executor',
+        model: 'gemini-2.5-flash',
+        codeExecutor: executor,
+      });
+      const ctx = createMockInvocationContext(agent);
+      const llmRequest = createLlmRequest({
+        contents: [{role: 'user', parts: [{text: 'hello'}]}],
+      });
+
+      // Should not throw — runPreProcessor exits early because
+      // isBuiltInCodeExecutor is false and optimizeDataFile is false
+      const events = await collectEvents(
+        CODE_EXECUTION_REQUEST_PROCESSOR.runAsync(ctx, llmRequest),
+      );
+
+      expect(events).toHaveLength(0);
+      // Content should still be present after processing
+      expect(llmRequest.contents).toHaveLength(1);
+    });
+  });
+});
+
+describe('CodeExecutionResponseProcessor', () => {
+  const responseProcessor = new CodeExecutionResponseProcessor();
+
+  describe('early-exit paths', () => {
+    it('yields no events for a partial response', async () => {
+      const agent = new LlmAgent({
+        name: 'agent',
+        model: 'gemini-2.5-flash',
+        codeExecutor: new TestCodeExecutor(),
+      });
+      const ctx = createMockInvocationContext(agent);
+      const partialResponse = {
+        partial: true,
+        content: {role: 'model', parts: [{text: 'thinking...'}]},
+      };
+
+      const events = await collectEvents(
+        responseProcessor.runAsync(ctx, partialResponse),
+      );
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('yields no events for a non-LlmAgent', async () => {
+      const agent = new MockBaseAgent('non-llm');
+      const ctx = createMockInvocationContext(agent);
+      const llmResponse = {
+        partial: false,
+        content: {role: 'model', parts: [{text: 'done'}]},
+      };
+
+      const events = await collectEvents(
+        responseProcessor.runAsync(ctx, llmResponse),
+      );
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('yields no events when LlmAgent has no codeExecutor', async () => {
+      const agent = new LlmAgent({
+        name: 'agent-no-executor',
+        model: 'gemini-2.5-flash',
+      });
+      const ctx = createMockInvocationContext(agent);
+      const llmResponse = {
+        partial: false,
+        content: {role: 'model', parts: [{text: 'done'}]},
+      };
+
+      const events = await collectEvents(
+        responseProcessor.runAsync(ctx, llmResponse),
+      );
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('yields no events when response has no content', async () => {
+      const agent = new LlmAgent({
+        name: 'agent-with-executor',
+        model: 'gemini-2.5-flash',
+        codeExecutor: new TestCodeExecutor(),
+      });
+      const ctx = createMockInvocationContext(agent);
+      const llmResponse = {partial: false};
+
+      const events = await collectEvents(
+        responseProcessor.runAsync(ctx, llmResponse),
+      );
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('yields no events when response content has no code block', async () => {
+      const agent = new LlmAgent({
+        name: 'agent-with-executor',
+        model: 'gemini-2.5-flash',
+        codeExecutor: new TestCodeExecutor(),
+      });
+      const ctx = createMockInvocationContext(agent);
+      const llmResponse = {
+        partial: false,
+        content: {role: 'model', parts: [{text: 'plain text response'}]},
+      };
+
+      const events = await collectEvents(
+        responseProcessor.runAsync(ctx, llmResponse),
+      );
+
+      expect(events).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the contribution guide before creating a pull request.**

### Link to Issue or Description of Change

Adds unit tests for `core/src/agents/processors/code_execution_request_processor.ts`, which had no test coverage. The tests focus on the early-exit guard paths in both processors, verifying that they short-circuit correctly before reaching the complex code-execution logic that requires a live executor.

**`CodeExecutionRequestProcessor.runAsync`** — 3 tests:
- Non-`LlmAgent` agent → yields no events, leaves request unchanged
- `LlmAgent` with no `codeExecutor` → yields no events
- `LlmAgent` with a `BaseCodeExecutor` (non-built-in, `optimizeDataFile = false`) → runs `runPreProcessor` and exits cleanly; contents preserved

**`CodeExecutionResponseProcessor.runAsync`** — 5 tests:
- Partial response → yields no events (skips post-processing)
- Non-`LlmAgent` → yields no events
- `LlmAgent` with no `codeExecutor` → yields no events
- Response with no content → yields no events
- Response content with no code block → yields no events (no code to extract)

### Testing Plan
**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
✓ core/test/agents/processors/code_execution_request_processor_test.ts (8 tests) 6ms
Test Files: 1 passed (1)
     Tests: 8 passed (8)
```

**Manual End-to-End (E2E) Tests:**
Pure unit tests with no dependencies on external services.

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Self-reviewed code
- [x] Commented hard-to-understand areas
- [x] Added tests proving fix/feature works
- [x] Unit tests pass locally
- [x] Manually tested end-to-end
- [x] Dependent changes merged/published