### PR TITLE
feat(skills): Dynamic SearchSkillsTool for LLM Agents

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -60,6 +60,7 @@
     "@opentelemetry/sdk-metrics": "^2.1.0",
     "@opentelemetry/sdk-trace-base": "^2.1.0",
     "@opentelemetry/sdk-trace-node": "^2.1.0",
+    "adm-zip": "^0.5.17",
     "express": "^4.22.1",
     "google-auth-library": "^10.3.0",
     "js-yaml": "^4.1.1",
@@ -71,6 +72,7 @@
   },
   "devDependencies": {
     "@mikro-orm/sqlite": "^6.6.6",
+    "@types/adm-zip": "^0.5.8",
     "@types/express": "^4.17.25",
     "@types/lodash-es": "^4.17.12",
     "openapi-types": "^12.1.3"

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -244,6 +244,8 @@ export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 
+export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
+export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';
 export {
   loadAllSkillsInDir,
   loadSkillFromDir,

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -244,7 +244,14 @@ export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 
+export {
+  loadAllSkillsInDir,
+  loadSkillFromDir,
+  loadSkillFromZipBuffer,
+  validateSkillDir,
+} from './skills/loader.js';
 export type {Frontmatter, Resources, Script, Skill} from './skills/skill.js';
+export type {SkillRegistry} from './skills/skill_registry.js';
 export {ListSkillsTool} from './tools/skill/list_skills_tool.js';
 export {LoadSkillResourceTool} from './tools/skill/load_skill_resource_tool.js';
 export {LoadSkillTool} from './tools/skill/load_skill_tool.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -257,6 +257,7 @@ export type {SkillRegistry} from './skills/skill_registry.js';
 export {ListSkillsTool} from './tools/skill/list_skills_tool.js';
 export {LoadSkillResourceTool} from './tools/skill/load_skill_resource_tool.js';
 export {LoadSkillTool} from './tools/skill/load_skill_tool.js';
+export {SearchSkillsTool} from './tools/skill/search_skills_tool.js';
 export {SkillToolset} from './tools/skill/skill_toolset.js';
 
 export * from './artifacts/base_artifact_service.js';

--- a/core/src/skills/gcp_skill_registry.ts
+++ b/core/src/skills/gcp_skill_registry.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Client} from '@google-cloud/vertexai';
+import {experimental} from '../utils/experimental.js';
+import {loadSkillFromZipBuffer} from './loader.js';
+import {Frontmatter, Skill} from './skill.js';
+import {SkillRegistry} from './skill_registry.js';
+
+export interface GCPSkillRegistryOptions {
+  projectId?: string;
+  location?: string;
+  client?: Client;
+}
+
+/**
+ * GCP implementation of SkillRegistry using GCP Skill Registry API.
+ */
+@experimental
+export class GCPSkillRegistry implements SkillRegistry {
+  private readonly projectId?: string;
+  private readonly location?: string;
+  private readonly client: Client;
+
+  constructor(options: GCPSkillRegistryOptions = {}) {
+    this.projectId = options.projectId || process.env.GOOGLE_CLOUD_PROJECT;
+    this.location = options.location || process.env.GOOGLE_CLOUD_LOCATION;
+    this.client =
+      options.client ||
+      new Client({
+        project: this.projectId,
+        location: this.location,
+      });
+  }
+
+  async getSkill(name: string): Promise<Skill> {
+    const apiClient = (this.client as unknown as {apiClient: unknown})
+      .apiClient as {
+      request(req: {
+        path: string;
+        httpMethod: string;
+        httpOptions?: {apiVersion?: string};
+      }): Promise<{json(): Promise<Record<string, unknown>>}>;
+    };
+
+    const httpResponse = await apiClient.request({
+      path: `skills/${name}`,
+      httpMethod: 'GET',
+      httpOptions: {apiVersion: 'v1beta1'},
+    });
+
+    const response = await httpResponse.json();
+    const zippedFilesystem =
+      (response.zippedFilesystem as string | undefined) ||
+      (response.zipped_filesystem as string | undefined);
+
+    if (!zippedFilesystem) {
+      throw new Error(`Skill '${name}' does not contain zipped filesystem.`);
+    }
+
+    const zipBuffer = Buffer.from(zippedFilesystem, 'base64');
+    return loadSkillFromZipBuffer(zipBuffer);
+  }
+
+  async searchSkills(query: string): Promise<Frontmatter[]> {
+    const apiClient = (this.client as unknown as {apiClient: unknown})
+      .apiClient as {
+      request(req: {
+        path: string;
+        httpMethod: string;
+        body: string;
+        httpOptions?: {apiVersion?: string};
+      }): Promise<{json(): Promise<Record<string, unknown>>}>;
+    };
+
+    const httpResponse = await apiClient.request({
+      path: 'skills:retrieve',
+      httpMethod: 'POST',
+      body: JSON.stringify({query}),
+      httpOptions: {apiVersion: 'v1beta1'},
+    });
+
+    const response = await httpResponse.json();
+    const retrievedSkills =
+      (response.retrievedSkills as
+        | Array<Record<string, unknown>>
+        | undefined) ||
+      (response.retrieved_skills as Array<Record<string, unknown>> | undefined);
+
+    const results: Frontmatter[] = [];
+    if (retrievedSkills && Array.isArray(retrievedSkills)) {
+      for (const s of retrievedSkills) {
+        const skillNameStr =
+          (s.skillName as string | undefined) ||
+          (s.skill_name as string | undefined) ||
+          '';
+        const descriptionStr = (s.description as string | undefined) || '';
+
+        const parts = skillNameStr.split('/');
+        const name = skillNameStr ? parts[parts.length - 1] : '';
+        results.push({
+          name,
+          description: descriptionStr,
+        });
+      }
+    }
+    return results;
+  }
+}

--- a/core/src/skills/gcp_skill_registry.ts
+++ b/core/src/skills/gcp_skill_registry.ts
@@ -71,31 +71,40 @@ export class GCPSkillRegistry implements SkillRegistry {
       request(req: {
         path: string;
         httpMethod: string;
-        body: string;
+        body?: string;
         httpOptions?: {apiVersion?: string};
       }): Promise<{json(): Promise<Record<string, unknown>>}>;
     };
 
+    const trimmedQuery = query.trim();
+    const isSearch = trimmedQuery.length > 0;
+    const path = isSearch
+      ? `skills:retrieve?query=${encodeURIComponent(trimmedQuery)}`
+      : 'skills';
+
     const httpResponse = await apiClient.request({
-      path: 'skills:retrieve',
-      httpMethod: 'POST',
-      body: JSON.stringify({query}),
+      path,
+      httpMethod: 'GET',
       httpOptions: {apiVersion: 'v1beta1'},
     });
 
     const response = await httpResponse.json();
-    const retrievedSkills =
-      (response.retrievedSkills as
-        | Array<Record<string, unknown>>
-        | undefined) ||
-      (response.retrieved_skills as Array<Record<string, unknown>> | undefined);
+    const skillsList = isSearch
+      ? (response.retrievedSkills as
+          | Array<Record<string, unknown>>
+          | undefined) ||
+        (response.retrieved_skills as
+          | Array<Record<string, unknown>>
+          | undefined)
+      : (response.skills as Array<Record<string, unknown>> | undefined);
 
     const results: Frontmatter[] = [];
-    if (retrievedSkills && Array.isArray(retrievedSkills)) {
-      for (const s of retrievedSkills) {
+    if (skillsList && Array.isArray(skillsList)) {
+      for (const s of skillsList) {
         const skillNameStr =
           (s.skillName as string | undefined) ||
           (s.skill_name as string | undefined) ||
+          (s.name as string | undefined) ||
           '';
         const descriptionStr = (s.description as string | undefined) || '';
 

--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import AdmZip from 'adm-zip';
 import yaml from 'js-yaml';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -323,4 +324,82 @@ export async function loadAllSkillsInDir(
   }
 
   return skills;
+}
+
+/**
+ * Loads a complete skill directly from in-memory zip file buffer.
+ *
+ * @param zipBuffer - The raw Buffer of the zip file containing the skill.
+ * @returns A Skill object with all components loaded.
+ */
+export function loadSkillFromZipBuffer(zipBuffer: Buffer): Skill {
+  const zip = new AdmZip(zipBuffer);
+  const entries = zip.getEntries();
+
+  let skillMdContent = '';
+  for (const entry of entries) {
+    if (entry.isDirectory) continue;
+    if (entry.entryName.toLowerCase() === 'skill.md') {
+      skillMdContent = entry.getData().toString('utf-8');
+      break;
+    }
+  }
+
+  if (!skillMdContent) {
+    throw new Error('SKILL.md not found in zipped filesystem.');
+  }
+
+  const {frontmatter: parsed, body} = parseSkillMdContent(skillMdContent);
+  const frontmatter = FrontmatterSchema.parse(parsed);
+
+  const references: Record<string, string | Buffer> = {};
+  const assets: Record<string, string | Buffer> = {};
+  const scripts: Record<string, Script> = {};
+
+  function loadZipDir(prefix: string): Record<string, string | Buffer> {
+    const res: Record<string, string | Buffer> = {};
+    const normPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+    for (const entry of entries) {
+      if (entry.isDirectory) continue;
+      if (entry.entryName.startsWith(normPrefix)) {
+        if (entry.entryName.includes('__pycache__')) continue;
+        const relativePath = entry.entryName.substring(normPrefix.length);
+        if (!relativePath) continue;
+        const data = entry.getData();
+        try {
+          res[relativePath] = data.toString('utf-8');
+        } catch (_e: unknown) {
+          res[relativePath] = data;
+        }
+      }
+    }
+    return res;
+  }
+
+  const refFiles = loadZipDir('references');
+  for (const [key, val] of Object.entries(refFiles)) {
+    references[key] = val;
+  }
+
+  const assetFiles = loadZipDir('assets');
+  for (const [key, val] of Object.entries(assetFiles)) {
+    assets[key] = val;
+  }
+
+  const rawScripts = loadZipDir('scripts');
+  for (const [key, val] of Object.entries(rawScripts)) {
+    if (typeof val === 'string') {
+      scripts[key] = {src: val};
+    }
+  }
+
+  return {
+    frontmatter,
+    instructions: body,
+    resources: {
+      references,
+      assets,
+      scripts,
+    },
+  };
 }

--- a/core/src/skills/skill_registry.ts
+++ b/core/src/skills/skill_registry.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Frontmatter, Skill} from './skill.js';
+
+/**
+ * Interface for a skill registry.
+ */
+export interface SkillRegistry {
+  /**
+   * Fetches a skill from the registry.
+   *
+   * @param name The name of the skill.
+   * @returns A Promise resolving to a Skill object.
+   */
+  getSkill(name: string): Promise<Skill>;
+
+  /**
+   * Searches for skills in the registry.
+   *
+   * @param query The search query.
+   * @returns A Promise resolving to a list of Frontmatter objects for discovery.
+   */
+  searchSkills(query: string): Promise<Frontmatter[]>;
+
+  /**
+   * Returns the description for the search_skills tool.
+   */
+  searchToolDescription?(): string | undefined;
+}

--- a/core/src/tools/skill/load_skill_resource_tool.ts
+++ b/core/src/tools/skill/load_skill_resource_tool.ts
@@ -50,7 +50,10 @@ export class LoadSkillResourceTool extends BaseTool {
     };
   }
 
-  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+  override async runAsync({
+    args,
+    toolContext,
+  }: RunAsyncToolRequest): Promise<unknown> {
     const skillName = args['skill_name'] as string;
     let resourcePath = args['path'] as string;
 
@@ -69,7 +72,19 @@ export class LoadSkillResourceTool extends BaseTool {
 
     resourcePath = path.posix.normalize(resourcePath);
 
-    const skill = this.toolset.getSkill(skillName);
+    let skill;
+    try {
+      skill = await this.toolset.getOrFetchSkill(
+        skillName,
+        toolContext.invocationId,
+      );
+    } catch (e: unknown) {
+      return {
+        error: `Failed to fetch skill '${skillName}' from registry: ${(e as Error).message || e}`,
+        error_code: 'REGISTRY_ERROR',
+      };
+    }
+
     if (!skill) {
       return {
         error: `Skill '${skillName}' not found.`,
@@ -144,7 +159,15 @@ export class LoadSkillResourceTool extends BaseTool {
           const skillName = response['skill_name'] as string;
           const resourcePath = response['path'] as string;
 
-          const skill = this.toolset.getSkill(skillName);
+          let skill;
+          try {
+            skill = await this.toolset.getOrFetchSkill(
+              skillName,
+              request.toolContext.invocationId,
+            );
+          } catch (_e: unknown) {
+            continue;
+          }
           if (!skill) continue;
           const skillResources = skill.resources || {};
 

--- a/core/src/tools/skill/load_skill_tool.ts
+++ b/core/src/tools/skill/load_skill_tool.ts
@@ -47,7 +47,19 @@ export class LoadSkillTool extends BaseTool {
       };
     }
 
-    const skill = this.toolset.getSkill(skillName);
+    let skill;
+    try {
+      skill = await this.toolset.getOrFetchSkill(
+        skillName,
+        toolContext.invocationId,
+      );
+    } catch (e: unknown) {
+      return {
+        error: `Failed to fetch skill '${skillName}' from registry: ${(e as Error).message || e}`,
+        error_code: 'REGISTRY_ERROR',
+      };
+    }
+
     if (!skill) {
       return {
         error: `Skill '${skillName}' not found.`,

--- a/core/src/tools/skill/run_skill_script_tool.ts
+++ b/core/src/tools/skill/run_skill_script_tool.ts
@@ -79,7 +79,19 @@ export class RunSkillScriptTool extends BaseTool {
       };
     }
 
-    const skill = this.toolset.getSkill(skillName);
+    let skill;
+    try {
+      skill = await this.toolset.getOrFetchSkill(
+        skillName,
+        toolContext.invocationId,
+      );
+    } catch (e: unknown) {
+      return {
+        error: `Failed to fetch skill '${skillName}' from registry: ${(e as Error).message || e}`,
+        errorCode: 'REGISTRY_ERROR',
+      };
+    }
+
     if (!skill) {
       return {
         error: `Skill '${skillName}' not found.`,

--- a/core/src/tools/skill/search_skills_tool.ts
+++ b/core/src/tools/skill/search_skills_tool.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Type} from '@google/genai';
+import {experimental} from '../../utils/experimental.js';
+import {logger} from '../../utils/logger.js';
+import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
+import {SkillToolset} from './skill_toolset.js';
+
+@experimental
+export class SearchSkillsTool extends BaseTool {
+  constructor(private toolset: SkillToolset) {
+    if (!toolset.registry) {
+      throw new Error('SearchSkillsTool requires a configured skill registry.');
+    }
+    super({
+      name: 'search_skills',
+      description:
+        toolset.registry.searchToolDescription?.() ||
+        'Searches for relevant skills in the registry based on a semantic or keyword query.',
+    });
+  }
+
+  override _getDeclaration(): FunctionDeclaration {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          query: {
+            type: Type.STRING,
+            description: 'Semantic or keyword search query.',
+          },
+        },
+        required: ['query'],
+      },
+    };
+  }
+
+  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    const query = args['query'] as string;
+    if (!query) {
+      return {
+        error: "Argument 'query' is required.",
+        error_code: 'INVALID_ARGUMENTS',
+      };
+    }
+
+    try {
+      const results = await this.toolset.registry!.searchSkills(query);
+      return results.filter((r) => {
+        if (this.toolset.skills[r.name]) {
+          logger.warn(
+            `Skill naming conflict: skill '${r.name}' already exists locally. Registry skill is filtered.`,
+          );
+          return false;
+        }
+        return true;
+      });
+    } catch (e: unknown) {
+      return {
+        error: `Failed to search skills from registry: ${(e as Error).message || e}`,
+        error_code: 'REGISTRY_ERROR',
+      };
+    }
+  }
+}

--- a/core/src/tools/skill/skill_toolset.ts
+++ b/core/src/tools/skill/skill_toolset.ts
@@ -20,6 +20,7 @@ import {LoadSkillResourceTool} from './load_skill_resource_tool.js';
 import {LoadSkillTool} from './load_skill_tool.js';
 import {RunSkillInlineScriptTool} from './run_skill_inline_script_tool.js';
 import {RunSkillScriptTool} from './run_skill_script_tool.js';
+import {SearchSkillsTool} from './search_skills_tool.js';
 
 const DEFAULT_SKILL_SYSTEM_INSTRUCTION = `You can use specialized 'skills' to help you with complex tasks. You MUST use the skill tools to interact with these skills.
 
@@ -70,6 +71,10 @@ export class SkillToolset extends BaseToolset {
       new RunSkillScriptTool(this),
       new RunSkillInlineScriptTool(this),
     ];
+
+    if (this.registry) {
+      this.tools.push(new SearchSkillsTool(this));
+    }
   }
 
   override async getTools(context?: ReadonlyContext): Promise<BaseTool[]> {
@@ -126,6 +131,12 @@ export class SkillToolset extends BaseToolset {
     const skillsXml = formatSkillsAsXml(skills);
 
     const instructions = [DEFAULT_SKILL_SYSTEM_INSTRUCTION, skillsXml];
+
+    if (this.registry) {
+      instructions.push(
+        '\nIf the locally available skills are not sufficient to complete your task, you can use the `search_skills` tool to discover additional skills from the registry.',
+      );
+    }
 
     appendInstructions(llmRequest, instructions);
   }

--- a/core/src/tools/skill/skill_toolset.ts
+++ b/core/src/tools/skill/skill_toolset.ts
@@ -10,7 +10,9 @@ import {BaseCodeExecutor} from '../../code_executors/base_code_executor.js';
 import {appendInstructions, LlmRequest} from '../../models/llm_request.js';
 import {formatSkillsAsXml} from '../../skills/prompt.js';
 import {Skill} from '../../skills/skill.js';
+import {SkillRegistry} from '../../skills/skill_registry.js';
 import {experimental} from '../../utils/experimental.js';
+import {logger} from '../../utils/logger.js';
 import {BaseTool} from '../base_tool.js';
 import {BaseToolset} from '../base_toolset.js';
 import {ListSkillsTool} from './list_skills_tool.js';
@@ -41,13 +43,16 @@ export class SkillToolset extends BaseToolset {
   private tools: BaseTool[];
   public additionalTools: Array<BaseTool | BaseToolset>;
   public codeExecutor?: BaseCodeExecutor;
+  public registry?: SkillRegistry;
   private toolCache = new Map<string, BaseTool[]>();
+  private fetchedSkillCache = new Map<string, Map<string, Skill>>();
 
   constructor(
     skills: Record<string, Skill> | Skill[],
     options: {
       codeExecutor?: BaseCodeExecutor;
       additionalTools?: Array<BaseTool | BaseToolset>;
+      registry?: SkillRegistry;
     } = {},
   ) {
     super([], 'adk_skill_toolset');
@@ -56,6 +61,7 @@ export class SkillToolset extends BaseToolset {
       : skills;
     this.codeExecutor = options.codeExecutor;
     this.additionalTools = options.additionalTools || [];
+    this.registry = options.registry;
 
     this.tools = [
       new ListSkillsTool(this),
@@ -71,10 +77,43 @@ export class SkillToolset extends BaseToolset {
     return [...this.tools, ...dynamicTools];
   }
 
-  override async close(): Promise<void> {}
+  override async close(): Promise<void> {
+    this.fetchedSkillCache.clear();
+  }
 
   getSkill(name: string): Skill | undefined {
     return this.skills[name];
+  }
+
+  async getOrFetchSkill(
+    name: string,
+    invocationId?: string,
+  ): Promise<Skill | undefined> {
+    if (this.skills[name]) {
+      return this.skills[name];
+    }
+    if (!this.registry) {
+      return undefined;
+    }
+
+    const contextKey = invocationId || 'default';
+    if (!this.fetchedSkillCache.has(contextKey)) {
+      this.fetchedSkillCache.set(contextKey, new Map());
+    }
+
+    const cache = this.fetchedSkillCache.get(contextKey)!;
+    if (cache.has(name)) {
+      return cache.get(name)!;
+    }
+
+    try {
+      const skill = await this.registry.getSkill(name);
+      cache.set(name, skill);
+      return skill;
+    } catch (e: unknown) {
+      logger.warn(`Failed to fetch skill '${name}' from registry: ${e}`);
+      throw e;
+    }
   }
 
   override async processLlmRequest(
@@ -86,10 +125,9 @@ export class SkillToolset extends BaseToolset {
     const skills = Object.values(this.skills);
     const skillsXml = formatSkillsAsXml(skills);
 
-    appendInstructions(llmRequest, [
-      DEFAULT_SKILL_SYSTEM_INSTRUCTION,
-      skillsXml,
-    ]);
+    const instructions = [DEFAULT_SKILL_SYSTEM_INSTRUCTION, skillsXml];
+
+    appendInstructions(llmRequest, instructions);
   }
 
   private async resolveAdditionalTools(
@@ -110,7 +148,7 @@ export class SkillToolset extends BaseToolset {
 
     const additionalToolNames = new Set<string>();
     for (const skillName of activatedSkills) {
-      const skill = this.skills[skillName];
+      const skill = await this.getOrFetchSkill(skillName, context.invocationId);
       if (skill && skill.frontmatter.metadata) {
         const tools = skill.frontmatter.metadata[
           'adk_additional_tools'

--- a/core/test/tools/skills/skill_registry_test.ts
+++ b/core/test/tools/skills/skill_registry_test.ts
@@ -13,6 +13,7 @@ import {
   LoadSkillResourceTool,
   LoadSkillTool,
   RunSkillScriptTool,
+  SearchSkillsTool,
   Skill,
   SkillToolset,
   loadSkillFromZipBuffer,
@@ -223,6 +224,98 @@ Instruction body`;
     });
   });
 
