### PR TITLE
Feat: Address TODO in agent_tool.ts: Validate input/output schemas

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -359,6 +359,8 @@ export class LlmAgent extends BaseAgent {
   includeContents: 'default' | 'none';
   inputSchema?: Schema;
   outputSchema?: Schema;
+  readonly originalInputSchema?: LlmAgentSchema;
+  readonly originalOutputSchema?: LlmAgentSchema;
   outputKey?: string;
   beforeModelCallback?: BeforeModelCallback;
   afterModelCallback?: AfterModelCallback;
@@ -384,6 +386,8 @@ export class LlmAgent extends BaseAgent {
     this.outputSchema = isZodObject(config.outputSchema)
       ? zodObjectToSchema(config.outputSchema)
       : config.outputSchema;
+    this.originalInputSchema = config.inputSchema;
+    this.originalOutputSchema = config.outputSchema;
     this.outputKey = config.outputKey;
     this.beforeModelCallback = config.beforeModelCallback;
     this.afterModelCallback = config.afterModelCallback;

--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -12,6 +12,7 @@ import {Event} from '../events/event.js';
 import {InMemoryMemoryService} from '../memory/in_memory_memory_service.js';
 import {Runner} from '../runner/runner.js';
 import {InMemorySessionService} from '../sessions/in_memory_session_service.js';
+import {isZodObject} from '../utils/simple_zod_to_json.js';
 import {GoogleLLMVariant} from '../utils/variant_utils.js';
 
 import {State} from '../sessions/state.js';
@@ -87,9 +88,6 @@ export class AgentTool extends BaseTool {
       declaration = {
         name: this.name,
         description: this.description,
-        // TODO(b/425992518): We should not use the agent's input schema as is.
-        // It should be validated and possibly transformed. Consider similar
-        // logic to one we have in Python ADK.
         parameters: this.agent.inputSchema,
       };
     } else {
@@ -130,16 +128,23 @@ export class AgentTool extends BaseTool {
     // returned verbatim below, which is the intended effect of
     // skipSummarization.
 
+    let validatedArgs = args;
+    if (isLlmAgent(this.agent) && isZodObject(this.agent.originalInputSchema)) {
+      const result = this.agent.originalInputSchema.safeParse(args);
+      if (!result.success) {
+        throw new Error(`Input validation failed: ${result.error.message}`);
+      }
+      validatedArgs = result.data as Record<string, unknown>;
+    }
+
     const hasInputSchema = isLlmAgent(this.agent) && this.agent.inputSchema;
     const content: Content = {
       role: 'user',
       parts: [
         {
-          // TODO(b/425992518): Should be validated. Consider similar
-          // logic to one we have in Python ADK.
           text: hasInputSchema
-            ? JSON.stringify(args)
-            : (args['request'] as string),
+            ? JSON.stringify(validatedArgs)
+            : (validatedArgs['request'] as string),
         },
       ],
     };
@@ -197,7 +202,6 @@ export class AgentTool extends BaseTool {
       return '';
     }
 
-    const hasOutputSchema = isLlmAgent(this.agent) && this.agent.outputSchema;
     // Exclude thoughts from the merged text.
     const mergedText = lastEvent.content.parts
       .filter((part) => !part.thought)
@@ -205,8 +209,22 @@ export class AgentTool extends BaseTool {
       .filter((text) => text)
       .join('\n');
 
-    // TODO - b/425992518: In case of output schema, the output should be
-    // validated. Consider similar logic to one we have in Python ADK.
-    return hasOutputSchema ? JSON.parse(mergedText) : mergedText;
+    if (isLlmAgent(this.agent) && this.agent.outputSchema) {
+      let parsedOutput: unknown;
+      try {
+        parsedOutput = JSON.parse(mergedText);
+      } catch (_e) {
+        throw new Error(`Failed to parse output as JSON: ${mergedText}`);
+      }
+      if (isZodObject(this.agent.originalOutputSchema)) {
+        const result = this.agent.originalOutputSchema.safeParse(parsedOutput);
+        if (!result.success) {
+          throw new Error(`Output validation failed: ${result.error.message}`);
+        }
+        return result.data;
+      }
+      return parsedOutput;
+    }
+    return mergedText;
   }
 }

--- a/core/src/utils/simple_zod_to_json.ts
+++ b/core/src/utils/simple_zod_to_json.ts
@@ -65,129 +65,133 @@ export function isZodObject(
 }
 
 export function zodObjectToSchema(
-  schema: z3.ZodObject<z3.ZodRawShape> | z4.ZodObject<z4.ZodRawShape>,
+  schema: z3.ZodObject<z3.ZodRawShape> | z4.ZodObject<z4.ZodRawShape> | Schema,
 ): Schema {
-  if (!isZodObject(schema)) {
-    throw new Error('Expected a Zod Object');
+  if (isZodSchema(schema)) {
+    if (!isZodObject(schema)) {
+      throw new Error('Expected a Zod Object');
+    }
+
+    if (isZodV4Schema(schema)) {
+      return toJSONSchemaV4(schema, {
+        target: 'openapi-3.0',
+        io: 'input',
+        override: (ctx) => {
+          const {jsonSchema} = ctx;
+
+          if (jsonSchema.additionalProperties !== undefined) {
+            delete jsonSchema.additionalProperties;
+          }
+
+          if (jsonSchema.readOnly !== undefined) {
+            delete jsonSchema.readOnly;
+          }
+
+          if (jsonSchema.maxItems !== undefined) {
+            (jsonSchema as Schema).maxItems = jsonSchema.maxItems.toString();
+          }
+
+          if (jsonSchema.format === 'email' || jsonSchema.format === 'uuid') {
+            delete jsonSchema.pattern;
+          }
+
+          if (jsonSchema.minItems !== undefined) {
+            (jsonSchema as Schema).minItems = jsonSchema.minItems.toString();
+          }
+
+          if (jsonSchema.minLength !== undefined) {
+            (jsonSchema as Schema).minLength = jsonSchema.minLength.toString();
+          }
+
+          if (jsonSchema.maxLength !== undefined) {
+            (jsonSchema as Schema).maxLength = jsonSchema.maxLength.toString();
+          }
+
+          if (jsonSchema.enum?.length === 1 && jsonSchema.enum[0] === null) {
+            (jsonSchema as Schema).type = Type.NULL;
+            delete jsonSchema.enum;
+          }
+
+          if (jsonSchema.type !== undefined) {
+            (jsonSchema as {type: string}).type = (
+              jsonSchema as {type: string}
+            ).type.toUpperCase();
+          }
+        },
+      }) as Schema;
+    }
+
+    if (isZodV3Schema(schema)) {
+      return toJSONSchemaV3(schema, {
+        target: 'openApi3',
+        emailStrategy: 'format:email',
+        postProcess: (jsonSchema) => {
+          if (!jsonSchema) {
+            return;
+          }
+
+          if (
+            (jsonSchema as JsonSchema7ObjectType).additionalProperties !==
+            undefined
+          ) {
+            delete (jsonSchema as JsonSchema7ObjectType).additionalProperties;
+          }
+
+          if ((jsonSchema as JsonSchema7ArrayType).maxItems !== undefined) {
+            (jsonSchema as Schema).maxItems = (
+              jsonSchema as JsonSchema7ArrayType
+            ).maxItems?.toString();
+          }
+
+          if ((jsonSchema as JsonSchema7ArrayType).minItems !== undefined) {
+            (jsonSchema as Schema).minItems = (
+              jsonSchema as JsonSchema7ArrayType
+            ).minItems?.toString();
+          }
+
+          if ((jsonSchema as JsonSchema7StringType).minLength !== undefined) {
+            (jsonSchema as Schema).minLength = (
+              jsonSchema as JsonSchema7StringType
+            ).minLength?.toString();
+          }
+
+          if ((jsonSchema as JsonSchema7StringType).maxLength !== undefined) {
+            (jsonSchema as Schema).maxLength = (
+              jsonSchema as JsonSchema7StringType
+            ).maxLength?.toString();
+          }
+
+          if (
+            (jsonSchema as JsonSchema7EnumType).enum?.length === 1 &&
+            (jsonSchema as JsonSchema7EnumType).enum[0] === 'null'
+          ) {
+            (jsonSchema as Schema).type = Type.NULL;
+            delete (jsonSchema as unknown as {enum?: []}).enum;
+          }
+
+          if (
+            (jsonSchema as JsonSchema7NumberType).type === 'integer' &&
+            (jsonSchema as JsonSchema7BigintType).format !== 'int64'
+          ) {
+            (jsonSchema as JsonSchema7NumberType).minimum ??=
+              Number.MIN_SAFE_INTEGER;
+            (jsonSchema as JsonSchema7NumberType).maximum ??=
+              Number.MAX_SAFE_INTEGER;
+          }
+
+          if ((jsonSchema as {type: string}).type !== undefined) {
+            (jsonSchema as {type: string}).type = (
+              jsonSchema as {type: string}
+            ).type.toUpperCase();
+          }
+
+          return jsonSchema;
+        },
+      }) as Schema;
+    }
+
+    throw new Error('Unsupported Zod schema version.');
   }
 
-  if (isZodV4Schema(schema)) {
-    return toJSONSchemaV4(schema, {
-      target: 'openapi-3.0',
-      io: 'input',
-      override: (ctx) => {
-        const {jsonSchema} = ctx;
-
-        if (jsonSchema.additionalProperties !== undefined) {
-          delete jsonSchema.additionalProperties;
-        }
-
-        if (jsonSchema.readOnly !== undefined) {
-          delete jsonSchema.readOnly;
-        }
-
-        if (jsonSchema.maxItems !== undefined) {
-          (jsonSchema as Schema).maxItems = jsonSchema.maxItems.toString();
-        }
-
-        if (jsonSchema.format === 'email' || jsonSchema.format === 'uuid') {
-          delete jsonSchema.pattern;
-        }
-
-        if (jsonSchema.minItems !== undefined) {
-          (jsonSchema as Schema).minItems = jsonSchema.minItems.toString();
-        }
-
-        if (jsonSchema.minLength !== undefined) {
-          (jsonSchema as Schema).minLength = jsonSchema.minLength.toString();
-        }
-
-        if (jsonSchema.maxLength !== undefined) {
-          (jsonSchema as Schema).maxLength = jsonSchema.maxLength.toString();
-        }
-
-        if (jsonSchema.enum?.length === 1 && jsonSchema.enum[0] === null) {
-          (jsonSchema as Schema).type = Type.NULL;
-          delete jsonSchema.enum;
-        }
-
-        if (jsonSchema.type !== undefined) {
-          (jsonSchema as {type: string}).type = (
-            jsonSchema as {type: string}
-          ).type.toUpperCase();
-        }
-      },
-    }) as Schema;
-  }
-
-  if (isZodV3Schema(schema)) {
-    return toJSONSchemaV3(schema, {
-      target: 'openApi3',
-      emailStrategy: 'format:email',
-      postProcess: (jsonSchema) => {
-        if (!jsonSchema) {
-          return;
-        }
-
-        if (
-          (jsonSchema as JsonSchema7ObjectType).additionalProperties !==
-          undefined
-        ) {
-          delete (jsonSchema as JsonSchema7ObjectType).additionalProperties;
-        }
-
-        if ((jsonSchema as JsonSchema7ArrayType).maxItems !== undefined) {
-          (jsonSchema as Schema).maxItems = (
-            jsonSchema as JsonSchema7ArrayType
-          ).maxItems?.toString();
-        }
-
-        if ((jsonSchema as JsonSchema7ArrayType).minItems !== undefined) {
-          (jsonSchema as Schema).minItems = (
-            jsonSchema as JsonSchema7ArrayType
-          ).minItems?.toString();
-        }
-
-        if ((jsonSchema as JsonSchema7StringType).minLength !== undefined) {
-          (jsonSchema as Schema).minLength = (
-            jsonSchema as JsonSchema7StringType
-          ).minLength?.toString();
-        }
-
-        if ((jsonSchema as JsonSchema7StringType).maxLength !== undefined) {
-          (jsonSchema as Schema).maxLength = (
-            jsonSchema as JsonSchema7StringType
-          ).maxLength?.toString();
-        }
-
-        if (
-          (jsonSchema as JsonSchema7EnumType).enum?.length === 1 &&
-          (jsonSchema as JsonSchema7EnumType).enum[0] === 'null'
-        ) {
-          (jsonSchema as Schema).type = Type.NULL;
-          delete (jsonSchema as unknown as {enum?: []}).enum;
-        }
-
-        if (
-          (jsonSchema as JsonSchema7NumberType).type === 'integer' &&
-          (jsonSchema as JsonSchema7BigintType).format !== 'int64'
-        ) {
-          (jsonSchema as JsonSchema7NumberType).minimum ??=
-            Number.MIN_SAFE_INTEGER;
-          (jsonSchema as JsonSchema7NumberType).maximum ??=
-            Number.MAX_SAFE_INTEGER;
-        }
-
-        if ((jsonSchema as {type: string}).type !== undefined) {
-          (jsonSchema as {type: string}).type = (
-            jsonSchema as {type: string}
-          ).type.toUpperCase();
-        }
-
-        return jsonSchema;
-      },
-    }) as Schema;
-  }
-
-  throw new Error('Unsupported Zod schema version.');
+  return schema as Schema;
 }

--- a/core/test/tools/agent_tool_test.ts
+++ b/core/test/tools/agent_tool_test.ts
@@ -17,7 +17,9 @@ import {
   Runner,
   State,
 } from '@google/adk';
+import {Content} from '@google/genai';
 import {describe, expect, it, vi} from 'vitest';
+import {z} from 'zod';
 
 vi.mock('../../src/runner/runner.js', async (importOriginal) => {
   const actual =
@@ -512,5 +514,262 @@ describe('AgentTool', () => {
     expect(subAgentSession?.state).not.toHaveProperty(
       `${State.TEMP_PREFIX}tempKey`,
     );
+  });
+
+  describe('Schema Validation', () => {
+    const LLM_AGENT_SIGNATURE_SYMBOL = Symbol.for('google.adk.llmAgent');
+
+    it('validates input arguments using Zod schema and succeeds', async () => {
+      const schema = z.object({
+        query: z.string(),
+        count: z.number(),
+      });
+
+      const mockAgent = {
+        name: 'sub-agent',
+        [LLM_AGENT_SIGNATURE_SYMBOL]: true,
+        originalInputSchema: schema,
+        inputSchema: {},
+      } as unknown as LlmAgent;
+
+      const tool = new AgentTool({agent: mockAgent});
+      const mockSessionService = new InMemorySessionService();
+      const invocationContext = new InvocationContext({
+        invocationId: 'test-invocation',
+        agent: mockAgent,
+        session: createSession({
+          id: 'parent',
+          appName: 'sub-agent',
+          userId: 'user',
+        }),
+        pluginManager: new PluginManager([]),
+        sessionService: mockSessionService,
+      });
+      const toolContext = new Context({invocationContext});
+
+      let receivedContent: Content | undefined;
+      const mockRunAsync = async function* (params: {newMessage: Content}) {
+        receivedContent = params.newMessage;
+        yield createEvent({
+          author: 'sub-agent',
+          content: {role: 'model', parts: [{text: 'result'}]},
+        });
+      };
+
+      vi.mocked(Runner).mockImplementation((config) => {
+        return {
+          appName: config?.appName,
+          sessionService: config?.sessionService,
+          runAsync: mockRunAsync,
+        } as unknown as Runner;
+      });
+
+      const result = await tool.runAsync({
+        args: {query: 'test', count: 10},
+        toolContext,
+      });
+
+      expect(result).toBe('result');
+      expect(receivedContent).toBeDefined();
+      expect(JSON.parse(receivedContent.parts[0].text)).toEqual({
+        query: 'test',
+        count: 10,
+      });
+    });
+
+    it('throws error if input validation fails', async () => {
+      const schema = z.object({
+        query: z.string(),
+        count: z.number(),
+      });
+
+      const mockAgent = {
+        name: 'sub-agent',
+        [LLM_AGENT_SIGNATURE_SYMBOL]: true,
+        originalInputSchema: schema,
+        inputSchema: {},
+      } as unknown as LlmAgent;
+
+      const tool = new AgentTool({agent: mockAgent});
+      const invocationContext = new InvocationContext({
+        invocationId: 'test-invocation',
+        agent: mockAgent,
+        session: createSession({
+          id: 'parent',
+          appName: 'sub-agent',
+          userId: 'user',
+        }),
+        pluginManager: new PluginManager([]),
+      });
+      const toolContext = new Context({invocationContext});
+
+      await expect(
+        tool.runAsync({
+          args: {query: 'test', count: 'not-a-number'},
+          toolContext,
+        }),
+      ).rejects.toThrow('Input validation failed');
+    });
+
+    it('validates output using Zod schema and succeeds', async () => {
+      const schema = z.object({
+        reply: z.string(),
+        status: z.number(),
+      });
+
+      const mockAgent = {
+        name: 'sub-agent',
+        [LLM_AGENT_SIGNATURE_SYMBOL]: true,
+        originalOutputSchema: schema,
+        outputSchema: {},
+      } as unknown as LlmAgent;
+
+      const tool = new AgentTool({agent: mockAgent});
+      const invocationContext = new InvocationContext({
+        invocationId: 'test-invocation',
+        agent: mockAgent,
+        session: createSession({
+          id: 'parent',
+          appName: 'sub-agent',
+          userId: 'user',
+        }),
+        pluginManager: new PluginManager([]),
+      });
+      const toolContext = new Context({invocationContext});
+
+      const mockRunAsync = async function* () {
+        yield createEvent({
+          author: 'sub-agent',
+          content: {
+            role: 'model',
+            parts: [{text: JSON.stringify({reply: 'ok', status: 200})}],
+          },
+        });
+      };
+
+      vi.mocked(Runner).mockImplementation((config) => {
+        return {
+          appName: config?.appName,
+          sessionService: config?.sessionService,
+          runAsync: mockRunAsync,
+        } as unknown as Runner;
+      });
+
+      const result = await tool.runAsync({
+        args: {request: 'go'},
+        toolContext,
+      });
+
+      expect(result).toEqual({reply: 'ok', status: 200});
+    });
+
+    it('throws error if output validation fails', async () => {
+      const schema = z.object({
+        reply: z.string(),
+        status: z.number(),
+      });
+
+      const mockAgent = {
+        name: 'sub-agent',
+        [LLM_AGENT_SIGNATURE_SYMBOL]: true,
+        originalOutputSchema: schema,
+        outputSchema: {},
+      } as unknown as LlmAgent;
+
+      const tool = new AgentTool({agent: mockAgent});
+      const invocationContext = new InvocationContext({
+        invocationId: 'test-invocation',
+        agent: mockAgent,
+        session: createSession({
+          id: 'parent',
+          appName: 'sub-agent',
+          userId: 'user',
+        }),
+        pluginManager: new PluginManager([]),
+      });
+      const toolContext = new Context({invocationContext});
+
+      const mockRunAsync = async function* () {
+        yield createEvent({
+          author: 'sub-agent',
+          content: {
+            role: 'model',
+            parts: [
+              {text: JSON.stringify({reply: 'ok', status: 'not-a-number'})},
+            ],
+          },
+        });
+      };
+
+      vi.mocked(Runner).mockImplementation((config) => {
+        return {
+          appName: config?.appName,
+          sessionService: config?.sessionService,
+          runAsync: mockRunAsync,
+        } as unknown as Runner;
+      });
+
+      await expect(
+        tool.runAsync({
+          args: {request: 'go'},
+          toolContext,
+        }),
+      ).rejects.toThrow('Output validation failed');
+    });
+
+    it('skips validation if schema is not Zod (raw GenAI Schema)', async () => {
+      const mockAgent = {
+        name: 'sub-agent',
+        [LLM_AGENT_SIGNATURE_SYMBOL]: true,
+        originalInputSchema: {
+          type: 'OBJECT',
+          properties: {query: {type: 'STRING'}},
+        },
+        inputSchema: {type: 'OBJECT', properties: {query: {type: 'STRING'}}},
+        originalOutputSchema: {
+          type: 'OBJECT',
+          properties: {reply: {type: 'STRING'}},
+        },
+        outputSchema: {type: 'OBJECT', properties: {reply: {type: 'STRING'}}},
+      } as unknown as LlmAgent;
+
+      const tool = new AgentTool({agent: mockAgent});
+      const invocationContext = new InvocationContext({
+        invocationId: 'test-invocation',
+        agent: mockAgent,
+        session: createSession({
+          id: 'parent',
+          appName: 'sub-agent',
+          userId: 'user',
+        }),
+        pluginManager: new PluginManager([]),
+      });
+      const toolContext = new Context({invocationContext});
+
+      const mockRunAsync = async function* () {
+        yield createEvent({
+          author: 'sub-agent',
+          content: {
+            role: 'model',
+            parts: [{text: JSON.stringify({reply: 'ok'})}],
+          },
+        });
+      };
+
+      vi.mocked(Runner).mockImplementation((config) => {
+        return {
+          appName: config?.appName,
+          sessionService: config?.sessionService,
+          runAsync: mockRunAsync,
+        } as unknown as Runner;
+      });
+
+      const result = await tool.runAsync({
+        args: {invalidKey: 'value'},
+        toolContext,
+      });
+
+      expect(result).toEqual({reply: 'ok'});
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "workspaces": [
         "core",
-        "dev"
+        "dev",
+        "integrations"
       ],
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -325,6 +326,13 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "integrations": {
+      "version": "1.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/adk": "^1.3.0"
       }
     },
     "node_modules/@a2a-js/sdk": {
@@ -1567,6 +1575,10 @@
     },
     "node_modules/@google/adk-devtools": {
       "resolved": "dev",
+      "link": true
+    },
+    "node_modules/@google/adk-integrations": {
+      "resolved": "integrations",
       "link": true
     },
     "node_modules/@google/genai": {
@@ -5171,7 +5183,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docs:generate": "typedoc",
     "docs:serve": "http-server api-reference/typescript",
     "docs:check": "typedoc --emit none --treatWarningsAsErrors",
-    "test": "vitest --project unit:core --project unit:dev --project integration --project e2e",
+    "test": "vitest run --project unit:core --project unit:dev --project integration --project e2e",
     "test:unit": "vitest --project unit:core --project unit:dev",
     "test:integration": "vitest --project integration",
     "test:e2e": "vitest --project e2e",

--- a/tests/integration/tools/agent_tool_test.ts
+++ b/tests/integration/tools/agent_tool_test.ts
@@ -13,6 +13,7 @@ import {
 } from '@google/adk';
 import {FinishReason} from '@google/genai';
 import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
 import {
   GeminiWithMockResponses,
   RawGenerateContentResponse,
@@ -126,5 +127,211 @@ describe('AgentTool', () => {
     expect(session).toBeDefined();
     expect(session!.state['initialStateKey']).toBe('contexto inicial');
     expect(session!.state['subAgentOutput']).toBe('Today is Tuesday');
+  });
+
+  it('validates schema in integration flow (success)', async () => {
+    const inputSchema = z.object({
+      query: z.string(),
+    });
+    const outputSchema = z.object({
+      result: z.string(),
+    });
+
+    const mockSubAgentResponses: RawGenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [{text: JSON.stringify({result: 'Success'})}],
+              role: 'model',
+            },
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+    ];
+
+    const mockParentAgentResponses: RawGenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'subAgent',
+                    args: {query: 'valid query'},
+                    id: 'call-1',
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            content: {
+              parts: [{text: 'Subagent responded.'}],
+              role: 'model',
+            },
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+    ];
+
+    const subAgentModel = new GeminiWithMockResponses(mockSubAgentResponses);
+    const subAgent = new LlmAgent({
+      model: subAgentModel,
+      name: 'subAgent',
+      description: 'subAgent',
+      instruction: 'answer',
+      inputSchema,
+      outputSchema,
+    });
+
+    const mainAgentModel = new GeminiWithMockResponses(
+      mockParentAgentResponses,
+    );
+    const mainAgent = new LlmAgent({
+      model: mainAgentModel,
+      name: 'mainAgent',
+      description: 'MainAgent',
+      instruction: 'use subAgent',
+      tools: [new AgentTool({agent: subAgent})],
+    });
+
+    const sessionService = new InMemorySessionService();
+    const memoryService = new InMemoryMemoryService();
+
+    await sessionService.createSession({
+      appName: 'ADKTest',
+      userId: 'TestUser',
+      sessionId: '1',
+    });
+
+    const runner = new Runner({
+      appName: 'ADKTest',
+      agent: mainAgent,
+      sessionService,
+      memoryService,
+    });
+
+    const runOptions = {
+      userId: 'TestUser',
+      sessionId: '1',
+      newMessage: {
+        role: 'user',
+        parts: [{text: 'Run'}],
+      },
+    };
+
+    const events = [];
+    for await (const event of runner.runAsync(runOptions)) {
+      events.push(event);
+    }
+
+    const toolResponseEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionResponse,
+    );
+    expect(toolResponseEvent).toBeDefined();
+    expect(
+      toolResponseEvent!.content!.parts[0].functionResponse!.response,
+    ).toEqual({result: 'Success'});
+  });
+
+  it('throws error in integration flow when input validation fails', async () => {
+    const inputSchema = z.object({
+      query: z.string(),
+    });
+
+    const mockParentAgentResponses: RawGenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'subAgent',
+                    args: {invalidKey: 'value'},
+                    id: 'call-1',
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+    ];
+
+    const subAgent = new LlmAgent({
+      name: 'subAgent',
+      description: 'subAgent',
+      instruction: 'answer',
+      inputSchema,
+    });
+
+    const mainAgentModel = new GeminiWithMockResponses(
+      mockParentAgentResponses,
+    );
+    const mainAgent = new LlmAgent({
+      model: mainAgentModel,
+      name: 'mainAgent',
+      description: 'MainAgent',
+      instruction: 'use subAgent',
+      tools: [new AgentTool({agent: subAgent})],
+    });
+
+    const sessionService = new InMemorySessionService();
+    const memoryService = new InMemoryMemoryService();
+
+    await sessionService.createSession({
+      appName: 'ADKTest',
+      userId: 'TestUser',
+      sessionId: '1',
+    });
+
+    const runner = new Runner({
+      appName: 'ADKTest',
+      agent: mainAgent,
+      sessionService,
+      memoryService,
+    });
+
+    const runOptions = {
+      userId: 'TestUser',
+      sessionId: '1',
+      newMessage: {
+        role: 'user',
+        parts: [{text: 'Run'}],
+      },
+    };
+
+    const events = [];
+    for await (const event of runner.runAsync(runOptions)) {
+      events.push(event);
+    }
+
+    const toolResponseEvent = events.find(
+      (e) => e.content?.parts?.[0]?.functionResponse,
+    );
+    expect(toolResponseEvent).toBeDefined();
+    expect(
+      toolResponseEvent!.content!.parts[0].functionResponse!.response,
+    ).toHaveProperty('error');
+    expect(
+      (
+        toolResponseEvent!.content!.parts[0].functionResponse!.response as {
+          error: string;
+        }
+      ).error,
+    ).toContain('Input validation failed');
   });
 });


### PR DESCRIPTION
# Description

This PR implements runtime input and output schema validation for agents wrapped as tools using `AgentTool`.

## Key Changes
- **Preserve Original Schemas**: Modified `LlmAgent` to store the original input and output schemas in `originalInputSchema` and `originalOutputSchema` properties, while still performing eager conversion to GenAI `Schema` for `inputSchema` and `outputSchema` to maintain backwards compatibility.
- **Runtime Validation in AgentTool**:
    - **Input Validation**: Before executing the sub-agent, `AgentTool.runAsync` validates the input arguments against the agent's `originalInputSchema` (if it's a Zod object). Throws an error on validation failure.
    - **Output Validation**: After executing the sub-agent, `AgentTool.runAsync` parses the output as JSON and validates it against the agent's `originalOutputSchema` (if it's a Zod object). Throws an error on validation failure.
- **Robust Helper**: Updated `zodObjectToSchema` helper to check if the schema is a Zod schema using `isZodSchema`. If it is a Zod schema but not a Zod object, it throws an error. If it is not a Zod schema (i.e. already a GenAI Schema), it returns it as-is.

## Testing
- Added unit tests in `core/test/tools/agent_tool_test.ts` covering:
    - Input validation success and failure.
    - Output validation success and failure.
    - Bypassing validation for raw GenAI schemas.
- Added integration tests in `tests/integration/tools/agent_tool_test.ts` to verify:
    - Schema validation in full runner flow.
    - Error propagation (validation errors wrapped in tool response instead of crashing).
- Verified E2E behavior using a manual scratch script on Vertex AI.
