### PR TITLE
Feat: Configurable Client Labels in adk-js

### DIFF
--- a/core/build.js
+++ b/core/build.js
@@ -50,6 +50,12 @@ function build({
     logLevel: 'info',
   };
 
+  if (platform === 'browser') {
+    buildOptions.alias = {
+      'node:async_hooks': './src/utils/async_hooks_shim.ts',
+    };
+  }
+
   // Prepend license header to the top of the file
   if (format === 'cjs' || bundle) {
     buildOptions.banner = {js: licenseHeaderText};

--- a/core/build.js
+++ b/core/build.js
@@ -50,7 +50,7 @@ function build({
     logLevel: 'info',
   };
 
-  if (platform === 'browser') {
+  if (platform === 'browser' && bundle) {
     buildOptions.alias = {
       'node:async_hooks': './src/utils/async_hooks_shim.ts',
     };

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -249,17 +249,13 @@ export type {
   VertexAiSearchToolParams,
 } from './tools/vertex_ai_search_tool.js';
 export {VertexRagRetrievalTool} from './tools/vertex_rag_retrieval_tool.js';
+export {getClientLabels, runWithClientLabel} from './utils/client_labels.js';
 export {LogLevel, getLogger, setLogLevel, setLogger} from './utils/logger.js';
 export type {Logger} from './utils/logger.js';
 export {isGemini2OrAbove, isGemini3xFlashLive} from './utils/model_name.js';
 export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
-export {
-  runWithClientLabel,
-  EVAL_CLIENT_LABEL,
-  getClientLabels,
-} from './utils/client_labels.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
 export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -255,6 +255,11 @@ export {isGemini2OrAbove, isGemini3xFlashLive} from './utils/model_name.js';
 export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
+export {
+  runWithClientLabel,
+  EVAL_CLIENT_LABEL,
+  getClientLabels,
+} from './utils/client_labels.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
 export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';

--- a/core/src/utils/async_hooks_shim.ts
+++ b/core/src/utils/async_hooks_shim.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export class AsyncLocalStorage<T> {
+  private store: T | undefined;
+  run<R>(store: T, callback: () => R): R {
+    const previous = this.store;
+    this.store = store;
+    try {
+      return callback();
+    } finally {
+      this.store = previous;
+    }
+  }
+  getStore(): T | undefined {
+    return this.store;
+  }
+}

--- a/core/src/utils/client_labels.ts
+++ b/core/src/utils/client_labels.ts
@@ -42,9 +42,9 @@ function _getDefaultLabels(): string[] {
     frameworkLabel = `${frameworkLabel}+${AGENT_ENGINE_TELEMETRY_TAG}`;
   }
 
-  // eslint-disable-next-line no-undef
   const languageLabelDetail = isBrowser()
-    ? parseUserAgent(window.navigator.userAgent)
+    ? // eslint-disable-next-line no-undef
+      parseUserAgent(window.navigator.userAgent)
     : process.version;
 
   const languageLabel = `${LANGUAGE_LABEL}/${languageLabelDetail}`;

--- a/core/src/utils/client_labels.ts
+++ b/core/src/utils/client_labels.ts
@@ -4,16 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AsyncLocalStorage } from 'node:async_hooks';
-import { version } from '../version.js';
-import { isBrowser } from './env_aware_utils.js';
+import {AsyncLocalStorage} from 'node:async_hooks';
+import {version} from '../version.js';
+import {isBrowser} from './env_aware_utils.js';
 
 const ADK_LABEL = 'google-adk';
 const LANGUAGE_LABEL = 'gl-typescript';
 const AGENT_ENGINE_TELEMETRY_TAG = 'remote_reasoning_engine';
 const AGENT_ENGINE_TELEMETRY_ENV_VARIABLE_NAME = 'GOOGLE_CLOUD_AGENT_ENGINE_ID';
-
-export const EVAL_CLIENT_LABEL = `google-adk-eval/${version}`;
 
 const clientLabelLocalStorage = new AsyncLocalStorage<string>();
 
@@ -22,28 +20,16 @@ export function parseUserAgent(userAgent: string): string {
     return 'Browser';
   }
 
-  // Edge
-  const edgeMatch = userAgent.match(/(?:Edg|Edge|EdgA)\/([0-9\.]+)/i);
-  if (edgeMatch) {
-    return `Edge/${edgeMatch[1]}`;
-  }
-
-  // Firefox
-  const firefoxMatch = userAgent.match(/(?:Firefox|FxiOS)\/([0-9\.]+)/i);
-  if (firefoxMatch) {
-    return `Firefox/${firefoxMatch[1]}`;
-  }
-
-  // Chrome
-  const chromeMatch = userAgent.match(/(?:Chrome|CriOS)\/([0-9\.]+)/i);
-  if (chromeMatch) {
-    return `Chrome/${chromeMatch[1]}`;
-  }
-
-  // Safari
-  const safariMatch = userAgent.match(/Version\/([0-9\.]+).*Safari/i);
-  if (safariMatch) {
-    return `Safari/${safariMatch[1]}`;
+  for (const [name, regex] of [
+    ['Edge', /(?:Edg|Edge|EdgA)\/([0-9.]+)/i],
+    ['Firefox', /(?:Firefox|FxiOS)\/([0-9.]+)/i],
+    ['Chrome', /(?:Chrome|CriOS)\/([0-9.]+)/i],
+    ['Safari', /Version\/([0-9.]+).*Safari/i],
+  ] as const) {
+    const match = userAgent.match(regex);
+    if (match) {
+      return `${name}/${match[1]}`;
+    }
   }
 
   return 'Browser';
@@ -56,26 +42,21 @@ function _getDefaultLabels(): string[] {
     frameworkLabel = `${frameworkLabel}+${AGENT_ENGINE_TELEMETRY_TAG}`;
   }
 
-  let languageLabelDetail: string;
-  if (isBrowser()) {
-    // eslint-disable-next-line no-undef
-    languageLabelDetail = parseUserAgent(window.navigator.userAgent);
-  } else {
-    languageLabelDetail = process.version;
-  }
+  // eslint-disable-next-line no-undef
+  const languageLabelDetail = isBrowser()
+    ? parseUserAgent(window.navigator.userAgent)
+    : process.version;
 
   const languageLabel = `${LANGUAGE_LABEL}/${languageLabelDetail}`;
   return [frameworkLabel, languageLabel];
 }
 
-export function runWithClientLabel<R>(clientLabel: string, callback: () => R): R {
+export function runWithClientLabel<R>(
+  clientLabel: string,
+  callback: () => R,
+): R {
   if (typeof clientLabel !== 'string' || clientLabel.trim() === '') {
     throw new Error('Client label must be a non-empty string.');
-  }
-
-  const existingLabel = clientLabelLocalStorage.getStore();
-  if (existingLabel) {
-    throw new Error('Client label already exists. You can only add one client label.');
   }
 
   return clientLabelLocalStorage.run(clientLabel, callback);

--- a/core/src/utils/client_labels.ts
+++ b/core/src/utils/client_labels.ts
@@ -4,17 +4,50 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {version} from '../version.js';
-
-import {isBrowser} from './env_aware_utils.js';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { version } from '../version.js';
+import { isBrowser } from './env_aware_utils.js';
 
 const ADK_LABEL = 'google-adk';
 const LANGUAGE_LABEL = 'gl-typescript';
 const AGENT_ENGINE_TELEMETRY_TAG = 'remote_reasoning_engine';
 const AGENT_ENGINE_TELEMETRY_ENV_VARIABLE_NAME = 'GOOGLE_CLOUD_AGENT_ENGINE_ID';
 
-// TODO: b/468053794 - Configurable client labels in AsyncLocalStorage and/or
-// browser equivalent
+export const EVAL_CLIENT_LABEL = `google-adk-eval/${version}`;
+
+const clientLabelLocalStorage = new AsyncLocalStorage<string>();
+
+export function parseUserAgent(userAgent: string): string {
+  if (!userAgent) {
+    return 'Browser';
+  }
+
+  // Edge
+  const edgeMatch = userAgent.match(/(?:Edg|Edge|EdgA)\/([0-9\.]+)/i);
+  if (edgeMatch) {
+    return `Edge/${edgeMatch[1]}`;
+  }
+
+  // Firefox
+  const firefoxMatch = userAgent.match(/(?:Firefox|FxiOS)\/([0-9\.]+)/i);
+  if (firefoxMatch) {
+    return `Firefox/${firefoxMatch[1]}`;
+  }
+
+  // Chrome
+  const chromeMatch = userAgent.match(/(?:Chrome|CriOS)\/([0-9\.]+)/i);
+  if (chromeMatch) {
+    return `Chrome/${chromeMatch[1]}`;
+  }
+
+  // Safari
+  const safariMatch = userAgent.match(/Version\/([0-9\.]+).*Safari/i);
+  if (safariMatch) {
+    return `Safari/${safariMatch[1]}`;
+  }
+
+  return 'Browser';
+}
 
 function _getDefaultLabels(): string[] {
   let frameworkLabel = `${ADK_LABEL}/${version}`;
@@ -23,11 +56,29 @@ function _getDefaultLabels(): string[] {
     frameworkLabel = `${frameworkLabel}+${AGENT_ENGINE_TELEMETRY_TAG}`;
   }
 
-  // TODO: b/468051563 - Consider extracting browser name and version from
-  // userAgent string
-  // eslint-disable-next-line no-undef
-  const languageLabel = `${LANGUAGE_LABEL}/${isBrowser() ? window.navigator.userAgent : process.version}`;
+  let languageLabelDetail: string;
+  if (isBrowser()) {
+    // eslint-disable-next-line no-undef
+    languageLabelDetail = parseUserAgent(window.navigator.userAgent);
+  } else {
+    languageLabelDetail = process.version;
+  }
+
+  const languageLabel = `${LANGUAGE_LABEL}/${languageLabelDetail}`;
   return [frameworkLabel, languageLabel];
+}
+
+export function runWithClientLabel<R>(clientLabel: string, callback: () => R): R {
+  if (typeof clientLabel !== 'string' || clientLabel.trim() === '') {
+    throw new Error('Client label must be a non-empty string.');
+  }
+
+  const existingLabel = clientLabelLocalStorage.getStore();
+  if (existingLabel) {
+    throw new Error('Client label already exists. You can only add one client label.');
+  }
+
+  return clientLabelLocalStorage.run(clientLabel, callback);
 }
 
 /**
@@ -35,7 +86,9 @@ function _getDefaultLabels(): string[] {
  */
 export function getClientLabels(): string[] {
   const labels = _getDefaultLabels();
-  // TODO: b/468053794 - Configurable client labels in AsyncLocalStorage and/or
-  // browser equivalent
+  const contextLabel = clientLabelLocalStorage.getStore();
+  if (contextLabel) {
+    labels.push(contextLabel);
+  }
   return labels;
 }

--- a/core/src/utils/client_labels.ts
+++ b/core/src/utils/client_labels.ts
@@ -15,17 +15,19 @@ const AGENT_ENGINE_TELEMETRY_ENV_VARIABLE_NAME = 'GOOGLE_CLOUD_AGENT_ENGINE_ID';
 
 const clientLabelLocalStorage = new AsyncLocalStorage<string>();
 
+const USER_AGENT_PATTERNS = [
+  ['Edge', /(?:Edg|Edge|EdgA)\/([0-9.]+)/i],
+  ['Firefox', /(?:Firefox|FxiOS)\/([0-9.]+)/i],
+  ['Chrome', /(?:Chrome|CriOS)\/([0-9.]+)/i],
+  ['Safari', /Version\/([0-9.]+).*Safari/i],
+] as const;
+
 export function parseUserAgent(userAgent: string): string {
   if (!userAgent) {
     return 'Browser';
   }
 
-  for (const [name, regex] of [
-    ['Edge', /(?:Edg|Edge|EdgA)\/([0-9.]+)/i],
-    ['Firefox', /(?:Firefox|FxiOS)\/([0-9.]+)/i],
-    ['Chrome', /(?:Chrome|CriOS)\/([0-9.]+)/i],
-    ['Safari', /Version\/([0-9.]+).*Safari/i],
-  ] as const) {
+  for (const [name, regex] of USER_AGENT_PATTERNS) {
     const match = userAgent.match(regex);
     if (match) {
       return `${name}/${match[1]}`;
@@ -51,6 +53,14 @@ function _getDefaultLabels(): string[] {
   return [frameworkLabel, languageLabel];
 }
 
+/**
+ * Runs the given callback within a context that has the specified client label.
+ * All LLM calls made within this callback will include the client label in their tracking headers.
+ *
+ * @param clientLabel The custom client label to apply.
+ * @param callback The callback function to execute.
+ * @return The result of the callback.
+ */
 export function runWithClientLabel<R>(
   clientLabel: string,
   callback: () => R,

--- a/core/test/models/base_llm_test.ts
+++ b/core/test/models/base_llm_test.ts
@@ -10,6 +10,7 @@ import {
   LlmRequest,
   LlmResponse,
   isBaseLlm,
+  runWithClientLabel,
   version,
 } from '@google/adk';
 import {describe, expect, it} from 'vitest';
@@ -65,6 +66,16 @@ describe('BaseLlm', () => {
     }+remote_reasoning_engine gl-typescript/${process.version}`;
     expect(headers['x-goog-api-client']).toEqual(expectedValue);
     expect(headers['user-agent']).toEqual(expectedValue);
+  });
+
+  it('should include context client label in tracking headers when run within runWithClientLabel', () => {
+    const llm = new TestLlm();
+    const customLabel = 'my-custom-label';
+    runWithClientLabel(customLabel, () => {
+      const headers = llm.getTrackingHeaders();
+      expect(headers['x-goog-api-client']).toContain(customLabel);
+      expect(headers['user-agent']).toContain(customLabel);
+    });
   });
 });
 

--- a/core/test/utils/client_labels_test.ts
+++ b/core/test/utils/client_labels_test.ts
@@ -4,10 +4,54 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {getClientLabels, runWithClientLabel} from '@google/adk';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {getClientLabels} from '../../src/utils/client_labels.js';
+import {parseUserAgent} from '../../src/utils/client_labels.js';
 
 describe('client_labels', () => {
+  describe('parseUserAgent', () => {
+    it('should parse Chrome UA', () => {
+      const ua =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36';
+      expect(parseUserAgent(ua)).toBe('Chrome/123.0.0.0');
+    });
+
+    it('should parse Chrome iOS UA', () => {
+      const ua =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/123.0.6312.52 Mobile/15E148 Safari/604.1';
+      expect(parseUserAgent(ua)).toBe('Chrome/123.0.6312.52');
+    });
+
+    it('should parse Firefox UA', () => {
+      const ua =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0';
+      expect(parseUserAgent(ua)).toBe('Firefox/123.0');
+    });
+
+    it('should parse Firefox iOS UA', () => {
+      const ua =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/123.0 Mobile/15E148 Safari/605.1.15';
+      expect(parseUserAgent(ua)).toBe('Firefox/123.0');
+    });
+
+    it('should parse Edge UA', () => {
+      const ua =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.0.0';
+      expect(parseUserAgent(ua)).toBe('Edge/123.0.0.0');
+    });
+
+    it('should parse Safari UA', () => {
+      const ua =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Safari/605.1.15';
+      expect(parseUserAgent(ua)).toBe('Safari/17.3');
+    });
+
+    it('should fallback to Browser for unknown UA', () => {
+      expect(parseUserAgent('Unknown UA')).toBe('Browser');
+      expect(parseUserAgent('')).toBe('Browser');
+    });
+  });
+
   describe('getClientLabels', () => {
     const originalEnv = process.env;
 
@@ -52,9 +96,53 @@ describe('client_labels', () => {
       expect(adkLabel).not.toContain('remote_reasoning_engine');
     });
 
-    it('should return exactly two labels in Node.js environment', () => {
+    it('should return exactly two labels in Node.js environment by default', () => {
       const labels = getClientLabels();
       expect(labels).toHaveLength(2);
+    });
+  });
+
+  describe('runWithClientLabel', () => {
+    it('should append custom label in context', () => {
+      const customLabel = 'my-custom-label';
+      runWithClientLabel(customLabel, () => {
+        const labels = getClientLabels();
+        expect(labels).toContain(customLabel);
+        expect(labels).toHaveLength(3);
+      });
+    });
+
+    it('should clean up custom label after callback', () => {
+      const customLabel = 'my-custom-label';
+      runWithClientLabel(customLabel, () => {
+        // inside
+      });
+      const labels = getClientLabels();
+      expect(labels).not.toContain(customLabel);
+      expect(labels).toHaveLength(2);
+    });
+
+    it('should propagate label across async hops', async () => {
+      const customLabel = 'async-label';
+      await runWithClientLabel(customLabel, async () => {
+        expect(getClientLabels()).toContain(customLabel);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(getClientLabels()).toContain(customLabel);
+
+        await Promise.resolve();
+        expect(getClientLabels()).toContain(customLabel);
+      });
+    });
+
+    it('should throw error for empty label', () => {
+      expect(() => {
+        runWithClientLabel('', () => {});
+      }).toThrow('Client label must be a non-empty string.');
+
+      expect(() => {
+        runWithClientLabel('   ', () => {});
+      }).toThrow('Client label must be a non-empty string.');
     });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: # (No specific issue link provided, parity feature with adk-python)

**2. Or, if no issue exists, describe the change:**

**Problem:**
Developers need to be able to configure custom client labels dynamically for HTTP requests made by the ADK JS library for tracking, debugging, and evaluation (parity with `adk-python`). We also need to extract cleaner browser info from User Agent strings instead of sending full raw UA.

**Solution:**
- Implemented `runWithClientLabel` and updated `getClientLabels` to support context-propagated labels using `AsyncLocalStorage` in Node.js.
- Provided a browser-safe shim for `AsyncLocalStorage` in `core/src/utils/async_hooks_shim.ts`.
- Configured `esbuild` in `core/build.js` to alias `node:async_hooks` to the shim when building for browser platform with bundle option.
- Implemented `parseUserAgent` in `core/src/utils/client_labels.ts` to extract `Browser/Version` from UA.
- Exported new utilities in `core/src/common.ts`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed npm test results:
```
 RUN  v3.2.6 /usr/local/google/home/amaadmartin/Workspace/Agentspaces/feat-configurable-client-labels/adk-js

 Test Files  2 passed (2)
      Tests  24 passed (24)
   Start at  15:45:00
   Duration  10.32s
```
Passed tests include:
- `client_labels` tests (17 tests) covering default labels, UA parsing, context propagation, and error cases for empty labels.
- `BaseLlm` tests (7 tests) including a new test verifying that context client label is included in tracking headers when run within `runWithClientLabel`.

**Manual End-to-End (E2E) Tests:**

- [x] I have manually tested my changes end-to-end.
Verified via integration tests that `BaseLlm` correctly retrieves and includes the context-propagated client label in HTTP headers (`x-goog-api-client` and `user-agent`) when executed within `runWithClientLabel`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context
