### PR TITLE
feat(skills): Dynamic SearchSkillsTool for LLM Agents (Skills Registry Part 3)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -257,6 +257,7 @@ export type {SkillRegistry} from './skills/skill_registry.js';
 export {ListSkillsTool} from './tools/skill/list_skills_tool.js';
 export {LoadSkillResourceTool} from './tools/skill/load_skill_resource_tool.js';
 export {LoadSkillTool} from './tools/skill/load_skill_tool.js';
+export {SearchSkillsTool} from './tools/skill/search_skills_tool.js';
 export {SkillToolset} from './tools/skill/skill_toolset.js';
 
 export {OpenApiSpecParser} from './tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.js';

--- a/core/src/tools/skill/search_skills_tool.ts
+++ b/core/src/tools/skill/search_skills_tool.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Type} from '@google/genai';
+import {experimental} from '../../utils/experimental.js';
+import {logger} from '../../utils/logger.js';
+import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
+import {SkillToolset} from './skill_toolset.js';
+
+@experimental
+export class SearchSkillsTool extends BaseTool {
+  constructor(private toolset: SkillToolset) {
+    if (!toolset.registry) {
+      throw new Error('SearchSkillsTool requires a configured skill registry.');
+    }
+    super({
+      name: 'search_skills',
+      description:
+        toolset.registry.searchToolDescription?.() ||
+        'Searches for relevant skills in the registry based on a semantic or keyword query.',
+    });
+  }
+
+  override _getDeclaration(): FunctionDeclaration {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          query: {
+            type: Type.STRING,
+            description: 'Semantic or keyword search query.',
+          },
+        },
+        required: ['query'],
+      },
+    };
+  }
+
+  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    const query = args['query'] as string;
+    if (!query) {
+      return {
+        error: "Argument 'query' is required.",
+        error_code: 'INVALID_ARGUMENTS',
+      };
+    }
+
+    try {
+      const results = await this.toolset.registry!.searchSkills(query);
+      return results.filter((r) => {
+        if (this.toolset.skills[r.name]) {
+          logger.warn(
+            `Skill naming conflict: skill '${r.name}' already exists locally. Registry skill is filtered.`,
+          );
+          return false;
+        }
+        return true;
+      });
+    } catch (e: unknown) {
+      return {
+        error: `Failed to search skills from registry: ${(e as Error).message || e}`,
+        error_code: 'REGISTRY_ERROR',
+      };
+    }
+  }
+}

--- a/core/src/tools/skill/skill_toolset.ts
+++ b/core/src/tools/skill/skill_toolset.ts
@@ -20,6 +20,7 @@ import {LoadSkillResourceTool} from './load_skill_resource_tool.js';
 import {LoadSkillTool} from './load_skill_tool.js';
 import {RunSkillInlineScriptTool} from './run_skill_inline_script_tool.js';
 import {RunSkillScriptTool} from './run_skill_script_tool.js';
+import {SearchSkillsTool} from './search_skills_tool.js';
 
 const DEFAULT_SKILL_SYSTEM_INSTRUCTION = `You can use specialized 'skills' to help you with complex tasks. You MUST use the skill tools to interact with these skills.
 
@@ -70,6 +71,10 @@ export class SkillToolset extends BaseToolset {
       new RunSkillScriptTool(this),
       new RunSkillInlineScriptTool(this),
     ];
+
+    if (this.registry) {
+      this.tools.push(new SearchSkillsTool(this));
+    }
   }
 
   override async getTools(context?: ReadonlyContext): Promise<BaseTool[]> {
@@ -126,6 +131,12 @@ export class SkillToolset extends BaseToolset {
     const skillsXml = formatSkillsAsXml(skills);
 
     const instructions = [DEFAULT_SKILL_SYSTEM_INSTRUCTION, skillsXml];
+
+    if (this.registry) {
+      instructions.push(
+        '\nIf the locally available skills are not sufficient to complete your task, you can use the `search_skills` tool to discover additional skills from the registry.',
+      );
+    }
 
     appendInstructions(llmRequest, instructions);
   }

--- a/core/test/tools/skills/skill_registry_test.ts
+++ b/core/test/tools/skills/skill_registry_test.ts
@@ -13,6 +13,7 @@ import {
   LoadSkillResourceTool,
   LoadSkillTool,
   RunSkillScriptTool,
+  SearchSkillsTool,
   Skill,
   SkillToolset,
   loadSkillFromZipBuffer,
@@ -223,6 +224,98 @@ Instruction body`;
     });
   });
 
