### PR TITLE
fix: gate token-based compaction on latest prompt size, not event sum

### DIFF
--- a/core/src/context/token_based_context_compactor.ts
+++ b/core/src/context/token_based_context_compactor.ts
@@ -5,13 +5,22 @@
  */
 
 import {InvocationContext} from '../agents/invocation_context.js';
+import {getContents} from '../agents/processors/content_processor_utils.js';
 import {CompactedEvent, isCompactedEvent} from '../events/compacted_event.js';
-import {Event, stringifyContent} from '../events/event.js';
+import {Event} from '../events/event.js';
 import {BaseContextCompactor} from './base_context_compactor.js';
 import {BaseSummarizer} from './summarizers/base_summarizer.js';
 
+/** Rough estimate used when no usage metadata is available. */
+const CHARS_PER_TOKEN = 4;
+
 export interface TokenBasedContextCompactorOptions {
-  /** The maximum number of tokens to retain in the session history before compaction. */
+  /**
+   * Prompt-size threshold (in tokens) that triggers compaction. Compared
+   * against the most recently observed LLM request size
+   * (`usageMetadata.promptTokenCount`), falling back to a character-based
+   * estimate of the effective contents when no usage metadata is available.
+   */
   tokenThreshold: number;
   /**
    * The minimum number of raw events to keep at the end of the session.
@@ -73,12 +82,15 @@ export class TokenBasedContextCompactor implements BaseContextCompactor {
       return false;
     }
 
-    let totalTokens = 0;
-    for (const event of activeEvents) {
-      totalTokens += getEventTokens(event);
+    const promptTokenCount = latestPromptTokenCount(
+      activeEvents,
+      invocationContext,
+    );
+    if (promptTokenCount === undefined) {
+      return false;
     }
 
-    return totalTokens > this.tokenThreshold;
+    return promptTokenCount > this.tokenThreshold;
   }
 
   async compact(invocationContext: InvocationContext): Promise<void> {
@@ -142,13 +154,66 @@ export class TokenBasedContextCompactor implements BaseContextCompactor {
   }
 }
 
-function getEventTokens(event: Event): number {
-  if (event.usageMetadata?.promptTokenCount !== undefined) {
-    return event.usageMetadata.promptTokenCount;
+/**
+ * Returns the most recently observed prompt token count, if available.
+ *
+ * Mirrors the Python ADK (`apps/compaction.py::_latest_prompt_token_count`):
+ * each model response's `usageMetadata.promptTokenCount` is the measured size
+ * of the entire request that produced it (system instruction + tools + full
+ * history), so the latest one is used directly. These values must not be
+ * summed across events: each already includes all prior history, so a sum
+ * grows with call count rather than context size.
+ */
+function latestPromptTokenCount(
+  activeEvents: Event[],
+  invocationContext: InvocationContext,
+): number | undefined {
+  for (let i = activeEvents.length - 1; i >= 0; i--) {
+    const count = activeEvents[i].usageMetadata?.promptTokenCount;
+    if (count !== undefined) {
+      return count;
+    }
   }
-  // Estimate: 4 chars per token.
-  const contentStr = stringifyContent(event);
-  return Math.ceil(contentStr.length / 4);
+  return estimatePromptTokenCount(activeEvents, invocationContext);
+}
+
+/**
+ * Returns an approximate prompt token count from the active events.
+ *
+ * Mirrors the effective content-building path used by the content request
+ * processor, so the estimate aligns with what would actually be sent to the
+ * LLM (it cannot account for the system instruction or tool schemas, which
+ * are not derivable from session events).
+ */
+function estimatePromptTokenCount(
+  activeEvents: Event[],
+  invocationContext: InvocationContext,
+): number | undefined {
+  const contents = getContents(
+    activeEvents,
+    invocationContext.agent.name,
+    invocationContext.branch,
+  );
+
+  let totalChars = 0;
+  for (const content of contents) {
+    for (const part of content.parts ?? []) {
+      if (part.text) {
+        totalChars += part.text.length;
+      }
+      if (part.functionCall) {
+        totalChars += JSON.stringify(part.functionCall).length;
+      }
+      if (part.functionResponse) {
+        totalChars += JSON.stringify(part.functionResponse).length;
+      }
+    }
+  }
+
+  if (totalChars <= 0) {
+    return undefined;
+  }
+  return Math.ceil(totalChars / CHARS_PER_TOKEN);
 }
 
 function hasFunctionCall(event: Event): boolean {

--- a/core/test/context/token_based_context_compactor_test.ts
+++ b/core/test/context/token_based_context_compactor_test.ts
@@ -46,11 +46,13 @@ function createMockEvent(
   tokenCount?: number,
   isFuncCall?: boolean,
   isFuncResp?: boolean,
+  text?: string,
 ): Event {
   const event: Event = {
     id,
+    author: 'user',
     timestamp: Date.now(),
-    content: {parts: []},
+    content: {role: 'user', parts: []},
   } as unknown as Event;
   if (tokenCount !== undefined) {
     event.usageMetadata = {promptTokenCount: tokenCount};
@@ -62,6 +64,9 @@ function createMockEvent(
     event.content!.parts!.push({
       functionResponse: {name: 'mock', response: {}},
     });
+  }
+  if (text !== undefined) {
+    event.content!.parts!.push({text});
   }
   return event;
 }
@@ -75,7 +80,7 @@ function createMockInvocationContext(events: Event[]): InvocationContext {
   } as unknown as Session;
   return new InvocationContext({
     invocationId: 'test-invocation',
-    agent: {} as BaseAgent,
+    agent: {name: 'test-agent'} as BaseAgent,
     session,
     pluginManager: new PluginManager([]),
   });
@@ -108,12 +113,12 @@ describe('TokenBasedContextCompactor', () => {
       summarizer: new MockSummarizer(),
     });
 
-    // Total tokens: 5 + 5 + 5 + 5 = 20 > 10. Length = 4 > 2.
+    // Latest observed prompt token count: 15 > 10. Length = 4 > 2.
     const context = createMockInvocationContext([
       createMockEvent('1', 5),
-      createMockEvent('2', 5),
-      createMockEvent('3', 5),
-      createMockEvent('4', 5),
+      createMockEvent('2', 8),
+      createMockEvent('3', 12),
+      createMockEvent('4', 15),
     ]);
 
     expect(await compactor.shouldCompact(context)).toBe(true);
@@ -165,5 +170,89 @@ describe('TokenBasedContextCompactor', () => {
     expect(context.session.events[1].id).toBe('1');
     expect(context.session.events[2].id).toBe('2');
     expect(context.session.events[3].id).toBe('3');
+  });
+
+  it('should use the latest prompt token count, not the sum across events', async () => {
+    const compactor = new TokenBasedContextCompactor({
+      tokenThreshold: 10,
+      eventRetentionSize: 2,
+      summarizer: new MockSummarizer(),
+    });
+
+    // Each event's promptTokenCount is the full request size of the call that
+    // produced it, so summing re-counts history: 6 + 7 + 8 + 9 = 30 > 10, but
+    // the actual latest request was only 9 tokens — must NOT compact.
+    const context = createMockInvocationContext([
+      createMockEvent('1', 6),
+      createMockEvent('2', 7),
+      createMockEvent('3', 8),
+      createMockEvent('4', 9),
+    ]);
+
+    expect(await compactor.shouldCompact(context)).toBe(false);
+  });
+
+  it('should prefer the newest usage metadata over older events', async () => {
+    const compactor = new TokenBasedContextCompactor({
+      tokenThreshold: 10,
+      eventRetentionSize: 2,
+      summarizer: new MockSummarizer(),
+    });
+
+    // Newest event with metadata reads 4 (< 10); an older event reads 15.
+    // The latest observation wins - must NOT compact.
+    const context = createMockInvocationContext([
+      createMockEvent('1', 15),
+      createMockEvent('2', 4),
+      createMockEvent('3'), // no usage metadata (e.g. user message)
+      createMockEvent('4'),
+    ]);
+
+    expect(await compactor.shouldCompact(context)).toBe(false);
+  });
+
+  it('should fall back to a character estimate when no usage metadata exists', async () => {
+    const compactor = new TokenBasedContextCompactor({
+      tokenThreshold: 10,
+      eventRetentionSize: 2,
+      summarizer: new MockSummarizer(),
+    });
+
+    // No event has usageMetadata; text totals 80 chars -> ~20 tokens > 10.
+    const bigText = 'x'.repeat(80);
+    const overThreshold = createMockInvocationContext([
+      createMockEvent('1', undefined, false, false, bigText),
+      createMockEvent('2', undefined, false, false, 'hi'),
+      createMockEvent('3', undefined, false, false, 'hi'),
+      createMockEvent('4', undefined, false, false, 'hi'),
+    ]);
+    expect(await compactor.shouldCompact(overThreshold)).toBe(true);
+
+    // Text totals 8 chars -> ~2 tokens < 10.
+    const underThreshold = createMockInvocationContext([
+      createMockEvent('1', undefined, false, false, 'hi'),
+      createMockEvent('2', undefined, false, false, 'hi'),
+      createMockEvent('3', undefined, false, false, 'hi'),
+      createMockEvent('4', undefined, false, false, 'hi'),
+    ]);
+    expect(await compactor.shouldCompact(underThreshold)).toBe(false);
+  });
+
+  it('should not compact when no token count or estimate is available', async () => {
+    const compactor = new TokenBasedContextCompactor({
+      tokenThreshold: 10,
+      eventRetentionSize: 2,
+      summarizer: new MockSummarizer(),
+    });
+
+    // No usage metadata and no measurable content.
+    const context = createMockInvocationContext([
+      createMockEvent('1'),
+      createMockEvent('2'),
+      createMockEvent('3'),
+      createMockEvent('4'),
+    ]);
+
+    expect(await compactor.shouldCompact(context)).toBe(false);
   });
 });

--- a/tests/integration/context_compaction/tokens/agent_test.ts
+++ b/tests/integration/context_compaction/tokens/agent_test.ts
@@ -37,9 +37,11 @@ describe('Context Compaction with Tokens', () => {
             },
           },
         ],
