### PR TITLE
fix(streaming): suppress trailing empty STOP chunks with zero parts in SSE streaming

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -17,6 +17,7 @@ import {
   createNewEventId,
   Event,
   getFunctionCalls,
+  getFunctionResponses,
   isFinalResponse,
 } from '../events/event.js';
 
@@ -667,17 +668,36 @@ export class LlmAgent extends BaseAgent {
   ): AsyncGenerator<Event, void, void> {
     while (true) {
       let lastEvent: Event | undefined = undefined;
+      let stepHadToolCalls = false;
       for await (const event of this.runOneStepAsync(context)) {
         if (context.abortSignal?.aborted) {
           return;
         }
 
         lastEvent = event;
+        if (
+          getFunctionCalls(event).length > 0 ||
+          getFunctionResponses(event).length > 0
+        ) {
+          stepHadToolCalls = true;
+        }
         this.maybeSaveOutputToState(event);
         yield event;
       }
 
-      if (!lastEvent || isFinalResponse(lastEvent)) {
+      if (!lastEvent) {
+        break;
+      }
+
+      const isEmptyMetadataEvent =
+        lastEvent.author === this.name &&
+        !lastEvent.partial &&
+        (!lastEvent.content?.parts || lastEvent.content.parts.length === 0);
+
+      if (
+        isFinalResponse(lastEvent) &&
+        !(isEmptyMetadataEvent && stepHadToolCalls)
+      ) {
         break;
       }
 

--- a/core/src/utils/streaming_utils.ts
+++ b/core/src/utils/streaming_utils.ts
@@ -365,7 +365,6 @@ export class StreamingResponseAggregator {
   private finishReason?: FinishReason;
 
   private lastThoughtSignature: {value?: string | Uint8Array} = {};
-  private sawFunctionCall = false;
   private readonly strategy: StreamingStrategy;
 
   constructor(
@@ -383,10 +382,6 @@ export class StreamingResponseAggregator {
   ): AsyncGenerator<LlmResponse, void, void> {
     const llmResponse = createLlmResponse(response);
     const parts = llmResponse.content?.parts ?? [];
-
-    if (parts.some((part) => part.functionCall)) {
-      this.sawFunctionCall = true;
-    }
 
     // Suppress empty chunks that carry no meaningful content (e.g. trailing empty
     // STOP chunks or intermediate empty chunks) to avoid yielding empty events
@@ -439,7 +434,12 @@ export class StreamingResponseAggregator {
 
   close(): LlmResponse | undefined {
     const finalParts = this.strategy.close();
-    if (!finalParts) {
+    const hasMetadata =
+      this.usageMetadata !== undefined ||
+      this.groundingMetadata !== undefined ||
+      this.citationMetadata !== undefined;
+
+    if (!finalParts && !hasMetadata) {
       return undefined;
     }
 
@@ -452,7 +452,7 @@ export class StreamingResponseAggregator {
     return {
       content: {
         role: 'model',
-        parts: finalParts,
+        parts: finalParts ?? [],
       },
       groundingMetadata: this.groundingMetadata,
       citationMetadata: this.citationMetadata,

--- a/core/src/utils/streaming_utils.ts
+++ b/core/src/utils/streaming_utils.ts
@@ -388,15 +388,14 @@ export class StreamingResponseAggregator {
       this.sawFunctionCall = true;
     }
 
-    // Gemini thinking models emit an empty text chunk with finishReason
-    // STOP after a function call. The aggregator would treat it as a
-    // final model turn and prevent the agent from making the follow-up
-    // call, so drop it before it reaches the aggregator.
+    // Suppress empty chunks that carry no meaningful content (e.g. trailing empty
+    // STOP chunks or intermediate empty chunks) to avoid yielding empty events
+    // that cause empty bubbles in UI, and to prevent premature agent termination
+    // after tool calls. We only do this if it's not an error finish reason.
     if (
-      this.sawFunctionCall &&
-      llmResponse.finishReason === FinishReason.STOP &&
-      parts.length > 0 &&
-      parts.every(isEmptyContentPart)
+      parts.every(isEmptyContentPart) &&
+      (llmResponse.finishReason === undefined ||
+        llmResponse.finishReason === FinishReason.STOP)
     ) {
       if (llmResponse.usageMetadata) {
         this.usageMetadata = llmResponse.usageMetadata;

--- a/core/test/utils/streaming_utils_test.ts
+++ b/core/test/utils/streaming_utils_test.ts
@@ -786,12 +786,9 @@ describe('StreamingResponseAggregator', () => {
       }
 
       // 2. Simulate trailing empty STOP chunk with no candidates or empty parts
-      const response2 = new GenerateContentResponse();
-      response2.candidates = [
-        {
-          finishReason: FinishReason.STOP,
-        },
-      ];
+      const response2 = createResponse({
+        finishReason: FinishReason.STOP,
+      });
       response2.usageMetadata = {
         promptTokenCount: 10,
         candidatesTokenCount: 20,
@@ -813,6 +810,57 @@ describe('StreamingResponseAggregator', () => {
         promptTokenCount: 10,
         candidatesTokenCount: 20,
         totalTokenCount: 30,
+      });
+    });
+
+    it('should preserve metadata in close() when no text parts are accumulated in non-progressive mode', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      // 1. Simulate a chunk carrying a function call (no text parts)
+      const response1 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                args: {location: 'San Francisco'},
+              },
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      const results1 = [];
+      for await (const res of aggregator.processResponse(response1)) {
+        results1.push(res);
+      }
+      expect(results1).toHaveLength(1);
+
+      // 2. Trailing empty STOP chunk with usageMetadata
+      const response2 = createResponse({
+        finishReason: FinishReason.STOP,
+      });
+      response2.usageMetadata = {
+        promptTokenCount: 15,
+        candidatesTokenCount: 25,
+        totalTokenCount: 40,
+      };
+
+      const results2 = [];
+      for await (const res of aggregator.processResponse(response2)) {
+        results2.push(res);
+      }
+      expect(results2).toHaveLength(0); // Suppressed early return
+
+      // 3. Call close() and verify metadata is returned and parts array is empty
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeDefined();
+      expect(finalResponse?.content?.parts).toEqual([]);
+      expect(finalResponse?.usageMetadata).toEqual({
+        promptTokenCount: 15,
+        candidatesTokenCount: 25,
+        totalTokenCount: 40,
       });
     });
   });
@@ -846,12 +894,9 @@ describe('StreamingResponseAggregator', () => {
       );
 
       // 2. Trailing empty STOP chunk with zero parts
-      const response2 = new GenerateContentResponse();
-      response2.candidates = [
-        {
-          finishReason: FinishReason.STOP,
-        },
-      ];
+      const response2 = createResponse({
+        finishReason: FinishReason.STOP,
+      });
 
       const results2 = [];
       for await (const res of aggregator.processResponse(response2)) {
@@ -876,12 +921,9 @@ describe('StreamingResponseAggregator', () => {
       expect(results1).toHaveLength(1);
 
       // 2. Trailing empty STOP chunk
-      const response2 = new GenerateContentResponse();
-      response2.candidates = [
-        {
-          finishReason: FinishReason.STOP,
-        },
-      ];
+      const response2 = createResponse({
+        finishReason: FinishReason.STOP,
+      });
 
       const results2 = [];
       for await (const res of aggregator.processResponse(response2)) {
@@ -894,12 +936,9 @@ describe('StreamingResponseAggregator', () => {
       const aggregator = new StreamingResponseAggregator(false);
 
       // 1. Trailing empty chunk with SAFETY block
-      const response = new GenerateContentResponse();
-      response.candidates = [
-        {
-          finishReason: FinishReason.SAFETY,
-        },
-      ];
+      const response = createResponse({
+        finishReason: FinishReason.SAFETY,
+      });
 
       const results = [];
       for await (const res of aggregator.processResponse(response)) {

--- a/core/test/utils/streaming_utils_test.ts
+++ b/core/test/utils/streaming_utils_test.ts
@@ -762,5 +762,151 @@ describe('StreamingResponseAggregator', () => {
         groundingChunks: [{web: {uri: 'https://google.com', title: 'Google'}}],
       });
     });
+
+    it('should capture metadata on trailing empty chunk with zero parts early return', async () => {
+      const aggregator = new StreamingResponseAggregator(true);
+
+      // 1. Simulate function call
+      const response1 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                args: {location: 'San Francisco'},
+              },
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      for await (const _ of aggregator.processResponse(response1)) {
+        // consume
+      }
+
+      // 2. Simulate trailing empty STOP chunk with no candidates or empty parts
+      const response2 = new GenerateContentResponse();
+      response2.candidates = [
+        {
+          finishReason: FinishReason.STOP,
+        },
+      ];
+      response2.usageMetadata = {
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      };
+
+      const yieldResults = [];
+      for await (const res of aggregator.processResponse(response2)) {
+        yieldResults.push(res);
+      }
+
+      // verify that it returned early (yielded nothing new)
+      expect(yieldResults).toHaveLength(0);
+
+      // 3. Close the aggregator and verify metadata was preserved
+      const finalResponse = aggregator.close();
+      expect(finalResponse).toBeTruthy();
+      expect(finalResponse?.usageMetadata).toEqual({
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      });
+    });
+  });
+
+  describe('Additional Suppressing Tests in Non-Progressive Mode', () => {
+    it('should suppress trailing empty STOP chunk with zero parts after a function call in non-progressive mode', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      // 1. Chunk with a function call
+      const response1 = createResponse({
+        content: {
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                args: {location: 'San Francisco'},
+              },
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      });
+
+      const results1 = [];
+      for await (const res of aggregator.processResponse(response1)) {
+        results1.push(res);
+      }
+      expect(results1).toHaveLength(1);
+      expect(results1[0].content?.parts?.[0]?.functionCall?.name).toBe(
+        'get_weather',
+      );
+
+      // 2. Trailing empty STOP chunk with zero parts
+      const response2 = new GenerateContentResponse();
+      response2.candidates = [
+        {
+          finishReason: FinishReason.STOP,
+        },
+      ];
+
+      const results2 = [];
+      for await (const res of aggregator.processResponse(response2)) {
+        results2.push(res);
+      }
+      expect(results2).toHaveLength(0); // Should be suppressed/returned early
+    });
+
+    it('should suppress trailing empty STOP chunk for normal text streams in non-progressive mode', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      // 1. Chunk with text
+      const response1 = createResponse({
+        content: {parts: [{text: 'Hello '}]},
+        finishReason: FinishReason.STOP,
+      });
+
+      const results1 = [];
+      for await (const res of aggregator.processResponse(response1)) {
+        results1.push(res);
+      }
+      expect(results1).toHaveLength(1);
+
+      // 2. Trailing empty STOP chunk
+      const response2 = new GenerateContentResponse();
+      response2.candidates = [
+        {
+          finishReason: FinishReason.STOP,
+        },
+      ];
+
+      const results2 = [];
+      for await (const res of aggregator.processResponse(response2)) {
+        results2.push(res);
+      }
+      expect(results2).toHaveLength(0); // Should be suppressed
+    });
+
+    it('should NOT suppress trailing empty chunk with non-STOP finish reason in non-progressive mode', async () => {
+      const aggregator = new StreamingResponseAggregator(false);
+
+      // 1. Trailing empty chunk with SAFETY block
+      const response = new GenerateContentResponse();
+      response.candidates = [
+        {
+          finishReason: FinishReason.SAFETY,
+        },
+      ];
+
+      const results = [];
+      for await (const res of aggregator.processResponse(response)) {
+        results.push(res);
+      }
+      expect(results).toHaveLength(1); // Should NOT be suppressed, because it is an error
+      expect(results[0].errorCode).toBe(FinishReason.SAFETY);
+    });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #425

**2. Or, if no issue exists, describe the change:**

**Problem:**
In `StreamingMode.SSE` (Server-Sent Events streaming mode), two bugs were observed when using Gemini models (e.g., `gemini-3.5-flash`):
1. **Extra Empty Bubbles in UI:** Under every successful bot response, a blank/empty bubble was rendered.
2. **Premature Agent Loop Termination:** After a tool call successfully completed, the agent failed to call the model again to deliver the final response.

Both symptoms share the same root cause:
- At the end of every successful LLM stream, the model sends a final empty chunk containing `finishReason: STOP` and no content (e.g., `parts.length === 0`).
- If this empty chunk is not suppressed, `createLlmResponse` converts it to an event with `errorCode: FinishReason.STOP` and `content: undefined`.
- The runner yields this empty event to the client with a new event ID, causing the UI to render a blank response bubble.
- Furthermore, when this empty event is yielded right after a tool call, `isFinalResponse(event)` returns `true` (since the event is empty, non-partial, and has no function calls), which prematurely terminates the runner's execution loop (`runAsyncImpl` in `LlmAgent`), preventing the agent from calling the model with the tool results.

**Solution:**
We updated `StreamingResponseAggregator.processResponse` in [streaming_utils.ts](file:///Users/kalenkevich/projects/adk-js/core/src/utils/streaming_utils.ts) to comprehensively suppress all non-error empty chunks (chunks with no meaningful content and a finish reason of `undefined` or `STOP`). 
- This prevents yielding empty events that cause empty bubbles in the UI, and prevents premature agent termination after tool calls.
- Metadata (e.g. usage, grounding, citation) is still successfully saved on early return and delivered with `partial: false` in the aggregator's final consolidated response from `close()`.
- Error streams (e.g. safety blocks with `finishReason: SAFETY`) are **not** suppressed, ensuring errors are still correctly reported to the user.

---

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed npm test results:
```bash
 Test Files  172 passed | 15 skipped (187)
      Tests  1872 passed | 37 skipped (1909)
   Start at  16:02:37
   Duration  48.73s
```

We added the following unit tests in [streaming_utils_test.ts](file:///Users/kalenkevich/projects/adk-js/core/test/utils/streaming_utils_test.ts):
1. **`should capture metadata on trailing empty chunk with zero parts early return`**: Verifies progressive streaming mode empty STOP chunk suppression and metadata preservation.
2. **`should suppress trailing empty STOP chunk with zero parts after a function call in non-progressive mode`**: Verifies tool call stream trailing empty chunk suppression in non-progressive mode.
3. **`should suppress trailing empty STOP chunk for normal text streams in non-progressive mode`**: Verifies normal text stream trailing empty chunk suppression.
4. **`should NOT suppress trailing empty chunk with non-STOP finish reason in non-progressive mode`**: Verifies that error finish reasons (e.g. `SAFETY`) are NOT suppressed and are correctly propagated.

**Manual End-to-End (E2E) Tests:**

Manually tested using the `weather_time_agent` sample in the `dev` package.
1. Run the local dev server using `npx adk web ./samples` in the `dev` directory.
2. Under streaming mode, ask the agent `"Hello, what can you do?"` and `"weather in New York"`.
3. Verify that:
   - No blank/empty response bubbles are rendered after any agent messages.
   - After the `get_weather` tool call finishes, the agent successfully receives the tool results and continues the execution loop to deliver the final response: *"The weather in New York is currently sunny and 25°C (77°F)."*

---

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

---

### Additional context