### PR TITLE
feat(devtools): add Reasoning Engine server compatibility routes and headers parser (Agent Engine Deployment Artifact registry fix part 1)

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -738,17 +738,16 @@ export class AdkApiServer {
 
       try {
         const events: Event[] = [];
-        await this.executeAgentRun({
+        for await (const e of this.executeAgentRun({
           appName,
           userId,
           sessionId,
           newMessage,
           stateDelta,
           abortSignal: abortController.signal,
-          onEvent: (e) => {
-            events.push(e);
-          },
-        });
+        })) {
+          events.push(e);
+        }
 
         responseCompleted = true;
         res.json(events);
@@ -790,17 +789,16 @@ export class AdkApiServer {
           req.on('close', () => {
             abortController.abort();
           });
-          await this.executeAgentRun({
+          for await (const e of this.executeAgentRun({
             appName,
             userId,
             sessionId,
             newMessage,
             stateDelta,
             abortSignal: abortController.signal,
-            onEvent: (e) => {
-              events.push(e);
-            },
-          });
+          })) {
+            events.push(e);
+          }
           res.json({output: events});
         } catch (e: unknown) {
           const error = `Failed to run agent via Reasoning Engine API: ${e}`;
@@ -873,7 +871,7 @@ export class AdkApiServer {
         res.setHeader('Connection', 'keep-alive');
         res.flushHeaders();
 
-        await this.executeAgentRun({
+        for await (const event of this.executeAgentRun({
           appName,
           userId,
           sessionId,
@@ -883,10 +881,9 @@ export class AdkApiServer {
             streamingMode: streaming ? StreamingMode.SSE : StreamingMode.NONE,
           },
           abortSignal: abortController.signal,
-          onEvent: (event) => {
-            res.write(`data: ${JSON.stringify(event)}\n\n`);
-          },
-        });
+        })) {
+          res.write(`data: ${JSON.stringify(event)}\n\n`);
+        }
 
         responseCompleted = true;
         res.end();
@@ -982,7 +979,7 @@ export class AdkApiServer {
     return this.runnerCache[appName];
   }
 
-  private async executeAgentRun(options: {
+  private async *executeAgentRun(options: {
     appName: string;
     userId: string;
     sessionId: string;
@@ -990,23 +987,20 @@ export class AdkApiServer {
     stateDelta?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     runConfig?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     abortSignal: AbortSignal;
-    onEvent: (event: Event) => void | Promise<void>;
-  }) {
+  }): AsyncGenerator<Event, void, undefined> {
     await using agentFile = await this.agentLoader.getAgentFile(
       options.appName,
     );
     const agent = await agentFile.load();
     const runner = await this.getRunner(agent, options.appName);
 
-    for await (const event of runner.runAsync({
+    yield* runner.runAsync({
       userId: options.userId,
       sessionId: options.sessionId,
       newMessage: options.newMessage,
       runConfig: options.runConfig,
       stateDelta: options.stateDelta,
       abortSignal: options.abortSignal,
-    })) {
-      await options.onEvent(event);
-    }
+    });
   }
 }

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -172,6 +172,13 @@ export class AdkApiServer {
           },
         }),
       );
+    } else {
+      app.get('/health', (req: Request, res: Response) => {
+        res.status(200).send('OK');
+      });
+      app.get('/', (req: Request, res: Response) => {
+        res.status(200).send('OK');
+      });
     }
 
     if (this.allowOrigins) {
@@ -753,6 +760,82 @@ export class AdkApiServer {
         res.status(500).json({error});
         this.logger.error(error);
       }
+    });
+
+    app.post('/api/reasoning_engine', async (req: Request, res: Response) => {
+      this.logger.info(
+        `Received Reasoning Engine query headers: ${JSON.stringify(req.headers)}`,
+      );
+      let rawBody = '';
+      req.on('data', (chunk) => {
+        rawBody += chunk;
+      });
+      req.on('end', async () => {
+        this.logger.info(`Received Reasoning Engine raw body: ${rawBody}`);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let body: any = {};
+        if (rawBody) {
+          try {
+            body = JSON.parse(rawBody);
+          } catch (e) {
+            this.logger.error(`Failed to parse raw body as JSON: ${e}`);
+          }
+        } else {
+          body = req.body || {};
+        }
+        this.logger.info(`Parsed body: ${JSON.stringify(body)}`);
+        const input = body.input || {};
+        const appName = input.appName || body.appName;
+        const userId = input.userId || body.userId || 'default-user';
+        const sessionId =
+          input.sessionId || body.sessionId || 'default-session';
+        const newMessage = input.newMessage || body.newMessage;
+        const stateDelta = input.stateDelta || body.stateDelta;
+        if (!appName) {
+          res.status(400).json({error: 'appName is required in input'});
+          return;
+        }
+        try {
+          let session = await this.sessionService.getSession({
+            appName,
+            userId,
+            sessionId,
+          });
+          if (!session) {
+            this.logger.info(
+              `Session ${sessionId} not found. Creating it automatically.`,
+            );
+            session = await this.sessionService.createSession({
+              appName,
+              userId,
+              sessionId,
+              state: {},
+            });
+          }
+          await using agentFile = await this.agentLoader.getAgentFile(appName);
+          const agent = await agentFile.load();
+          const runner = await this.getRunner(agent, appName);
+          const events: Event[] = [];
+          const abortController = new AbortController();
+          req.on('close', () => {
+            abortController.abort();
+          });
+          for await (const e of runner.runAsync({
+            userId,
+            sessionId,
+            newMessage,
+            stateDelta,
+            abortSignal: abortController.signal,
+          })) {
+            events.push(e);
+          }
+          res.json({output: events});
+        } catch (e: unknown) {
+          const error = `Failed to run agent via Reasoning Engine API: ${e}`;
+          res.status(500).json({error});
+          this.logger.error(error);
+        }
+      });
     });
 
     app.post('/run_sse', async (req: Request, res: Response) => {

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -17,10 +17,12 @@ import {
   InMemorySessionService,
   Logger,
   LogLevel,
+  RunConfig,
   Runner,
   StreamingMode,
   toA2a,
 } from '@google/adk';
+import {Content} from '@google/genai';
 import {trace, TracerProvider} from '@opentelemetry/api';
 import {SimpleSpanProcessor} from '@opentelemetry/sdk-trace-base';
 import cors from 'cors';
@@ -983,11 +985,11 @@ export class AdkApiServer {
     appName: string;
     userId: string;
     sessionId: string;
-    newMessage: Parameters<Runner['runAsync']>[0]['newMessage'];
-    stateDelta?: Parameters<Runner['runAsync']>[0]['stateDelta'];
-    runConfig?: Parameters<Runner['runAsync']>[0]['runConfig'];
+    newMessage: Content;
+    stateDelta?: Record<string, unknown>;
+    runConfig?: RunConfig;
     abortSignal: AbortSignal;
-  }): AsyncGenerator<Event, void, undefined> {
+  }): AsyncGenerator<Event> {
     await using agentFile = await this.agentLoader.getAgentFile(
       options.appName,
     );

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -766,24 +766,9 @@ export class AdkApiServer {
       this.logger.info(
         `Received Reasoning Engine query headers: ${JSON.stringify(req.headers)}`,
       );
-      let rawBody = '';
-      req.on('data', (chunk) => {
-        rawBody += chunk;
-      });
-      req.on('end', async () => {
-        this.logger.info(`Received Reasoning Engine raw body: ${rawBody}`);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let body: any = {};
-        if (rawBody) {
-          try {
-            body = JSON.parse(rawBody);
-          } catch (e) {
-            this.logger.error(`Failed to parse raw body as JSON: ${e}`);
-          }
-        } else {
-          body = req.body || {};
-        }
-        this.logger.info(`Parsed body: ${JSON.stringify(body)}`);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const executeQuery = async (body: any) => {
         const input = body.input || {};
         const appName = input.appName || body.appName;
         const userId = input.userId || body.userId || 'default-user';
@@ -835,7 +820,34 @@ export class AdkApiServer {
           res.status(500).json({error});
           this.logger.error(error);
         }
-      });
+      };
+
+      const isParsed =
+        req.body && (Object.keys(req.body).length > 0 || !req.readable);
+      if (isParsed) {
+        this.logger.info(
+          `Using already parsed body: ${JSON.stringify(req.body)}`,
+        );
+        await executeQuery(req.body);
+      } else {
+        let rawBody = '';
+        req.on('data', (chunk) => {
+          rawBody += chunk;
+        });
+        req.on('end', async () => {
+          this.logger.info(`Received Reasoning Engine raw body: ${rawBody}`);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let body: any = {};
+          if (rawBody) {
+            try {
+              body = JSON.parse(rawBody);
+            } catch (e) {
+              this.logger.error(`Failed to parse raw body as JSON: ${e}`);
+            }
+          }
+          await executeQuery(body);
+        });
+      }
     });
 
     app.post('/run_sse', async (req: Request, res: Response) => {

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -737,20 +737,18 @@ export class AdkApiServer {
       });
 
       try {
-        await using agentFile = await this.agentLoader.getAgentFile(appName);
-        const agent = await agentFile.load();
-        const runner = await this.getRunner(agent, appName);
         const events: Event[] = [];
-
-        for await (const e of runner.runAsync({
+        await this.executeAgentRun({
+          appName,
           userId,
           sessionId,
           newMessage,
           stateDelta,
           abortSignal: abortController.signal,
-        })) {
-          events.push(e);
-        }
+          onEvent: (e) => {
+            events.push(e);
+          },
+        });
 
         responseCompleted = true;
         res.json(events);
@@ -781,39 +779,28 @@ export class AdkApiServer {
           return;
         }
         try {
-          let session = await this.sessionService.getSession({
+          await this.sessionService.getOrCreateSession({
             appName,
             userId,
             sessionId,
+            state: {},
           });
-          if (!session) {
-            this.logger.info(
-              `Session ${sessionId} not found. Creating it automatically.`,
-            );
-            session = await this.sessionService.createSession({
-              appName,
-              userId,
-              sessionId,
-              state: {},
-            });
-          }
-          await using agentFile = await this.agentLoader.getAgentFile(appName);
-          const agent = await agentFile.load();
-          const runner = await this.getRunner(agent, appName);
           const events: Event[] = [];
           const abortController = new AbortController();
           req.on('close', () => {
             abortController.abort();
           });
-          for await (const e of runner.runAsync({
+          await this.executeAgentRun({
+            appName,
             userId,
             sessionId,
             newMessage,
             stateDelta,
             abortSignal: abortController.signal,
-          })) {
-            events.push(e);
-          }
+            onEvent: (e) => {
+              events.push(e);
+            },
+          });
           res.json({output: events});
         } catch (e: unknown) {
           const error = `Failed to run agent via Reasoning Engine API: ${e}`;
@@ -881,27 +868,25 @@ export class AdkApiServer {
       });
 
       try {
-        await using agentFile = await this.agentLoader.getAgentFile(appName);
-        const agent = await agentFile.load();
-        const runner = await this.getRunner(agent, appName);
-
         res.setHeader('Cache-Control', 'no-cache');
         res.setHeader('Content-Type', 'text/event-stream');
         res.setHeader('Connection', 'keep-alive');
         res.flushHeaders();
 
-        for await (const event of runner.runAsync({
+        await this.executeAgentRun({
+          appName,
           userId,
           sessionId,
           newMessage,
+          stateDelta,
           runConfig: {
             streamingMode: streaming ? StreamingMode.SSE : StreamingMode.NONE,
           },
-          stateDelta,
           abortSignal: abortController.signal,
-        })) {
-          res.write(`data: ${JSON.stringify(event)}\n\n`);
-        }
+          onEvent: (event) => {
+            res.write(`data: ${JSON.stringify(event)}\n\n`);
+          },
+        });
 
         responseCompleted = true;
         res.end();
@@ -995,5 +980,33 @@ export class AdkApiServer {
     }
 
     return this.runnerCache[appName];
+  }
+
+  private async executeAgentRun(options: {
+    appName: string;
+    userId: string;
+    sessionId: string;
+    newMessage: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    stateDelta?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    runConfig?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    abortSignal: AbortSignal;
+    onEvent: (event: Event) => void | Promise<void>;
+  }) {
+    await using agentFile = await this.agentLoader.getAgentFile(
+      options.appName,
+    );
+    const agent = await agentFile.load();
+    const runner = await this.getRunner(agent, options.appName);
+
+    for await (const event of runner.runAsync({
+      userId: options.userId,
+      sessionId: options.sessionId,
+      newMessage: options.newMessage,
+      runConfig: options.runConfig,
+      stateDelta: options.stateDelta,
+      abortSignal: options.abortSignal,
+    })) {
+      await options.onEvent(event);
+    }
   }
 }

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -983,9 +983,9 @@ export class AdkApiServer {
     appName: string;
     userId: string;
     sessionId: string;
-    newMessage: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    stateDelta?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    runConfig?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    newMessage: Parameters<Runner['runAsync']>[0]['newMessage'];
+    stateDelta?: Parameters<Runner['runAsync']>[0]['stateDelta'];
+    runConfig?: Parameters<Runner['runAsync']>[0]['runConfig'];
     abortSignal: AbortSignal;
   }): AsyncGenerator<Event, void, undefined> {
     await using agentFile = await this.agentLoader.getAgentFile(

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -929,6 +929,142 @@ describe('AdkWebServer', () => {
     });
   });
 
+  describe('Reasoning Engine', () => {
+    it('should return 200 OK on health endpoints when debug UI is disabled', async () => {
+      const healthResponse = await client.get<string>('/health');
+      expect(healthResponse.status).toBe(200);
+      expect(healthResponse.text).toBe('OK');
+
+      const rootResponse = await client.get<string>('/');
+      expect(rootResponse.status).toBe(200);
+      expect(rootResponse.text).toBe('OK');
+    });
+
+    it('should query the agent using reasoning_engine route with valid JSON', async () => {
+      await sessionService.createSession({
+        appName: 'testApp',
+        userId: 'testUser',
+        sessionId: 'sessionId',
+      });
+
+      const response = await client.post<{output: Event[]}>(
+        '/api/reasoning_engine',
+        {
+          input: {
+            appName: 'testApp',
+            userId: 'testUser',
+            sessionId: 'sessionId',
+            newMessage: {
+              parts: [{text: 'Hello'}],
+              role: 'user',
+            },
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data?.output).toBeDefined();
+      expect(response.data?.output.length).toBe(3);
+      expect(response.data?.output[0].content?.parts?.[0].text).toBe(
+        "Hello user! I'm streaming you events now!",
+      );
+    });
+
+    it('should auto-create session if not exists on reasoning_engine query', async () => {
+      const response = await client.post<{output: Event[]}>(
+        '/api/reasoning_engine',
+        {
+          input: {
+            appName: 'testApp',
+            userId: 'testUser',
+            sessionId: 'newSessionId',
+            newMessage: {
+              parts: [{text: 'Hello'}],
+              role: 'user',
+            },
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data?.output).toBeDefined();
+
+      const session = await sessionService.getSession({
+        appName: 'testApp',
+        userId: 'testUser',
+        sessionId: 'newSessionId',
+      });
+      expect(session).toBeDefined();
+    });
+
+    it('should support raw body query and parse headers workaround', async () => {
+      const url = `${server.url}/api/reasoning_engine`;
+      const payload = {
+        input: {
+          appName: 'testApp',
+          userId: 'testUser',
+          sessionId: 'rawSessionId',
+          newMessage: {
+            parts: [{text: 'Hello'}],
+            role: 'user',
+          },
+        },
+      };
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json,application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {output: Event[]};
+      expect(data.output).toBeDefined();
+      expect(data.output[0].content?.parts?.[0].text).toBe(
+        "Hello user! I'm streaming you events now!",
+      );
+    });
+
+    it('should return 400 if appName is missing', async () => {
+      try {
+        await client.post('/api/reasoning_engine', {
+          input: {
+            userId: 'testUser',
+            sessionId: 'sessionId',
+          },
+        });
+        expect.fail('Should fail with 400');
+      } catch (e: unknown) {
+        expect((e as {response: {status: number}}).response.status).toBe(400);
+        expect((e as {message: string}).message).toContain(
+          'appName is required',
+        );
+      }
+    });
+
+    it('should return 500 if execution fails', async () => {
+      const originalGetAgentFile = agentLoader.getAgentFile;
+      agentLoader.getAgentFile = () => Promise.reject(new Error('Load failed'));
+
+      try {
+        await client.post('/api/reasoning_engine', {
+          input: {
+            appName: 'testApp',
+            userId: 'testUser',
+            sessionId: 'sessionId',
+          },
+        });
+        expect.fail('Should fail with 500');
+      } catch (e: unknown) {
+        expect((e as {response: {status: number}}).response.status).toBe(500);
+      } finally {
+        agentLoader.getAgentFile = originalGetAgentFile;
+      }
+    });
+  });
+
   describe('Startup', () => {
     it('should throw an error if the port is already in use', async () => {
       const portString = server.url.split(':').pop();


### PR DESCRIPTION
Please ensure you have read the contribution guide https://google.github.io/adk-docs/contributing-guide/ before creating a pull request.

### Link to Issue or Description of Change

1. Link to an existing issue (if applicable):

• Closes: #none
• Related: #none

2. Or, if no issue exists, describe the change:

Problem:
Vertex AI's Reasoning Engine execution gateway and liveness checks impose two key constraints:

1. Containers must pass liveness probes at `/` and `/health` without redirects (Vertex AI kills containers that return 3xx codes, which broke ADK because it redirected `/` to `/dev-ui`).
2. Vertex AI forwards query payloads with duplicate content-type headers (`Content-Type: application/json,application/json`), which causes Express's standard body-parser to skip parsing and results in empty request bodies `{}`.

Solution:
Implemented native routing in `adk_api_server.ts` for `/health` and `/` endpoints to return `200 OK` when the Debug UI is disabled. Added a custom raw-body fallback stream listener on the `POST /api/reasoning_engine` query endpoint to parse incoming payloads manually if standard body-parser was skipped.

### Testing Plan

Unit Tests:

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed test results:

   ✓ |unit:dev| dev/test/server/adk_api_server_test.ts (45 tests) 3797ms    
     ✓ AdkWebServer > Reasoning Engine > should return 200 OK on health endpoints when debug UI is disabled 99ms                                    
     ✓ AdkWebServer > Reasoning Engine > should query the agent using reasoning_engine route with valid JSON 42ms                                 
     ✓ AdkWebServer > Reasoning Engine > should auto-create session if not exists on reasoning_engine query 56ms                                       
     ✓ AdkWebServer > Reasoning Engine > should support raw body query and parse headers workaround 83ms                                               
     ✓ AdkWebServer > Reasoning Engine > should return 400 if appName is missing 36ms                                                                
     ✓ AdkWebServer > Reasoning Engine > should return 500 if execution fails 34ms                                                                  

Files tested:

•  dev/test/server/adk_api_server_test.ts

Manual End-to-End (E2E) Tests:

Manually deployed and verified querying the weather tool agent on Vertex AI Reasoning Engines with unmocked traffic.

### Checklist

- [x] I have read the CONTRIBUTING.md https://github.com/google/adk-js/blob/main/CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context

None.
