### PR TITLE
feat(skills): Skills Registry Core Interfaces & Fallback Caching (Skills Registry Part 1)

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -60,6 +60,7 @@
     "@opentelemetry/sdk-metrics": "^2.1.0",
     "@opentelemetry/sdk-trace-base": "^2.1.0",
     "@opentelemetry/sdk-trace-node": "^2.1.0",
+    "adm-zip": "^0.5.17",
     "express": "^4.22.1",
     "google-auth-library": "^10.3.0",
     "js-yaml": "^4.1.1",
@@ -71,6 +72,7 @@
   },
   "devDependencies": {
     "@mikro-orm/sqlite": "^6.6.6",
+    "@types/adm-zip": "^0.5.8",
     "@types/express": "^4.17.25",
     "@types/lodash-es": "^4.17.12",
     "openapi-types": "^12.1.3"

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -244,7 +244,14 @@ export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 
+export {
+  loadAllSkillsInDir,
+  loadSkillFromDir,
+  loadSkillFromZipBuffer,
+  validateSkillDir,
+} from './skills/loader.js';
 export type {Frontmatter, Resources, Script, Skill} from './skills/skill.js';
+export type {SkillRegistry} from './skills/skill_registry.js';
 export {ListSkillsTool} from './tools/skill/list_skills_tool.js';
 export {LoadSkillResourceTool} from './tools/skill/load_skill_resource_tool.js';
 export {LoadSkillTool} from './tools/skill/load_skill_tool.js';

--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import AdmZip from 'adm-zip';
 import yaml from 'js-yaml';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -323,4 +324,82 @@ export async function loadAllSkillsInDir(
   }
 
   return skills;
+}
+
+/**
+ * Loads a complete skill directly from in-memory zip file buffer.
+ *
+ * @param zipBuffer - The raw Buffer of the zip file containing the skill.
+ * @returns A Skill object with all components loaded.
+ */
+export function loadSkillFromZipBuffer(zipBuffer: Buffer): Skill {
+  const zip = new AdmZip(zipBuffer);
+  const entries = zip.getEntries();
+
+  let skillMdContent = '';
+  for (const entry of entries) {
+    if (entry.isDirectory) continue;
+    if (entry.entryName.toLowerCase() === 'skill.md') {
+      skillMdContent = entry.getData().toString('utf-8');
+      break;
+    }
+  }
+
+  if (!skillMdContent) {
+    throw new Error('SKILL.md not found in zipped filesystem.');
+  }
+
+  const {frontmatter: parsed, body} = parseSkillMdContent(skillMdContent);
+  const frontmatter = FrontmatterSchema.parse(parsed);
+
+  const references: Record<string, string | Buffer> = {};
+  const assets: Record<string, string | Buffer> = {};
+  const scripts: Record<string, Script> = {};
+
+  function loadZipDir(prefix: string): Record<string, string | Buffer> {
+    const res: Record<string, string | Buffer> = {};
+    const normPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+    for (const entry of entries) {
+      if (entry.isDirectory) continue;
+      if (entry.entryName.startsWith(normPrefix)) {
+        if (entry.entryName.includes('__pycache__')) continue;
+        const relativePath = entry.entryName.substring(normPrefix.length);
+        if (!relativePath) continue;
+        const data = entry.getData();
+        try {
+          res[relativePath] = data.toString('utf-8');
+        } catch (_e: unknown) {
+          res[relativePath] = data;
+        }
+      }
+    }
+    return res;
+  }
+
+  const refFiles = loadZipDir('references');
+  for (const [key, val] of Object.entries(refFiles)) {
+    references[key] = val;
+  }
+
+  const assetFiles = loadZipDir('assets');
+  for (const [key, val] of Object.entries(assetFiles)) {
+    assets[key] = val;
+  }
+
+  const rawScripts = loadZipDir('scripts');
+  for (const [key, val] of Object.entries(rawScripts)) {
+    if (typeof val === 'string') {
+      scripts[key] = {src: val};
+    }
+  }
+
+  return {
+    frontmatter,
+    instructions: body,
+    resources: {
+      references,
+      assets,
+      scripts,
+    },
+  };
 }

