### PR TITLE
Feat: Replace Promise<void> with proper Task type in ActiveStreamingTool Staging

### DIFF
--- a/core/src/agents/active_streaming_tool.ts
+++ b/core/src/agents/active_streaming_tool.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {Task} from '../utils/task.js';
 import {LiveRequestQueue} from './live_request_queue.js';
 
 /**
  * The parameters for creating an ActiveStreamingTool.
  */
 export interface ActiveStreamingToolParams {
-  task?: Promise<void>;
+  task?: Task<void>;
   stream?: LiveRequestQueue;
 }
 
@@ -20,10 +21,8 @@ export interface ActiveStreamingToolParams {
 export class ActiveStreamingTool {
   /**
    * The active task of this streaming tool.
-   * TODO: Replace 'Promise<void>' with a proper Task type if available in this
-   * env.
    */
-  task?: Promise<void>;
+  task?: Task<void>;
 
   /**
    * The active (input) streams of this streaming tool.

--- a/core/src/agents/active_streaming_tool.ts
+++ b/core/src/agents/active_streaming_tool.ts
@@ -11,7 +11,7 @@ import {LiveRequestQueue} from './live_request_queue.js';
  * The parameters for creating an ActiveStreamingTool.
  */
 export interface ActiveStreamingToolParams {
-  task?: Task<void>;
+  task?: Task<void> | Promise<void>;
   stream?: LiveRequestQueue;
 }
 
@@ -30,7 +30,11 @@ export class ActiveStreamingTool {
   stream?: LiveRequestQueue;
 
   constructor(params: ActiveStreamingToolParams = {}) {
-    this.task = params.task;
+    if (params.task instanceof Promise) {
+      this.task = new Task(() => params.task as Promise<void>);
+    } else {
+      this.task = params.task;
+    }
     this.stream = params.stream;
   }
 }

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -253,6 +253,7 @@ export {LogLevel, getLogger, setLogLevel, setLogger} from './utils/logger.js';
 export type {Logger} from './utils/logger.js';
 export {isGemini2OrAbove, isGemini3xFlashLive} from './utils/model_name.js';
 export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
+export {Task} from './utils/task.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 
@@ -272,6 +273,11 @@ export {LoadSkillTool} from './tools/skill/load_skill_tool.js';
 export {SearchSkillsTool} from './tools/skill/search_skills_tool.js';
 export {SkillToolset} from './tools/skill/skill_toolset.js';
 
+export * from './artifacts/base_artifact_service.js';
+export * from './features/feature_registry.js';
+export * from './memory/base_memory_service.js';
+export * from './sessions/base_session_service.js';
+export * from './tools/base_tool.js';
 export {OpenApiSpecParser} from './tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.js';
 export type {
   OperationEndpoint,
@@ -286,9 +292,3 @@ export {
   RestApiTool,
   createRestApiTool,
 } from './tools/openapi_tool/rest_api_tool.js';
-
-export * from './artifacts/base_artifact_service.js';
-export * from './features/feature_registry.js';
-export * from './memory/base_memory_service.js';
-export * from './sessions/base_session_service.js';
-export * from './tools/base_tool.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -254,6 +254,7 @@ export type {Logger} from './utils/logger.js';
 export {isGemini2OrAbove, isGemini3xFlashLive} from './utils/model_name.js';
 export {zodObjectToSchema} from './utils/simple_zod_to_json.js';
 export {Task} from './utils/task.js';
+export type {TaskExecutable} from './utils/task.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 

--- a/core/src/utils/task.ts
+++ b/core/src/utils/task.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Represents a runtime task wrapping a promise, allowing status check and cancellation.
+ */
+export class Task<T = void> {
+  private isDone = false;
+
+  constructor(
+    readonly promise: Promise<T>,
+    private readonly cancelFn?: () => void,
+  ) {
+    const markDone = () => {
+      this.isDone = true;
+    };
+    promise.then(markDone, markDone);
+  }
+
+  /**
+   * Cancels the task execution.
+   */
+  cancel(): void {
+    this.cancelFn?.();
+  }
+
+  /**
+   * Returns true if the task has completed (either resolved or rejected).
+   */
+  done(): boolean {
+    return this.isDone;
+  }
+}

--- a/core/src/utils/task.ts
+++ b/core/src/utils/task.ts
@@ -4,27 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export type TaskExecutable<T = void> = (abortSignal: AbortSignal) => Promise<T>;
+
 /**
  * Represents a runtime task wrapping a promise, allowing status check and cancellation.
  */
 export class Task<T = void> {
   private isDone = false;
+  private abortController = new AbortController();
+  public promise: Promise<T>;
 
-  constructor(
-    readonly promise: Promise<T>,
-    private readonly cancelFn?: () => void,
-  ) {
+  constructor(public executable: TaskExecutable<T>) {
     const markDone = () => {
       this.isDone = true;
     };
-    promise.then(markDone, markDone);
+
+    this.promise = executable(this.abortController.signal);
+    this.promise.then(markDone).catch(markDone);
   }
 
   /**
    * Cancels the task execution.
    */
   cancel(): void {
-    this.cancelFn?.();
+    this.abortController.abort();
   }
 
   /**

--- a/core/test/agents/active_streaming_tool_test.ts
+++ b/core/test/agents/active_streaming_tool_test.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {ActiveStreamingTool, Task} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('ActiveStreamingTool', () => {
+  it('should construct with default parameters', () => {
+    const tool = new ActiveStreamingTool();
+    expect(tool.task).toBeUndefined();
+    expect(tool.stream).toBeUndefined();
+  });
+
+  it('should store task when constructed with one', () => {
+    const promise = Promise.resolve();
+    const task = new Task(promise);
+    const tool = new ActiveStreamingTool({task});
+    expect(tool.task).toBe(task);
+  });
+});

--- a/core/test/agents/active_streaming_tool_test.ts
+++ b/core/test/agents/active_streaming_tool_test.ts
@@ -16,7 +16,7 @@ describe('ActiveStreamingTool', () => {
 
   it('should store task when constructed with one', () => {
     const promise = Promise.resolve();
-    const task = new Task(promise);
+    const task = new Task(() => promise);
     const tool = new ActiveStreamingTool({task});
     expect(tool.task).toBe(task);
   });

--- a/core/test/utils/task_test.ts
+++ b/core/test/utils/task_test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Task} from '@google/adk';
+import {describe, expect, it, vi} from 'vitest';
+
+describe('task utils', () => {
+  describe('Task class', () => {
+    it('should initialize with done() returning false', () => {
+      const promise = new Promise<void>(() => {});
+      const task = new Task(promise);
+      expect(task.done()).toBe(false);
+    });
+
+    it('should set done() to true when promise resolves', async () => {
+      const promise = Promise.resolve();
+      const task = new Task(promise);
+
+      expect(task.done()).toBe(false);
+
+      await promise;
+
+      expect(task.done()).toBe(true);
+    });
+
+    it('should set done() to true when promise rejects', async () => {
+      const promise = Promise.reject(new Error('test error'));
+      const task = new Task(promise);
+
+      expect(task.done()).toBe(false);
+
+      try {
+        await promise;
+      } catch (_) {
+        // expected
+      }
+
+      expect(task.done()).toBe(true);
+    });
+
+    it('should call cancelFn when cancel is called', () => {
+      const cancelFn = vi.fn();
+      const promise = new Promise<void>(() => {});
+      const task = new Task(promise, cancelFn);
+
+      task.cancel();
+
+      expect(cancelFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw if cancel is called but no cancelFn is provided', () => {
+      const promise = new Promise<void>(() => {});
+      const task = new Task(promise);
+
+      expect(() => task.cancel()).not.toThrow();
+    });
+  });
+});

--- a/core/test/utils/task_test.ts
+++ b/core/test/utils/task_test.ts
@@ -5,57 +5,61 @@
  */
 
 import {Task} from '@google/adk';
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it} from 'vitest';
 
 describe('task utils', () => {
   describe('Task class', () => {
     it('should initialize with done() returning false', () => {
-      const promise = new Promise<void>(() => {});
-      const task = new Task(promise);
+      const task = new Task(() => new Promise<void>(() => {}));
       expect(task.done()).toBe(false);
     });
 
     it('should set done() to true when promise resolves', async () => {
-      const promise = Promise.resolve();
-      const task = new Task(promise);
+      let resolvePromise!: () => void;
+      const promise = new Promise<void>((resolve) => {
+        resolvePromise = resolve;
+      });
+      const task = new Task(() => promise);
 
       expect(task.done()).toBe(false);
 
-      await promise;
+      resolvePromise();
+      await task.promise;
 
       expect(task.done()).toBe(true);
     });
 
     it('should set done() to true when promise rejects', async () => {
-      const promise = Promise.reject(new Error('test error'));
-      const task = new Task(promise);
+      let rejectPromise!: (err: Error) => void;
+      const promise = new Promise<void>((_, reject) => {
+        rejectPromise = reject;
+      });
+      const task = new Task(() => promise);
 
       expect(task.done()).toBe(false);
 
+      rejectPromise(new Error('test error'));
       try {
-        await promise;
+        await task.promise;
       } catch (_) {
         // expected
       }
+      // allow microtask queue to flush the .catch(markDone)
+      await new Promise((resolve) => process.nextTick(resolve));
 
       expect(task.done()).toBe(true);
     });
 
-    it('should call cancelFn when cancel is called', () => {
-      const cancelFn = vi.fn();
-      const promise = new Promise<void>(() => {});
-      const task = new Task(promise, cancelFn);
+    it('should trip abort signal when cancel is called', () => {
+      let signal: AbortSignal | undefined;
+      const task = new Task((s) => {
+        signal = s;
+        return new Promise<void>(() => {});
+      });
 
+      expect(signal?.aborted).toBe(false);
       task.cancel();
-
-      expect(cancelFn).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not throw if cancel is called but no cancelFn is provided', () => {
-      const promise = new Promise<void>(() => {});
-      const task = new Task(promise);
-
-      expect(() => task.cancel()).not.toThrow();
+      expect(signal?.aborted).toBe(true);
     });
   });
 });

--- a/tests/e2e/streaming/task_e2e_test.ts
+++ b/tests/e2e/streaming/task_e2e_test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {ActiveStreamingTool, LiveRequestQueue, Task} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('ActiveStreamingTool E2E Simulation', () => {
+  it('should manage a simulated streaming tool task', async () => {
+    const queue = new LiveRequestQueue();
+    let cancelled = false;
+
+    // Simulate a background task
+    const promise = new Promise<void>((resolve) => {
+      const interval = setInterval(() => {
+        if (cancelled) {
+          clearInterval(interval);
+          resolve();
+          return;
+        }
+        // Push some dummy data to the queue
+        queue.sendContent({parts: [{text: 'data'}]});
+      }, 10);
+    });
+
+    const task = new Task(promise, () => {
+      cancelled = true;
+    });
+
+    const activeTool = new ActiveStreamingTool({task, stream: queue});
+
+    expect(activeTool.task).toBe(task);
+    expect(activeTool.stream).toBe(queue);
+    expect(activeTool.task?.done()).toBe(false);
+
+    // Let it run a bit to generate some data
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify queue got some data
+    const nextItem = await queue.get();
+    expect(nextItem).toBeDefined();
+    expect(nextItem?.content?.parts?.[0]?.text).toBe('data');
+
+    // Cancel it
+    activeTool.task?.cancel();
+    await promise;
+
+    expect(activeTool.task?.done()).toBe(true);
+  });
+});

--- a/tests/e2e/streaming/task_e2e_test.ts
+++ b/tests/e2e/streaming/task_e2e_test.ts
@@ -10,23 +10,19 @@ import {describe, expect, it} from 'vitest';
 describe('ActiveStreamingTool E2E Simulation', () => {
   it('should manage a simulated streaming tool task', async () => {
     const queue = new LiveRequestQueue();
-    let cancelled = false;
-
-    // Simulate a background task
-    const promise = new Promise<void>((resolve) => {
-      const interval = setInterval(() => {
-        if (cancelled) {
-          clearInterval(interval);
-          resolve();
-          return;
-        }
-        // Push some dummy data to the queue
-        queue.sendContent({parts: [{text: 'data'}]});
-      }, 10);
-    });
-
-    const task = new Task(promise, () => {
-      cancelled = true;
+    // Simulate a background task using AbortSignal
+    const task = new Task((signal) => {
+      return new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (signal.aborted) {
+            clearInterval(interval);
+            resolve();
+            return;
+          }
+          // Push some dummy data to the queue
+          queue.sendContent({parts: [{text: 'data'}]});
+        }, 10);
+      });
     });
 
     const activeTool = new ActiveStreamingTool({task, stream: queue});
@@ -45,7 +41,7 @@ describe('ActiveStreamingTool E2E Simulation', () => {
 
     // Cancel it
     activeTool.task?.cancel();
-    await promise;
+    await task.promise;
 
     expect(activeTool.task?.done()).toBe(true);
   });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

**Problem:**
`ActiveStreamingTool.task` was typed as `Promise<void>`, which didn't allow for runtime control (cancellation, status check) like the Python reference implementation which uses `asyncio.Task`.

**Solution:**
Implemented a concrete `Task` class in `core/src/utils/task.ts` that wraps a promise and supports `cancel()` and `done()`. Updated `ActiveStreamingTool` to use this `Task` type. Updated exports in `common.ts` and `index.ts`.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed vitest results for:
- `core/test/utils/task_test.ts`
- `core/test/agents/active_streaming_tool_test.ts`

**Manual End-to-End (E2E) Tests:**

Updated `tests/e2e/streaming/task_e2e_test.ts` to simulate a streaming tool task using the new `Task` class and `LiveRequestQueue`, and verified it runs and passes.

- [x] I have manually tested my changes end-to-end.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

None.
