### PR TITLE
fix(core): default newMessage role to 'user' when omitted (#475)

### DIFF
--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -47,9 +47,7 @@ export function getContents(
 
     // Skip events without content, or generated neither by user nor by model.
     // E.g. events purely for mutating session states.
-    const role =
-      event.content?.role || (event.author === 'user' ? 'user' : undefined);
-    if (!role || event.content?.parts?.[0]?.text === '') {
+    if (!event.content?.role || event.content.parts?.[0]?.text === '') {
       continue;
     }
 
@@ -84,9 +82,6 @@ export function getContents(
   const contents = [];
   for (const event of resultEvents) {
     const content = cloneDeep(event.content!);
-    if (!content.role && event.author === 'user') {
-      content.role = 'user';
-    }
     removeClientFunctionCallId(content);
     contents.push(content);
   }

--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -47,7 +47,9 @@ export function getContents(
 
     // Skip events without content, or generated neither by user nor by model.
     // E.g. events purely for mutating session states.
-    if (!event.content?.role || event.content.parts?.[0]?.text === '') {
+    const role =
+      event.content?.role || (event.author === 'user' ? 'user' : undefined);
+    if (!role || event.content?.parts?.[0]?.text === '') {
       continue;
     }
 
@@ -82,6 +84,9 @@ export function getContents(
   const contents = [];
   for (const event of resultEvents) {
     const content = cloneDeep(event.content!);
+    if (!content.role && event.author === 'user') {
+      content.role = 'user';
+    }
     removeClientFunctionCallId(content);
     contents.push(content);
   }

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -211,6 +211,9 @@ export class Runner {
     const {userId, sessionId, stateDelta} = params;
     const runConfig = createRunConfig(params.runConfig);
     let newMessage = params.newMessage;
+    if (newMessage && !newMessage.role) {
+      newMessage.role = 'user';
+    }
 
     // =========================================================================
     // Setup the session and invocation context

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -686,4 +686,34 @@ describe('Runner customMetadata support', () => {
 
     appendEventSpy.mockRestore();
   });
+
+  it('should default newMessage role to "user" when role is omitted (issue #475)', async () => {
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: 'test_session_475',
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {parts: [{text: 'Hello without role'}]},
+    })) {
+      events.push(event);
+    }
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: 'test_session_475',
+    });
+
+    expect(updatedSession).not.toBeNull();
+    expect(updatedSession!.events.length).toBeGreaterThan(0);
+
+    const userEvent = updatedSession!.events[0];
+    expect(userEvent.author).toBe('user');
+    expect(userEvent.content?.role).toBe('user');
+  });
 });


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: [#475](https://github.com/google/adk-js/issues/475)
- Related: [#475](https://github.com/google/adk-js/issues/475)

**Problem:**

When calling `Runner.runAsync()` with a role-less `newMessage` payload (e.g., `newMessage: { parts: [{ text: 'Hello' }] }`), exactly as shown in the library's JSDoc examples, the message is appended to session storage without a `content.role`. During tool-calling execution loops, when `getContents()` rebuilds the conversation history for follow-up requests after tool execution, it filters out and drops any event where `content.role` is undefined. Consequently, the outgoing follow-up payload sent to Gemini starts with a model `functionCall` turn instead of a user turn, causing the Gemini API to reject the request with `400 INVALID_ARGUMENT: Please ensure that function call turn comes immediately after a user turn or after a function response turn.`

**Solution:**

**Ingestion Normalization (`runner.ts`)**: In `Runner.runAsync()`, default `newMessage.role` to `'user'` whenever it is omitted. This guarantees that messages entering the runner without a role (as shown in official JSDoc examples) are immediately saved to session storage with `"role": "user"` intact, preventing the user turn from being stripped out during tool-calling execution loops.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added a new unit test in `core/test/runner/runner_test.ts`: `"should default newMessage role to "user" when role is omitted (issue #475)"`.

```
stdout | core/test/runner/runner_test.ts > Runner customMetadata support > should default newMessage role to "user" when role is omitted (issue #475)
INFO: [ADK] ... event: {"author":"user", ... ,"content":{"parts":[{"text":"Hello without role"}],"role":"user"}}

 ✓ |unit:core| core/test/runner/runner_test.ts (20 tests) 10ms

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  2.01s
```

**Manual End-to-End (E2E) Tests:**

1. Created a minimal agent setup with an `echo` FunctionTool and an `InMemoryRunner`.
2. Invoked `runner.runAsync(...)` passing `newMessage: { parts: [{ text: 'Call the echo tool with the text "hi" and tell me its result.' }] }` (without an explicit `role`).

**Before Fix (Logs showing HTTP 400 crash on tool loop follow-up):**
```
INFO: [ADK] event: {"author":"user", ... "content":{"parts":[{"text":"Call the echo tool..."}]}}
INFO: [ADK] Sending out request, model: gemini-3.5-flash...
INFO: [ADK] Sending out request, model: gemini-3.5-flash...
ERROR 400 Please ensure that function call turn comes immediately after a user turn or after a function response turn.
```

**After Fix (Logs showing role defaulted and clean execution):**
```
INFO: [ADK] event: {"author":"user", ... "content":{"role":"user","parts":[{"text":"Call the echo tool..."}]}}
INFO: [ADK] Sending out request, model: gemini-3.5-flash...
OUTPUT: {"functionCall":{"name":"echo","args":{"text":"hi"}}}
OUTPUT: {"functionResponse":{"name":"echo","response":{"result":"echo: hi"}}}
INFO: [ADK] Sending out request, model: gemini-3.5-flash...
OUTPUT: The echo tool returned: "echo: hi"
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This change is 100% non-breaking and backward compatible. It purely supplies the standard `'user'` role when it is left undefined on user turns, aligning library runtime behavior with the published JSDoc examples while leaving explicitly roled messages, tool calls, tool responses, and state mutations completely untouched.
