### PR TITLE
Block 127.0.0.0/8 and cloud-metadata hostnames in OAuth2 discovery SSRF check

### DIFF
--- a/core/src/auth/oauth2/oauth2_discovery.ts
+++ b/core/src/auth/oauth2/oauth2_discovery.ts
@@ -201,10 +201,12 @@ function validateDiscoveryUrl(urlStr: string): boolean {
 
     const host = normaliseHostname(url.hostname.toLowerCase());
 
-    // Block localhost and common private IP ranges
+    // Block localhost, cloud metadata, and common private IP ranges
     if (
       host === 'localhost' ||
-      host === '127.0.0.1' ||
+      host === 'metadata.google.internal' ||
+      host === 'metadata.goog' ||
+      host.startsWith('127.') ||
       host === '[::1]' ||
       host === '0.0.0.0' ||
       host.startsWith('10.') ||

--- a/core/test/auth/oauth2/oauth2_discovery_test.ts
+++ b/core/test/auth/oauth2/oauth2_discovery_test.ts
@@ -44,6 +44,18 @@ describe('OAuth2DiscoveryManager', () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
+    it('blocks 127.0.0.0/8 and cloud-metadata hostnames', async () => {
+      for (const url of [
+        'https://127.0.0.2',
+        'https://metadata.google.internal',
+        'https://metadata.goog',
+      ]) {
+        expect(await manager.discoverAuthServerMetadata(url)).toBeUndefined();
+      }
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
     it('tries endpoints in order if path is present', async () => {
       const issuerUrl = 'https://example.com/api';
 


### PR DESCRIPTION
## Summary

`validateDiscoveryUrl` (`core/src/auth/oauth2/oauth2_discovery.ts`) gates the `fetch()` in OAuth2 metadata discovery against SSRF. Following the SSRF hardening in #354, two reachable internal targets remain allowed:

1. **`127.0.0.0/8` loopback** — the check is exact-match `host === '127.0.0.1'`, so `https://127.0.0.2` (and the rest of the range) is allowed. `normaliseHostname()` even un-maps `[::ffff:7f00:2]` → `127.0.0.2`, which then passes.
2. **Cloud metadata by hostname** — the blocklist is IP-literal only, so the canonical GCP metadata endpoint `metadata.google.internal` (and `metadata.goog`) is allowed even though `169.254.169.254` is blocked.

The handler's own test suite asserts that loopback/`localhost` discovery URLs must be rejected, so blocking these is by-design; the existing fix is just incomplete.

## Change

- Replace the exact-match loopback check with a `127.` prefix check (whole `127.0.0.0/8`).
- Block `metadata.google.internal` and `metadata.goog`.
- Add regression tests for `127.0.0.2`, `metadata.google.internal`, `metadata.goog`.

Existing allowed hosts are unaffected.
