### PR TITLE
fix(auth): apply SSRF blocklist to OAuth2 token endpoint in fetchOAuth2Tokens

### DIFF
--- a/core/src/auth/oauth2/oauth2_discovery.ts
+++ b/core/src/auth/oauth2/oauth2_discovery.ts
@@ -179,7 +179,7 @@ export class OAuth2DiscoveryManager {
  * Without this step an attacker can bypass every IPv4 block by encoding
  * the address as its IPv4-mapped IPv6 equivalent (CWE-918).
  */
-function normaliseHostname(raw: string): string {
+export function normaliseHostname(raw: string): string {
   const stripped = raw.replace(/^\[|\]$/g, '');
   const m = stripped.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
   if (m) {
@@ -191,7 +191,7 @@ function normaliseHostname(raw: string): string {
   if (mDot) return mDot[1];
   return raw;
 }
-function validateDiscoveryUrl(urlStr: string): boolean {
+export function validateDiscoveryUrl(urlStr: string): boolean {
   try {
     const url = new URL(urlStr);
     if (url.protocol !== 'https:') {

--- a/core/src/auth/oauth2/oauth2_utils.ts
+++ b/core/src/auth/oauth2/oauth2_utils.ts
@@ -51,15 +51,11 @@ export async function fetchOAuth2Tokens(
   endpoint: string,
   body: URLSearchParams,
 ): Promise<OAuth2Auth> {
-  // Validate the token endpoint URL against the same SSRF blocklist used for
-  // discovery URLs (validateDiscoveryUrl in oauth2_discovery.ts). Without this
-  // check, an attacker who controls the OpenAPI spec's tokenUrl can direct the
-  // agent to POST credentials to a cloud metadata endpoint (GCP 169.254.169.254,
-  // AWS IMDSv1, Azure IMDS) and receive IAM tokens in the response.
+  // Guard against SSRF: apply the same blocklist used in oauth2_discovery.ts
+  // so callers can't point tokenUrl at a private/cloud-metadata address.
   if (!validateDiscoveryUrl(endpoint)) {
     throw new Error(
-      `SSRF protection: OAuth2 token endpoint '${endpoint}' is not allowed. ` +
-      'The endpoint must use HTTPS and must not target private/loopback/cloud-metadata addresses.',
+      `SSRF protection: OAuth2 token endpoint '${endpoint}' is not allowed. Must use HTTPS and must not target private/loopback/cloud-metadata addresses.`,
     );
   }
   try {

--- a/core/src/auth/oauth2/oauth2_utils.ts
+++ b/core/src/auth/oauth2/oauth2_utils.ts
@@ -8,6 +8,7 @@ import {logger} from '../../utils/logger.js';
 import {OAuth2Auth} from '../auth_credential.js';
 
 import {AuthScheme, OpenIdConnectWithConfig} from '../auth_schemes.js';
+import {validateDiscoveryUrl} from './oauth2_discovery.js';
 
 /**
  * Returns the token endpoint for the given auth scheme.
@@ -50,6 +51,17 @@ export async function fetchOAuth2Tokens(
   endpoint: string,
   body: URLSearchParams,
 ): Promise<OAuth2Auth> {
+  // Validate the token endpoint URL against the same SSRF blocklist used for
+  // discovery URLs (validateDiscoveryUrl in oauth2_discovery.ts). Without this
+  // check, an attacker who controls the OpenAPI spec's tokenUrl can direct the
+  // agent to POST credentials to a cloud metadata endpoint (GCP 169.254.169.254,
+  // AWS IMDSv1, Azure IMDS) and receive IAM tokens in the response.
+  if (!validateDiscoveryUrl(endpoint)) {
+    throw new Error(
+      `SSRF protection: OAuth2 token endpoint '${endpoint}' is not allowed. ` +
+      'The endpoint must use HTTPS and must not target private/loopback/cloud-metadata addresses.',
+    );
+  }
   try {
     const response = await fetch(endpoint, {
       method: 'POST',


### PR DESCRIPTION
## Summary
`fetchOAuth2Tokens()` in `oauth2_utils.ts` makes an unauthenticated POST to
a `tokenUrl` derived from a user-supplied OpenAPI spec, with no IP or hostname
validation. An attacker who controls the spec can direct the agent to POST
OAuth credentials to cloud metadata endpoints:

- GCP: `http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token`
- AWS IMDSv1: `http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>`
- Azure: `http://169.254.169.254/metadata/identity/oauth2/token`

## Critical Inconsistency Fixed
The same `oauth2/` module already had comprehensive SSRF protection in
`oauth2_discovery.ts:validateDiscoveryUrl()`, covering:
- Loopback (`127.x.x.x`, `[::1]`)
- Cloud metadata (`169.254.x.x`, `metadata.google.internal`)
- RFC1918 private ranges (`10.x`, `172.16-31.x`, `192.168.x`)
- CGNAT RFC6598 (`100.64-127.x`)
- IPv6 ULA + link-local + IPv4-mapped IPv6

But `fetchOAuth2Tokens()` — accepting URLs from the same source — had **zero validation**.

## Fix
1. Export `validateDiscoveryUrl()` and `normaliseHostname()` from `oauth2_discovery.ts`
2. Import and call `validateDiscoveryUrl(endpoint)` at the top of `fetchOAuth2Tokens()`
   before the `fetch()` call

```typescript
// Before (vulnerable):
const response = await fetch(endpoint, { method: 'POST', ... });

// After (fixed):
if (!validateDiscoveryUrl(endpoint)) {
  throw new Error(`SSRF protection: OAuth2 token endpoint '${endpoint}' is not allowed.`);
}
const response = await fetch(endpoint, { method: 'POST', ... });

Files Changed
- core/src/auth/oauth2/oauth2_discovery.ts — export validateDiscoveryUrl + normaliseHostname
- core/src/auth/oauth2/oauth2_utils.ts — import and call validator before fetch



