### PR TITLE
Feat: Implement Trajectory Thought Pruning in adk-js

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -107,6 +107,8 @@ export {LlmSummarizer} from './context/summarizers/llm_summarizer.js';
 export type {LlmSummarizerOptions} from './context/summarizers/llm_summarizer.js';
 export {TokenBasedContextCompactor} from './context/token_based_context_compactor.js';
 export type {TokenBasedContextCompactorOptions} from './context/token_based_context_compactor.js';
+export {TrajectoryThoughtPruningCompactor} from './context/trajectory_thought_pruning_compactor.js';
+export type {TrajectoryThoughtPruningCompactorOptions} from './context/trajectory_thought_pruning_compactor.js';
 export {TruncatingContextCompactor} from './context/truncating_context_compactor.js';
 export type {TruncatingContextCompactorOptions} from './context/truncating_context_compactor.js';
 export {isCompactedEvent} from './events/compacted_event.js';

--- a/core/src/context/trajectory_thought_pruning_compactor.ts
+++ b/core/src/context/trajectory_thought_pruning_compactor.ts
@@ -5,7 +5,7 @@
  */
 
 import {InvocationContext} from '../agents/invocation_context.js';
-import {Event} from '../events/event.js';
+import {hasThoughts, pruneThoughts} from '../events/event.js';
 import {BaseContextCompactor} from './base_context_compactor.js';
 
 /**
@@ -45,7 +45,7 @@ export class TrajectoryThoughtPruningCompactor implements BaseContextCompactor {
       0,
       events.length - this.eventRetentionSize,
     );
-    return olderEvents.some((event) => this.hasThoughts(event));
+    return olderEvents.some((event) => hasThoughts(event));
   }
 
   compact(invocationContext: InvocationContext): void | Promise<void> {
@@ -57,27 +57,9 @@ export class TrajectoryThoughtPruningCompactor implements BaseContextCompactor {
     const pruneLimit = events.length - this.eventRetentionSize;
     for (let i = 0; i < pruneLimit; i++) {
       const event = events[i];
-      if (this.hasThoughts(event)) {
-        events[i] = this.pruneThoughts(event);
+      if (hasThoughts(event)) {
+        events[i] = pruneThoughts(event);
       }
     }
-  }
-
-  private hasThoughts(event: Event): boolean {
-    return !!event.content?.parts?.some((part) => part.thought === true);
-  }
-
-  private pruneThoughts(event: Event): Event {
-    const prunedParts = event.content!.parts!.filter(
-      (part) => part.thought !== true,
-    );
-
-    return {
-      ...event,
-      content: {
-        ...event.content!,
-        parts: prunedParts,
-      },
-    };
   }
 }

--- a/core/src/context/trajectory_thought_pruning_compactor.ts
+++ b/core/src/context/trajectory_thought_pruning_compactor.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {InvocationContext} from '../agents/invocation_context.js';
+import {Event} from '../events/event.js';
+import {BaseContextCompactor} from './base_context_compactor.js';
+
+/**
+ * Options for TrajectoryThoughtPruningCompactor.
+ */
+export interface TrajectoryThoughtPruningCompactorOptions {
+  /**
+   * The minimum number of raw events to keep at the end of the session.
+   * Compaction will not affect these tail events.
+   */
+  eventRetentionSize: number;
+}
+
+/**
+ * A context compactor that prunes thought parts from older events in the session history.
+ * Preserves the causal history (actions and observations) while reducing token usage.
+ */
+export class TrajectoryThoughtPruningCompactor implements BaseContextCompactor {
+  private readonly eventRetentionSize: number;
+
+  constructor(options: TrajectoryThoughtPruningCompactorOptions) {
+    if (options.eventRetentionSize < 0) {
+      throw new Error('eventRetentionSize must be a non-negative integer.');
+    }
+    this.eventRetentionSize = options.eventRetentionSize;
+  }
+
+  shouldCompact(
+    invocationContext: InvocationContext,
+  ): boolean | Promise<boolean> {
+    const events = invocationContext.session.events;
+    if (events.length <= this.eventRetentionSize) {
+      return false;
+    }
+
+    const olderEvents = events.slice(
+      0,
+      events.length - this.eventRetentionSize,
+    );
+    return olderEvents.some((event) => this.hasThoughts(event));
+  }
+
+  compact(invocationContext: InvocationContext): void | Promise<void> {
+    const events = invocationContext.session.events;
+    if (events.length <= this.eventRetentionSize) {
+      return;
+    }
+
+    const pruneLimit = events.length - this.eventRetentionSize;
+    for (let i = 0; i < pruneLimit; i++) {
+      const event = events[i];
+      if (this.hasThoughts(event)) {
+        events[i] = this.pruneThoughts(event);
+      }
+    }
+  }
+
+  private hasThoughts(event: Event): boolean {
+    return !!event.content?.parts?.some((part) => part.thought === true);
+  }
+
+  private pruneThoughts(event: Event): Event {
+    const prunedParts = event.content!.parts!.filter(
+      (part) => part.thought !== true,
+    );
+
+    return {
+      ...event,
+      content: {
+        ...event.content!,
+        parts: prunedParts,
+      },
+    };
+  }
+}

