### PR TITLE
feat: enable concurrent replacement with key deduplication

### DIFF
--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -31,6 +31,9 @@ async function resolveKey(
       filename: fileName,
     });
     if (!artifact) {
+      if (isOptional) {
+        return '';
+      }
       throw new Error(`Artifact ${fileName} not found.`);
     }
     return String(artifact);
@@ -88,48 +91,72 @@ export async function injectSessionState(
     return template;
   }
 
-  // Map of unique placeholder specifier -> resolution promise
-  const resolutions = new Map<string, Promise<string>>();
-
-  const getSpecifier = (key: string, isOptional: boolean) => {
-    return `${key}${isOptional ? '?' : ''}`;
-  };
-
-  for (const match of matches) {
-    const rawMatch = match[0];
-    let key = rawMatch.replace(/^\{+/, '').replace(/\}+$/, '').trim();
+  // Pre-parse matches to avoid redundant string manipulation in loops
+  const parsedMatches = matches.map((match) => {
+    const raw = match[0];
+    let key = raw.replace(/^\{+/, '').replace(/\}+$/, '').trim();
     const isOptional = key.endsWith('?');
     if (isOptional) {
       key = key.slice(0, -1);
     }
+    const isValid = key.startsWith('artifact.') || isValidStateName(key);
+    return {
+      raw,
+      key,
+      isOptional,
+      isValid,
+      index: match.index!,
+    };
+  });
 
-    const specifier = getSpecifier(key, isOptional);
-    if (!resolutions.has(specifier)) {
-      resolutions.set(
-        specifier,
-        resolveKey(key, isOptional, rawMatch, readonlyContext),
-      );
+  // Deduplicate only valid keys by base key, merging optionality
+  const uniqueKeys = new Map<
+    string,
+    {key: string; isOptional: boolean; raw: string}
+  >();
+
+  for (const pm of parsedMatches) {
+    if (!pm.isValid) {
+      continue;
+    }
+    const existing = uniqueKeys.get(pm.key);
+    if (existing) {
+      if (existing.isOptional && !pm.isOptional) {
+        existing.isOptional = false;
+      }
+    } else {
+      uniqueKeys.set(pm.key, {
+        key: pm.key,
+        isOptional: pm.isOptional,
+        raw: pm.raw,
+      });
     }
   }
 
-  // Trigger concurrent resolution of all unique keys
+  // Map of unique key -> resolution promise
+  const resolutions = new Map<string, Promise<string>>();
+  for (const info of uniqueKeys.values()) {
+    resolutions.set(
+      info.key,
+      resolveKey(info.key, info.isOptional, info.raw, readonlyContext),
+    );
+  }
+
+  // Trigger concurrent resolution
   await Promise.all(resolutions.values());
 
+  // Reconstruct template using pre-parsed matches
   const result: string[] = [];
   let lastEnd = 0;
-  for (const match of matches) {
-    const rawMatch = match[0];
-    let key = rawMatch.replace(/^\{+/, '').replace(/\}+$/, '').trim();
-    const isOptional = key.endsWith('?');
-    if (isOptional) {
-      key = key.slice(0, -1);
+  for (const pm of parsedMatches) {
+    result.push(template.slice(lastEnd, pm.index));
+    if (pm.isValid) {
+      const replacement = await resolutions.get(pm.key)!;
+      result.push(replacement);
+    } else {
+      result.push(pm.raw);
     }
-    const specifier = getSpecifier(key, isOptional);
-
-    result.push(template.slice(lastEnd, match.index));
-    const replacement = await resolutions.get(specifier)!;
-    result.push(replacement);
-    lastEnd = match.index! + rawMatch.length;
+    lastEnd = pm.index + pm.raw.length;
   }
   result.push(template.slice(lastEnd));
   return result.join('');

--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -8,6 +8,51 @@ import {State} from '../sessions/state.js';
 import {ReadonlyContext} from './readonly_context.js';
 
 /**
+ * Resolves a single key from the context (state or artifact).
+ */
+async function resolveKey(
+  key: string,
+  isOptional: boolean,
+  rawMatch: string,
+  readonlyContext: ReadonlyContext,
+): Promise<string> {
+  const invocationContext = readonlyContext.invocationContext;
+
+  // Step 2: handle artifact injection
+  if (key.startsWith('artifact.')) {
+    const fileName = key.substring('artifact.'.length);
+    if (invocationContext.artifactService === undefined) {
+      throw new Error('Artifact service is not initialized.');
+    }
+    const artifact = await invocationContext.artifactService.loadArtifact({
+      appName: invocationContext.session.appName,
+      userId: invocationContext.session.userId,
+      sessionId: invocationContext.session.id,
+      filename: fileName,
+    });
+    if (!artifact) {
+      throw new Error(`Artifact ${fileName} not found.`);
+    }
+    return String(artifact);
+  }
+
+  // Step 3: Handle state variable injection.
+  if (!isValidStateName(key)) {
+    return rawMatch;
+  }
+
+  if (key in invocationContext.session.state) {
+    return String(invocationContext.session.state[key]);
+  }
+
+  if (isOptional) {
+    return '';
+  }
+
+  throw new Error(`Context variable not found: \`${key}\`.`);
+}
+
+/**
  * Populates values in the instruction template, e.g. state, artifact, etc.
  *
  * ```
@@ -36,69 +81,55 @@ export async function injectSessionState(
   template: string,
   readonlyContext: ReadonlyContext,
 ): Promise<string> {
-  const invocationContext = readonlyContext.invocationContext;
+  const pattern = /\{+[^{}]*}+/g;
+  const matches = Array.from(template.matchAll(pattern));
 
-  /**
-   * Replaces a matched string in the template with the corresponding value from
-   * the context.
-   *
-   * @param match The matched string in the template.
-   * @returns The replaced string.
-   */
-  async function replaceMatchedKeyWithItsValue(
-    match: RegExpMatchArray,
-  ): Promise<string> {
-    // Step 1: extract the key from the match
-    let key = match[0].replace(/^\{+/, '').replace(/\}+$/, '').trim();
+  if (matches.length === 0) {
+    return template;
+  }
+
+  // Map of unique placeholder specifier -> resolution promise
+  const resolutions = new Map<string, Promise<string>>();
+
+  const getSpecifier = (key: string, isOptional: boolean) => {
+    return `${key}${isOptional ? '?' : ''}`;
+  };
+
+  for (const match of matches) {
+    const rawMatch = match[0];
+    let key = rawMatch.replace(/^\{+/, '').replace(/\}+$/, '').trim();
     const isOptional = key.endsWith('?');
     if (isOptional) {
       key = key.slice(0, -1);
     }
 
-    // Step 2: handle artifact injection
-    if (key.startsWith('artifact.')) {
-      const fileName = key.substring('artifact.'.length);
-      if (invocationContext.artifactService === undefined) {
-        throw new Error('Artifact service is not initialized.');
-      }
-      const artifact = await invocationContext.artifactService.loadArtifact({
-        appName: invocationContext.session.appName,
-        userId: invocationContext.session.userId,
-        sessionId: invocationContext.session.id,
-        filename: fileName,
-      });
-      if (!artifact) {
-        throw new Error(`Artifact ${fileName} not found.`);
-      }
-      return String(artifact);
+    const specifier = getSpecifier(key, isOptional);
+    if (!resolutions.has(specifier)) {
+      resolutions.set(
+        specifier,
+        resolveKey(key, isOptional, rawMatch, readonlyContext),
+      );
     }
-
-    // Step 3: Handle state variable injection.
-    if (!isValidStateName(key)) {
-      return match[0];
-    }
-
-    if (key in invocationContext.session.state) {
-      return String(invocationContext.session.state[key]);
-    }
-
-    if (isOptional) {
-      return '';
-    }
-
-    throw new Error(`Context variable not found: \`${key}\`.`);
   }
-  // TODO - b/425992518: enable concurrent repalcement with key deduplication.
-  const pattern = /\{+[^{}]*}+/g;
+
+  // Trigger concurrent resolution of all unique keys
+  await Promise.all(resolutions.values());
+
   const result: string[] = [];
   let lastEnd = 0;
-  const matches = template.matchAll(pattern);
-
   for (const match of matches) {
+    const rawMatch = match[0];
+    let key = rawMatch.replace(/^\{+/, '').replace(/\}+$/, '').trim();
+    const isOptional = key.endsWith('?');
+    if (isOptional) {
+      key = key.slice(0, -1);
+    }
+    const specifier = getSpecifier(key, isOptional);
+
     result.push(template.slice(lastEnd, match.index));
-    const replacement = await replaceMatchedKeyWithItsValue(match);
+    const replacement = await resolutions.get(specifier)!;
     result.push(replacement);
-    lastEnd = match.index! + match[0].length;
+    lastEnd = match.index! + rawMatch.length;
   }
   result.push(template.slice(lastEnd));
   return result.join('');

--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -7,6 +7,8 @@
 import {State} from '../sessions/state.js';
 import {ReadonlyContext} from './readonly_context.js';
 
+const ARTIFACT_PREFIX = 'artifact.';
+
 /**
  * Resolves a single key from the context (state or artifact).
  */
@@ -19,8 +21,8 @@ async function resolveKey(
   const invocationContext = readonlyContext.invocationContext;
 
   // Step 2: handle artifact injection
-  if (key.startsWith('artifact.')) {
-    const fileName = key.substring('artifact.'.length);
+  if (key.startsWith(ARTIFACT_PREFIX)) {
+    const fileName = key.substring(ARTIFACT_PREFIX.length);
     if (invocationContext.artifactService === undefined) {
       throw new Error('Artifact service is not initialized.');
     }
@@ -99,7 +101,7 @@ export async function injectSessionState(
     if (isOptional) {
       key = key.slice(0, -1);
     }
-    const isValid = key.startsWith('artifact.') || isValidStateName(key);
+    const isValid = key.startsWith(ARTIFACT_PREFIX) || isValidStateName(key);
     return {
       raw,
       key,

--- a/core/test/agents/instructions_test.ts
+++ b/core/test/agents/instructions_test.ts
@@ -186,6 +186,16 @@ describe('injectSessionState', () => {
       ).rejects.toThrow('Artifact missing.txt not found.');
     });
 
+    it('resolves missing optional artifact to empty string', async () => {
+      const mockArtifactService = {
+        loadArtifact: vi.fn().mockResolvedValue(null),
+      };
+
+      const ctx = makeContext({}, mockArtifactService);
+      const result = await injectSessionState('{artifact.missing.txt?}', ctx);
+      expect(result).toBe('');
+    });
+
     it('deduplicates artifact loads', async () => {
       const fakeArtifact = 'artifact content';
       const mockArtifactService = {
@@ -225,5 +235,26 @@ describe('injectSessionState', () => {
       expect(callOrder[0]).toBe('start:r1.txt');
       expect(callOrder[1]).toBe('start:r2.txt');
     });
+  });
+
+  it('resolves mixed required and optional placeholders for the same key', async () => {
+    const ctx = makeContext({'user:name': 'Alice'});
+    expect(
+      await injectSessionState('Hello {user:name} and {user:name?}!', ctx),
+    ).toBe('Hello Alice and Alice!');
+  });
+
+  it('throws when mixed required and optional placeholders are missing the key', async () => {
+    const ctx = makeContext({});
+    await expect(
+      injectSessionState('Hello {user:name} and {user:name?}!', ctx),
+    ).rejects.toThrow('Context variable not found: `user:name`');
+  });
+
+  it('keeps invalid placeholders as-is even when mixed', async () => {
+    const ctx = makeContext({});
+    expect(
+      await injectSessionState('Hello {invalid key?} and {invalid key}!', ctx),
+    ).toBe('Hello {invalid key?} and {invalid key}!');
   });
 });

--- a/core/test/agents/instructions_test.ts
+++ b/core/test/agents/instructions_test.ts
@@ -47,6 +47,20 @@ describe('injectSessionState', () => {
     );
   });
 
+  it('deduplicates state variable lookups', async () => {
+    let accessCount = 0;
+    const state = {
+      get name() {
+        accessCount++;
+        return 'Alice';
+      },
+    };
+    const ctx = makeContext(state);
+    const result = await injectSessionState('Hello {name} and {name}!', ctx);
+    expect(result).toBe('Hello Alice and Alice!');
+    expect(accessCount).toBe(1);
+  });
+
   it('coerces numeric state values to string', async () => {
     const ctx = makeContext({count: 42});
     expect(await injectSessionState('count={count}', ctx)).toBe('count=42');
@@ -86,6 +100,32 @@ describe('injectSessionState', () => {
     expect(await injectSessionState('value={invalid key}', ctx)).toBe(
       'value={invalid key}',
     );
+  });
+
+  it('passes through keys with too many colons', async () => {
+    const ctx = makeContext({});
+    expect(await injectSessionState('value={a:b:c}', ctx)).toBe(
+      'value={a:b:c}',
+    );
+  });
+
+  it('passes through keys with invalid prefixes', async () => {
+    const ctx = makeContext({});
+    expect(await injectSessionState('value={invalid:key}', ctx)).toBe(
+      'value={invalid:key}',
+    );
+  });
+
+  it('passes through keys with valid prefix but invalid identifier', async () => {
+    const ctx = makeContext({});
+    expect(await injectSessionState('value={app:invalid key}', ctx)).toBe(
+      'value={app:invalid key}',
+    );
+  });
+
+  it('passes through empty placeholders', async () => {
+    const ctx = makeContext({});
+    expect(await injectSessionState('value={}', ctx)).toBe('value={}');
   });
 
   it('replaces app: prefixed keys', async () => {
@@ -144,6 +184,46 @@ describe('injectSessionState', () => {
       await expect(
         injectSessionState('{artifact.missing.txt}', ctx),
       ).rejects.toThrow('Artifact missing.txt not found.');
+    });
+
+    it('deduplicates artifact loads', async () => {
+      const fakeArtifact = 'artifact content';
+      const mockArtifactService = {
+        loadArtifact: vi.fn().mockResolvedValue(fakeArtifact),
+      };
+
+      const ctx = makeContext({}, mockArtifactService);
+      const result = await injectSessionState(
+        'data={artifact.report.txt} and {artifact.report.txt}',
+        ctx,
+      );
+      expect(result).toBe('data=artifact content and artifact content');
+      expect(mockArtifactService.loadArtifact).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves artifacts concurrently', async () => {
+      const delays: Record<string, number> = {
+        'r1.txt': 50,
+        'r2.txt': 50,
+      };
+      const callOrder: string[] = [];
+      const mockArtifactService = {
+        loadArtifact: vi.fn().mockImplementation(async ({filename}) => {
+          callOrder.push(`start:${filename}`);
+          await new Promise((resolve) => setTimeout(resolve, delays[filename]));
+          callOrder.push(`end:${filename}`);
+          return `content:${filename}`;
+        }),
+      };
+
+      const ctx = makeContext({}, mockArtifactService);
+      const result = await injectSessionState(
+        '{artifact.r1.txt} and {artifact.r2.txt}',
+        ctx,
+      );
+      expect(result).toBe('content:r1.txt and content:r2.txt');
+      expect(callOrder[0]).toBe('start:r1.txt');
+      expect(callOrder[1]).toBe('start:r2.txt');
     });
   });
 });


### PR DESCRIPTION
### Link to Issue or Description of Change

Or, if no issue exists, describe the change:

**Problem:**
The `injectSessionState` function in `adk-js` resolved placeholders sequentially. If the same placeholder (especially artifacts) was used multiple times, it resulted in redundant and slow service calls. It also lacked concurrency for resolving different placeholders.

**Solution:**
Refactored `injectSessionState` to:

1. Parse all placeholders in the template.
2. Deduplicate them based on their normalized key and optionality.
3. Resolve unique placeholders concurrently using `Promise.all`.
4. Reconstruct the template with the resolved values.
5. Extracted the resolution logic to a standalone function `resolveKey` at the module level.
6. Support optional artifacts (`{artifact.name?}`) by resolving to `""` if missing (closing parity gap with Python).
7. Skip resolving invalid placeholders, leaving them as-is.
8. Extracted `"artifact."` prefix to a constant `ARTIFACT_PREFIX` to avoid literals.

### Testing Plan

Unit Tests:

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed results:

- Added a unit test `loads artifact only once when duplicate placeholders are present` to verify that duplicate artifact placeholders only trigger a single load call.
- Added unit tests for optional artifacts (`resolves missing optional artifact to empty string`), mixed required/optional placeholders, and invalid placeholder passthrough.
- Verified all unit tests pass.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.