### PR TITLE
Feat: Implement tracing for tool execution

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -5,6 +5,7 @@
  */
 
 import {Content, createUserContent, FunctionCall, Part} from '@google/genai';
+import {SpanStatusCode} from '@opentelemetry/api';
 import {isEmpty} from 'lodash-es';
 
 import {InvocationContext} from '../agents/invocation_context.js';
@@ -211,69 +212,6 @@ export function generateRequestConfirmationEvent({
   });
 }
 
-async function callToolAsync(
-  tool: BaseTool,
-  args: Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
-  toolContext: Context,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
-  return tracer.startActiveSpan(`execute_tool ${tool.name}`, async (span) => {
-    try {
-      logger.debug(`callToolAsync ${tool.name}`);
-      const result = await tool.runAsync({args, toolContext});
-      traceToolCall({
-        tool,
-        args,
-        functionResponseEvent: buildResponseEvent(
-          tool,
-          result,
-          toolContext,
-          toolContext.invocationContext,
-        ),
-      });
-      return result;
-    } finally {
-      span.end();
-    }
-  });
-}
-
-function buildResponseEvent(
-  tool: BaseTool,
-  functionResult: unknown,
-  toolContext: Context,
-  invocationContext: InvocationContext,
-): Event {
-  let responseResult: Record<string, unknown>;
-  if (typeof functionResult !== 'object' || functionResult == null) {
-    responseResult = {result: functionResult};
-  } else if (Array.isArray(functionResult)) {
-    responseResult = {results: functionResult};
-  } else {
-    responseResult = functionResult as Record<string, unknown>;
-  }
-
-  const partFunctionResponse: Part = {
-    functionResponse: {
-      name: tool.name,
-      response: responseResult,
-      id: toolContext.functionCallId,
-    },
-  };
-
-  const content: Content = {
-    role: 'user',
-    parts: [partFunctionResponse],
-  };
-
-  return createEvent({
-    invocationId: invocationContext.invocationId,
-    author: invocationContext.agent.name,
-    content: content,
-    actions: toolContext.actions,
-    branch: invocationContext.branch,
-  });
-}
 /**
  * Handles function calls.
  * Runtime behavior to pay attention to:
@@ -357,142 +295,142 @@ export async function handleFunctionCallList({
       toolConfirmation,
     });
 
-    // TODO - b/436079721: implement [tracer.start_as_current_span]
-    logger.debug(`execute_tool ${tool.name}`);
     const functionArgs = functionCall.args ?? {};
 
-    // Step 1: Check if plugin before_tool_callback overrides the function
-    // response.
-    let functionResponse = null;
-    let functionResponseError: string | unknown | undefined;
-    functionResponse =
-      await invocationContext.pluginManager.runBeforeToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-      });
-
-    // Step 2: If no overrides are provided from the plugins, further run the
-    // canonical callback.
-    // TODO - b/425992518: validate the callback response type matches.
-    if (functionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of beforeToolCallbacks) {
-        functionResponse = await callback({
-          tool: tool,
-          args: functionArgs,
-          context: toolContext,
-        });
-        if (functionResponse) {
-          break;
-        }
-      }
-    }
-
-    // Step 3: Otherwise, proceed calling the tool normally.
-    if (functionResponse == null) {
-      // Cover both null and undefined
+    await tracer.startActiveSpan(`execute_tool ${tool.name}`, async (span) => {
       try {
-        functionResponse = await callToolAsync(tool, functionArgs, toolContext);
-      } catch (e: unknown) {
-        if (e instanceof Error) {
-          const onToolErrorResponse =
-            await invocationContext.pluginManager.runOnToolErrorCallback({
+        // Step 1: Check if plugin before_tool_callback overrides the function
+        // response.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let functionResponse: any =
+          await invocationContext.pluginManager.runBeforeToolCallback({
+            tool,
+            toolArgs: functionArgs,
+            toolContext,
+          });
+        let functionResponseError: string | unknown | undefined;
+
+        // Step 2: If no overrides are provided from the plugins, further run the
+        // canonical callback.
+        // TODO - b/425992518: validate the callback response type matches.
+        if (functionResponse == null) {
+          // Cover both null and undefined
+          for (const callback of beforeToolCallbacks) {
+            functionResponse = await callback({
               tool: tool,
-              toolArgs: functionArgs,
-              toolContext: toolContext,
-              error: e,
+              args: functionArgs,
+              context: toolContext,
             });
-
-          // Set function response to the result of the error callback and
-          // continue execution, do not shortcut
-          if (onToolErrorResponse) {
-            functionResponse = onToolErrorResponse;
-          } else {
-            // If the error callback returns undefined, use the error message
-            // as the function response error.
-            functionResponseError = e.message;
+            if (functionResponse) {
+              break;
+            }
           }
-        } else {
-          // If the error is not an Error, use the error object as the function
-          // response error.
-          functionResponseError = e;
         }
-      }
-    }
 
-    // Step 4: Check if plugin after_tool_callback overrides the function
-    // response.
-    let alteredFunctionResponse =
-      await invocationContext.pluginManager.runAfterToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-        result: functionResponse,
-      });
+        // Step 3: Otherwise, proceed calling the tool normally.
+        if (functionResponse == null) {
+          // Cover both null and undefined
+          try {
+            logger.debug(`callToolAsync ${tool.name}`);
+            functionResponse = await tool.runAsync({
+              args: functionArgs,
+              toolContext,
+            });
+          } catch (e: unknown) {
+            const err = e instanceof Error ? e : new Error(String(e));
+            span.recordException(err);
+            if (e instanceof Error) {
+              functionResponse =
+                await invocationContext.pluginManager.runOnToolErrorCallback({
+                  tool,
+                  toolArgs: functionArgs,
+                  toolContext,
+                  error: e,
+                });
+            }
+            if (!functionResponse) {
+              functionResponseError = e instanceof Error ? e.message : e;
+              span.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: err.message,
+              });
+            }
+          }
+        }
 
-    // Step 5: If no overrides are provided from the plugins, further run the
-    // canonical after_tool_callbacks.
-    if (alteredFunctionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of afterToolCallbacks) {
-        alteredFunctionResponse = await callback({
-          tool: tool,
-          args: functionArgs,
-          context: toolContext,
-          response: functionResponse,
+        // Step 4: Check if plugin after_tool_callback overrides the function
+        // response.
+        let alteredFunctionResponse =
+          await invocationContext.pluginManager.runAfterToolCallback({
+            tool: tool,
+            toolArgs: functionArgs,
+            toolContext: toolContext,
+            result: functionResponse,
+          });
+
+        // Step 5: If no overrides are provided from the plugins, further run the
+        // canonical after_tool_callbacks.
+        if (alteredFunctionResponse == null) {
+          // Cover both null and undefined
+          for (const callback of afterToolCallbacks) {
+            alteredFunctionResponse = await callback({
+              tool: tool,
+              args: functionArgs,
+              context: toolContext,
+              response: functionResponse,
+            });
+            if (alteredFunctionResponse) {
+              break;
+            }
+          }
+        }
+
+        // Step 6: If alternative response exists from after_tool_callback, use it
+        // instead of the original function response.
+        functionResponse = alteredFunctionResponse ?? functionResponse;
+
+        // TODO - b/425992518: state event polluting runtime, consider fix.
+        // Allow long running function to return None as response.
+        if (tool.isLongRunning && !functionResponse) {
+          return;
+        }
+
+        if (functionResponseError) {
+          functionResponse = {error: functionResponseError};
+        } else if (
+          typeof functionResponse !== 'object' ||
+          functionResponse == null
+        ) {
+          functionResponse = {result: functionResponse};
+        } else if (Array.isArray(functionResponse)) {
+          functionResponse = {results: functionResponse};
+        }
+
+        // Builds the function response event.
+        const functionResponseEvent = createEvent({
+          invocationId: invocationContext.invocationId,
+          author: invocationContext.agent.name,
+          content: createUserContent({
+            functionResponse: {
+              id: toolContext.functionCallId,
+              name: tool.name,
+              response: functionResponse,
+            },
+          }),
+          actions: toolContext.actions,
+          branch: invocationContext.branch,
         });
-        if (alteredFunctionResponse) {
-          break;
-        }
+
+        traceToolCall({
+          tool,
+          args: functionArgs,
+          functionResponseEvent,
+        });
+        functionResponseEvents.push(functionResponseEvent);
+      } finally {
+        span.end();
       }
-    }
-
-    // Step 6: If alternative response exists from after_tool_callback, use it
-    // instead of the original function response.
-    if (alteredFunctionResponse != null) {
-      functionResponse = alteredFunctionResponse;
-    }
-
-    // TODO - b/425992518: state event polluting runtime, consider fix.
-    // Allow long running function to return None as response.
-    if (tool.isLongRunning && !functionResponse) {
-      continue;
-    }
-
-    if (functionResponseError) {
-      functionResponse = {error: functionResponseError};
-    } else if (
-      typeof functionResponse !== 'object' ||
-      functionResponse == null
-    ) {
-      functionResponse = {result: functionResponse};
-    } else if (Array.isArray(functionResponse)) {
-      functionResponse = {results: functionResponse};
-    }
-
-    // Builds the function response event.
-    const functionResponseEvent = createEvent({
-      invocationId: invocationContext.invocationId,
-      author: invocationContext.agent.name,
-      content: createUserContent({
-        functionResponse: {
-          id: toolContext.functionCallId,
-          name: tool.name,
-          response: functionResponse,
-        },
-      }),
-      actions: toolContext.actions,
-      branch: invocationContext.branch,
     });
-
-    // TODO - b/436079721: implement [traceToolCall]
-    logger.debug('traceToolCall', {
-      tool: tool.name,
-      args: functionArgs,
-      functionResponseEvent: functionResponseEvent.id,
-    });
-    functionResponseEvents.push(functionResponseEvent);
   }
 
   if (!functionResponseEvents.length) {
@@ -506,11 +444,6 @@ export async function handleFunctionCallList({
     tracer.startActiveSpan('execute_tool (merged)', (span) => {
       try {
         logger.debug('execute_tool (merged)');
-        // TODO - b/436079721: implement [traceMergedToolCalls]
-        logger.debug('traceMergedToolCalls', {
-          responseEventId: mergedEvent.id,
-          functionResponseEvent: mergedEvent.id,
-        });
         traceMergedToolCalls({
           responseEventId: mergedEvent.id,
           functionResponseEvent: mergedEvent,

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -20,6 +20,7 @@ import {
   ToolConfirmation,
 } from '@google/adk';
 import {Content, FunctionCall} from '@google/genai';
+import {SpanStatusCode} from '@opentelemetry/api';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
@@ -29,6 +30,27 @@ import {
   populateClientFunctionCallId,
   removeClientFunctionCallId,
 } from '../../src/agents/functions.js';
+import {
+  traceMergedToolCalls,
+  tracer,
+  traceToolCall,
+} from '../../src/telemetry/tracing.js';
+
+const mockSpan = {
+  end: vi.fn(),
+  recordException: vi.fn(),
+  setStatus: vi.fn(),
+};
+
+vi.mock('../../src/telemetry/tracing.js', () => {
+  return {
+    tracer: {
+      startActiveSpan: vi.fn().mockImplementation((name, cb) => cb(mockSpan)),
+    },
+    traceToolCall: vi.fn(),
+    traceMergedToolCalls: vi.fn(),
+  };
+});
 
 // Get the test target function
 const {
@@ -115,6 +137,8 @@ describe('handleFunctionCallList', () => {
       args: {},
     };
     toolsDict = {'testTool': testTool};
+
+    vi.clearAllMocks();
   });
 
   it('should execute tool with no callbacks or plugins', async () => {
@@ -360,6 +384,70 @@ describe('handleFunctionCallList', () => {
         toolContext: expect.objectContaining({
           abortSignal: signal,
         }),
+      }),
+    );
+  });
+
+  it('should trace tool execution', async () => {
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [functionCall],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    expect(tracer.startActiveSpan).toHaveBeenCalledWith(
+      `execute_tool ${testTool.name}`,
+      expect.any(Function),
+    );
+    expect(traceToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: testTool,
+        args: functionCall.args,
+        functionResponseEvent: event,
+      }),
+    );
+  });
+
+  it('should record exception on span when tool throws', async () => {
+    const errorFunctionCall: FunctionCall = {
+      id: randomIdForTestingOnly(),
+      name: 'errorTool',
+      args: {},
+    };
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [errorFunctionCall],
+      toolsDict: {'errorTool': errorTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    expect(mockSpan.recordException).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockSpan.setStatus).toHaveBeenCalledWith({
+      code: SpanStatusCode.ERROR,
+      message: expect.stringContaining('tool error message content'),
+    });
+  });
+
+  it('should trace merged tool calls when multiple tools executed', async () => {
+    const functionCall1 = {id: '1', name: 'testTool', args: {}};
+    const functionCall2 = {id: '2', name: 'testTool', args: {}};
+
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [functionCall1, functionCall2],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    expect(traceMergedToolCalls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseEventId: event!.id,
+        functionResponseEvent: event,
       }),
     );
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,7 +5171,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/tests/integration/test_api_server.ts
+++ b/tests/integration/test_api_server.ts
@@ -32,7 +32,7 @@ export class AdkTsApiServer extends BaseTestServer {
   private params: TestApiServerParams;
 
   constructor(params: TestApiServerParams) {
-    super('localhost', params.port || 0);
+    super('127.0.0.1', params.port || 0);
     this.params = params;
   }
 
@@ -64,6 +64,8 @@ export class AdkTsApiServer extends BaseTestServer {
       cliPath,
       params.serveDebugUI ? 'web' : 'api_server',
       params.agentsDir,
+      '--host',
+      this.host,
       '--port',
       this.port.toString(),
       '--allow_origins',


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #
- Related: #

**2. Or, if no issue exists, describe the change:**

**Problem:**
Tool execution in `adk-js` was not traced, making it difficult to debug tool calls and performance in production.

**Solution:**
Wrapped tool execution inside `handleFunctionCallList` with OpenTelemetry spans. Inlined `callToolAsync` and simplified event building to ensure the span covers the entire tool execution lifecycle (including callbacks and plugins). Recorded exceptions to the span and set span status to ERROR when appropriate.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed npm test results:
```
 ✓ |unit:core| core/test/agents/functions_test.ts (32 tests)
   ✓ handleFunctionCallList > should execute tool with no callbacks or plugins
   ✓ handleFunctionCallList > should wrap array responses into a {results: array} object
   ✓ handleFunctionCallList > should trace tool execution
   ✓ handleFunctionCallList > should record exception on span when tool throws
   ✓ handleFunctionCallList > should trace merged tool calls when multiple tools executed
```

**Manual End-to-End (E2E) Tests:**

N/A

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

N/A