--- a/core/src/events/event.ts
+++ b/core/src/events/event.ts
@@ -166,6 +166,33 @@ export function stringifyContent(event: Event): string {
     .join('');
 }
 
+/**
+ * Returns whether the event contains any thought parts.
+ */
+export function hasThoughts(event: Event): boolean {
+  return !!event.content?.parts?.some((part) => part.thought === true);
+}
+
+/**
+ * Returns a copy of the event with all thought parts removed.
+ */
+export function pruneThoughts(event: Event): Event {
+  if (!event.content?.parts) {
+    return event;
+  }
+  const prunedParts = event.content.parts.filter(
+    (part) => part.thought !== true,
+  );
+
+  return {
+    ...event,
+    content: {
+      ...event.content,
+      parts: prunedParts,
+    },
+  };
+}
+
 const ASCII_LETTERS_AND_NUMBERS =
   'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 

--- a/core/src/sessions/base_session_service.ts
+++ b/core/src/sessions/base_session_service.ts
@@ -186,7 +186,12 @@ export abstract class BaseSessionService {
     event = trimTempDeltaState(event);
 
     this.updateSessionState({session, event});
-    session.events.push(event);
+    const index = session.events.findIndex((e) => e.id === event.id);
+    if (index >= 0) {
+      session.events[index] = event;
+    } else {
+      session.events.push(event);
+    }
 
     return event;
   }

--- a/core/src/sessions/database_session_service.ts
+++ b/core/src/sessions/database_session_service.ts
@@ -467,16 +467,29 @@ export class DatabaseSessionService extends BaseSessionService {
         }
       }
 
-      const newStorageEvent = txEm.create(StorageEvent, {
+      const existingStorageEvent = await txEm.findOne(StorageEvent, {
         id: trimmedEvent.id,
         appName: session.appName,
         userId: session.userId,
         sessionId: session.id,
-        invocationId: trimmedEvent.invocationId,
-        timestamp: new Date(trimmedEvent.timestamp),
-        eventData: trimmedEvent,
       });
-      txEm.persist(newStorageEvent);
+
+      if (existingStorageEvent) {
+        existingStorageEvent.eventData = trimmedEvent;
+        existingStorageEvent.timestamp = new Date(trimmedEvent.timestamp);
+        txEm.persist(existingStorageEvent);
+      } else {
+        const newStorageEvent = txEm.create(StorageEvent, {
+          id: trimmedEvent.id,
+          appName: session.appName,
+          userId: session.userId,
+          sessionId: session.id,
+          invocationId: trimmedEvent.invocationId,
+          timestamp: new Date(trimmedEvent.timestamp),
+          eventData: trimmedEvent,
+        });
+        txEm.persist(newStorageEvent);
+      }
       await txEm.commit();
 
       // Update session timestamp to match event timestamp
@@ -488,7 +501,13 @@ export class DatabaseSessionService extends BaseSessionService {
         storageSession.state,
       );
       session.state = newMergedState;
-      session.events.push(event);
+
+      const index = session.events.findIndex((e) => e.id === event.id);
+      if (index >= 0) {
+        session.events[index] = event;
+      } else {
+        session.events.push(event);
+      }
       session.lastUpdateTime = storageSession.updateTime.getTime();
     });
 

