### PR TITLE
fix(streaming): supress empty part arrays

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -919,7 +919,7 @@ export class LlmAgent extends BaseAgent {
     // =========================================================================
     // If no model response, skip.
     if (
-      !llmResponse.content &&
+      (!llmResponse.content || llmResponse.content.parts?.length === 0) &&
       !llmResponse.errorCode &&
       !llmResponse.interrupted
     ) {

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -786,6 +786,46 @@ describe('LlmAgent Abort Handling', () => {
   });
 });
 
+describe('LlmAgent postprocess empty parts filtering', () => {
+  it('should not yield an event when LLM response has empty parts array', async () => {
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: new MockLlm({
+        content: {role: 'model', parts: []},
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 0,
+          totalTokenCount: 10,
+        },
+        finishReason: 'STOP' as never,
+        partial: false,
+      }),
+    });
+    const mockState = {
+      hasDelta: () => false,
+      get: () => undefined,
+      set: () => {},
+    };
+    const invocationContext = new InvocationContext({
+      invocationId: 'inv_123',
+      session: {
+        id: 'sess_123',
+        state: mockState,
+        events: [],
+      } as unknown as Session,
+      agent,
+      pluginManager: new PluginManager(),
+    });
+
+    const events: Event[] = [];
+    for await (const event of agent.runAsync(invocationContext)) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(0);
+  });
+});
+
 describe('LlmAgent Default Request Processors', () => {
   it('includes AUTH_PREPROCESSOR in default requestProcessors before CONTENT_REQUEST_PROCESSOR', () => {
     const agent = new LlmAgent({

--- a/dev/samples/agent_transfer_return.ts
+++ b/dev/samples/agent_transfer_return.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 import {LlmAgent} from '@google/adk';

--- a/dev/samples/agent_transfer_return.ts
+++ b/dev/samples/agent_transfer_return.ts
@@ -1,0 +1,15 @@
+import {LlmAgent} from '@google/adk';
+
+const subAgent = new LlmAgent({
+  name: 'sub_agent',
+  model: 'gemini-3.5-flash',
+  instruction: `You are a sub-agent. Reply to the user's greeting.`,
+  description: 'A sub-agent that returns to root',
+});
+
+export const rootAgent = new LlmAgent({
+  name: 'root_agent',
+  model: 'gemini-3.5-flash',
+  instruction: `You are the root agent. For any greeting, transfer to sub_agent.`,
+  subAgents: [subAgent],
+});

--- a/dev/samples/agent_transfer_return.ts
+++ b/dev/samples/agent_transfer_return.ts
@@ -1,3 +1,8 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import {LlmAgent} from '@google/adk';
 
 const subAgent = new LlmAgent({


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

**2. Or, if no issue exists, describe the change:**

**Problem:**
When transferring to a subagent an error occurs.

This occurs only when using SSE streaming with Gemini 3 models.

<img width="2505" height="803" alt="image" src="https://github.com/user-attachments/assets/dc983880-0d8d-4e98-ac08-c2896195643d" />

This happens because the root agent emits a trailing STOP chunk with `content: { role: 'model', parts: [] }` after the subagent runs.

This event is yielded and is persisted in the session by the runner. When the root agent resumes in the following step the `ContentRequestProcessor` adds this `{ role: 'model', parts: [] }` object to the `llmRequest`'s `contents` array, causing an API error.

This seems to be related to #426.

**Solution:**

Added a condition in the `postprocess` method in `llm_agent.ts` to skip emitting events where `llmResponse.content.parts?.length === 0`.

### Testing Plan

I verified the change by doing the reproduction and seeing the error did not happen.

I have added a sample with the agent setup that can be used to replicate the original issue.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

I have two failing tests that fail even without my changes, I haven't been able to set up my crendentials properly to get the Gemini Live E2E test to run properly. All other tests pass.

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL   e2e  tests/e2e/live_model_test.ts > Live Gemini Live Connection E2E > should connect and stream responses from Gemini Live using Vertex AI
AssertionError: expected 0 to be greater than 0
 ❯ tests/e2e/live_model_test.ts:79:36
     77|     }
     78| 
     79|     expect(accumulatedText.length).toBeGreaterThan(0);
       |                                    ^
     80|     expect(accumulatedText.toLowerCase()).toMatch(/4|four/);
     81|     expect(gotTurnComplete).toBe(true);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL   e2e  tests/e2e/live_model_test.ts > Live Gemini Live Connection E2E > should support multi-turn conversations over the same live connection
AssertionError: expected '' to contain 'alice'

- Expected
+ Received

- alice

 ❯ tests/e2e/live_model_test.ts:158:43
    156|     }
    157| 
    158|     expect(accumulatedText.toLowerCase()).toContain('alice');
       |                                           ^
    159|     expect(gotTurnComplete).toBe(true);
    160| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed | 192 passed | 16 skipped (209)
      Tests  2 failed | 2195 passed | 39 skipped (2236)
   Start at  22:07:25
   Duration  44.44s (transform 3.29s, setup 0ms, collect 138.31s, tests 87.35s, environment 20ms, prepare 6.77s)
```

**Manual End-to-End (E2E) Tests:**

I tested this change with the `adk web` command and with a project on my machine after `npm pack`-ing the core package and testing with it.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

There are likely other ways to fix this issue. This solution in particular replicates the behavior from the v1.2.0 release which we have been working with recently.

If there is a better way to fix this, let me know!