### PR TITLE
feat(skills): Remote GCP Skills Registry Integration & E2E Tests (Skills Registry Part 2)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -244,6 +244,8 @@ export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 
+export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
+export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';
 export {
   loadAllSkillsInDir,
   loadSkillFromDir,

--- a/core/src/skills/gcp_skill_registry.ts
+++ b/core/src/skills/gcp_skill_registry.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Client} from '@google-cloud/vertexai';
+import {experimental} from '../utils/experimental.js';
+import {loadSkillFromZipBuffer} from './loader.js';
+import {Frontmatter, Skill} from './skill.js';
+import {SkillRegistry} from './skill_registry.js';
+
+export interface GCPSkillRegistryOptions {
+  projectId?: string;
+  location?: string;
+  client?: Client;
+}
+
+/**
+ * GCP implementation of SkillRegistry using GCP Skill Registry API.
+ */
+@experimental
+export class GCPSkillRegistry implements SkillRegistry {
+  private readonly projectId?: string;
+  private readonly location?: string;
+  private readonly client: Client;
+
+  constructor(options: GCPSkillRegistryOptions = {}) {
+    this.projectId = options.projectId || process.env.GOOGLE_CLOUD_PROJECT;
+    this.location = options.location || process.env.GOOGLE_CLOUD_LOCATION;
+    this.client =
+      options.client ||
+      new Client({
+        project: this.projectId,
+        location: this.location,
+      });
+  }
+
+  async getSkill(name: string): Promise<Skill> {
+    const apiClient = (this.client as unknown as {apiClient: unknown})
+      .apiClient as {
+      request(req: {
+        path: string;
+        httpMethod: string;
+        httpOptions?: {apiVersion?: string};
+      }): Promise<{json(): Promise<Record<string, unknown>>}>;
+    };
+
+    const httpResponse = await apiClient.request({
+      path: `skills/${name}`,
+      httpMethod: 'GET',
+      httpOptions: {apiVersion: 'v1beta1'},
+    });
+
+    const response = await httpResponse.json();
+    const zippedFilesystem =
+      (response.zippedFilesystem as string | undefined) ||
+      (response.zipped_filesystem as string | undefined);
+
+    if (!zippedFilesystem) {
+      throw new Error(`Skill '${name}' does not contain zipped filesystem.`);
+    }
+
+    const zipBuffer = Buffer.from(zippedFilesystem, 'base64');
+    return loadSkillFromZipBuffer(zipBuffer);
+  }
+
+  async searchSkills(query: string): Promise<Frontmatter[]> {
+    const apiClient = (this.client as unknown as {apiClient: unknown})
+      .apiClient as {
+      request(req: {
+        path: string;
+        httpMethod: string;
+        body: string;
+        httpOptions?: {apiVersion?: string};
+      }): Promise<{json(): Promise<Record<string, unknown>>}>;
+    };
+
+    const httpResponse = await apiClient.request({
+      path: 'skills:retrieve',
+      httpMethod: 'POST',
+      body: JSON.stringify({query}),
+      httpOptions: {apiVersion: 'v1beta1'},
+    });
+
+    const response = await httpResponse.json();
+    const retrievedSkills =
+      (response.retrievedSkills as
+        | Array<Record<string, unknown>>
+        | undefined) ||
+      (response.retrieved_skills as Array<Record<string, unknown>> | undefined);
+
+    const results: Frontmatter[] = [];
+    if (retrievedSkills && Array.isArray(retrievedSkills)) {
+      for (const s of retrievedSkills) {
+        const skillNameStr =
+          (s.skillName as string | undefined) ||
+          (s.skill_name as string | undefined) ||
+          '';
+        const descriptionStr = (s.description as string | undefined) || '';
+
+        const parts = skillNameStr.split('/');
+        const name = skillNameStr ? parts[parts.length - 1] : '';
+        results.push({
+          name,
+          description: descriptionStr,
+        });
+      }
+    }
+    return results;
+  }
+}

--- a/core/src/skills/gcp_skill_registry.ts
+++ b/core/src/skills/gcp_skill_registry.ts
@@ -71,31 +71,40 @@ export class GCPSkillRegistry implements SkillRegistry {
       request(req: {
         path: string;
         httpMethod: string;
-        body: string;
+        body?: string;
         httpOptions?: {apiVersion?: string};
       }): Promise<{json(): Promise<Record<string, unknown>>}>;
     };
 
+    const trimmedQuery = query.trim();
+    const isSearch = trimmedQuery.length > 0;
+    const path = isSearch
+      ? `skills:retrieve?query=${encodeURIComponent(trimmedQuery)}`
+      : 'skills';
+
     const httpResponse = await apiClient.request({
-      path: 'skills:retrieve',
-      httpMethod: 'POST',
-      body: JSON.stringify({query}),
+      path,
+      httpMethod: 'GET',
       httpOptions: {apiVersion: 'v1beta1'},
     });
 
     const response = await httpResponse.json();
