### PR TITLE
feat: validate callback response types

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -14,6 +14,7 @@ import {BaseTool} from '../tools/base_tool.js';
 import {ToolConfirmation} from '../tools/tool_confirmation.js';
 import {randomUUID} from '../utils/env_aware_utils.js';
 import {logger} from '../utils/logger.js';
+import {validateSchema} from '../utils/schema_utils.js';
 import {Context} from './context.js';
 
 import {
@@ -387,6 +388,14 @@ export async function handleFunctionCallList({
           break;
         }
       }
+    }
+
+    if (functionResponse != null && tool.outputSchema) {
+      validateSchema(
+        functionResponse,
+        tool.outputSchema,
+        `beforeToolCallback for tool ${tool.name}`,
+      );
     }
 
     // Step 3: Otherwise, proceed calling the tool normally.

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -4,12 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {GenerateContentConfig, Schema} from '@google/genai';
+import {GenerateContentConfig} from '@google/genai';
 import {context, trace} from '@opentelemetry/api';
 import {FunctionTool} from '../tools/function_tool.js';
-
-import {z as z3} from 'zod/v3';
-import {z as z4} from 'zod/v4';
 
 import {BaseCodeExecutor} from '../code_executors/base_code_executor.js';
 
@@ -40,7 +37,7 @@ import {
   traceCallLlm,
   tracer,
 } from '../telemetry/tracing.js';
