### PR TITLE
fix: resolve infinite loop when combining outputSchema and tools also added unit tests

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -6,6 +6,7 @@
 
 import {GenerateContentConfig, Schema} from '@google/genai';
 import {context, trace} from '@opentelemetry/api';
+import {FunctionTool} from '../tools/function_tool.js';
 
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
@@ -743,7 +744,23 @@ export class LlmAgent extends BaseAgent {
     }
     // TODO - b/425992518: check if tool preprocessors can be simplified.
     // Run pre-processors for tools.
-    for (const toolUnion of this.tools) {
+    const allTools = [...this.tools];
+    if (this.outputSchema && allTools.length > 0) {
+      const setModelResponseTool = new FunctionTool({
+        name: 'set_model_response',
+        description:
+          'Call this tool to submit your final response conforming to the output schema. Use this tool only when you have collected all the information and are ready to return the final answer.',
+        parameters: this.outputSchema,
+        execute: async (args, toolContext) => {
+          if (toolContext) {
+            toolContext.actions.skipSummarization = true;
+          }
+          return JSON.stringify(args);
+        },
+      });
+      allTools.push(setModelResponseTool);
+    }
+    for (const toolUnion of allTools) {
       const toolContext = new Context({invocationContext});
 
       // process all tools from this tool union
@@ -758,7 +775,8 @@ export class LlmAgent extends BaseAgent {
         // The allowedTools set is populated by request processors.
         return (
           !llmRequest.allowedTools ||
-          llmRequest.allowedTools.includes(tool.name)
+          llmRequest.allowedTools.includes(tool.name) ||
+          tool.name === 'set_model_response'
         );
       });
 
@@ -880,8 +898,14 @@ export class LlmAgent extends BaseAgent {
 
     if (mergedEvent.content) {
       const functionCalls = getFunctionCalls(mergedEvent);
-      if (functionCalls?.length) {
-        // TODO - b/425992518: rename topopulate if missing.
+      const setModelResponseCall = functionCalls.find(
+        (call) => call.name === 'set_model_response',
+      );
+      if (setModelResponseCall) {
+        const args = setModelResponseCall.args;
+        mergedEvent.content.parts = [{text: JSON.stringify(args)}];
+        mergedEvent.actions.skipSummarization = true;
+      } else if (functionCalls && functionCalls.length) {
         populateClientFunctionCallId(mergedEvent);
         // TODO - b/425992518: hacky, transaction log, simplify.
         // Long running is a property of tool in registry.

--- a/core/src/agents/processors/basic_llm_request_processor.ts
+++ b/core/src/agents/processors/basic_llm_request_processor.ts
@@ -30,7 +30,7 @@ export class BasicLlmRequestProcessor extends BaseLlmRequestProcessor {
     llmRequest.model = agent.canonicalModel.model;
 
     llmRequest.config = {...(agent.generateContentConfig ?? {})};
-    if (agent.outputSchema) {
+    if (agent.outputSchema && (!agent.tools || agent.tools.length === 0)) {
       setOutputSchema(llmRequest, agent.outputSchema);
     }
 

--- a/core/src/agents/processors/instructions_llm_request_processor.ts
+++ b/core/src/agents/processors/instructions_llm_request_processor.ts
@@ -61,6 +61,12 @@ export class InstructionsLlmRequestProcessor extends BaseLlmRequestProcessor {
       }
       appendInstructions(llmRequest, [instructionWithState]);
     }
+
+    if (agent.outputSchema && agent.tools && agent.tools.length > 0) {
+      appendInstructions(llmRequest, [
+        'To output the final result, you must call the "set_model_response" function with the appropriate values. Do not output anything else.',
+      ]);
+    }
   }
 }
 

--- a/core/test/agents/processors/basic_llm_request_processor_test.ts
+++ b/core/test/agents/processors/basic_llm_request_processor_test.ts
@@ -9,6 +9,7 @@ import {
   BaseLlm,
   BaseLlmConnection,
   createSession,
+  FunctionTool,
   InvocationContext,
   LlmAgent,
   LLMRegistry,
@@ -166,6 +167,34 @@ describe('BasicLlmRequestProcessor', () => {
 
     expect(llmRequest.config?.responseSchema).toBeDefined();
     expect(llmRequest.config?.responseMimeType).toBe('application/json');
+  });
+
+  it('should not set outputSchema in config when agent has outputSchema and tools', async () => {
+    const outputSchema = {
+      type: 'object' as const,
+      properties: {
+        answer: {type: 'string' as const},
+      },
+    };
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: 'test-basic-processor-model',
+      outputSchema,
+      tools: [
+        new FunctionTool({
+          name: 'some_tool',
+          description: 'A test tool',
+          execute: () => 'result',
+        }),
+      ],
+    });
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest = makeLlmRequest();
+
+    await runProcessor(invocationContext, llmRequest);
+
+    expect(llmRequest.config?.responseSchema).toBeUndefined();
+    expect(llmRequest.config?.responseMimeType).toBeUndefined();
   });
 
   it('should populate liveConnectConfig from runConfig', async () => {

--- a/core/test/agents/processors/instructions_llm_request_processor_test.ts
+++ b/core/test/agents/processors/instructions_llm_request_processor_test.ts
@@ -6,12 +6,13 @@
 
 import {
   BaseAgent,
+  createSession,
+  FunctionTool,
   InvocationContext,
   LlmAgent,
   LlmRequest,
   PluginManager,
   ReadonlyContext,
-  createSession,
 } from '@google/adk';
 import {describe, expect, it} from 'vitest';
 import {INSTRUCTIONS_LLM_REQUEST_PROCESSOR} from '../../../src/agents/processors/instructions_llm_request_processor.js';
@@ -157,6 +158,46 @@ describe('InstructionsLlmRequestProcessor', () => {
     expect(llmRequest.config?.systemInstruction).toContain('Local instruction');
     expect(llmRequest.config?.systemInstruction).toBe(
       'Global instruction\n\nLocal instruction',
+    );
+  });
+
+  it('should append set_model_response instruction when outputSchema and tools are present', async () => {
+    const outputSchema = {
+      type: 'object' as const,
+      properties: {
+        answer: {type: 'string' as const},
+      },
+    };
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: 'gemini-2.5-flash',
+      instruction: 'Base instruction',
+      outputSchema,
+      tools: [
+        new FunctionTool({
+          name: 'some_tool',
+          description: 'A test tool',
+          execute: () => 'result',
+        }),
+      ],
+    });
+
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+
+    for await (const _ of INSTRUCTIONS_LLM_REQUEST_PROCESSOR.runAsync(
+      invocationContext,
+      llmRequest,
+    )) {
+      // intentionally empty
+    }
+
+    expect(llmRequest.config?.systemInstruction).toContain(
+      'To output the final result, you must call the "set_model_response" function with the appropriate values. Do not output anything else.',
     );
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-
  docs/contributing-guide/) before creating a pull request.**

    ### Link to Issue or Description of Change

    **1. Link to an existing issue (if applicable):**

    - Closes: #411
    - Related: https://github.com/google/adk-js/issues/411

    **2. Or, if no issue exists, describe the change:**

    **Problem:**
    When an agent is configured with both `outputSchema` and tools:
    1. The `BasicLlmRequestProcessor` sets `responseMimeType: "application/json"` and
  `responseSchema` on the model configuration.
    2. In the Gemini API, combining strict JSON mode and Function Calling (tools) in the same
  call is architecturally unsupported:
       - Stable models immediately return a `400 Bad Request` API error.
       - Preview models (such as `gemini-3.1-flash-lite`) get confused, calling tools
  recursively and getting trapped in an infinite loop.

    **Solution:**
    We implemented the **Tool-Based Structured Output** pattern (aligning with `adk-python`):
    1. **API-level bypass**: If tools are present, we bypass setting `responseMimeType:
  "application/json"` and `responseSchema` at the Gemini API level
  (`BasicLlmRequestProcessor`), allowing standard function calling without API conflicts.
    2. **Dynamic Tool Registration**: In `LlmAgent.ts`, we dynamically inject a special
  `set_model_response` tool into the agent's toolset when `outputSchema` and tools are both
  present.
    3. **Filter Bypass**: Ensured that the `set_model_response` tool is never filtered out by
  plugin-driven `allowedTools` restrictions.
    4. **System Instruction Injection**: Appended a system instruction instructing the model
  that it must submit its final structured output by calling the `set_model_response` tool.
    5. **Turn Interception**: Intercepted the `set_model_response` call in the agent's post-
  processing lifecycle to parse the arguments and format the final text JSON response,
  setting `skipSummarization = true` to break the agent execution loop and exit the turn
  immediately. Added safe-checks for TS compiler compatibility (`toolContext` null-checks).

    ---

    ### Testing Plan

    **Unit Tests:**

    - [x] I have added or updated unit tests for my change.
    - [x] All unit tests pass locally.

    **Summary of unit test results:**
    Run successfully via Vitest (`vitest --project unit:core --project unit:dev --run`):
    - `basic_llm_request_processor_test.ts`: Passed (9 tests, including new verification that
  `outputSchema` is not set at API level when tools are present).
    - `instructions_llm_request_processor_test.ts`: Passed (5 tests, including new
  verification that instructions to call `set_model_response` are successfully appended).
    - Total test suite: 1,787 test cases successfully executed and passed.

    **Manual End-to-End (E2E) Tests:**
    To manually verify, run an agent configured with an `outputSchema` and one or more custom
  tools. The agent will successfully execute the custom tools and then return a single
  structured JSON response by calling `set_model_response` at the end of the turn without
  triggering a `400 Bad Request` or entering recursive tool call loops.

    ---

    ### Checklist

    - [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-
  js/blob/main/CONTRIBUTING.md) document.
    - [x] I have performed a self-review of my own code.
    - [x] I have commented my code, particularly in hard-to-understand areas.
    - [x] I have added tests that prove my fix is effective or that my feature works.
    - [x] New and existing unit tests pass locally with my changes.
    - [x] I have manually tested my changes end-to-end.
    - [ ] Any dependent changes have been merged and published in downstream modules.