--- a/core/test/context/trajectory_thought_pruning_compactor_test.ts
+++ b/core/test/context/trajectory_thought_pruning_compactor_test.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  Event,
+  InvocationContext,
+  PluginManager,
+  Session,
+  TrajectoryThoughtPruningCompactor,
+} from '@google/adk';
+import {FunctionCall, FunctionResponse} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+
+function createMockEvent(
+  id: string,
+  parts: Array<{
+    text?: string;
+    thought?: boolean;
+    functionCall?: FunctionCall;
+    functionResponse?: FunctionResponse;
+  }>,
+): Event {
+  return {
+    id,
+    timestamp: Date.now(),
+    content: {
+      role: 'model',
+      parts: parts.map((p) => ({
+        ...p,
+      })),
+    },
+    actions: {
+      stateDelta: {},
+      artifactDelta: {},
+      requestedAuthConfigs: {},
+      requestedToolConfirmations: {},
+    },
+  } as unknown as Event;
+}
+
+function createMockInvocationContext(events: Event[]): InvocationContext {
+  const session = {
+    id: 'test-session',
+    events,
+    appName: 'test-app',
+    userId: 'test-user',
+  } as unknown as Session;
+  return new InvocationContext({
+    invocationId: 'test-invocation',
+    agent: {} as BaseAgent,
+    session,
+    pluginManager: new PluginManager([]),
+  });
+}
+
+describe('TrajectoryThoughtPruningCompactor', () => {
+  describe('constructor', () => {
+    it('should throw on negative eventRetentionSize', () => {
+      expect(
+        () => new TrajectoryThoughtPruningCompactor({eventRetentionSize: -1}),
+      ).toThrow('eventRetentionSize must be a non-negative integer.');
+    });
+
+    it('should not throw on non-negative eventRetentionSize', () => {
+      expect(
+        () => new TrajectoryThoughtPruningCompactor({eventRetentionSize: 0}),
+      ).not.toThrow();
+      expect(
+        () => new TrajectoryThoughtPruningCompactor({eventRetentionSize: 5}),
+      ).not.toThrow();
+    });
+  });
+
+  describe('shouldCompact', () => {
+    it('should return false if events length is less than or equal to retention size', async () => {
+      const compactor = new TrajectoryThoughtPruningCompactor({
+        eventRetentionSize: 2,
+      });
+      const context = createMockInvocationContext([
+        createMockEvent('1', [{text: 'thought', thought: true}]),
+      ]);
+      expect(await compactor.shouldCompact(context)).toBe(false);
+    });
+
+    it('should return false if older events have no thoughts', async () => {
+      const compactor = new TrajectoryThoughtPruningCompactor({
+        eventRetentionSize: 2,
+      });
+      const context = createMockInvocationContext([
+        createMockEvent('1', [
+          {text: 'action', functionCall: {name: 'mock', args: {}}},
+        ]),
+        createMockEvent('2', [
+          {text: 'response', functionResponse: {name: 'mock', response: {}}},
+        ]),
+        createMockEvent('3', [{text: 'thought', thought: true}]), // in retention
+        createMockEvent('4', [{text: 'thought', thought: true}]), // in retention
+      ]);
+      expect(await compactor.shouldCompact(context)).toBe(false);
+    });
+
+    it('should return true if older events have thoughts', async () => {
+      const compactor = new TrajectoryThoughtPruningCompactor({
+        eventRetentionSize: 2,
+      });
+      const context = createMockInvocationContext([
+        createMockEvent('1', [
+          {text: 'thinking', thought: true},
+          {functionCall: {name: 'mock', args: {}}},
+        ]),
+        createMockEvent('2', [
+          {text: 'response', functionResponse: {name: 'mock', response: {}}},
+        ]),
+        createMockEvent('3', [{text: 'thought', thought: true}]), // in retention
+        createMockEvent('4', [{text: 'thought', thought: true}]), // in retention
+      ]);
+      expect(await compactor.shouldCompact(context)).toBe(true);
+    });
+  });
+
+  describe('compact', () => {
+    it('should do nothing if events length is less than or equal to retention size', async () => {
+      const compactor = new TrajectoryThoughtPruningCompactor({
+        eventRetentionSize: 2,
+      });
+      const event1 = createMockEvent('1', [{text: 'thought', thought: true}]);
+      const context = createMockInvocationContext([event1]);
+
+      await compactor.compact(context);
+
+      expect(context.session.events.length).toBe(1);
+      expect(context.session.events[0]).toBe(event1);
+    });
+
+    it('should prune thoughts from older events and preserve other parts', async () => {
+      const compactor = new TrajectoryThoughtPruningCompactor({
+        eventRetentionSize: 1,
+      });
+      const event1 = createMockEvent('1', [
+        {text: 'thinking 1', thought: true},
+        {text: 'action 1', functionCall: {name: 'tool1', args: {}}},
+      ]);
+      const event2 = createMockEvent('2', [
+        {text: 'thinking 2', thought: true},
+        {text: 'final answer'},
+      ]); // in retention
+
+      const context = createMockInvocationContext([event1, event2]);
+
+      await compactor.compact(context);
+
+      expect(context.session.events.length).toBe(2);
+
+      const prunedEvent1 = context.session.events[0];
+      expect(prunedEvent1.id).toBe('1');
+      expect(prunedEvent1).not.toBe(event1); // new instance
+      expect(prunedEvent1.content?.parts).toEqual([
+        {text: 'action 1', functionCall: {name: 'tool1', args: {}}},
+      ]);
+
+      const unchangedEvent2 = context.session.events[1];
+      expect(unchangedEvent2).toBe(event2); // same reference
+    });
+
+    it('should handle events with no content or parts gracefully', async () => {
+      const compactor = new TrajectoryThoughtPruningCompactor({
+        eventRetentionSize: 1,
+      });
+      const event1 = {id: '1', timestamp: Date.now()} as Event;
+      const event2 = createMockEvent('2', [{text: 'thought', thought: true}]);
+
+      const context = createMockInvocationContext([event1, event2]);
+
+      await compactor.compact(context);
+
+      expect(context.session.events.length).toBe(2);
+      expect(context.session.events[0]).toBe(event1);
+    });
+  });
+});