-import {isZodObject, zodObjectToSchema} from '../utils/simple_zod_to_json.js';
+import {LlmAgentSchema} from '../utils/schema_utils.js';
 import {BaseAgent, BaseAgentConfig} from './base_agent.js';
 import {
   BaseLlmRequestProcessor,
@@ -73,10 +70,7 @@ import {StreamingMode} from './run_config.js';
 /**
  * Input/output schema type for agent.
  */
-export type LlmAgentSchema =
-  | z3.ZodObject<z3.ZodRawShape>
-  | z4.ZodObject<z4.ZodRawShape>
-  | Schema;
+export {LlmAgentSchema};
 
 /** An object that can provide an instruction string. */
 export type InstructionProvider = (
@@ -357,8 +351,8 @@ export class LlmAgent extends BaseAgent {
   disallowTransferToParent: boolean;
   disallowTransferToPeers: boolean;
   includeContents: 'default' | 'none';
-  inputSchema?: Schema;
-  outputSchema?: Schema;
+  inputSchema?: LlmAgentSchema;
+  outputSchema?: LlmAgentSchema;
   outputKey?: string;
   beforeModelCallback?: BeforeModelCallback;
   afterModelCallback?: AfterModelCallback;
@@ -378,12 +372,8 @@ export class LlmAgent extends BaseAgent {
     this.disallowTransferToParent = config.disallowTransferToParent ?? false;
     this.disallowTransferToPeers = config.disallowTransferToPeers ?? false;
     this.includeContents = config.includeContents ?? 'default';
-    this.inputSchema = isZodObject(config.inputSchema)
-      ? zodObjectToSchema(config.inputSchema)
-      : config.inputSchema;
-    this.outputSchema = isZodObject(config.outputSchema)
-      ? zodObjectToSchema(config.outputSchema)
-      : config.outputSchema;
+    this.inputSchema = config.inputSchema;
+    this.outputSchema = config.outputSchema;
     this.outputKey = config.outputKey;
     this.beforeModelCallback = config.beforeModelCallback;
     this.afterModelCallback = config.afterModelCallback;

--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -12,6 +12,7 @@ import {Event} from '../events/event.js';
 import {InMemoryMemoryService} from '../memory/in_memory_memory_service.js';
 import {Runner} from '../runner/runner.js';
 import {InMemorySessionService} from '../sessions/in_memory_session_service.js';
+import {toSchema} from '../utils/schema_utils.js';
 import {GoogleLLMVariant} from '../utils/variant_utils.js';
 
 import {State} from '../sessions/state.js';
@@ -75,6 +76,9 @@ export class AgentTool extends BaseTool {
     super({
       name: config.agent.name,
       description: config.agent.description || '',
+      outputSchema: isLlmAgent(config.agent)
+        ? config.agent.outputSchema
+        : undefined,
     });
     this.agent = config.agent;
     this.skipSummarization = config.skipSummarization || false;
@@ -90,7 +94,7 @@ export class AgentTool extends BaseTool {
         // TODO(b/425992518): We should not use the agent's input schema as is.
         // It should be validated and possibly transformed. Consider similar
         // logic to one we have in Python ADK.
-        parameters: this.agent.inputSchema,
+        parameters: toSchema(this.agent.inputSchema),
       };
     } else {
       declaration = {

--- a/core/src/tools/base_tool.ts
+++ b/core/src/tools/base_tool.ts
@@ -7,6 +7,7 @@
 import {FunctionDeclaration, Tool} from '@google/genai';
 
 import {LlmRequest} from '../models/llm_request.js';
+import {LlmAgentSchema} from '../utils/schema_utils.js';
 import {getGoogleLlmVariant} from '../utils/variant_utils.js';
 
 import {Context} from '../agents/context.js';
@@ -34,6 +35,7 @@ export interface BaseToolParams {
   name: string;
   description: string;
   isLongRunning?: boolean;
+  outputSchema?: LlmAgentSchema;
 }
 
 /**
@@ -66,6 +68,7 @@ export abstract class BaseTool {
   readonly name: string;
   readonly description: string;
   readonly isLongRunning: boolean;
+  readonly outputSchema?: LlmAgentSchema;
 
   /**
    * Base constructor for a tool.
@@ -76,6 +79,7 @@ export abstract class BaseTool {
     this.name = params.name;
     this.description = params.description;
     this.isLongRunning = params.isLongRunning ?? false;
+    this.outputSchema = params.outputSchema;
   }
 
   /**

--- a/core/src/tools/function_tool.ts
+++ b/core/src/tools/function_tool.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {FunctionDeclaration, Schema, Type} from '@google/genai';
+import {FunctionDeclaration, Schema} from '@google/genai';
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
 
-import {isZodObject, zodObjectToSchema} from '../utils/simple_zod_to_json.js';
+import {LlmAgentSchema, toSchema} from '../utils/schema_utils.js';
+import {isZodObject} from '../utils/simple_zod_to_json.js';
 
 import {Context} from '../agents/context.js';
 import {BaseTool, RunAsyncToolRequest} from './base_tool.js';
@@ -16,11 +17,7 @@ import {BaseTool, RunAsyncToolRequest} from './base_tool.js';
 /**
  * Input parameters of the function tool.
  */
-export type ToolInputParameters =
-  | z3.ZodObject<z3.ZodRawShape>
-  | z4.ZodObject<z4.ZodRawShape>
-  | Schema
-  | undefined;
+export type ToolInputParameters = LlmAgentSchema | undefined;
 
 /**
  * The arguments passed to the function tool's `execute` callback, inferred
@@ -57,21 +54,8 @@ export type ToolOptions<TParameters extends ToolInputParameters> = {
   parameters?: TParameters;
   execute: ToolExecuteFunction<TParameters>;
   isLongRunning?: boolean;
+  outputSchema?: LlmAgentSchema;
 };
-
-function toSchema<TParameters extends ToolInputParameters>(
-  parameters: TParameters,
-): Schema {
-  if (parameters === undefined) {
-    return {type: Type.OBJECT, properties: {}};
-  }
-
-  if (isZodObject(parameters)) {
-    return zodObjectToSchema(parameters);
-  }
-
-  return parameters;
-}
 
 /**
  * A unique symbol to identify ADK agent classes.
@@ -127,6 +111,7 @@ export class FunctionTool<
       name,
       description: options.description,
       isLongRunning: options.isLongRunning,
+      outputSchema: options.outputSchema,
     });
     this.execute = options.execute;
     this.parameters = options.parameters;

--- a/core/src/utils/schema_utils.ts
+++ b/core/src/utils/schema_utils.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Schema, Type} from '@google/genai';
+import {z as z3} from 'zod/v3';
+import {z as z4} from 'zod/v4';
+import {
+  isZodObject,
+  isZodSchema,
+  zodObjectToSchema,
+} from './simple_zod_to_json.js';
+
+/**
+ * Input/output schema type for agent.
+ */
+export type LlmAgentSchema =
+  | z3.ZodObject<z3.ZodRawShape>
+  | z4.ZodObject<z4.ZodRawShape>
+  | Schema;
+
+/**
+ * Validates a value against a schema.
+ * Throws an error if validation fails.
+ */
+export function validateSchema(
+  value: unknown,
+  schema: LlmAgentSchema,
+  contextName: string,
+): void {
+  if (isZodSchema(schema)) {
+    const result = schema.safeParse(value);
+    if (!result.success) {
+      throw new Error(
+        `Validation failed for ${contextName}: ${result.error.message}`,
+      );
+    }
+  } else {
+    validateJsonSchema(value, schema, contextName);
+  }
+}
+
+function fail(contextName: string, path: string, msg: string): never {
+  throw new Error(`Validation failed for ${contextName}${path}: ${msg}`);
+}
+
+function validateJsonSchema(
+  value: unknown,
+  schema: Schema,
+  contextName: string,
+  path: string = '',
+): void {
+  if (Object.keys(schema).length === 0) {
+    return;
+  }
+
+  const type = schema.type;
+  if (!type) {
+    if (schema.properties && (typeof value !== 'object' || value === null)) {
+      fail(contextName, path, `expected object, got ${typeof value}`);
+    }
+    return;
+  }
+
+  const expectedType = type.toLowerCase();
+  const actualType = typeof value;
+
+  if (value === null) {
+    if (schema.nullable) {
+      return;
+    }
+    fail(contextName, path, 'value is null but schema is not nullable');
+  }
+
+  if (value === undefined) {
+    fail(contextName, path, 'value is undefined');
+  }
+
+  const checkType = (expected: string) => {
+    if (actualType !== expected) {
+      fail(contextName, path, `expected ${expected}, got ${actualType}`);
+    }
+  };
+
+  switch (expectedType) {
+    case 'string':
+      checkType('string');
+      break;
+    case 'number':
+    case 'integer':
+      checkType('number');
+      if (expectedType === 'integer' && !Number.isInteger(value)) {
+        fail(contextName, path, 'expected integer, got float');
+      }
+      break;
+    case 'boolean':
+      checkType('boolean');
+      break;
+    case 'array':
+      if (!Array.isArray(value)) {
+        fail(contextName, path, `expected array, got ${actualType}`);
+      }
+      if (schema.items) {
+        for (let i = 0; i < value.length; i++) {
+          validateJsonSchema(
+            value[i],
+            schema.items,
+            contextName,
+            `${path}[${i}]`,
+          );
+        }
+      }
+      break;
+    case 'object': {
+      if (actualType !== 'object' || value === null || Array.isArray(value)) {
+        fail(contextName, path, `expected object, got ${actualType}`);
+      }
+      const obj = value as Record<string, unknown>;
+
+      if (schema.required) {
+        for (const reqKey of schema.required) {
+          if (!(reqKey in obj) || obj[reqKey] === undefined) {
+            fail(contextName, path, `missing required property "${reqKey}"`);
+          }
+        }
+      }
+
+      if (schema.properties) {
+        for (const key in obj) {
+          if (schema.properties[key]) {
+            validateJsonSchema(
+              obj[key],
+              schema.properties[key],
+              contextName,
+              `${path}.${key}`,
+            );
+          }
+        }
+      }
+      break;
+    }
+    case 'null':
+      if (value !== null) {
+        fail(contextName, path, `expected null, got ${actualType}`);
+      }
+      break;
+  }
+}
+
+/**
+ * Converts a LlmAgentSchema (Zod or GenAI Schema) to a GenAI Schema.
+ */
+export function toSchema(schema: LlmAgentSchema | undefined): Schema {
+  if (schema === undefined) {
+    return {type: Type.OBJECT, properties: {}};
+  }
+
+  if (isZodObject(schema)) {
+    return zodObjectToSchema(schema);
+  }
+
+  return schema;
+}

--- a/core/src/utils/simple_zod_to_json.ts
+++ b/core/src/utils/simple_zod_to_json.ts
@@ -17,9 +17,9 @@ import {
 import {z as z3} from 'zod/v3';
 import {toJSONSchema as toJSONSchemaV4, z as z4} from 'zod/v4';
 
-type ZodSchema<T = unknown> = z3.ZodType<T> | z4.ZodType<T>;
+export type ZodSchema<T = unknown> = z3.ZodType<T> | z4.ZodType<T>;
 
-function isZodSchema(obj: unknown): obj is ZodSchema {
+export function isZodSchema(obj: unknown): obj is ZodSchema {
   return (
     obj !== null &&
     typeof obj === 'object' &&

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -19,7 +19,7 @@ import {
   SingleBeforeToolCallback,
   ToolConfirmation,
 } from '@google/adk';
-import {Content, FunctionCall} from '@google/genai';
+import {Content, FunctionCall, Schema} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
@@ -53,6 +53,48 @@ const errorTool = new FunctionTool({
   parameters: z.object({}),
   execute: async () => {
     throw new Error('tool error message content');
+  },
+});
+
+const zodSchemaTool = new FunctionTool({
+  name: 'zodSchemaTool',
+  description: 'tool with zod schema',
+  parameters: z.object({}),
+  outputSchema: z.object({
+    status: z.string(),
+    code: z.number(),
+  }),
+  execute: async () => {
+    return {status: 'ok', code: 200};
+  },
+});
+
+const rawSchemaTool = new FunctionTool({
+  name: 'rawSchemaTool',
+  description: 'tool with raw schema',
+  parameters: z.object({}),
+  outputSchema: {
+    type: 'OBJECT',
+    properties: {
+      status: {type: 'STRING'},
+      code: {type: 'NUMBER'},
+    },
+    required: ['status', 'code'],
+  } as Schema,
+  execute: async () => {
+    return {status: 'ok', code: 200};
+  },
+});
+
+const primitiveSchemaTool = new FunctionTool({
+  name: 'primitiveSchemaTool',
+  description: 'tool with primitive schema',
+  parameters: z.object({}),
+  outputSchema: {
+    type: 'STRING',
+  } as Schema,
+  execute: async () => {
+    return 'ok';
   },
 });
 
@@ -361,6 +403,115 @@ describe('handleFunctionCallList', () => {
           abortSignal: signal,
         }),
       }),
+    );
+  });
+
+  it('should succeed when beforeToolCallback returns valid object matching Zod schema', async () => {
+    const beforeToolCallback: SingleBeforeToolCallback = async () => {
+      return {status: 'success', code: 200};
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: '1', name: 'zodSchemaTool', args: {}}],
+      toolsDict: {'zodSchemaTool': zodSchemaTool},
+      beforeToolCallbacks: [beforeToolCallback],
+      afterToolCallbacks: [],
+    });
+    expect(event).not.toBeNull();
+    const definedEvent = event as Event;
+    expect(definedEvent.content!.parts![0].functionResponse!.response).toEqual({
+      status: 'success',
+      code: 200,
+    });
+  });
+
+  it('should throw Error when beforeToolCallback returns invalid object not matching Zod schema', async () => {
+    const beforeToolCallback: SingleBeforeToolCallback = async () => {
+      return {status: 'success'}; // missing code
+    };
+    await expect(
+      handleFunctionCallList({
+        invocationContext,
+        functionCalls: [{id: '1', name: 'zodSchemaTool', args: {}}],
+        toolsDict: {'zodSchemaTool': zodSchemaTool},
+        beforeToolCallbacks: [beforeToolCallback],
+        afterToolCallbacks: [],
+      }),
+    ).rejects.toThrow(
+      'Validation failed for beforeToolCallback for tool zodSchemaTool',
+    );
+  });
+
+  it('should succeed when beforeToolCallback returns valid object matching raw Schema', async () => {
+    const beforeToolCallback: SingleBeforeToolCallback = async () => {
+      return {status: 'success', code: 200};
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: '1', name: 'rawSchemaTool', args: {}}],
+      toolsDict: {'rawSchemaTool': rawSchemaTool},
+      beforeToolCallbacks: [beforeToolCallback],
+      afterToolCallbacks: [],
+    });
+    expect(event).not.toBeNull();
+    const definedEvent = event as Event;
+    expect(definedEvent.content!.parts![0].functionResponse!.response).toEqual({
+      status: 'success',
+      code: 200,
+    });
+  });
+
+  it('should throw Error when beforeToolCallback returns invalid object not matching raw Schema', async () => {
+    const beforeToolCallback: SingleBeforeToolCallback = async () => {
+      return {status: 'success'}; // missing code
+    };
+    await expect(
+      handleFunctionCallList({
+        invocationContext,
+        functionCalls: [{id: '1', name: 'rawSchemaTool', args: {}}],
+        toolsDict: {'rawSchemaTool': rawSchemaTool},
+        beforeToolCallbacks: [beforeToolCallback],
+        afterToolCallbacks: [],
+      }),
+    ).rejects.toThrow(
+      'Validation failed for beforeToolCallback for tool rawSchemaTool',
+    );
+  });
+
+  it('should succeed when beforeToolCallback returns valid primitive matching raw Schema', async () => {
+    const beforeToolCallback: SingleBeforeToolCallback = async () => {
+      // @ts-expect-error callback is typed to return Record<string, unknown> but we want to test primitive at runtime
+      return 'success';
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: '1', name: 'primitiveSchemaTool', args: {}}],
+      toolsDict: {'primitiveSchemaTool': primitiveSchemaTool},
+      beforeToolCallbacks: [beforeToolCallback],
+      afterToolCallbacks: [],
+    });
+    expect(event).not.toBeNull();
+    const definedEvent = event as Event;
+    expect(definedEvent.content!.parts![0].functionResponse!.response).toEqual({
+      result: 'success',
+    });
+  });
+
+  it('should throw Error when beforeToolCallback returns invalid primitive not matching raw Schema', async () => {
+    const beforeToolCallback: SingleBeforeToolCallback = async () => {
+      // @ts-expect-error callback is typed to return Record<string, unknown> but we want to test primitive at runtime
+      return 123; // expected string
+    };
+    await expect(
+      handleFunctionCallList({
+        invocationContext,
+        functionCalls: [{id: '1', name: 'primitiveSchemaTool', args: {}}],
+        toolsDict: {'primitiveSchemaTool': primitiveSchemaTool},
+        beforeToolCallbacks: [beforeToolCallback],
+        afterToolCallbacks: [],
+      }),
+    ).rejects.toThrow(
+      'Validation failed for beforeToolCallback for tool primitiveSchemaTool',
     );
   });
 });

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -17,6 +17,7 @@ import {
   ContextCompactorRequestProcessor,
   createEvent,
   Event,
+  FunctionTool,
   InvocationContext,
   LlmAgent,
   LlmRequest,
@@ -345,9 +346,7 @@ describe('LlmAgent Schema Initialization', () => {
       name: 'test',
       inputSchema: zodSchema,
     });
-    expect(agent.inputSchema).toBeDefined();
-    expect((agent.inputSchema as Schema).type).toBe('OBJECT');
-    expect((agent.inputSchema as Schema).properties?.foo?.type).toBe('STRING');
+    expect(agent.inputSchema).toBe(zodSchema);
   });
 
   it('should initialize inputSchema from Zod v3 object', () => {
@@ -358,9 +357,7 @@ describe('LlmAgent Schema Initialization', () => {
       name: 'test',
       inputSchema: zodSchema,
     });
-    expect(agent.inputSchema).toBeDefined();
-    expect((agent.inputSchema as Schema).type).toBe('OBJECT');
-    expect((agent.inputSchema as Schema).properties?.foo?.type).toBe('STRING');
+    expect(agent.inputSchema).toBe(zodSchema);
   });
 
   it('should initialize outputSchema from Schema object', () => {
@@ -378,9 +375,7 @@ describe('LlmAgent Schema Initialization', () => {
       name: 'test',
       outputSchema: zodSchema,
     });
-    expect(agent.outputSchema).toBeDefined();
-    expect((agent.outputSchema as Schema).type).toBe('OBJECT');
-    expect((agent.outputSchema as Schema).properties?.bar?.type).toBe('NUMBER');
+    expect(agent.outputSchema).toBe(zodSchema);
   });
 
   it('should initialize outputSchema from Zod v3 object', () => {
@@ -391,9 +386,7 @@ describe('LlmAgent Schema Initialization', () => {
       name: 'test',
       outputSchema: zodSchema,
     });
-    expect(agent.outputSchema).toBeDefined();
-    expect((agent.outputSchema as Schema).type).toBe('OBJECT');
-    expect((agent.outputSchema as Schema).properties?.bar?.type).toBe('NUMBER');
+    expect(agent.outputSchema).toBe(zodSchema);
   });
 
   it('should enforce transfer restrictions when outputSchema is present', () => {
@@ -797,5 +790,132 @@ describe('LlmAgent Default Request Processors', () => {
       CONTENT_REQUEST_PROCESSOR,
     );
     expect(authIndex).toBeLessThan(contentIndex);
+  });
+});
+
+describe('LlmAgent Callback Validation Integration', () => {
+  let schemaTool: BaseTool;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockState: any;
+  let session: Session;
+
+  beforeEach(() => {
+    schemaTool = new FunctionTool({
+      name: 'schemaTool',
+      description: 'mock tool with schema',
+      parameters: z4.object({}),
+      outputSchema: z4.object({
+        result: z4.string(),
+      }),
+      execute: async () => ({result: 'ok'}),
+    });
+    mockState = {
+      hasDelta: () => false,
+      get: () => undefined,
+      set: () => {},
+      update: () => {},
+      toRecord: () => ({}),
+    };
+    session = {
+      id: 'sess_123',
+      state: mockState,
+      events: [],
+    } as unknown as Session;
+  });
+
+  class SequentialMockLlm extends BaseLlm {
+    private responseIndex = 0;
+    constructor(private responses: LlmResponse[]) {
+      super({model: 'sequential-mock-llm'});
+    }
+    async *generateContentAsync(
+      _request: LlmRequest,
+    ): AsyncGenerator<LlmResponse, void, void> {
+      if (this.responseIndex < this.responses.length) {
+        yield this.responses[this.responseIndex++];
+      } else {
+        yield {content: {parts: [{text: 'final response'}]}};
+      }
+    }
+    async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+      return new MockLlmConnection();
+    }
+  }
+
+  it('should succeed when beforeToolCallback returns valid response matching schema during agent run', async () => {
+    const functionCallResponse: LlmResponse = {
+      content: {
+        parts: [{functionCall: {name: 'schemaTool', args: {}, id: 'call_1'}}],
+      },
+    };
+    const mockModel = new SequentialMockLlm([functionCallResponse]);
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      tools: [schemaTool],
+      model: mockModel,
+      beforeToolCallback: async () => {
+        return {result: 'valid_mock_response'};
+      },
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'inv_123',
+      session,
+      agent: agent,
+      pluginManager: new PluginManager(),
+    });
+
+    const generator = agent.runAsync(invocationContext);
+    const events: Event[] = [];
+    for await (const event of generator) {
+      events.push(event);
+    }
+
+    expect(events.length).toBeGreaterThan(0);
+    const responseEvent = events.find(
+      (e) => e.content?.parts?.[0].functionResponse,
+    );
+    expect(responseEvent).toBeDefined();
+    expect(
+      responseEvent!.content!.parts![0].functionResponse!.response,
+    ).toEqual({
+      result: 'valid_mock_response',
+    });
+  });
+
+  it('should yield error event when beforeToolCallback returns invalid response during agent run', async () => {
+    const functionCallResponse: LlmResponse = {
+      content: {
+        parts: [{functionCall: {name: 'schemaTool', args: {}, id: 'call_1'}}],
+      },
+    };
+    const mockModel = new SequentialMockLlm([functionCallResponse]);
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      tools: [schemaTool],
+      model: mockModel,
+      beforeToolCallback: async () => {
+        return {invalid_field: 'bad'};
+      },
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'inv_123',
+      session,
+      agent: agent,
+      pluginManager: new PluginManager(),
+    });
+
+    const generator = agent.runAsync(invocationContext);
+    const events: Event[] = [];
+    for await (const event of generator) {
+      events.push(event);
+    }
+
+    const errorEvent = events.find((e) => e.errorCode);
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.errorMessage).toContain(
+      'Validation failed for beforeToolCallback for tool schemaTool',
+    );
   });
 });

