### PR TITLE
fix(core): replace 'any' with typed AuthConfig in EventActions

### DIFF
--- a/core/src/context/token_based_context_compactor.ts
+++ b/core/src/context/token_based_context_compactor.ts
@@ -132,7 +132,7 @@ export class TokenBasedContextCompactor implements BaseContextCompactor {
       compactedEvent.actions = {
         stateDelta: {},
         artifactDelta: {},
-        requestedAuthConfigs: [],
+        requestedAuthConfigs: {},
         requestedToolConfirmations: {},
       };
     }

--- a/core/src/events/event_actions.ts
+++ b/core/src/events/event_actions.ts
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {AuthConfig} from '../auth/auth_tool.js';
 import {ToolConfirmation} from '../tools/tool_confirmation.js';
-
-// TODO: b/425992518 - Replace 'any' with a proper AuthConfig.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AuthConfig = any;
 
 /**
  * Represents the actions attached to an event.

--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -17,6 +17,7 @@ import {Content, GenerateContentResponseUsageMetadata} from '@google/genai';
 import {isCompactedEvent} from '../events/compacted_event.js';
 import {experimental} from '../utils/experimental.js';
 
+import {AuthConfig} from '../auth/auth_tool.js';
 import {Event} from '../events/event.js';
 import {EventActions} from '../events/event_actions.js';
 import {ToolConfirmation} from '../tools/tool_confirmation.js';
@@ -478,7 +479,7 @@ function _fromApiEvent(apiEventObj: VertexAiSessionEvent): Event {
     stateDelta: (actions['stateDelta'] as {[key: string]: unknown}) || {},
     artifactDelta: (actions['artifactDelta'] as {[key: string]: number}) || {},
     requestedAuthConfigs:
-      (actions.requestedAuthConfigs as Record<string, unknown>) || {},
+      (actions.requestedAuthConfigs as Record<string, AuthConfig>) || {},
     requestedToolConfirmations:
       ((actions as Record<string, unknown>)[
         'requestedToolConfirmations'


### PR DESCRIPTION
### Link to Issue or Description of Change
**Problem:**
The `AuthConfig` type in `EventActions` (defined in `core/src/events/event_actions.ts`) was typed as `any` with a `TODO: b/425992518`. This lacked proper type safety and permitted incorrect assignments elsewhere in the codebase.

**Solution:**
Replaced `any` with the proper `AuthConfig` import from `../auth/auth_tool.js`.
To resolve resulting TypeScript compiler errors:
- Initialized `requestedAuthConfigs` as an empty object `{}` instead of an empty array `[]` inside the default actions block of `token_based_context_compactor.ts`.
- Imported `AuthConfig` and cast `actions.requestedAuthConfigs` as `Record<string, AuthConfig>` (rather than `Record<string, unknown>`) in `vertex_ai_session_service.ts`.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed npm test results:
- Ran `npm run test:unit` locally.
- All 142 test files and 1782/1782 tests passed successfully.

**Manual End-to-End (E2E) Tests:**

Verified that compiling the workspaces via `npm run build` succeeds without any TypeScript diagnostic errors (which previously failed on `tsc` with `TS2322`).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Addresses `TODO: b/425992518 - Replace 'any' with a proper AuthConfig.`