+  describe('SearchSkillsTool', () => {
+    it('throws error if toolset has no registry', () => {
+      const toolset = new SkillToolset([]);
+      expect(() => new SearchSkillsTool(toolset)).toThrow(
+        'SearchSkillsTool requires a configured skill registry.',
+      );
+    });
+
+    it('returns declaration with search_skills', () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn(),
+        searchToolDescription: vi
+          .fn()
+          .mockReturnValue('Custom search description'),
+      };
+
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const dec = tool._getDeclaration();
+      expect(dec.name).toBe('search_skills');
+      expect(dec.description).toBe('Custom search description');
+    });
+
+    it('runAsync validates missing query', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('INVALID_ARGUMENTS');
+    });
+
+    it('runAsync searches registry and filters local skills', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn().mockResolvedValue([
+          {name: 'remote-only', description: 'remote'},
+          {name: 'already-local', description: 'local'},
+        ]),
+      };
+      const localSkill: Skill = {
+        frontmatter: {name: 'already-local', description: 'desc'},
+        instructions: 'inst',
+      };
+
+      const toolset = new SkillToolset([localSkill], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {query: 'skills'},
+        toolContext: createMockContext(),
+      })) as Array<Record<string, unknown>>;
+
+      expect(res.length).toBe(1);
+      expect(res[0].name).toBe('remote-only');
+    });
+
+    it('runAsync returns error on registry exception', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn().mockRejectedValue(new Error('Registry failure')),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {query: 'skills'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+    });
+
+    it('runAsync returns error on string throw', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn().mockRejectedValue('String error failure'),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const tool = new SearchSkillsTool(toolset);
+      const res = (await tool.runAsync({
+        args: {query: 'skills'},
+        toolContext: createMockContext(),
+      })) as Record<string, unknown>;
+      expect(res.error_code).toBe('REGISTRY_ERROR');
+      expect(res.error).toContain('String error failure');
+    });
+  });
+
   describe('SkillToolset upgraded capabilities', () => {
     it('getOrFetchSkill returns local skill', async () => {
       const localSkill: Skill = {
@@ -272,6 +365,21 @@ Instruction body`;
       await expect(
         toolset.getOrFetchSkill('bad-skill', 'inv-1'),
       ).rejects.toThrow('Registry error');
+    });
+
+    it('processLlmRequest appends search instruction if registry configured', async () => {
+      const mockRegistry = {
+        getSkill: vi.fn(),
+        searchSkills: vi.fn(),
+      };
+      const toolset = new SkillToolset([], {registry: mockRegistry});
+      const req: LlmRequest = {
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+      await toolset.processLlmRequest(createMockContext(), req);
+      expect(req.config?.systemInstruction).toContain('search_skills');
     });
   });
 

--- a/tests/integration/tools/skills_registry_integration_test.ts
+++ b/tests/integration/tools/skills_registry_integration_test.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  InMemoryRunner,
+  LlmAgent,
+  Skill,
+  SkillRegistry,
+  SkillToolset,
+  UnsafeLocalCodeExecutor,
+} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {GeminiWithMockResponses} from '../test_case_utils.js';
+
+class MockSkillRegistry implements SkillRegistry {
+  private skillsMap = new Map<string, Skill>();
+
+  registerSkill(name: string, skill: Skill) {
+    this.skillsMap.set(name, skill);
+  }
+
+  async getSkill(name: string): Promise<Skill | undefined> {
+    return this.skillsMap.get(name);
+  }
+
+  async searchSkills(
+    query: string,
+  ): Promise<Array<{name: string; description: string}>> {
+    const results: Array<{name: string; description: string}> = [];
+    for (const [name, skill] of this.skillsMap.entries()) {
+      if (
+        name.includes(query) ||
+        skill.frontmatter.description?.includes(query)
+      ) {
+        results.push({
+          name,
+          description: skill.frontmatter.description || '',
+        });
+      }
+    }
+    return results;
+  }
+}
+
+describe('Skills Registry Integration', () => {
+  const remoteMathSkill: Skill = {
+    frontmatter: {
+      name: 'remote-math-skill',
+      description: 'A registry skill that handles math operations.',
+    },
+    instructions: 'When asked to solve math, double the number.',
+    resources: {
+      references: {
+        'formulas.txt': 'Double of X is 2*X',
+      },
+      scripts: {
+        'double.js': {
+          src: 'const args = process.argv; const val = parseInt(args[args.indexOf("--val") + 1]); console.log(val * 2);',
+        },
+      },
+    },
+  };
+
+  const remotePhysicsSkill: Skill = {
+    frontmatter: {
+      name: 'remote-physics-skill',
+      description: 'A registry skill for physics.',
+    },
+    instructions: 'Force = mass * acceleration.',
+  };
+
+  it('should search skills from registry, load a remote skill, and execute its scripts', async () => {
+    const registry = new MockSkillRegistry();
+    registry.registerSkill('remote-math-skill', remoteMathSkill);
+    registry.registerSkill('remote-physics-skill', remotePhysicsSkill);
+
+    const toolset = new SkillToolset([], {
+      registry,
+      codeExecutor: new UnsafeLocalCodeExecutor(),
+    });
+
+    const agent = new LlmAgent({
+      name: 'skills_agent',
+      description: 'An agent that uses skills.',
+      tools: [toolset],
+    });
+
+    agent.model = new GeminiWithMockResponses([
+      // Turn 1: Model response requests search_skills
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'search_skills',
+                    args: {query: 'math'},
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 2: Model response requests load_skill
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'load_skill',
+                    args: {name: 'remote-math-skill'},
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 3: Model response requests load_skill_resource
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'load_skill_resource',
+                    args: {
+                      skill_name: 'remote-math-skill',
+                      path: 'references/formulas.txt',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 4: Model response requests run_skill_script
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'run_skill_script',
+                    args: {
+                      skill_name: 'remote-math-skill',
+                      script_path: 'scripts/double.js',
+                      args: {
+                        val: 21,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      // Turn 5: Model final response
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{text: 'The result is 42.'}],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const runner = new InMemoryRunner({
+      agent,
+      appName: 'test_skills_app',
+    });
+
+    const session = await runner.sessionService.createSession({
+      appName: 'test_skills_app',
+      userId: 'test_user',
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'test_user',
+      sessionId: session.id,
+      newMessage: createUserContent('Help me solve some math.'),
+    })) {
+      events.push(event);
+    }
+
+    // Verify search_skills tool execution
+    const searchCallEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionCall?.name === 'search_skills',
+    );
+    expect(searchCallEvent).toBeDefined();
+
+    const searchResponseEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionResponse?.name === 'search_skills',
+    );
+    expect(searchResponseEvent).toBeDefined();
+    expect(
+      searchResponseEvent.content.parts[0].functionResponse.response,
+    ).toEqual({
+      results: [
+        {
+          name: 'remote-math-skill',
+          description: 'A registry skill that handles math operations.',
+        },
+      ],
+    });
+
+    // Verify load_skill tool execution
+    const loadCallEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionCall?.name === 'load_skill',
+    );
+    expect(loadCallEvent).toBeDefined();
+
+    const loadResponseEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionResponse?.name === 'load_skill',
+    );
+    expect(loadResponseEvent).toBeDefined();
+    expect(
+      loadResponseEvent.content.parts[0].functionResponse.response.instructions,
+    ).toBe('When asked to solve math, double the number.');
+
+    // Verify load_skill_resource tool execution
+    const resourceCallEvent = events.find(
+      (e) =>
+        e.content?.parts?.[0]?.functionCall?.name === 'load_skill_resource',
+    );
+    expect(resourceCallEvent).toBeDefined();
+
+    const resourceResponseEvent = events.find(
+      (e) =>
+        e.content?.parts?.[0]?.functionResponse?.name === 'load_skill_resource',
+    );
+    expect(resourceResponseEvent).toBeDefined();
+    expect(
+      resourceResponseEvent.content.parts[0].functionResponse.response.content,
+    ).toBe('Double of X is 2*X');
+
+    // Verify run_skill_script tool execution
+    const runCallEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionCall?.name === 'run_skill_script',
+    );
+    expect(runCallEvent).toBeDefined();
+
+    const runResponseEvent = events.find(
+      (e) =>
+        e.content?.parts?.[0]?.functionResponse?.name === 'run_skill_script',
+    );
+    expect(runResponseEvent).toBeDefined();
+    expect(
+      runResponseEvent.content.parts[0].functionResponse.response.stdout,
+    ).toContain('42');
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #423 (Stacked on top of PR #423)

**2. Or, if no issue exists, describe the change:**

**Problem:**
LLM agents are unaware of remote registry capabilities and cannot dynamically query registries for missing skills.

**Solution:**
Implement `SearchSkillsTool` and integrate it into the execution pipeline:
- Exposes semantic and keyword registry search directly to agents.
- Integrates with `SkillToolset` to automatically register the tool when a registry is present.
- Automatically appends search tips to system instructions on initialization.
- Safeguards against local duplicates (avoids loading conflicting remote skills).

This forms Part 3 of 3 of the modular Skills Registry PR stack. Please only review `core/src/tools/skill/search_skills_tool.ts`, integration in `skill_toolset.ts`, and corresponding tests.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

*Summary of passed npm test results:*
```
   ✓ skill_registry > SearchSkillsTool > throws error if toolset has no registry 4ms
   ✓ skill_registry > SearchSkillsTool > returns declaration with search_skills 1ms
   ✓ skill_registry > SearchSkillsTool > runAsync validates missing query 1ms
   ✓ skill_registry > SearchSkillsTool > runAsync searches registry and filters local skills 2ms
   ✓ skill_registry > SearchSkillsTool > runAsync returns error on registry exception 1ms
   ✓ skill_registry > SearchSkillsTool > runAsync returns error on string throw 1ms
   ✓ skill_registry > SkillToolset upgraded capabilities > processLlmRequest appends search instruction if registry configured 1ms
```
*Note: Achieved **100% line, statement, function, and branch coverage** on `search_skills_tool.ts`!*

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

### Additional context
Stacked on PR #423 (`feat-skills-registry-gcp`).