+        // This request's measured prompt size exceeds the threshold (40), so
+        // the next turn's request processing triggers compaction.
         usageMetadata: {
-          promptTokenCount: 25,
-          totalTokenCount: 35,
+          promptTokenCount: 45,
+          totalTokenCount: 55,
         },
       },
       {
@@ -85,8 +87,9 @@ describe('Context Compaction with Tokens', () => {
       // intentionally empty
     }
 
-    // Turn 3 - The threshold (40) is low enough that by turn 3, we should exceed it
-    // and compaction should be triggered by the CompactorRequestProcessor.
+    // Turn 3 - The latest observed prompt token count (45, from turn 2's
+    // response) exceeds the threshold (40), so compaction should be triggered
+    // by the CompactorRequestProcessor before this turn's model call.
     for await (const _ of runner.runAsync({
       userId: 'test_user',
       sessionId: session.id,


### PR DESCRIPTION
Fixes #473.

`TokenBasedContextCompactor.shouldCompact` summed `usageMetadata.promptTokenCount` across active events. Each of those values is the full prompt size of the call that produced it (system instruction + tools + entire history), so the sum re-counts the same history once per event and grows with call count rather than context size — and after a compaction, retained tail events still carry pre-compaction counts, leaving the sum permanently above any threshold (compact-every-call thrashing). Details and production impact in #473.

This ports the Python ADK's semantics ([`apps/compaction.py::_latest_prompt_token_count`](https://github.com/google/adk-python/blob/main/src/google/adk/apps/compaction.py)):

- use the **most recently observed** `promptTokenCount` — the measured size of the last real request
- fall back to a chars/4 estimate over the effective request contents (`getContents`, mirroring the content request processor) when no usage metadata is available

`compact()` and retention behavior are unchanged.

**Testing**: rewrote the threshold unit test against the new semantics and added: a latest-not-sum regression case, newest-metadata-wins, estimate fallback (over and under threshold), and the no-signal case. Full `unit:core` suite passes (954 tests).