### PR TITLE
Feat: Refactor ForwardingArtifactService and introduce SessionArtifactService

### DIFF
--- a/core/src/agents/context.ts
+++ b/core/src/agents/context.ts
@@ -88,9 +88,6 @@ export class Context extends ReadonlyContext {
     }
 
     return this.invocationContext.artifactService.loadArtifact({
-      appName: this.invocationContext.appName,
-      userId: this.invocationContext.userId,
-      sessionId: this.invocationContext.session.id,
       filename,
       version,
     });
@@ -109,9 +106,6 @@ export class Context extends ReadonlyContext {
     }
 
     const version = await this.invocationContext.artifactService.saveArtifact({
-      appName: this.invocationContext.appName,
-      userId: this.invocationContext.userId,
-      sessionId: this.invocationContext.session.id,
       filename,
       artifact,
     });
@@ -152,11 +146,7 @@ export class Context extends ReadonlyContext {
       throw new Error('Artifact service is not initialized.');
     }
 
-    return this.invocationContext.artifactService.listArtifactKeys({
-      appName: this.invocationContext.session.appName,
-      userId: this.invocationContext.session.userId,
-      sessionId: this.invocationContext.session.id,
-    });
+    return this.invocationContext.artifactService.listArtifactKeys();
   }
 
   /**

--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -27,9 +27,6 @@ async function resolveKey(
       throw new Error('Artifact service is not initialized.');
     }
     const artifact = await invocationContext.artifactService.loadArtifact({
-      appName: invocationContext.session.appName,
-      userId: invocationContext.session.userId,
-      sessionId: invocationContext.session.id,
       filename: fileName,
     });
     if (!artifact) {

--- a/core/src/agents/invocation_context.ts
+++ b/core/src/agents/invocation_context.ts
@@ -6,7 +6,7 @@
 
 import {Content} from '@google/genai';
 
-import {BaseArtifactService} from '../artifacts/base_artifact_service.js';
+import {SessionArtifactService} from '../artifacts/session_artifact_service.js';
 import {BaseCredentialService} from '../auth/credential_service/base_credential_service.js';
 import {BaseMemoryService} from '../memory/base_memory_service.js';
 import {PluginManager} from '../plugins/plugin_manager.js';
@@ -23,7 +23,7 @@ import {TranscriptionEntry} from './transcription_entry.js';
  * The parameters for creating an invocation context.
  */
 export interface InvocationContextParams {
-  artifactService?: BaseArtifactService;
+  artifactService?: SessionArtifactService;
   sessionService?: BaseSessionService;
   memoryService?: BaseMemoryService;
   credentialService?: BaseCredentialService;
@@ -111,7 +111,7 @@ class InvocationCostManager {
  *  ```
  */
 export class InvocationContext {
-  readonly artifactService?: BaseArtifactService;
+  readonly artifactService?: SessionArtifactService;
   readonly sessionService?: BaseSessionService;
   readonly memoryService?: BaseMemoryService;
   readonly credentialService?: BaseCredentialService;

--- a/core/src/agents/processors/code_execution_request_processor.ts
+++ b/core/src/agents/processors/code_execution_request_processor.ts
@@ -503,9 +503,6 @@ async function postProcessCodeExecutionResult(
   // Handle output files
   for (const outputFile of codeExecutionResult.outputFiles) {
     const version = await invocationContext.artifactService.saveArtifact({
-      appName: invocationContext.appName || '',
-      userId: invocationContext.userId || '',
-      sessionId: invocationContext.session.id,
       filename: outputFile.name,
       artifact: {
         inlineData: {data: outputFile.content, mimeType: outputFile.mimeType},

--- a/core/src/artifacts/scoped_artifact_service.ts
+++ b/core/src/artifacts/scoped_artifact_service.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Part} from '@google/genai';
+import {ArtifactVersion, BaseArtifactService} from './base_artifact_service.js';
+import {
+  SessionArtifactService,
+  SessionLoadArtifactRequest,
+  SessionSaveArtifactRequest,
+} from './session_artifact_service.js';
+
+/**
+ * A wrapper that scopes a BaseArtifactService to a specific session.
+ */
+export class ScopedArtifactService implements SessionArtifactService {
+  constructor(
+    private readonly delegate: BaseArtifactService,
+    private readonly appName: string,
+    private readonly userId: string,
+    private readonly sessionId: string,
+  ) {}
+
+  async saveArtifact(request: SessionSaveArtifactRequest): Promise<number> {
+    return this.delegate.saveArtifact({
+      appName: this.appName,
+      userId: this.userId,
+      sessionId: this.sessionId,
+      ...request,
+    });
+  }
+
+  async loadArtifact(
+    request: SessionLoadArtifactRequest,
+  ): Promise<Part | undefined> {
+    return this.delegate.loadArtifact({
+      appName: this.appName,
+      userId: this.userId,
+      sessionId: this.sessionId,
+      ...request,
+    });
+  }
+
+  async listArtifactKeys(): Promise<string[]> {
+    return this.delegate.listArtifactKeys({
+      appName: this.appName,
+      userId: this.userId,
+      sessionId: this.sessionId,
+    });
+  }
+
+  async deleteArtifact(filename: string): Promise<void> {
+    return this.delegate.deleteArtifact({
+      appName: this.appName,
+      userId: this.userId,
+      sessionId: this.sessionId,
+      filename,
+    });
+  }
+
+  async listVersions(filename: string): Promise<number[]> {
+    return this.delegate.listVersions({
+      appName: this.appName,
+      userId: this.userId,
+      sessionId: this.sessionId,
+      filename,
+    });
+  }
+
+  async listArtifactVersions(filename: string): Promise<ArtifactVersion[]> {
+    return this.delegate.listArtifactVersions({
+      appName: this.appName,
+      userId: this.userId,
+      sessionId: this.sessionId,
+      filename,
+    });
+  }
+
+  async getArtifactVersion(
+    request: SessionLoadArtifactRequest,
+  ): Promise<ArtifactVersion | undefined> {
+    return this.delegate.getArtifactVersion({
+      appName: this.appName,
+      userId: this.userId,
+      sessionId: this.sessionId,
+      ...request,
+    });
+  }
+}

--- a/core/src/artifacts/session_artifact_service.ts
+++ b/core/src/artifacts/session_artifact_service.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Part} from '@google/genai';
+import {ArtifactVersion} from './base_artifact_service.js';
+
+export interface SessionSaveArtifactRequest {
+  filename: string;
+  artifact: Part;
+  customMetadata?: Record<string, unknown>;
+}
+
+export interface SessionLoadArtifactRequest {
+  filename: string;
+  version?: number;
+}
+
+export interface SessionArtifactService {
+  saveArtifact(request: SessionSaveArtifactRequest): Promise<number>;
+  loadArtifact(request: SessionLoadArtifactRequest): Promise<Part | undefined>;
+  listArtifactKeys(): Promise<string[]>;
+  deleteArtifact(filename: string): Promise<void>;
+  listVersions(filename: string): Promise<number[]>;
+  listArtifactVersions(filename: string): Promise<ArtifactVersion[]>;
+  getArtifactVersion(
+    request: SessionLoadArtifactRequest,
+  ): Promise<ArtifactVersion | undefined>;
+}

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -63,6 +63,11 @@ export type {
   SaveArtifactRequest,
 } from './artifacts/base_artifact_service.js';
 export {InMemoryArtifactService} from './artifacts/in_memory_artifact_service.js';
+export type {
+  SessionArtifactService,
+  SessionLoadArtifactRequest,
+  SessionSaveArtifactRequest,
+} from './artifacts/session_artifact_service.js';
 export {AuthCredentialTypes} from './auth/auth_credential.js';
 export type {
   AuthCredential,

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -15,6 +15,8 @@ import {
 import {isLlmAgent} from '../agents/llm_agent.js';
 import {createRunConfig, RunConfig} from '../agents/run_config.js';
 import {BaseArtifactService} from '../artifacts/base_artifact_service.js';
+import {ScopedArtifactService} from '../artifacts/scoped_artifact_service.js';
+
 import {BaseCredentialService} from '../auth/credential_service/base_credential_service.js';
 import {
   BuiltInCodeExecutor,
@@ -255,7 +257,14 @@ export class Runner {
           }
 
           const invocationContext = new InvocationContext({
-            artifactService: this.artifactService,
+            artifactService: this.artifactService
+              ? new ScopedArtifactService(
+                  this.artifactService,
+                  this.appName,
+                  userId,
+                  sessionId,
+                )
+              : undefined,
             sessionService: this.sessionService,
             memoryService: this.memoryService,
             credentialService: this.credentialService,

--- a/core/src/tools/forwarding_artifact_service.ts
+++ b/core/src/tools/forwarding_artifact_service.ts
@@ -11,10 +11,12 @@ import {
   ArtifactVersion,
   BaseArtifactService,
   DeleteArtifactRequest,
+  ListArtifactKeysRequest,
   ListVersionsRequest,
   LoadArtifactRequest,
   SaveArtifactRequest,
 } from '../artifacts/base_artifact_service.js';
+import {SessionArtifactService} from '../artifacts/session_artifact_service.js';
 
 import {Context} from '../agents/context.js';
 
@@ -28,8 +30,6 @@ export class ForwardingArtifactService implements BaseArtifactService {
     this.invocationContext = toolContext.invocationContext;
   }
 
-  // TODO - b/425992518: Remove unnecessary parameters. We should rethink the
-  // abstraction layer to make it more clear.
   async saveArtifact(request: SaveArtifactRequest): Promise<number> {
     return this.toolContext.saveArtifact(request.filename, request.artifact);
   }
@@ -38,51 +38,38 @@ export class ForwardingArtifactService implements BaseArtifactService {
     return this.toolContext.loadArtifact(request.filename, request.version);
   }
 
-  async listArtifactKeys(): Promise<string[]> {
+  async listArtifactKeys(_request: ListArtifactKeysRequest): Promise<string[]> {
     return this.toolContext.listArtifacts();
   }
 
-  async deleteArtifact(request: DeleteArtifactRequest): Promise<void> {
-    if (!this.toolContext.invocationContext.artifactService) {
+  private getArtifactService(): SessionArtifactService {
+    const service = this.invocationContext.artifactService;
+    if (!service) {
       throw new Error('Artifact service is not initialized.');
     }
+    return service;
+  }
 
-    return this.toolContext.invocationContext.artifactService.deleteArtifact(
-      request,
-    );
+  async deleteArtifact(request: DeleteArtifactRequest): Promise<void> {
+    return this.getArtifactService().deleteArtifact(request.filename);
   }
 
   async listVersions(request: ListVersionsRequest): Promise<number[]> {
-    if (!this.toolContext.invocationContext.artifactService) {
-      throw new Error('Artifact service is not initialized.');
-    }
-
-    return this.toolContext.invocationContext.artifactService.listVersions(
-      request,
-    );
+    return this.getArtifactService().listVersions(request.filename);
   }
 
-  listArtifactVersions(
+  async listArtifactVersions(
     request: ListVersionsRequest,
   ): Promise<ArtifactVersion[]> {
-    if (!this.toolContext.invocationContext.artifactService) {
-      throw new Error('Artifact service is not initialized.');
-    }
-
-    return this.toolContext.invocationContext.artifactService.listArtifactVersions(
-      request,
-    );
+    return this.getArtifactService().listArtifactVersions(request.filename);
   }
 
-  getArtifactVersion(
+  async getArtifactVersion(
     request: LoadArtifactRequest,
   ): Promise<ArtifactVersion | undefined> {
-    if (!this.toolContext.invocationContext.artifactService) {
-      throw new Error('Artifact service is not initialized.');
-    }
-
-    return this.toolContext.invocationContext.artifactService.getArtifactVersion(
-      request,
-    );
+    return this.getArtifactService().getArtifactVersion({
+      filename: request.filename,
+      version: request.version,
+    });
   }
 }

--- a/core/test/agents/instructions_test.ts
+++ b/core/test/agents/instructions_test.ts
@@ -161,9 +161,6 @@ describe('injectSessionState', () => {
       );
       expect(result).toBe('data=artifact content here');
       expect(mockArtifactService.loadArtifact).toHaveBeenCalledWith({
-        appName: 'app',
-        userId: 'user-1',
-        sessionId: 'sess-1',
         filename: 'report.txt',
       });
     });

--- a/core/test/artifacts/scoped_artifact_service_test.ts
+++ b/core/test/artifacts/scoped_artifact_service_test.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Part} from '@google/genai';
+import {describe, expect, it, vi} from 'vitest';
+import {BaseArtifactService} from '../../src/artifacts/base_artifact_service.js';
+import {ScopedArtifactService} from '../../src/artifacts/scoped_artifact_service.js';
+import {
+  SessionLoadArtifactRequest,
+  SessionSaveArtifactRequest,
+} from '../../src/artifacts/session_artifact_service.js';
+
+function makeBaseArtifactServiceStub(): BaseArtifactService {
+  return {
+    saveArtifact: vi.fn(),
+    loadArtifact: vi.fn(),
+    listArtifactKeys: vi.fn(),
+    deleteArtifact: vi.fn(),
+    listVersions: vi.fn(),
+    listArtifactVersions: vi.fn(),
+    getArtifactVersion: vi.fn(),
+  };
+}
+
+describe('ScopedArtifactService', () => {
+  const appName = 'test-app';
+  const userId = 'test-user';
+  const sessionId = 'test-session';
+
+  describe('saveArtifact', () => {
+    it('delegates with scoped context', async () => {
+      const delegate = makeBaseArtifactServiceStub();
+      vi.mocked(delegate.saveArtifact).mockResolvedValue(42);
+      const service = new ScopedArtifactService(
+        delegate,
+        appName,
+        userId,
+        sessionId,
+      );
+
+      const request: SessionSaveArtifactRequest = {
+        filename: 'file.txt',
+        artifact: {text: 'hello'},
+        customMetadata: {foo: 'bar'},
+      };
+
+      const result = await service.saveArtifact(request);
+
+      expect(delegate.saveArtifact).toHaveBeenCalledWith({
+        appName,
+        userId,
+        sessionId,
+        filename: 'file.txt',
+        artifact: {text: 'hello'},
+        customMetadata: {foo: 'bar'},
+      });
+      expect(result).toBe(42);
+    });
+  });
+
+  describe('loadArtifact', () => {
+    it('delegates with scoped context', async () => {
+      const delegate = makeBaseArtifactServiceStub();
+      const part: Part = {text: 'content'};
+      vi.mocked(delegate.loadArtifact).mockResolvedValue(part);
+      const service = new ScopedArtifactService(
+        delegate,
+        appName,
+        userId,
+        sessionId,
+      );
+
+      const request: SessionLoadArtifactRequest = {
+        filename: 'file.txt',
+        version: 2,
+      };
+
+      const result = await service.loadArtifact(request);
+
+      expect(delegate.loadArtifact).toHaveBeenCalledWith({
+        appName,
+        userId,
+        sessionId,
+        filename: 'file.txt',
+        version: 2,
+      });
+      expect(result).toBe(part);
+    });
+  });
+
+  describe('listArtifactKeys', () => {
+    it('delegates with scoped context', async () => {
+      const delegate = makeBaseArtifactServiceStub();
+      vi.mocked(delegate.listArtifactKeys).mockResolvedValue(['a', 'b']);
+      const service = new ScopedArtifactService(
+        delegate,
+        appName,
+        userId,
+        sessionId,
+      );
+
+      const result = await service.listArtifactKeys();
+
+      expect(delegate.listArtifactKeys).toHaveBeenCalledWith({
+        appName,
+        userId,
+        sessionId,
+      });
+      expect(result).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('deleteArtifact', () => {
+    it('delegates with scoped context', async () => {
+      const delegate = makeBaseArtifactServiceStub();
+      const service = new ScopedArtifactService(
+        delegate,
+        appName,
+        userId,
+        sessionId,
+      );
+
+      await service.deleteArtifact('file.txt');
+
+      expect(delegate.deleteArtifact).toHaveBeenCalledWith({
+        appName,
+        userId,
+        sessionId,
+        filename: 'file.txt',
+      });
+    });
+  });
+
+  describe('listVersions', () => {
+    it('delegates with scoped context', async () => {
+      const delegate = makeBaseArtifactServiceStub();
+      vi.mocked(delegate.listVersions).mockResolvedValue([1, 2]);
+      const service = new ScopedArtifactService(
+        delegate,
+        appName,
+        userId,
+        sessionId,
+      );
+
+      const result = await service.listVersions('file.txt');
+
+      expect(delegate.listVersions).toHaveBeenCalledWith({
+        appName,
+        userId,
+        sessionId,
+        filename: 'file.txt',
+      });
+      expect(result).toEqual([1, 2]);
+    });
+  });
+
+  describe('listArtifactVersions', () => {
+    it('delegates with scoped context', async () => {
+      const delegate = makeBaseArtifactServiceStub();
+      const versions = [{version: 1}];
+      vi.mocked(delegate.listArtifactVersions).mockResolvedValue(versions);
+      const service = new ScopedArtifactService(
+        delegate,
+        appName,
+        userId,
+        sessionId,
+      );
+
+      const result = await service.listArtifactVersions('file.txt');
+
+      expect(delegate.listArtifactVersions).toHaveBeenCalledWith({
+        appName,
+        userId,
+        sessionId,
+        filename: 'file.txt',
+      });
+      expect(result).toEqual(versions);
+    });
+  });
+
+  describe('getArtifactVersion', () => {
+    it('delegates with scoped context', async () => {
+      const delegate = makeBaseArtifactServiceStub();
+      const version = {version: 1};
+      vi.mocked(delegate.getArtifactVersion).mockResolvedValue(version);
+      const service = new ScopedArtifactService(
+        delegate,
+        appName,
+        userId,
+        sessionId,
+      );
+
+      const request: SessionLoadArtifactRequest = {
+        filename: 'file.txt',
+        version: 1,
+      };
+
+      const result = await service.getArtifactVersion(request);
+
+      expect(delegate.getArtifactVersion).toHaveBeenCalledWith({
+        appName,
+        userId,
+        sessionId,
+        filename: 'file.txt',
+        version: 1,
+      });
+      expect(result).toBe(version);
+    });
+  });
+});

--- a/core/test/tools/forwarding_artifact_service_test.ts
+++ b/core/test/tools/forwarding_artifact_service_test.ts
@@ -8,6 +8,7 @@ import {Part} from '@google/genai';
 import {describe, expect, it, vi} from 'vitest';
 import {
   DeleteArtifactRequest,
+  ListArtifactKeysRequest,
   ListVersionsRequest,
   LoadArtifactRequest,
   SaveArtifactRequest,
@@ -88,12 +89,14 @@ describe('ForwardingArtifactService', () => {
       toolContext.loadArtifact.mockResolvedValue(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      await service.loadArtifact({
+      const request: LoadArtifactRequest = {
         appName: 'app',
         userId: 'user',
         sessionId: 'session',
         filename: 'file.txt',
-      });
+      };
+
+      await service.loadArtifact(request);
       expect(toolContext.loadArtifact).toHaveBeenCalledWith(
         'file.txt',
         undefined,
@@ -107,7 +110,13 @@ describe('ForwardingArtifactService', () => {
       toolContext.listArtifacts.mockResolvedValue(['a.txt', 'b.txt']);
       const service = new ForwardingArtifactService(toolContext);
 
-      const result = await service.listArtifactKeys();
+      const request: ListArtifactKeysRequest = {
+        appName: 'app',
+        userId: 'user',
+        sessionId: 'session',
+      };
+
+      const result = await service.listArtifactKeys(request);
       expect(toolContext.listArtifacts).toHaveBeenCalled();
       expect(result).toEqual(['a.txt', 'b.txt']);
     });
@@ -128,21 +137,23 @@ describe('ForwardingArtifactService', () => {
       };
 
       await service.deleteArtifact(request);
-      expect(artifactService.deleteArtifact).toHaveBeenCalledWith(request);
+      expect(artifactService.deleteArtifact).toHaveBeenCalledWith('file.txt');
     });
 
     it('throws when artifactService is undefined', async () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      await expect(
-        service.deleteArtifact({
-          appName: 'app',
-          userId: 'user',
-          sessionId: 'session',
-          filename: 'file.txt',
-        }),
-      ).rejects.toThrow('Artifact service is not initialized.');
+      const request: DeleteArtifactRequest = {
+        appName: 'app',
+        userId: 'user',
+        sessionId: 'session',
+        filename: 'file.txt',
+      };
+
+      await expect(service.deleteArtifact(request)).rejects.toThrow(
+        'Artifact service is not initialized.',
+      );
     });
   });
 
@@ -161,7 +172,7 @@ describe('ForwardingArtifactService', () => {
       };
 
       const result = await service.listVersions(request);
-      expect(artifactService.listVersions).toHaveBeenCalledWith(request);
+      expect(artifactService.listVersions).toHaveBeenCalledWith('file.txt');
       expect(result).toEqual([0, 1, 2]);
     });
 
@@ -169,14 +180,16 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      await expect(
-        service.listVersions({
-          appName: 'app',
-          userId: 'user',
-          sessionId: 'session',
-          filename: 'file.txt',
-        }),
-      ).rejects.toThrow('Artifact service is not initialized.');
+      const request: ListVersionsRequest = {
+        appName: 'app',
+        userId: 'user',
+        sessionId: 'session',
+        filename: 'file.txt',
+      };
+
+      await expect(service.listVersions(request)).rejects.toThrow(
+        'Artifact service is not initialized.',
+      );
     });
   });
 
@@ -197,23 +210,25 @@ describe('ForwardingArtifactService', () => {
 
       const result = await service.listArtifactVersions(request);
       expect(artifactService.listArtifactVersions).toHaveBeenCalledWith(
-        request,
+        'file.txt',
       );
       expect(result).toEqual(versions);
     });
 
-    it('throws when artifactService is undefined', () => {
+    it('throws when artifactService is undefined', async () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      expect(() =>
-        service.listArtifactVersions({
-          appName: 'app',
-          userId: 'user',
-          sessionId: 'session',
-          filename: 'file.txt',
-        }),
-      ).toThrow('Artifact service is not initialized.');
+      const request: ListVersionsRequest = {
+        appName: 'app',
+        userId: 'user',
+        sessionId: 'session',
+        filename: 'file.txt',
+      };
+
+      await expect(service.listArtifactVersions(request)).rejects.toThrow(
+        'Artifact service is not initialized.',
+      );
     });
   });
 
@@ -234,23 +249,28 @@ describe('ForwardingArtifactService', () => {
       };
 
       const result = await service.getArtifactVersion(request);
-      expect(artifactService.getArtifactVersion).toHaveBeenCalledWith(request);
+      expect(artifactService.getArtifactVersion).toHaveBeenCalledWith({
+        filename: 'file.txt',
+        version: 1,
+      });
       expect(result).toEqual(versionMeta);
     });
 
-    it('throws when artifactService is undefined', () => {
+    it('throws when artifactService is undefined', async () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      expect(() =>
-        service.getArtifactVersion({
-          appName: 'app',
-          userId: 'user',
-          sessionId: 'session',
-          filename: 'file.txt',
-          version: 0,
-        }),
-      ).toThrow('Artifact service is not initialized.');
+      const request: LoadArtifactRequest = {
+        appName: 'app',
+        userId: 'user',
+        sessionId: 'session',
+        filename: 'file.txt',
+        version: 0,
+      };
+
+      await expect(service.getArtifactVersion(request)).rejects.toThrow(
+        'Artifact service is not initialized.',
+      );
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,6 +5171,7 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,7 +5171,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #
- Related: #

**2. Or, if no issue exists, describe the change:**

**Problem:**
`ForwardingArtifactService` had unnecessary parameters (`appName`, `userId`, `sessionId`) in its interface, causing leaked abstractions and complicated signatures.

**Solution:**
- Introduced a scoped `SessionArtifactService` interface to define session-specific artifact operations.
- Implemented `ScopedArtifactService` to bind session metadata to `BaseArtifactService` for use within the execution context.
- Updated `Context` and `InvocationContext` to use the new scoped `SessionArtifactService` interface instead of `BaseArtifactService`.
- Refactored `ForwardingArtifactService` to implement `BaseArtifactService` directly, delegating internally to the parent's scoped `SessionArtifactService` by stripping session metadata.
- Simplified `RunnerConfig` to only accept `BaseArtifactService`, letting `Runner` handle the scoping internally using `ScopedArtifactService`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed npm test results:
Ran unit tests for `scoped_artifact_service_test.ts`, `forwarding_artifact_service_test.ts`, and `agent_tool_test.ts`. All 28 tests passed.
Also verified with full test run: `core/test/artifacts/scoped_artifact_service_test.ts`, `core/test/tools/forwarding_artifact_service_test.ts`, and `core/test/tools/agent_tool_test.ts` (35 tests passed in total including the new ones).

**Manual End-to-End (E2E) Tests:**
None. Changes are covered by unit and integration tests.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context
None.