--- a/core/test/manual_callback_validation_test.ts
+++ b/core/test/manual_callback_validation_test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionTool, Gemini, InMemoryRunner, LlmAgent} from '@google/adk';
+import {createUserContent} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
+
+const hasAKey =
+  !!process.env.GEMINI_API_KEY ||
+  !!process.env.GOOGLE_GENAI_API_KEY ||
+  !!process.env.GOOGLE_CLOUD_PROJECT ||
+  !!process.env.GCP_PROJECT;
+
+describe.skipIf(!hasAKey)('Manual Callback Validation E2E', () => {
+  it('should throw validation error when beforeToolCallback returns invalid data', async () => {
+    const schemaTool = new FunctionTool({
+      name: 'schemaTool',
+      description: 'a tool that returns a string result',
+      parameters: z.object({}),
+      outputSchema: z.object({
+        result: z.string(),
+      }),
+      execute: async () => ({result: 'ok'}),
+    });
+
+    const project = process.env.GCP_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
+    const location =
+      process.env.GCP_LOCATION ||
+      process.env.GOOGLE_CLOUD_LOCATION ||
+      'us-central1';
+
+    const llm = new Gemini({
+      model: 'gemini-2.5-flash',
+      vertexai: true,
+      project,
+      location,
+    });
+
+    const agent = new LlmAgent({
+      name: 'validation_agent',
+      instruction: 'Call schemaTool and report the result.',
+      model: llm,
+      tools: [schemaTool],
+      beforeToolCallback: async () => {
+        // Return invalid data (missing 'result' field, or wrong type)
+        return {wrong_field: 123};
+      },
+    });
+
+    const runner = new InMemoryRunner({
+      agent,
+      appName: 'manual_validation_test',
+    });
+
+    const session = await runner.sessionService.createSession({
+      appName: 'manual_validation_test',
+      userId: 'test_user',
+    });
+
+    const generator = runner.runAsync({
+      userId: 'test_user',
+      sessionId: session.id,
+      newMessage: createUserContent('Call the schemaTool.'),
+    });
+
+    const events = [];
+    for await (const event of generator) {
+      events.push(event);
+    }
+
+    const errorEvent = events.find((e) => e.errorCode);
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.errorMessage).toContain(
+      'Validation failed for beforeToolCallback for tool schemaTool',
+    );
+  }, 30000);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "workspaces": [
         "core",
-        "dev"
+        "dev",
+        "integrations"
       ],
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -325,6 +326,13 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "integrations": {
+      "version": "1.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/adk": "^1.3.0"
       }
     },
     "node_modules/@a2a-js/sdk": {
@@ -1567,6 +1575,10 @@
     },
     "node_modules/@google/adk-devtools": {
       "resolved": "dev",
+      "link": true
+    },
+    "node_modules/@google/adk-integrations": {
+      "resolved": "integrations",
       "link": true
     },
     "node_modules/@google/genai": {
@@ -5171,7 +5183,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docs:generate": "typedoc",
     "docs:serve": "http-server api-reference/typescript",
     "docs:check": "typedoc --emit none --treatWarningsAsErrors",
-    "test": "vitest --project unit:core --project unit:dev --project integration --project e2e",
+    "test": "vitest run --project unit:core --project unit:dev --project integration --project e2e",
     "test:unit": "vitest --project unit:core --project unit:dev",
     "test:integration": "vitest --project integration",
     "test:e2e": "vitest --project e2e",


### PR DESCRIPTION
This PR implements validation for callback response types in ADK JS.

### Changes:
- **Schema Validation Utility**: Added `validateSchema` in `core/src/utils/schema_utils.ts` supporting Zod and GenAI Schema.
- **Tool Configuration**: Added `outputSchema` to `BaseToolParams` and propagated it through `FunctionTool` and `AgentTool`.
- **Callback Response Validation**: Integrated `validateSchema` inside `handleFunctionCallList` (in `functions.ts`) to validate `beforeToolCallback` responses against the tool's `outputSchema` before executing the tool.
- **Simplifications & Shared Logic**: Added `toSchema` helper in `schema_utils.ts` to convert Zod/GenAI Schema to GenAI Schema, reducing duplication in `FunctionTool` and `AgentTool`.
- **Tests**:
  - Unit tests in `functions_test.ts` for Zod/Schema/primitive validation in `handleFunctionCallList`.
  - Integration tests in `llm_agent_test.ts` verifying validation during agent run loop.
  - Manual E2E test in `manual_callback_validation_test.ts` verifying E2E behavior with real Gemini Vertex AI.