--- a/tests/integration/context_compaction/trajectory_thought_pruning_test.ts
+++ b/tests/integration/context_compaction/trajectory_thought_pruning_test.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Agent,
+  Event,
+  FunctionTool,
+  InMemoryRunner,
+  TrajectoryThoughtPruningCompactor,
+} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {GeminiWithMockResponses} from '../test_case_utils.js';
+
+describe('TrajectoryThoughtPruning Integration', () => {
+  it('should prune thoughts from older turns in a multi-turn conversation', async () => {
+    const compactor = new TrajectoryThoughtPruningCompactor({
+      eventRetentionSize: 1,
+    });
+
+    const agent = new Agent({
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      contextCompactors: [compactor],
+    });
+
+    const mockResponses = [
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {text: 'Thinking about calling tool...', thought: true},
+                {functionCall: {name: 'mock_tool', args: {}}},
+              ],
+            },
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {text: 'Thinking about the final answer...', thought: true},
+                {text: 'The weather is nice.'},
+              ],
+            },
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{text: 'Final answer for turn 2.'}],
+            },
+          },
+        ],
+      },
+    ];
+
+    agent.model = new GeminiWithMockResponses(mockResponses);
+
+    const tool = new FunctionTool({
+      name: 'mock_tool',
+      description: 'A mock tool',
+      execute: async () => 'Tool response',
+    });
+    agent.tools = [tool];
+
+    const appName = agent.name;
+    const userId = 'test_user';
+    const runner = new InMemoryRunner({agent, appName});
+    const session = await runner.sessionService.createSession({
+      appName,
+      userId,
+    });
+
+    // --- Turn 1 ---
+    const turn1Events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId,
+      sessionId: session.id,
+      newMessage: createUserContent('What is the weather like?'),
+    })) {
+      if (!event.partial) {
+        turn1Events.push(event);
+      }
+    }
+
+    const sessionAfterTurn1 = await runner.sessionService.getSession({
+      appName,
+      userId,
+      sessionId: session.id,
+    });
+    expect(sessionAfterTurn1).toBeDefined();
+    const events1 = sessionAfterTurn1!.events;
+    expect(events1.length).toBe(4);
+
+    // Event 1: Model response 1 (should be pruned because compaction ran before step 2)
+    const modelEvent1 = events1[1];
+    expect(modelEvent1.content?.parts).toEqual([
+      expect.objectContaining({
+        functionCall: expect.objectContaining({
+          name: 'mock_tool',
+          args: {},
+        }),
+      }),
+    ]);
+
+    // Event 3: Model response 2 (not pruned yet, it was the tail event when appended)
+    const modelEvent2 = events1[3];
+    expect(modelEvent2.content?.parts).toEqual([
+      {text: 'Thinking about the final answer...', thought: true},
+      {text: 'The weather is nice.'},
+    ]);
+
+    // --- Turn 2 ---
+    for await (const _event of runner.runAsync({
+      userId,
+      sessionId: session.id,
+      newMessage: createUserContent('Thank you.'),
+    })) {
+      // consume
+    }
+
+    const sessionAfterTurn2 = await runner.sessionService.getSession({
+      appName,
+      userId,
+      sessionId: session.id,
+    });
+    const events2 = sessionAfterTurn2!.events;
+    expect(events2.length).toBe(6);
+
+    // Event 3: Model response 2 (should be pruned now because it is older than retention size in turn 2)
+    const modelEvent2_after = events2[3];
+    expect(modelEvent2_after.content?.parts).toEqual([
+      {text: 'The weather is nice.'},
+    ]);
+
+    // Event 5: Model response 3 (not pruned, no thoughts anyway)
+    const modelEvent3 = events2[5];
+    expect(modelEvent3.content?.parts).toEqual([
+      {text: 'Final answer for turn 2.'},
+    ]);
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