+  describe('SearchSkillsTool', () => {
+    it('throws error if toolset has no registry', () => {
+      const toolset = new SkillToolset([]);
+      expect(() => new SearchSkillsTool(toolset)).toThrow(
+        'SearchSkillsTool requires a configured skill registry.',
+      );
+    });
+
+    it('returns declaration with search_skills', () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn(),
+        searchToolDescription: vi
+          .fn()
+          .mockReturnValue('Custom search description'),
+      };
+
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const dec = tool._getDeclaration();
+      expect(dec.name).toBe('search_skills');
+      expect(dec.description).toBe('Custom search description');
+    });
+
+    it('runAsync validates missing query', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('INVALID_ARGUMENTS');
+    });
+
+    it('runAsync searches registry and filters local skills', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn().mockResolvedValue([
+          {name: 'remote-only', description: 'remote'},
+          {name: 'already-local', description: 'local'},
+        ]),
+      };
+      const localSkill: Skill = {
+        frontmatter: {name: 'already-local', description: 'desc'},
+        instructions: 'inst',
+      };
+
+      const toolset = new SkillToolset([localSkill], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {query: 'skills'},
+        toolContext: createMockContext(),
+      })) as Array<Record<string, unknown>>;
+
+      expect(res.length).toBe(1);
+      expect(res[0].name).toBe('remote-only');
+    });
+
+    it('runAsync returns error on registry exception', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn().mockRejectedValue(new Error('Registry failure')),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {query: 'skills'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+    });
+
+    it('runAsync returns error on string throw', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn().mockRejectedValue('String error failure'),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {query: 'skills'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+      expect(res.error).toContain('String error failure');
+    });
+  });
+
   describe('SkillToolset upgraded capabilities', () => {
     it('getOrFetchSkill returns local skill', async () => {
       const localSkill: Skill = {
@@ -272,6 +365,21 @@ Instruction body`;
       await expect(
         toolset.getOrFetchSkill('bad-skill', 'inv-1'),
       ).rejects.toThrow('Registry error');
+    });
+
+    it('processLlmRequest appends search instruction if registry configured', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const req: LlmRequest = {
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+      await toolset.processLlmRequest(createMockContext(), req);
+      expect(req.config?.systemInstruction).toContain('search_skills');
     });
   });
 

--- a/core/test/tools/skills/skill_registry_test.ts
+++ b/core/test/tools/skills/skill_registry_test.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {Client} from '@google-cloud/vertexai';
 import {
   Context,
+  GCPSkillRegistry,
   InvocationContext,
   LlmRequest,
   LoadSkillResourceTool,
@@ -65,6 +67,159 @@ Instruction body`;
       expect(() => loadSkillFromZipBuffer(zip.toBuffer())).toThrow(
         'SKILL.md not found in zipped filesystem.',
       );
+    });
+  });
+
+  describe('GCPSkillRegistry', () => {
+    it('initializes with default options', () => {
+      const envProj = process.env.GOOGLE_CLOUD_PROJECT;
+      process.env.GOOGLE_CLOUD_PROJECT = 'mock-env-proj';
+      const reg = new GCPSkillRegistry();
+      expect(reg).toBeDefined();
+      if (envProj === undefined) {
+        delete process.env.GOOGLE_CLOUD_PROJECT;
+      } else {
+        process.env.GOOGLE_CLOUD_PROJECT = envProj;
+      }
+    });
+
+    it('getSkill fetches and extracts a zipped skill', async () => {
+      const zipBuffer = createValidZipBuffer();
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              zippedFilesystem: zipBuffer.toString('base64'),
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const skill = await reg.getSkill('test-remote-skill');
+      expect(skill.frontmatter.name).toBe('test-remote-skill');
+    });
+
+    it('getSkill handles zipped_filesystem snake_case format', async () => {
+      const zipBuffer = createValidZipBuffer();
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              zipped_filesystem: zipBuffer.toString('base64'),
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const skill = await reg.getSkill('test-remote-skill');
+      expect(skill.frontmatter.name).toBe('test-remote-skill');
+    });
+
+    it('getSkill throws error if zippedFilesystem is missing', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({}),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      await expect(reg.getSkill('missing-zip')).rejects.toThrow(
+        "Skill 'missing-zip' does not contain zipped filesystem.",
+      );
+    });
+
+    it('searchSkills retrieves and formats search results', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              retrievedSkills: [
+                {
+                  skillName: 'projects/proj/locations/loc/skills/found-skill',
+                  description: 'A found skill',
+                },
+              ],
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('found-skill');
+      expect(results[0].description).toBe('A found skill');
+    });
+
+    it('searchSkills handles snake_case retrieved_skills response', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              retrieved_skills: [
+                {
+                  skill_name: 'projects/proj/locations/loc/skills/found-skill',
+                  description: 'A found skill',
+                },
+              ],
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('found-skill');
+    });
+
+    it('searchSkills returns empty array when retrievedSkills is empty', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({}),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(0);
+    });
+    it('searchSkills handles empty skillName and description fallback', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              retrievedSkills: [{}],
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('');
+      expect(results[0].description).toBe('');
     });
   });
 

