### PR TITLE
fix(streaming): prevent prototype pollution via model-controlled JSON path

### DIFF
--- a/core/src/utils/streaming_utils.ts
+++ b/core/src/utils/streaming_utils.ts
@@ -27,6 +27,12 @@ interface StreamingStrategy {
 }
 
 /**
+ * Property keys that must never be written through a model-controlled JSON
+ * path, to prevent prototype pollution of `Object.prototype`.
+ */
+const UNSAFE_PROPERTY_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
  * Progressive strategy for SSE streaming mode: flushes parts as they arrive.
  */
 class ProgressiveStrategy implements StreamingStrategy {
@@ -118,10 +124,17 @@ class ProgressiveStrategy implements StreamingStrategy {
       (p) => p !== '$' && p !== '$[',
     );
 
+    // Reject model-controlled paths that target prototype-chain properties,
+    // which would otherwise pollute `Object.prototype` (e.g.
+    // `$.__proto__.polluted`).
+    if (pathParts.some((part) => UNSAFE_PROPERTY_KEYS.has(String(part)))) {
+      return;
+    }
+
     let current = this.currentFcArgs;
     for (let i = 0; i < pathParts.length - 1; i++) {
       const part = pathParts[i];
-      if (!(part in current)) {
+      if (!Object.prototype.hasOwnProperty.call(current, part)) {
         current[part] = {};
       }
       current = current[part] as Record<string, unknown>;

--- a/core/test/utils/streaming_utils_test.ts
+++ b/core/test/utils/streaming_utils_test.ts
@@ -491,6 +491,38 @@ describe('StreamingResponseAggregator', () => {
       ]);
     });
 
+    it('should not pollute Object.prototype via a malicious jsonPath', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+      const response = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'evil_func',
+                partialArgs: [
+                  {jsonPath: '$.__proto__.polluted', stringValue: 'PWNED'},
+                  {
+                    jsonPath: '$.constructor.prototype.polluted2',
+                    stringValue: 'PWNED',
+                  },
+                ],
+                willContinue: false,
+              } as unknown as FunctionCall,
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response)) {
+        // just consume iterator
+      }
+      aggregator.close();
+
+      expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+      expect(({} as Record<string, unknown>)['polluted2']).toBeUndefined();
+    });
+
     it('should handle deeply nested structures and mixed notation', async () => {
       const aggregator = new StreamingResponseAggregator(true);
       const response = createResponse({


### PR DESCRIPTION
## Summary

In progressive SSE streaming mode, `FunctionCall.partialArgs[].jsonPath` is read directly from the model's streamed output and written into the accumulated function-call arguments by `ProgressiveStrategy.setValueByJsonPath` (`core/src/utils/streaming_utils.ts`). The path segments were not validated, so a model-emitted path such as `$.__proto__.polluted` (or `$.constructor.prototype.x`) traversed the prototype chain and assigned onto `Object.prototype`, polluting it for the entire process.

This path is reachable whenever progressive SSE streaming is enabled and the model output is influenceable (e.g. via indirect prompt injection through a tool result, fetched page, or RAG document).

## Fix

- Reject path segments resolving to `__proto__`, `constructor`, or `prototype`.
- Build intermediate containers using `Object.prototype.hasOwnProperty` instead of the `in` operator, so inherited members are never traversed when creating nested objects.

## Test

Adds a regression test under `JSONPath Plus Integration` asserting that a malicious `jsonPath` does not pollute `Object.prototype`. Verified the test fails on the pre-fix code (`({}).polluted === 'PWNED'`) and passes with the fix; full `streaming_utils` suite remains green.