### PR TITLE
fix: update default server port from 8000 to 8080

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -105,8 +105,8 @@ const HOST_OPTION = new Option(
 ).default('localhost');
 const PORT_OPTION = new Option(
   '-p, --port <number>',
-  'Optional. The port of the server. Default: 8080',
-).default('8080');
+  'Optional. The port of the server. Default: 8000',
+).default('8000');
 const ORIGINS_OPTION = new Option(
   '--allow_origins <string>',
   'Optional. The allow origins of the server',
@@ -436,7 +436,6 @@ export function createProgram(): Command {
       .addArgument(AGENT_DIR_ARGUMENT)
       .allowUnknownOption()
       .allowExcessArguments()
-      .addOption(PORT_OPTION)
       .addOption(PROJECT_DEPLOY_OPTION)
       .addOption(REGION_DEPLOY_OPTION)
       .addOption(DISPLAY_NAME_OPTION)
@@ -466,7 +465,7 @@ export function createProgram(): Command {
             displayName: options['display_name'],
             description: options['description'],
             tempFolder: options['temp_folder'],
-            port: parseInt(options['port'], 10),
+            port: 8080, // Agent Engine requires fixed port of 8080
             withUi: getBoolean(options['with_ui']),
             logLevel: options['log_level'],
             adkVersion: options['adk_version'],

--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -105,8 +105,8 @@ const HOST_OPTION = new Option(
 ).default('localhost');
 const PORT_OPTION = new Option(
   '-p, --port <number>',
-  'Optional. The port of the server',
-).default('8000');
+  'Optional. The port of the server. Default: 8080',
+).default('8080');
 const ORIGINS_OPTION = new Option(
   '--allow_origins <string>',
   'Optional. The allow origins of the server',

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -9,6 +9,7 @@ import {afterEach, beforeEach, describe, expect, it, Mock, vi} from 'vitest';
 import {createProgram} from '../../src/cli/cli.js';
 import {createAgent} from '../../src/cli/cli_create.js';
 import {runAgent} from '../../src/cli/cli_run.js';
+import {deployToAgentEngine} from '../../src/cli/deploy/cli_deploy_agent_engine.js';
 import {deployToCloudRun} from '../../src/cli/deploy/cli_deploy_cloud_run.js';
 import {AdkApiServer} from '../../src/server/adk_api_server.js';
 
@@ -22,6 +23,10 @@ vi.mock('../../src/server/adk_api_server', () => {
 
 vi.mock('../../src/cli/cli_create', () => ({
   createAgent: vi.fn(),
+}));
+
+vi.mock('../../src/cli/deploy/cli_deploy_agent_engine', () => ({
+  deployToAgentEngine: vi.fn(),
 }));
 
 vi.mock('../../src/cli/deploy/cli_deploy_cloud_run', () => ({
@@ -88,7 +93,7 @@ describe('CLI Entrypoint', () => {
       expect(AdkApiServer).toHaveBeenCalled();
       const args = (AdkApiServer as unknown as Mock).mock.calls[0]?.[0];
       expect(args).toBeDefined();
-      expect(args.port).toBe(8080);
+      expect(args.port).toBe(8000);
       expect(args.serveDebugUI).toBe(true);
       expect(args.a2a).toBe(false);
 
@@ -251,7 +256,7 @@ describe('CLI Entrypoint', () => {
 
       expect(deployToCloudRun).toHaveBeenCalledWith(
         expect.objectContaining({
-          port: 8080,
+          port: 8000,
           serviceName: 'adk-default-service-name',
           adkVersion: 'latest',
           withUi: false,
@@ -297,6 +302,69 @@ describe('CLI Entrypoint', () => {
       expect((deployToCloudRun as Mock).mock.calls[0][0]).toMatchObject({
         a2a: true,
       });
+    });
+  });
+
+  describe('command: deploy agent_engine', () => {
+    it('should call deployToAgentEngine with defaults', async () => {
+      await parse(['deploy', 'agent_engine']);
+
+      expect(deployToAgentEngine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          port: 8080,
+          adkVersion: 'latest',
+          withUi: false,
+        }),
+      );
+    });
+
+    it('should pass args to deployToAgentEngine', async () => {
+      const args = [
+        'deploy',
+        'agent_engine',
+        './my-agent-path',
+        '--project=my-proj',
+        '--region=us-west1',
+        '--display_name=my-display-name',
+        '--description=my-description',
+        '--with_ui',
+        '--adk_version=1.0.0',
+      ];
+
+      await parse(args);
+
+      expect((deployToAgentEngine as Mock).mock.calls[0][0]).toMatchObject({
+        agentPath: expect.stringContaining('my-agent-path'),
+        project: 'my-proj',
+        region: 'us-west1',
+        displayName: 'my-display-name',
+        description: 'my-description',
+        port: 8080,
+        withUi: true,
+        adkVersion: '1.0.0',
+      });
+    });
+
+    it('should pass a2a flag to deployToAgentEngine when --a2a is set', async () => {
+      await parse(['deploy', 'agent_engine', '--a2a']);
+
+      expect((deployToAgentEngine as Mock).mock.calls[0][0]).toMatchObject({
+        a2a: true,
+      });
+    });
+  });
+
+  describe('command: deploy reasoning_engine', () => {
+    it('should call deployToAgentEngine for reasoning_engine', async () => {
+      await parse(['deploy', 'reasoning_engine']);
+
+      expect(deployToAgentEngine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          port: 8080,
+          adkVersion: 'latest',
+          withUi: false,
+        }),
+      );
     });
   });
 });

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -88,7 +88,7 @@ describe('CLI Entrypoint', () => {
       expect(AdkApiServer).toHaveBeenCalled();
       const args = (AdkApiServer as unknown as Mock).mock.calls[0]?.[0];
       expect(args).toBeDefined();
-      expect(args.port).toBe(8000);
+      expect(args.port).toBe(8080);
       expect(args.serveDebugUI).toBe(true);
       expect(args.a2a).toBe(false);
 
@@ -251,7 +251,7 @@ describe('CLI Entrypoint', () => {
 
       expect(deployToCloudRun).toHaveBeenCalledWith(
         expect.objectContaining({
-          port: 8000,
+          port: 8080,
           serviceName: 'adk-default-service-name',
           adkVersion: 'latest',
           withUi: false,


### PR DESCRIPTION
#438 

The default port for the ADK CLI (api_server and web commands) needs to be updated from 8000 to 8080.

## Context & Necessity
Google Cloud Agent Engine's underlying infrastructure runs on top of Google Cloud Run, which expects the deployed container to listen on and expose port 8080 by default.

Currently, when deploying to Agent Engine, the custom port option specified via the CLI or configuration is not fully passed down/honored by the underlying Agent Engine orchestration layers. As a result, if the ADK server defaults to port 8000, the container will listen on 8000, but Cloud Run will attempt to route traffic and health checks to port 8080. This mismatch causes deployment to fail with container startup timeouts or health check failures.

By changing the default port in the ADK CLI to 8080, we ensure that out-of-the-box deployments align with the Cloud Run / Agent Engine expectations without requiring manual port configuration or facing deployment failures.