--- a/core/test/tools/skills/skill_registry_test.ts
+++ b/core/test/tools/skills/skill_registry_test.ts
@@ -1,0 +1,361 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  InvocationContext,
+  LlmRequest,
+  LoadSkillResourceTool,
+  LoadSkillTool,
+  RunSkillScriptTool,
+  Skill,
+  SkillToolset,
+  loadSkillFromZipBuffer,
+} from '@google/adk';
+import AdmZip from 'adm-zip';
+import {describe, expect, it, vi} from 'vitest';
+
+describe('skill_registry', () => {
+  function createMockContext(agentName = 'test-agent') {
+    return new Context({
+      invocationContext: {
+        invocationId: 'inv-123',
+        session: {state: {}},
+        agent: {name: agentName},
+      } as unknown as InvocationContext,
+    });
+  }
+
+  const validSkillMd = `---
+name: test-remote-skill
+description: A test remote skill
+---
+Instruction body`;
+
+  function createValidZipBuffer() {
+    const zip = new AdmZip();
+    zip.addFile('SKILL.md', Buffer.from(validSkillMd, 'utf-8'));
+    zip.addFile('references/ref1.md', Buffer.from('ref content', 'utf-8'));
+    zip.addFile('assets/asset1.txt', Buffer.from('asset content', 'utf-8'));
+    zip.addFile('scripts/run.sh', Buffer.from('echo hello', 'utf-8'));
+    zip.addFile('__pycache__/cache.pyc', Buffer.from('dummy', 'utf-8'));
+    zip.addFile('references/subdir/', Buffer.from(''));
+    zip.addFile('references/', Buffer.from(''));
+    return zip.toBuffer();
+  }
+
+  describe('loadSkillFromZipBuffer', () => {
+    it('successfully loads a skill with all resources from zip buffer', () => {
+      const zipBuffer = createValidZipBuffer();
+      const skill = loadSkillFromZipBuffer(zipBuffer);
+
+      expect(skill.frontmatter.name).toBe('test-remote-skill');
+      expect(skill.instructions).toBe('Instruction body');
+      expect(skill.resources?.references?.['ref1.md']).toBe('ref content');
+      expect(skill.resources?.assets?.['asset1.txt']).toBe('asset content');
+      expect(skill.resources?.scripts?.['run.sh']?.src).toBe('echo hello');
+    });
+
+    it('throws error if SKILL.md is missing', () => {
+      const zip = new AdmZip();
+      zip.addFile('dummy.txt', Buffer.from('hello'));
+      expect(() => loadSkillFromZipBuffer(zip.toBuffer())).toThrow(
+        'SKILL.md not found in zipped filesystem.',
+      );
+    });
+  });
+
+  describe('SkillToolset upgraded capabilities', () => {
+    it('getOrFetchSkill returns local skill', async () => {
+      const localSkill: Skill = {
+        frontmatter: {name: 'local-skill', description: 'desc'},
+        instructions: 'inst',
+      };
+      const toolset = new SkillToolset([localSkill]);
+      const res = await toolset.getOrFetchSkill('local-skill');
+      expect(res).toBe(localSkill);
+    });
+
+    it('getOrFetchSkill returns undefined if no registry and skill not local', async () => {
+      const toolset = new SkillToolset([]);
+      const res = await toolset.getOrFetchSkill('remote-skill');
+      expect(res).toBeUndefined();
+    });
+
+    it('getOrFetchSkill fetches from registry and caches per invocation', async () => {
+      const remoteSkill: Skill = {
+        frontmatter: {name: 'fetched-skill', description: 'desc'},
+        instructions: 'inst',
+      };
+      const mockRegistry = {
+        getSkill: vi.fn().mockResolvedValue(remoteSkill),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+
+      const res1 = await toolset.getOrFetchSkill('fetched-skill', 'inv-1');
+      expect(res1).toBe(remoteSkill);
+      expect(mockRegistry.getSkill).toHaveBeenCalledTimes(1);
+
+      // Second call with same invocation ID should hit cache
+      const res2 = await toolset.getOrFetchSkill('fetched-skill', 'inv-1');
+      expect(res2).toBe(remoteSkill);
+      expect(mockRegistry.getSkill).toHaveBeenCalledTimes(1);
+
+      await toolset.close();
+    });
+
+    it('getOrFetchSkill rethrows registry fetch errors', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn().mockRejectedValue(new Error('Registry error')),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      await expect(
+        toolset.getOrFetchSkill('bad-skill', 'inv-1'),
+      ).rejects.toThrow('Registry error');
+    });
+  });
+
+  describe('Updated Tool implementations with Registry integration', () => {
+    const remoteSkill: Skill = {
+      frontmatter: {
+        name: 'test-registry-skill',
+        description: 'desc',
+        metadata: {adk_additional_tools: []},
+      },
+      instructions: 'instructions',
+      resources: {
+        references: {'doc.md': 'doc text'},
+        assets: {'img.png': Buffer.from('img data')},
+        scripts: {'test.js': {src: 'console.log(1)'}},
+      },
+    };
+
+    const mockRegistry = {
+      getSkill: vi.fn().mockImplementation((name: string) => {
+        if (name === 'test-registry-skill') return Promise.resolve(remoteSkill);
+        if (name === 'error-skill')
+          return Promise.reject(new Error('Fetch err'));
+        return Promise.resolve(undefined);
+      }),
+      searchSkills: vi.fn(),
+    };
+
+    it('LoadSkillTool fetches remote skill on demand', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+
+      const res = (await tool.runAsync({
+        args: {name: 'test-registry-skill'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+
+      expect(res.skill_name).toBe('test-registry-skill');
+      expect(res.instructions).toBe('instructions');
+    });
+
+    it('LoadSkillTool handles missing skill name', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+      const res = (await tool.runAsync({
+        args: {},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('MISSING_SKILL_NAME');
+    });
+
+    it('LoadSkillTool handles registry fetch errors', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+      const res = (await tool.runAsync({
+        args: {name: 'error-skill'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+    });
+
+    it('LoadSkillTool handles skill not found', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+      const res = (await tool.runAsync({
+        args: {name: 'unknown-skill'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('SKILL_NOT_FOUND');
+    });
+
+    it('LoadSkillResourceTool fetches remote skill resource on demand', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+
+      const res = (await tool.runAsync({
+        args: {skill_name: 'test-registry-skill', path: 'references/doc.md'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+
+      expect(res.content).toBe('doc text');
+    });
+
+    it('LoadSkillResourceTool validates missing parameters', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+      let res = (await tool.runAsync({
+        args: {path: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('MISSING_SKILL_NAME');
+
+      res = (await tool.runAsync({
+        args: {skill_name: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('MISSING_RESOURCE_PATH');
+    });
+
+    it('LoadSkillResourceTool handles registry fetch error', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'error-skill', path: 'references/doc.md'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+    });
+
+    it('LoadSkillResourceTool handles skill not found', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'unknown-skill', path: 'references/doc.md'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('SKILL_NOT_FOUND');
+    });
+
+    it('LoadSkillResourceTool processLlmRequest successfully resolves binary injection for remote skill', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+
+      const req: LlmRequest = {
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'load_skill_resource',
+                  response: {
+                    status:
+                      'Binary file detected. The content has been injected into the conversation history for you to analyze.',
+                    skill_name: 'test-registry-skill',
+                    path: 'assets/img.png',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await tool.processLlmRequest({
+        toolContext: createMockContext(),
+        llmRequest: req,
+      });
+      expect(req.contents!.length).toBe(2);
+      expect(req.contents![1].parts![1].inlineData?.data).toBe(
+        Buffer.from('img data').toString('base64'),
+      );
+    });
+
+    it('LoadSkillResourceTool processLlmRequest continues gracefully on error fetching skill', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+
+      const req: LlmRequest = {
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'load_skill_resource',
+                  response: {
+                    status:
+                      'Binary file detected. The content has been injected into the conversation history for you to analyze.',
+                    skill_name: 'error-skill',
+                    path: 'assets/img.png',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await tool.processLlmRequest({
+        toolContext: createMockContext(),
+        llmRequest: req,
+      });
+      expect(req.contents!.length).toBe(1);
+    });
+
+    it('RunSkillScriptTool checks remote skill script on demand', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+
+      const res = (await tool.runAsync({
+        args: {
+          skill_name: 'test-registry-skill',
+          script_path: 'scripts/test.js',
+        },
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+
+      expect(res.error).toBe('No code executor configured.');
+    });
+
+    it('RunSkillScriptTool validates missing parameters', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+      let res = (await tool.runAsync({
+        args: {script_path: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('MISSING_SKILL_NAME');
+
+      res = (await tool.runAsync({
+        args: {skill_name: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('MISSING_SCRIPT_PATH');
+    });
+
+    it('RunSkillScriptTool handles registry fetch error', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'error-skill', script_path: 'scripts/test.js'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('REGISTRY_ERROR');
+    });
+
+    it('RunSkillScriptTool handles skill not found', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'unknown-skill', script_path: 'scripts/test.js'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('SKILL_NOT_FOUND');
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@opentelemetry/sdk-metrics": "^2.1.0",
         "@opentelemetry/sdk-trace-base": "^2.1.0",
         "@opentelemetry/sdk-trace-node": "^2.1.0",
+        "adm-zip": "^0.5.17",
         "express": "^4.22.1",
         "google-auth-library": "^10.3.0",
         "js-yaml": "^4.1.1",
@@ -73,6 +74,7 @@
       },
       "devDependencies": {
         "@mikro-orm/sqlite": "^6.6.6",
+        "@types/adm-zip": "^0.5.8",
         "@types/express": "^4.17.25",
         "@types/lodash-es": "^4.17.12",
         "openapi-types": "^12.1.3"
@@ -3872,6 +3874,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -5160,6 +5172,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {

--- a/tests/e2e/tools/skills_registry_e2e_test.ts
+++ b/tests/e2e/tools/skills_registry_e2e_test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  GCPSkillRegistry,
+  InMemoryRunner,
+  LlmAgent,
+  SkillToolset,
+} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+import {fileURLToPath} from 'url';
+import {describe, expect, it} from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('E2E Live GCP Skills Registry', () => {
+  const envPath = path.resolve(__dirname, '../../.env');
+  if (fs.existsSync(envPath)) {
+    dotenv.config({path: envPath});
+  }
+
+  // Live E2E runs require an actual GCP project and a target skill name in the registry
+  const hasLiveCredentials =
+    !!process.env.GOOGLE_CLOUD_PROJECT && !!process.env.GCP_LIVE_SKILL_NAME;
+
+  it.skipIf(!hasLiveCredentials)(
+    'performs live operations against the remote GCP Skill Registry',
+    async () => {
+      const projectId = process.env.GOOGLE_CLOUD_PROJECT!;
+      const location = process.env.GOOGLE_CLOUD_LOCATION || 'us-central1';
+      const skillName = process.env.GCP_LIVE_SKILL_NAME!;
+
+      const registry = new GCPSkillRegistry({
+        projectId,
+        location,
+      });
+
+      // 1. Fetch remote skill directly from registry
+      const skill = await registry.getSkill(skillName);
+      expect(skill).toBeDefined();
+      expect(skill.frontmatter).toBeDefined();
+      expect(skill.frontmatter.name).toBeDefined();
+      expect(typeof skill.instructions).toBe('string');
+
+      // 2. Perform search if search query is provided
+      if (process.env.GCP_LIVE_SKILL_SEARCH_QUERY) {
+        const results = await registry.searchSkills(
+          process.env.GCP_LIVE_SKILL_SEARCH_QUERY,
+        );
+        expect(Array.isArray(results)).toBe(true);
+        expect(results.length).toBeGreaterThan(0);
+        const found = results.some((r) => r.name.includes(skillName));
+        expect(found).toBe(true);
+      }
+
+      // 3. Integrate with SkillToolset and run a multi-turn agent flow to load the skill
+      const toolset = new SkillToolset([], {registry});
+      const agent = new LlmAgent({
+        name: 'e2e_skills_agent',
+        description: 'An agent that resolves skills remotely.',
+        tools: [toolset],
+        model: 'gemini-2.5-flash',
+      });
+
+      const runner = new InMemoryRunner({
+        agent,
+        appName: 'e2e_skills_test',
+      });
+
+      const session = await runner.sessionService.createSession({
+        appName: 'e2e_skills_test',
+        userId: 'test_user',
+      });
+
+      // Execute a prompt asking the agent to load the remote skill.
+      // This will force the LLM to request the `load_skill` tool, which fetches from the registry.
+      const prompt = `Load the skill named "${skillName}" and summarize its purpose.`;
+
+      let finalResponse = '';
+      for await (const event of runner.runAsync({
+        userId: 'test_user',
+        sessionId: session.id,
+        newMessage: createUserContent(prompt),
+      })) {
+        if (
+          event.author === 'e2e_skills_agent' &&
+          event.content?.parts?.[0]?.text
+        ) {
+          finalResponse += event.content.parts[0].text;
+        }
+      }
+
+      expect(finalResponse.length).toBeGreaterThan(0);
+    },
+    90000, // E2E remote runs can take time
+  );
+});

--- a/tests/integration/tools/skills_registry_integration_test.ts
+++ b/tests/integration/tools/skills_registry_integration_test.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  InMemoryRunner,
+  LlmAgent,
+  Skill,
+  SkillRegistry,
+  SkillToolset,
+  UnsafeLocalCodeExecutor,
+} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {GeminiWithMockResponses} from '../test_case_utils.js';
+
+class MockSkillRegistry implements SkillRegistry {
+  private skillsMap = new Map<string, Skill>();
+
+  registerSkill(name: string, skill: Skill) {
+    this.skillsMap.set(name, skill);
+  }
+
+  async getSkill(name: string): Promise<Skill | undefined> {
+    return this.skillsMap.get(name);
+  }
+
+  async searchSkills(
+    query: string,
+  ): Promise<Array<{name: string; description: string}>> {
+    const results: Array<{name: string; description: string}> = [];
+    for (const [name, skill] of this.skillsMap.entries()) {
+      if (
+        name.includes(query) ||
+        skill.frontmatter.description?.includes(query)
+      ) {
+        results.push({
+          name,
+          description: skill.frontmatter.description || '',
+        });
+      }
+    }
+    return results;
+  }
+}
+
+describe('Skills Registry Integration', () => {
+  const remoteMathSkill: Skill = {
+    frontmatter: {
+      name: 'remote-math-skill',
+      description: 'A registry skill that handles math operations.',
+    },
+    instructions: 'When asked to solve math, double the number.',
+    resources: {
+      references: {
+        'formulas.txt': 'Double of X is 2*X',
+      },
+      scripts: {
+        'double.js': {
+          src: 'const args = process.argv; const val = parseInt(args[args.indexOf("--val") + 1]); console.log(val * 2);',
+        },
+      },
+    },
+  };
+
+  const remotePhysicsSkill: Skill = {
+    frontmatter: {
+      name: 'remote-physics-skill',
+      description: 'A registry skill for physics.',
+    },
+    instructions: 'Force = mass * acceleration.',
+  };
+
+  it('should search skills from registry, load a remote skill, and execute its scripts', async () => {
+    const registry = new MockSkillRegistry();
+    registry.registerSkill('remote-math-skill', remoteMathSkill);
+    registry.registerSkill('remote-physics-skill', remotePhysicsSkill);
+
+    const toolset = new SkillToolset([], {
+      registry,
+      codeExecutor: new UnsafeLocalCodeExecutor(),
+    });
+
+    const agent = new LlmAgent({
+      name: 'skills_agent',
+      description: 'An agent that uses skills.',
+      tools: [toolset],
+    });
+
+    agent.model = new GeminiWithMockResponses([
+      // Turn 1: Model response requests search_skills
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'search_skills',
+                    args: {query: 'math'},
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 2: Model response requests load_skill
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'load_skill',
+                    args: {name: 'remote-math-skill'},
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 3: Model response requests load_skill_resource
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'load_skill_resource',
+                    args: {
+                      skill_name: 'remote-math-skill',
+                      path: 'references/formulas.txt',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 4: Model response requests run_skill_script
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'run_skill_script',
+                    args: {
+                      skill_name: 'remote-math-skill',
+                      script_path: 'scripts/double.js',
+                      args: {
+                        val: 21,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 5: Model final response
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{text: 'The result is 42.'}],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const runner = new InMemoryRunner({
+      agent,
+      appName: 'test_skills_app',
+    });
+
+    const session = await runner.sessionService.createSession({
+      appName: 'test_skills_app',
+      userId: 'test_user',
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'test_user',
+      sessionId: session.id,
+      newMessage: createUserContent('Help me solve some math.'),
+    })) {
+      events.push(event);
+    }
+
+    // Verify search_skills tool execution
+    const searchCallEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionCall?.name === 'search_skills',
+    );
+    expect(searchCallEvent).toBeDefined();
+
+    const searchResponseEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionResponse?.name === 'search_skills',
+    );
+    expect(searchResponseEvent).toBeDefined();
+    expect(
+      searchResponseEvent.content.parts[0].functionResponse.response,
+    ).toEqual({
+      results: [
+        {
+          name: 'remote-math-skill',
+          description: 'A registry skill that handles math operations.',
+        },
+      ],
+    });
+
+    // Verify load_skill tool execution
+    const loadCallEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionCall?.name === 'load_skill',
+    );
+    expect(loadCallEvent).toBeDefined();
+
+    const loadResponseEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionResponse?.name === 'load_skill',
+    );
+    expect(loadResponseEvent).toBeDefined();
+    expect(
+      loadResponseEvent.content.parts[0].functionResponse.response.instructions,
+    ).toBe('When asked to solve math, double the number.');
+
+    // Verify load_skill_resource tool execution
+    const resourceCallEvent = events.find(
+      (e) =>
+        e.content?.parts?.[0]?.functionCall?.name === 'load_skill_resource',
+    );
+    expect(resourceCallEvent).toBeDefined();
+
+    const resourceResponseEvent = events.find(
+      (e) =>
+        e.content?.parts?.[0]?.functionResponse?.name === 'load_skill_resource',
+    );
+    expect(resourceResponseEvent).toBeDefined();
+    expect(
+      resourceResponseEvent.content.parts[0].functionResponse.response.content,
+    ).toBe('Double of X is 2*X');
+
+    // Verify run_skill_script tool execution
+    const runCallEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionCall?.name === 'run_skill_script',
+    );
+    expect(runCallEvent).toBeDefined();
+
+    const runResponseEvent = events.find(
+      (e) =>
+        e.content?.parts?.[0]?.functionResponse?.name === 'run_skill_script',
+    );
+    expect(runResponseEvent).toBeDefined();
+    expect(
+      runResponseEvent.content.parts[0].functionResponse.response.stdout,
+    ).toContain('42');
+  });
+});


### PR DESCRIPTION
Creates a new function-calling tool allowing LLM agents to dynamically query the remote registry for missing skills. Registers tool and injects system instruction tips, and adds integration tests. Depends on PR #420.