--- a/core/src/skills/skill_registry.ts
+++ b/core/src/skills/skill_registry.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Frontmatter, Skill} from './skill.js';
+
+/**
+ * Interface for a skill registry.
+ */
+export interface SkillRegistry {
+  /**
+   * Fetches a skill from the registry.
+   *
+   * @param name The name of the skill.
+   * @returns A Promise resolving to a Skill object.
+   */
+  getSkill(name: string): Promise<Skill>;
+
+  /**
+   * Searches for skills in the registry.
+   *
+   * @param query The search query.
+   * @returns A Promise resolving to a list of Frontmatter objects for discovery.
+   */
+  searchSkills(query: string): Promise<Frontmatter[]>;
+
+  /**
+   * Returns the description for the search_skills tool.
+   */
+  searchToolDescription?(): string | undefined;
+}

--- a/core/src/tools/skill/load_skill_resource_tool.ts
+++ b/core/src/tools/skill/load_skill_resource_tool.ts
@@ -50,7 +50,10 @@ export class LoadSkillResourceTool extends BaseTool {
     };
   }
 
-  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+  override async runAsync({
+    args,
+    toolContext,
+  }: RunAsyncToolRequest): Promise<unknown> {
     const skillName = args['skill_name'] as string;
     let resourcePath = args['path'] as string;
 
@@ -69,7 +72,19 @@ export class LoadSkillResourceTool extends BaseTool {
 
     resourcePath = path.posix.normalize(resourcePath);
 
-    const skill = this.toolset.getSkill(skillName);
+    let skill;
+    try {
+      skill = await this.toolset.getOrFetchSkill(
+        skillName,
+        toolContext.invocationId,
+      );
+    } catch (e: unknown) {
+      return {
+        error: `Failed to fetch skill '${skillName}' from registry: ${(e as Error).message || e}`,
+        error_code: 'REGISTRY_ERROR',
+      };
+    }
+
     if (!skill) {
       return {
         error: `Skill '${skillName}' not found.`,
@@ -144,7 +159,15 @@ export class LoadSkillResourceTool extends BaseTool {
           const skillName = response['skill_name'] as string;
           const resourcePath = response['path'] as string;
 
-          const skill = this.toolset.getSkill(skillName);
+          let skill;
+          try {
+            skill = await this.toolset.getOrFetchSkill(
+              skillName,
+              request.toolContext.invocationId,
+            );
+          } catch (_e: unknown) {
+            continue;
+          }
           if (!skill) continue;
           const skillResources = skill.resources || {};
 

--- a/core/src/tools/skill/load_skill_tool.ts
+++ b/core/src/tools/skill/load_skill_tool.ts
@@ -47,7 +47,19 @@ export class LoadSkillTool extends BaseTool {
       };
     }
 
-    const skill = this.toolset.getSkill(skillName);
+    let skill;
+    try {
+      skill = await this.toolset.getOrFetchSkill(
+        skillName,
+        toolContext.invocationId,
+      );
+    } catch (e: unknown) {
+      return {
+        error: `Failed to fetch skill '${skillName}' from registry: ${(e as Error).message || e}`,
+        error_code: 'REGISTRY_ERROR',
+      };
+    }
+
     if (!skill) {
       return {
         error: `Skill '${skillName}' not found.`,

--- a/core/src/tools/skill/run_skill_script_tool.ts
+++ b/core/src/tools/skill/run_skill_script_tool.ts
@@ -79,7 +79,19 @@ export class RunSkillScriptTool extends BaseTool {
       };
     }
 
-    const skill = this.toolset.getSkill(skillName);
+    let skill;
+    try {
+      skill = await this.toolset.getOrFetchSkill(
+        skillName,
+        toolContext.invocationId,
+      );
+    } catch (e: unknown) {
+      return {
+        error: `Failed to fetch skill '${skillName}' from registry: ${(e as Error).message || e}`,
+        errorCode: 'REGISTRY_ERROR',
+      };
+    }
+
     if (!skill) {
       return {
         error: `Skill '${skillName}' not found.`,

--- a/core/src/tools/skill/skill_toolset.ts
+++ b/core/src/tools/skill/skill_toolset.ts
@@ -10,7 +10,9 @@ import {BaseCodeExecutor} from '../../code_executors/base_code_executor.js';
 import {appendInstructions, LlmRequest} from '../../models/llm_request.js';
 import {formatSkillsAsXml} from '../../skills/prompt.js';
 import {Skill} from '../../skills/skill.js';
+import {SkillRegistry} from '../../skills/skill_registry.js';
 import {experimental} from '../../utils/experimental.js';
+import {logger} from '../../utils/logger.js';
 import {BaseTool} from '../base_tool.js';
 import {BaseToolset} from '../base_toolset.js';
 import {ListSkillsTool} from './list_skills_tool.js';
@@ -41,13 +43,16 @@ export class SkillToolset extends BaseToolset {
   private tools: BaseTool[];
   public additionalTools: Array<BaseTool | BaseToolset>;
   public codeExecutor?: BaseCodeExecutor;
+  public registry?: SkillRegistry;
   private toolCache = new Map<string, BaseTool[]>();
+  private fetchedSkillCache = new Map<string, Map<string, Skill>>();
 
   constructor(
     skills: Record<string, Skill> | Skill[],
     options: {
       codeExecutor?: BaseCodeExecutor;
       additionalTools?: Array<BaseTool | BaseToolset>;
+      registry?: SkillRegistry;
     } = {},
   ) {
     super([], 'adk_skill_toolset');
@@ -56,6 +61,7 @@ export class SkillToolset extends BaseToolset {
       : skills;
     this.codeExecutor = options.codeExecutor;
     this.additionalTools = options.additionalTools || [];
+    this.registry = options.registry;
 
     this.tools = [
       new ListSkillsTool(this),
@@ -71,10 +77,43 @@ export class SkillToolset extends BaseToolset {
     return [...this.tools, ...dynamicTools];
   }
 
-  override async close(): Promise<void> {}
+  override async close(): Promise<void> {
+    this.fetchedSkillCache.clear();
+  }
 
   getSkill(name: string): Skill | undefined {
     return this.skills[name];
+  }
+
+  async getOrFetchSkill(
+    name: string,
+    invocationId?: string,
+  ): Promise<Skill | undefined> {
+    if (this.skills[name]) {
+      return this.skills[name];
+    }
+    if (!this.registry) {
+      return undefined;
+    }
+
+    const contextKey = invocationId || 'default';
+    if (!this.fetchedSkillCache.has(contextKey)) {
+      this.fetchedSkillCache.set(contextKey, new Map());
+    }
+
+    const cache = this.fetchedSkillCache.get(contextKey)!;
+    if (cache.has(name)) {
+      return cache.get(name)!;
+    }
+
+    try {
+      const skill = await this.registry.getSkill(name);
+      cache.set(name, skill);
+      return skill;
+    } catch (e: unknown) {
+      logger.warn(`Failed to fetch skill '${name}' from registry: ${e}`);
+      throw e;
+    }
   }
 
   override async processLlmRequest(
@@ -86,10 +125,9 @@ export class SkillToolset extends BaseToolset {
     const skills = Object.values(this.skills);
     const skillsXml = formatSkillsAsXml(skills);
 
-    appendInstructions(llmRequest, [
-      DEFAULT_SKILL_SYSTEM_INSTRUCTION,
-      skillsXml,
-    ]);
+    const instructions = [DEFAULT_SKILL_SYSTEM_INSTRUCTION, skillsXml];
+
+    appendInstructions(llmRequest, instructions);
   }
 
   private async resolveAdditionalTools(
@@ -110,7 +148,7 @@ export class SkillToolset extends BaseToolset {
 
     const additionalToolNames = new Set<string>();
     for (const skillName of activatedSkills) {
-      const skill = this.skills[skillName];
+      const skill = await this.getOrFetchSkill(skillName, context.invocationId);
       if (skill && skill.frontmatter.metadata) {
         const tools = skill.frontmatter.metadata[
           'adk_additional_tools'

--- a/core/test/tools/skills/skill_registry_test.ts
+++ b/core/test/tools/skills/skill_registry_test.ts
@@ -1,0 +1,361 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  InvocationContext,
+  LlmRequest,
+  LoadSkillResourceTool,
+  LoadSkillTool,
+  RunSkillScriptTool,
+  Skill,
+  SkillToolset,
+  loadSkillFromZipBuffer,
+} from '@google/adk';
+import AdmZip from 'adm-zip';
+import {describe, expect, it, vi} from 'vitest';
+
+describe('skill_registry', () => {
+  function createMockContext(agentName = 'test-agent') {
+    return new Context({
+      invocationContext: {
+        invocationId: 'inv-123',
+        session: {state: {}},
+        agent: {name: agentName},
+      } as unknown as InvocationContext,
+    });
+  }
+
+  const validSkillMd = `---
+name: test-remote-skill
+description: A test remote skill
+---
+Instruction body`;
+
+  function createValidZipBuffer() {
+    const zip = new AdmZip();
+    zip.addFile('SKILL.md', Buffer.from(validSkillMd, 'utf-8'));
+    zip.addFile('references/ref1.md', Buffer.from('ref content', 'utf-8'));
+    zip.addFile('assets/asset1.txt', Buffer.from('asset content', 'utf-8'));
+    zip.addFile('scripts/run.sh', Buffer.from('echo hello', 'utf-8'));
+    zip.addFile('__pycache__/cache.pyc', Buffer.from('dummy', 'utf-8'));
+    zip.addFile('references/subdir/', Buffer.from(''));
+    zip.addFile('references/', Buffer.from(''));
+    return zip.toBuffer();
+  }
+
+  describe('loadSkillFromZipBuffer', () => {
+    it('successfully loads a skill with all resources from zip buffer', () => {
+      const zipBuffer = createValidZipBuffer();
+      const skill = loadSkillFromZipBuffer(zipBuffer);
+
+      expect(skill.frontmatter.name).toBe('test-remote-skill');
+      expect(skill.instructions).toBe('Instruction body');
+      expect(skill.resources?.references?.['ref1.md']).toBe('ref content');
+      expect(skill.resources?.assets?.['asset1.txt']).toBe('asset content');
+      expect(skill.resources?.scripts?.['run.sh']?.src).toBe('echo hello');
+    });
+
+    it('throws error if SKILL.md is missing', () => {
+      const zip = new AdmZip();
+      zip.addFile('dummy.txt', Buffer.from('hello'));
+      expect(() => loadSkillFromZipBuffer(zip.toBuffer())).toThrow(
+        'SKILL.md not found in zipped filesystem.',
+      );
+    });
+  });
+
+  describe('SkillToolset upgraded capabilities', () => {
+    it('getOrFetchSkill returns local skill', async () => {
+      const localSkill: Skill = {
+        frontmatter: {name: 'local-skill', description: 'desc'},
+        instructions: 'inst',
+      };
+      const toolset = new SkillToolset([localSkill]);
+      const res = await toolset.getOrFetchSkill('local-skill');
+      expect(res).toBe(localSkill);
+    });
+
+    it('getOrFetchSkill returns undefined if no registry and skill not local', async () => {
+      const toolset = new SkillToolset([]);
+      const res = await toolset.getOrFetchSkill('remote-skill');
+      expect(res).toBeUndefined();
+    });
+
+    it('getOrFetchSkill fetches from registry and caches per invocation', async () => {
+      const remoteSkill: Skill = {
+        frontmatter: {name: 'fetched-skill', description: 'desc'},
+        instructions: 'inst',
+      };
+      const mockRegistry = {
+        getSkill: vi.fn().mockResolvedValue(remoteSkill),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+
+      const res1 = await toolset.getOrFetchSkill('fetched-skill', 'inv-1');
+      expect(res1).toBe(remoteSkill);
+      expect(mockRegistry.getSkill).toHaveBeenCalledTimes(1);
+
+      // Second call with same invocation ID should hit cache
+      const res2 = await toolset.getOrFetchSkill('fetched-skill', 'inv-1');
+      expect(res2).toBe(remoteSkill);
+      expect(mockRegistry.getSkill).toHaveBeenCalledTimes(1);
+
+      await toolset.close();
+    });
+
+    it('getOrFetchSkill rethrows registry fetch errors', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn().mockRejectedValue(new Error('Registry error')),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      await expect(
+        toolset.getOrFetchSkill('bad-skill', 'inv-1'),
+      ).rejects.toThrow('Registry error');
+    });
+  });
+
+  describe('Updated Tool implementations with Registry integration', () => {
+    const remoteSkill: Skill = {
+      frontmatter: {
+        name: 'test-registry-skill',
+        description: 'desc',
+        metadata: {adk_additional_tools: []},
+      },
+      instructions: 'instructions',
+      resources: {
+        references: {'doc.md': 'doc text'},
+        assets: {'img.png': Buffer.from('img data')},
+        scripts: {'test.js': {src: 'console.log(1)'}},
+      },
+    };
+
+    const mockRegistry = {
+      getSkill: vi.fn().mockImplementation((name: string) => {
+        if (name === 'test-registry-skill') return Promise.resolve(remoteSkill);
+        if (name === 'error-skill')
+          return Promise.reject(new Error('Fetch err'));
+        return Promise.resolve(undefined);
+      }),
+      searchSkills: vi.fn(),
+    };
+
+    it('LoadSkillTool fetches remote skill on demand', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+
+      const res = (await tool.runAsync({
+        args: {name: 'test-registry-skill'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+
+      expect(res.skill_name).toBe('test-registry-skill');
+      expect(res.instructions).toBe('instructions');
+    });
+
+    it('LoadSkillTool handles missing skill name', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+      const res = (await tool.runAsync({
+        args: {},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('MISSING_SKILL_NAME');
+    });
+
+    it('LoadSkillTool handles registry fetch errors', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+      const res = (await tool.runAsync({
+        args: {name: 'error-skill'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+    });
+
+    it('LoadSkillTool handles skill not found', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillTool(toolset);
+      const res = (await tool.runAsync({
+        args: {name: 'unknown-skill'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('SKILL_NOT_FOUND');
+    });
+
+    it('LoadSkillResourceTool fetches remote skill resource on demand', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+
+      const res = (await tool.runAsync({
+        args: {skill_name: 'test-registry-skill', path: 'references/doc.md'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+
+      expect(res.content).toBe('doc text');
+    });
+
+    it('LoadSkillResourceTool validates missing parameters', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+      let res = (await tool.runAsync({
+        args: {path: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('MISSING_SKILL_NAME');
+
+      res = (await tool.runAsync({
+        args: {skill_name: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('MISSING_RESOURCE_PATH');
+    });
+
+    it('LoadSkillResourceTool handles registry fetch error', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'error-skill', path: 'references/doc.md'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+    });
+
+    it('LoadSkillResourceTool handles skill not found', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'unknown-skill', path: 'references/doc.md'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('SKILL_NOT_FOUND');
+    });
+
+    it('LoadSkillResourceTool processLlmRequest successfully resolves binary injection for remote skill', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+
+      const req: LlmRequest = {
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'load_skill_resource',
+                  response: {
+                    status:
+                      'Binary file detected. The content has been injected into the conversation history for you to analyze.',
+                    skill_name: 'test-registry-skill',
+                    path: 'assets/img.png',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await tool.processLlmRequest({
+        toolContext: createMockContext(),
+        llmRequest: req,
+      });
+      expect(req.contents!.length).toBe(2);
+      expect(req.contents![1].parts![1].inlineData?.data).toBe(
+        Buffer.from('img data').toString('base64'),
+      );
+    });
+
+    it('LoadSkillResourceTool processLlmRequest continues gracefully on error fetching skill', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new LoadSkillResourceTool(toolset);
+
+      const req: LlmRequest = {
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'load_skill_resource',
+                  response: {
+                    status:
+                      'Binary file detected. The content has been injected into the conversation history for you to analyze.',
+                    skill_name: 'error-skill',
+                    path: 'assets/img.png',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await tool.processLlmRequest({
+        toolContext: createMockContext(),
+        llmRequest: req,
+      });
+      expect(req.contents!.length).toBe(1);
+    });
+
+    it('RunSkillScriptTool checks remote skill script on demand', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+
+      const res = (await tool.runAsync({
+        args: {
+          skill_name: 'test-registry-skill',
+          script_path: 'scripts/test.js',
+        },
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+
+      expect(res.error).toBe('No code executor configured.');
+    });
+
+    it('RunSkillScriptTool validates missing parameters', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+      let res = (await tool.runAsync({
+        args: {script_path: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('MISSING_SKILL_NAME');
+
+      res = (await tool.runAsync({
+        args: {skill_name: 'foo'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('MISSING_SCRIPT_PATH');
+    });
+
+    it('RunSkillScriptTool handles registry fetch error', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'error-skill', script_path: 'scripts/test.js'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('REGISTRY_ERROR');
+    });
+
+    it('RunSkillScriptTool handles skill not found', async () => {
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new RunSkillScriptTool(toolset);
+      const res = (await tool.runAsync({
+        args: {skill_name: 'unknown-skill', script_path: 'scripts/test.js'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.errorCode).toBe('SKILL_NOT_FOUND');
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@opentelemetry/sdk-metrics": "^2.1.0",
         "@opentelemetry/sdk-trace-base": "^2.1.0",
         "@opentelemetry/sdk-trace-node": "^2.1.0",
+        "adm-zip": "^0.5.17",
         "express": "^4.22.1",
         "google-auth-library": "^10.3.0",
         "js-yaml": "^4.1.1",
@@ -73,6 +74,7 @@
       },
       "devDependencies": {
         "@mikro-orm/sqlite": "^6.6.6",
+        "@types/adm-zip": "^0.5.8",
         "@types/express": "^4.17.25",
         "@types/lodash-es": "^4.17.12",
         "openapi-types": "^12.1.3"
@@ -3872,6 +3874,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -5160,6 +5172,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: # (No existing issue)

**2. Or, if no issue exists, describe the change:**

**Problem:**
`adk-js` lacks parity with the Python ADK Skills Registry, meaning developers cannot load dynamic/remote skills or cache them at the invocation level when local skills are missing.

**Solution:**
Implement the core Skills Registry interfaces and in-memory ZIP buffer extraction helper. 
Lays down:
- `SkillRegistry` interface contract.
- In-memory zip decompression using `adm-zip` inside `loadSkillFromZipBuffer`.
- Invocation-level fallback caching inside `SkillToolset` for `load_skill`, `load_skill_resource`, and `run_skill_script` tools.

This forms Part 1 of 3 of the modular Skills Registry PR stack.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

*Summary of passed npm test results:*
```
 ✓ skill_registry > loadSkillFromZipBuffer > successfully loads a skill with all resources from zip buffer 47ms
   ✓ skill_registry > loadSkillFromZipBuffer > throws error if SKILL.md is missing 3ms
   ✓ skill_registry > SkillToolset upgraded capabilities > getOrFetchSkill returns local skill 3ms
   ✓ skill_registry > SkillToolset upgraded capabilities > getOrFetchSkill returns undefined if no registry and skill not local 0ms
   ✓ skill_registry > SkillToolset upgraded capabilities > getOrFetchSkill fetches from registry and caches per invocation 1ms
   ✓ skill_registry > SkillToolset upgraded capabilities > getOrFetchSkill rethrows registry fetch errors 3ms
```

**Manual End-to-End (E2E) Tests:**
None for this isolated core PR; E2E capability is achieved in stacked PR #11 and PR #12.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

### Additional context
None.