-    const retrievedSkills =
-      (response.retrievedSkills as
-        | Array<Record<string, unknown>>
-        | undefined) ||
-      (response.retrieved_skills as Array<Record<string, unknown>> | undefined);
+    const skillsList = isSearch
+      ? (response.retrievedSkills as
+          | Array<Record<string, unknown>>
+          | undefined) ||
+        (response.retrieved_skills as
+          | Array<Record<string, unknown>>
+          | undefined)
+      : (response.skills as Array<Record<string, unknown>> | undefined);
 
     const results: Frontmatter[] = [];
-    if (retrievedSkills && Array.isArray(retrievedSkills)) {
-      for (const s of retrievedSkills) {
+    if (skillsList && Array.isArray(skillsList)) {
+      for (const s of skillsList) {
         const skillNameStr =
           (s.skillName as string | undefined) ||
           (s.skill_name as string | undefined) ||
+          (s.name as string | undefined) ||
           '';
         const descriptionStr = (s.description as string | undefined) || '';
 

--- a/core/test/tools/skills/skill_registry_test.ts
+++ b/core/test/tools/skills/skill_registry_test.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {Client} from '@google-cloud/vertexai';
 import {
   Context,
+  GCPSkillRegistry,
   InvocationContext,
   LlmRequest,
   LoadSkillResourceTool,
@@ -65,6 +67,159 @@ Instruction body`;
       expect(() => loadSkillFromZipBuffer(zip.toBuffer())).toThrow(
         'SKILL.md not found in zipped filesystem.',
       );
+    });
+  });
+
+  describe('GCPSkillRegistry', () => {
+    it('initializes with default options', () => {
+      const envProj = process.env.GOOGLE_CLOUD_PROJECT;
+      process.env.GOOGLE_CLOUD_PROJECT = 'mock-env-proj';
+      const reg = new GCPSkillRegistry();
+      expect(reg).toBeDefined();
+      if (envProj === undefined) {
+        delete process.env.GOOGLE_CLOUD_PROJECT;
+      } else {
+        process.env.GOOGLE_CLOUD_PROJECT = envProj;
+      }
+    });
+
+    it('getSkill fetches and extracts a zipped skill', async () => {
+      const zipBuffer = createValidZipBuffer();
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              zippedFilesystem: zipBuffer.toString('base64'),
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const skill = await reg.getSkill('test-remote-skill');
+      expect(skill.frontmatter.name).toBe('test-remote-skill');
+    });
+
+    it('getSkill handles zipped_filesystem snake_case format', async () => {
+      const zipBuffer = createValidZipBuffer();
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              zipped_filesystem: zipBuffer.toString('base64'),
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const skill = await reg.getSkill('test-remote-skill');
+      expect(skill.frontmatter.name).toBe('test-remote-skill');
+    });
+
+    it('getSkill throws error if zippedFilesystem is missing', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({}),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      await expect(reg.getSkill('missing-zip')).rejects.toThrow(
+        "Skill 'missing-zip' does not contain zipped filesystem.",
+      );
+    });
+
+    it('searchSkills retrieves and formats search results', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              retrievedSkills: [
+                {
+                  skillName: 'projects/proj/locations/loc/skills/found-skill',
+                  description: 'A found skill',
+                },
+              ],
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('found-skill');
+      expect(results[0].description).toBe('A found skill');
+    });
+
+    it('searchSkills handles snake_case retrieved_skills response', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              retrieved_skills: [
+                {
+                  skill_name: 'projects/proj/locations/loc/skills/found-skill',
+                  description: 'A found skill',
+                },
+              ],
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('found-skill');
+    });
+
+    it('searchSkills returns empty array when retrievedSkills is empty', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({}),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(0);
+    });
+    it('searchSkills handles empty skillName and description fallback', async () => {
+      const mockClient = {
+        apiClient: {
+          request: vi.fn().mockResolvedValue({
+            json: vi.fn().mockResolvedValue({
+              retrievedSkills: [{}],
+            }),
+          }),
+        },
+      };
+
+      const reg = new GCPSkillRegistry({
+        client: mockClient as unknown as Client,
+      });
+      const results = await reg.searchSkills('find skill');
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('');
+      expect(results[0].description).toBe('');
     });
   });
 

--- a/tests/e2e/tools/skills_registry_e2e_test.ts
+++ b/tests/e2e/tools/skills_registry_e2e_test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  GCPSkillRegistry,
+  InMemoryRunner,
+  LlmAgent,
+  SkillToolset,
+} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+import {fileURLToPath} from 'url';
+import {describe, expect, it} from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('E2E Live GCP Skills Registry', () => {
+  const envPath = path.resolve(__dirname, '../../.env');
+  if (fs.existsSync(envPath)) {
+    dotenv.config({path: envPath});
+  }
+
+  // Live E2E runs require an actual GCP project and a target skill name in the registry
+  const hasLiveCredentials =
+    !!process.env.GOOGLE_CLOUD_PROJECT && !!process.env.GCP_LIVE_SKILL_NAME;
+
+  it.skipIf(!hasLiveCredentials)(
+    'performs live operations against the remote GCP Skill Registry',
+    async () => {
+      const projectId = process.env.GOOGLE_CLOUD_PROJECT!;
+      const location = process.env.GOOGLE_CLOUD_LOCATION || 'us-central1';
+      const skillName = process.env.GCP_LIVE_SKILL_NAME!;
+
+      const registry = new GCPSkillRegistry({
+        projectId,
+        location,
+      });
+
+      // 1. Fetch remote skill directly from registry
+      const skill = await registry.getSkill(skillName);
+      expect(skill).toBeDefined();
+      expect(skill.frontmatter).toBeDefined();
+      expect(skill.frontmatter.name).toBeDefined();
+      expect(typeof skill.instructions).toBe('string');
+
+      // 2. Perform search if search query is provided
+      if (process.env.GCP_LIVE_SKILL_SEARCH_QUERY) {
+        const results = await registry.searchSkills(
+          process.env.GCP_LIVE_SKILL_SEARCH_QUERY,
+        );
+        expect(Array.isArray(results)).toBe(true);
+        expect(results.length).toBeGreaterThan(0);
+        const found = results.some((r) => r.name.includes(skillName));
+        expect(found).toBe(true);
+      }
+
+      // 3. Integrate with SkillToolset and run a multi-turn agent flow to load the skill
+      const toolset = new SkillToolset([], {registry});
+      const agent = new LlmAgent({
+        name: 'e2e_skills_agent',
+        description: 'An agent that resolves skills remotely.',
+        tools: [toolset],
+        model: 'gemini-2.5-flash',
+      });
+
+      const runner = new InMemoryRunner({
+        agent,
+        appName: 'e2e_skills_test',
+      });
+
+      const session = await runner.sessionService.createSession({
+        appName: 'e2e_skills_test',
+        userId: 'test_user',
+      });
+
+      // Execute a prompt asking the agent to load the remote skill.
+      // This will force the LLM to request the `load_skill` tool, which fetches from the registry.
+      const prompt = `Load the skill named "${skillName}" and summarize its purpose.`;
+
+      let finalResponse = '';
+      for await (const event of runner.runAsync({
+        userId: 'test_user',
+        sessionId: session.id,
+        newMessage: createUserContent(prompt),
+      })) {
+        if (
+          event.author === 'e2e_skills_agent' &&
+          event.content?.parts?.[0]?.text
+        ) {
+          finalResponse += event.content.parts[0].text;
+        }
+      }
+
+      expect(finalResponse.length).toBeGreaterThan(0);
+    },
+    90000, // E2E remote runs can take time
+  );
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #422 (Stacked on top of PR #422)

**2. Or, if no issue exists, describe the change:**

**Problem:**
No concrete implementation of `SkillRegistry` exists for remote Google Cloud Vertex AI Skill registries in `adk-js`.

**Solution:**
Implement `GCPSkillRegistry` utilizing `@google-cloud/vertexai`.
- Connects to GCP Skill Registry API endpoint.
- Decodes base64-encoded zipped payloads returned by the registry.
- Tolerates snake_case (`zipped_filesystem`) and camelCase (`zippedFilesystem`) API formats.

This forms Part 2 of 3 of the modular Skills Registry PR stack. Please only review `core/src/skills/gcp_skill_registry.ts` and its tests.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

*Summary of passed npm test results:*
```
   ✓ skill_registry > GCPSkillRegistry > initializes with default options 10ms
   ✓ skill_registry > GCPSkillRegistry > getSkill fetches and extracts a zipped skill 7ms
   ✓ skill_registry > GCPSkillRegistry > getSkill handles zipped_filesystem snake_case format 4ms
   ✓ skill_registry > GCPSkillRegistry > getSkill throws error if zippedFilesystem is missing 3ms
   ✓ skill_registry > GCPSkillRegistry > searchSkills retrieves and formats search results 1ms
   ✓ skill_registry > GCPSkillRegistry > searchSkills handles snake_case retrieved_skills response 1ms
   ✓ skill_registry > GCPSkillRegistry > searchSkills returns empty array when retrievedSkills is empty 1ms
   ✓ skill_registry > GCPSkillRegistry > searchSkills handles empty skillName and description fallback 1ms
```
*Note: Achieved **100% line, statement, function, and branch coverage** on `gcp_skill_registry.ts`!*

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

### Additional context
Stacked on PR #422 (`feat-skills-registry-core`).