### PR TITLE
feat: simplify transaction log session implementation in LlmAgent

### DIFF
--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -20,7 +20,12 @@ import {
   BuiltInCodeExecutor,
   isBuiltInCodeExecutor,
 } from '../code_executors/built_in_code_executor.js';
-import {createEvent, Event, getFunctionCalls} from '../events/event.js';
+import {
+  createEvent,
+  Event,
+  getFunctionCalls,
+  getFunctionResponses,
+} from '../events/event.js';
 import {createEventActions} from '../events/event_actions.js';
 import {BaseMemoryService} from '../memory/base_memory_service.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
@@ -308,17 +313,19 @@ export class Runner {
               }
             }
             // Append the user message to the session with optional state delta.
+            const userEvent = createEvent({
+              invocationId: invocationContext.invocationId,
+              author: 'user',
+              actions: stateDelta
+                ? createEventActions({stateDelta})
+                : undefined,
+              content: newMessage,
+              customMetadata: params.customMetadata,
+            });
+            this.updatePendingToolCalls(session, userEvent);
             await this.sessionService.appendEvent({
               session,
-              event: createEvent({
-                invocationId: invocationContext.invocationId,
-                author: 'user',
-                actions: stateDelta
-                  ? createEventActions({stateDelta})
-                  : undefined,
-                content: newMessage,
-                customMetadata: params.customMetadata,
-              }),
+              event: userEvent,
             });
             if (params.abortSignal?.aborted) {
               return;
@@ -376,6 +383,7 @@ export class Runner {
                 }
 
                 if (!event.partial) {
+                  this.updatePendingToolCalls(session, event);
                   await this.sessionService.appendEvent({session, event});
                 }
                 // Step 3: Run the on_event callbacks to optionally modify the event.
@@ -460,13 +468,45 @@ export class Runner {
     session: Session,
     rootAgent: BaseAgent,
   ): BaseAgent {
+    if (!session.events.length) {
+      return rootAgent;
+    }
+
     // =========================================================================
-    // Case 1: If the last event is a function response, this returns the
-    // agent that made the original function call.
+    // Case 1: Use _sys_pending_tool_calls if available, fallback to event scan.
     // =========================================================================
-    const event = findEventByLastFunctionResponseId(session.events);
-    if (event && event.author) {
-      return rootAgent.findAgent(event.author) || rootAgent;
+    const lastEvent = session.events[session.events.length - 1];
+    const functionResponseId = getFunctionResponses(lastEvent)[0]?.id;
+
+    if (functionResponseId) {
+      const agentName = (
+        session.state['_sys_pending_tool_calls'] as Record<string, string>
+      )?.[functionResponseId];
+      if (agentName) {
+        const agent = rootAgent.findAgent(agentName);
+        if (agent) {
+          logger.info(
+            `Resuming agent ${agentName} using pending tool calls state.`,
+          );
+          return agent;
+        }
+        logger.warn(
+          `Agent ${agentName} found in pending tool calls but not in agent tree. Defaulting to root.`,
+        );
+        return rootAgent;
+      } else {
+        // Fallback to scanning event log
+        logger.info(
+          `Tool response ID ${functionResponseId} not found in pending tool calls state. Falling back to event log scan.`,
+        );
+        const event = findEventByFunctionCallId(
+          session.events,
+          functionResponseId,
+        );
+        if (event && event.author) {
+          return rootAgent.findAgent(event.author) || rootAgent;
+        }
+      }
     }
 
     // =========================================================================
@@ -527,38 +567,57 @@ export class Runner {
     }
     return true;
   }
+
+  private updatePendingToolCalls(session: Session, event: Event) {
+    const {author, longRunningToolIds, actions} = event;
+    let pendingToolCallsChanged = false;
+    const pendingToolCalls = {
+      ...(session.state['_sys_pending_tool_calls'] as Record<string, string>),
+    };
+
+    // 1. Add new pending tool calls
+    if (longRunningToolIds?.length && author) {
+      for (const toolCallId of longRunningToolIds) {
+        pendingToolCalls[toolCallId] = author;
+        pendingToolCallsChanged = true;
+      }
+    }
+
+    // 2. Clean up resolved tool calls
+    // We only clean up when the agent steps forward and emits a new event.
+    if (author && author !== 'user' && session.events.length) {
+      const previousEvent = session.events[session.events.length - 1];
+      for (const {id} of getFunctionResponses(previousEvent)) {
+        if (id && pendingToolCalls[id]) {
+          delete pendingToolCalls[id];
+          pendingToolCallsChanged = true;
+          logger.info(
+            `Cleaned up resolved tool call ${id} from pending state.`,
+          );
+        }
+      }
+    }
+
+    if (pendingToolCallsChanged) {
+      actions.stateDelta['_sys_pending_tool_calls'] = pendingToolCalls;
+    }
+  }
   // TODO - b/425992518: Implement runLive and related methods.
 }
 
 /**
  * It iterates through the events in reverse order, and returns the event
  * containing a function call with a functionCall.id matching the
- * functionResponse.id from the last event in the session.
+ * functionCallId.
  */
-// TODO - b/425992518: a hack that used event log as transaction log. Fix.
-function findEventByLastFunctionResponseId(events: Event[]): Event | null {
-  if (!events.length) {
-    return null;
-  }
-
-  const lastEvent = events[events.length - 1];
-  const functionCallId = lastEvent.content?.parts?.find(
-    (part) => part.functionResponse,
-  )?.functionResponse?.id;
-  if (!functionCallId) {
-    return null;
-  }
-
+function findEventByFunctionCallId(
+  events: Event[],
+  functionCallId: string,
+): Event | null {
   // TODO - b/425992518: inefficient search, fix.
   for (let i = events.length - 2; i >= 0; i--) {
     const event = events[i];
-    // Looking for the system long running request euc function call.
-    const functionCalls = getFunctionCalls(event);
-    if (!functionCalls) {
-      continue;
-    }
-
-    for (const functionCall of functionCalls) {
+    for (const functionCall of getFunctionCalls(event)) {
       if (functionCall.id === functionCallId) {
         return event;
       }

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -9,6 +9,7 @@ import {
   BasePlugin,
   createEvent,
   Event,
+  getLogger,
   InMemoryArtifactService,
   InMemorySessionService,
   InvocationContext,
@@ -685,5 +686,253 @@ describe('Runner customMetadata support', () => {
     expect(userEventCall![0].event.customMetadata).toEqual(customMetadata);
 
     appendEventSpy.mockRestore();
+  });
+});
+
+describe('Runner pending tool calls tracking', () => {
+  let sessionService: InMemorySessionService;
+  let artifactService: InMemoryArtifactService;
+  let runner: Runner;
+
+  beforeEach(() => {
+    sessionService = new InMemorySessionService();
+    artifactService = new InMemoryArtifactService();
+  });
+
+  class DynamicMockAgent extends LlmAgent {
+    yields = 0;
+    constructor(name: string, parentAgent?: BaseAgent) {
+      super({
+        name,
+        model: 'gemini-2.5-flash',
+        subAgents: [],
+        parentAgent,
+      });
+    }
+
+    protected override async *runAsyncImpl(
+      context: InvocationContext,
+    ): AsyncGenerator<Event, void, void> {
+      this.yields++;
+      if (this.yields === 1) {
+        yield createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          content: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_lro_1',
+                  name: 'long_running_tool',
+                  args: {},
+                },
+              },
+            ],
+          },
+          longRunningToolIds: ['call_lro_1'],
+        });
+      } else {
+        yield createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          content: {role: 'model', parts: [{text: 'Done'}]},
+        });
+      }
+    }
+  }
+
+  it('should populate _sys_pending_tool_calls when agent yields long-running tool calls', async () => {
+    const toolAgent = new DynamicMockAgent('tool_agent');
+    runner = new Runner({
+      appName: TEST_APP_ID,
+      agent: toolAgent,
+      sessionService,
+      artifactService,
+    });
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'Run tool'}]},
+    })) {
+      events.push(event);
+    }
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(updatedSession).not.toBeNull();
+    const pendingCalls = updatedSession!.state[
+      '_sys_pending_tool_calls'
+    ] as Record<string, string>;
+    expect(pendingCalls).toBeDefined();
+    expect(pendingCalls['call_lro_1']).toBe('tool_agent');
+  });
+
+  it('should resume correct agent using _sys_pending_tool_calls and clean it up', async () => {
+    const rootAgent = new MockLlmAgent('root_agent');
+    const toolAgent = new DynamicMockAgent('tool_agent', rootAgent);
+    rootAgent.subAgents.push(toolAgent);
+
+    runner = new Runner({
+      appName: TEST_APP_ID,
+      agent: rootAgent,
+      sessionService,
+      artifactService,
+    });
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+      state: {
+        _sys_pending_tool_calls: {
+          call_lro_1: 'tool_agent',
+        },
+      },
+    });
+
+    const functionResponse: FunctionResponse = {
+      id: 'call_lro_1',
+      name: 'long_running_tool',
+      response: {result: 'success'},
+    };
+
+    // Pretend the agent already yielded once, so it yields 'Done' next.
+    toolAgent.yields = 1;
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{functionResponse}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events[0].author).toBe('tool_agent');
+    expect(events[0].content?.parts?.[0].text).toBe('Done');
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(updatedSession).not.toBeNull();
+    const pendingCalls = updatedSession!.state[
+      '_sys_pending_tool_calls'
+    ] as Record<string, string>;
+    expect(pendingCalls).toBeDefined();
+    expect(pendingCalls['call_lro_1']).toBeUndefined();
+  });
+
+  it('should fallback to event scanning if _sys_pending_tool_calls is missing', async () => {
+    const rootAgent = new MockLlmAgent('root_agent');
+    const toolAgent = new MockLlmAgent('tool_agent', false, rootAgent);
+    rootAgent.subAgents.push(toolAgent);
+
+    runner = new Runner({
+      appName: TEST_APP_ID,
+      agent: rootAgent,
+      sessionService,
+      artifactService,
+    });
+
+    const functionCall: FunctionCall = {
+      id: 'call_fallback',
+      name: 'some_tool',
+      args: {},
+    };
+    const functionResponse: FunctionResponse = {
+      id: 'call_fallback',
+      name: 'some_tool',
+      response: {},
+    };
+
+    const callEvent = createEvent({
+      invocationId: 'inv1',
+      author: 'tool_agent',
+      content: {role: 'model', parts: [{functionCall}]},
+    });
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    await sessionService.appendEvent({session, event: callEvent});
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{functionResponse}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events[0].author).toBe('tool_agent');
+  });
+
+  it('should log warning and fallback if agent in pending tool calls is not in tree', async () => {
+    const rootAgent = new MockLlmAgent('root_agent');
+
+    runner = new Runner({
+      appName: TEST_APP_ID,
+      agent: rootAgent,
+      sessionService,
+      artifactService,
+    });
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+      state: {
+        _sys_pending_tool_calls: {
+          'call_lro_1': 'missing_agent',
+        },
+      },
+    });
+
+    const functionResponse: FunctionResponse = {
+      id: 'call_lro_1',
+      name: 'long_running_tool',
+      response: {result: 'success'},
+    };
+
+    const loggerInstance = getLogger();
+    const warnSpy = vi.spyOn(loggerInstance, 'warn');
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{functionResponse}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events[0].author).toBe('root_agent');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Agent missing_agent found in pending tool calls but not in agent tree.',
+      ),
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "workspaces": [
         "core",
-        "dev"
+        "dev",
+        "integrations"
       ],
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -325,6 +326,13 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "integrations": {
+      "version": "1.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/adk": "^1.3.0"
       }
     },
     "node_modules/@a2a-js/sdk": {
@@ -1567,6 +1575,10 @@
     },
     "node_modules/@google/adk-devtools": {
       "resolved": "dev",
+      "link": true
+    },
+    "node_modules/@google/adk-integrations": {
+      "resolved": "integrations",
       "link": true
     },
     "node_modules/@google/genai": {
@@ -5171,7 +5183,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docs:generate": "typedoc",
     "docs:serve": "http-server api-reference/typescript",
     "docs:check": "typedoc --emit none --treatWarningsAsErrors",
-    "test": "vitest --project unit:core --project unit:dev --project integration --project e2e",
+    "test": "vitest run --project unit:core --project unit:dev --project integration --project e2e",
     "test:unit": "vitest --project unit:core --project unit:dev",
     "test:integration": "vitest --project integration",
     "test:e2e": "vitest --project e2e",


### PR DESCRIPTION
# Description

Simplify session resumption logic by tracking pending tool calls in session state, avoiding inefficient event history scanning.

## Problem

Previously, ADK used the event log as a transaction log. When resuming a session with a tool response, the runner had to scan all previous events backwards to find the corresponding tool call and identify which agent initiated it. This was inefficient (especially for long sessions) and hacky.

## Solution

1.  **State-based tracking**: Introduce `_sys_pending_tool_calls` in `Session.state` (type: `Record<string, string>`, mapping `tool_call_id` to `agent_name`).
2.  **Populate pending calls**: When an agent yields an event with `longRunningToolIds`, the `Runner` intercepts it and records these in `_sys_pending_tool_calls` via `stateDelta`.
3.  **Fast resumption**: When resuming, the `Runner` looks up the last function response ID in `_sys_pending_tool_calls` to immediately identify and resume the correct agent.
4.  **Cleanup**: Clean up resolved tool calls from `_sys_pending_tool_calls` when the resumed agent steps forward and yields its next event.
5.  **Backward compatibility**: Fallback to event log scanning if `_sys_pending_tool_calls` is missing or doesn't contain the ID.
6.  **Refactoring**: Refactored `findEventByLastFunctionResponseId` to a more generic `findEventByFunctionCallId` and removed redundant checks.

## Testing

Added comprehensive unit tests in `core/test/runner/runner_test.ts`:
-   `should populate _sys_pending_tool_calls when agent yields long-running tool calls`
-   `should resume correct agent using _sys_pending_tool_calls and clean it up`
-   `should fallback to event scanning if _sys_pending_tool_calls is missing`
-   `should log warning and fallback if agent in pending tool calls is not in tree` (handles edge case where agent was removed from tree but still in state).