Link to Issue or Description of Change
1. Link to an existing issue (if applicable):
Closes: #none

2. Or, if no issue exists, describe the change:
This PR implements Trajectory Thought Pruning (ReAct Step Distillation) in `adk-js` to reduce token consumption in long-running agent sessions.

Problem:
Long-running agent sessions consume a large number of tokens because they keep the full history of internal LLM thinking/thought parts from older turns.

Solution:
1. Introduced `TrajectoryThoughtPruningCompactor` that implements `BaseContextCompactor`. It prunes parts with `thought: true` from events older than `eventRetentionSize`.
2. Updated `BaseSessionService` and `DatabaseSessionService` to support upsert in `appendEvent` (updating existing events if the ID matches). This allows persisting pruned events without creating duplicates or causing primary key violations.

Testing Plan
Unit and integration tests have been implemented and pass cleanly.

Unit Tests:
- Added `core/test/context/trajectory_thought_pruning_compactor_test.ts` covering constructor validation, `shouldCompact`, and `compact` logic (including edge cases).
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Integration Tests:
- Added `tests/integration/context_compaction/trajectory_thought_pruning_test.ts` verifying that thoughts are pruned correctly over a multi-turn conversation and that the changes are persisted correctly via `SessionService`.
- Run with: `npx vitest run tests/integration/context_compaction/trajectory_thought_pruning_test.ts`

Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
