### PR TITLE
Feat: Implement OpenTelemetry tool call tracing parity with Python

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -211,15 +211,6 @@ export function generateRequestConfirmationEvent({
   });
 }
 
-async function callToolAsync(
-  tool: BaseTool,
-  args: Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
-  toolContext: Context,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
-  logger.debug(`callToolAsync ${tool.name}`);
-  return await tool.runAsync({args, toolContext});
-}
 /**
  * Handles function calls.
  * Runtime behavior to pay attention to:
@@ -312,7 +303,8 @@ export async function handleFunctionCallList({
       try {
         // Step 1: Check if plugin before_tool_callback overrides the function
         // response.
-        let functionResponse = null;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let functionResponse: any = null;
         let functionResponseError: string | unknown | undefined;
         functionResponse =
           await invocationContext.pluginManager.runBeforeToolCallback({
@@ -342,11 +334,11 @@ export async function handleFunctionCallList({
         if (functionResponse == null) {
           // Cover both null and undefined
           try {
-            functionResponse = await callToolAsync(
-              tool,
-              functionArgs,
+            logger.debug(`callToolAsync ${tool.name}`);
+            functionResponse = (await tool.runAsync({
+              args: functionArgs,
               toolContext,
-            );
+            })) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
           } catch (e: unknown) {
             caughtExecutionError = e;
             if (e instanceof Error) {
@@ -453,7 +445,7 @@ export async function handleFunctionCallList({
         if (
           functionResponseEvent ||
           caughtExecutionError ||
-          !(tool.isLongRunning && !functionResponseEvent)
+          !tool.isLongRunning
         ) {
           traceToolCall({
             tool,

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -217,62 +217,8 @@ async function callToolAsync(
   toolContext: Context,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
-  return tracer.startActiveSpan(`execute_tool ${tool.name}`, async (span) => {
-    try {
-      logger.debug(`callToolAsync ${tool.name}`);
-      const result = await tool.runAsync({args, toolContext});
-      traceToolCall({
-        tool,
-        args,
-        functionResponseEvent: buildResponseEvent(
-          tool,
-          result,
-          toolContext,
-          toolContext.invocationContext,
-        ),
-      });
-      return result;
-    } finally {
-      span.end();
-    }
-  });
-}
-
-function buildResponseEvent(
-  tool: BaseTool,
-  functionResult: unknown,
-  toolContext: Context,
-  invocationContext: InvocationContext,
-): Event {
-  let responseResult: Record<string, unknown>;
-  if (typeof functionResult !== 'object' || functionResult == null) {
-    responseResult = {result: functionResult};
-  } else if (Array.isArray(functionResult)) {
-    responseResult = {results: functionResult};
-  } else {
-    responseResult = functionResult as Record<string, unknown>;
-  }
-
-  const partFunctionResponse: Part = {
-    functionResponse: {
-      name: tool.name,
-      response: responseResult,
-      id: toolContext.functionCallId,
-    },
-  };
-
-  const content: Content = {
-    role: 'user',
-    parts: [partFunctionResponse],
-  };
-
-  return createEvent({
-    invocationId: invocationContext.invocationId,
-    author: invocationContext.agent.name,
-    content: content,
-    actions: toolContext.actions,
-    branch: invocationContext.branch,
-  });
+  logger.debug(`callToolAsync ${tool.name}`);
+  return await tool.runAsync({args, toolContext});
 }
 /**
  * Handles function calls.
@@ -357,142 +303,170 @@ export async function handleFunctionCallList({
       toolConfirmation,
     });
 
-    // TODO - b/436079721: implement [tracer.start_as_current_span]
-    logger.debug(`execute_tool ${tool.name}`);
-    const functionArgs = functionCall.args ?? {};
+    await tracer.startActiveSpan(`execute_tool ${tool.name}`, async (span) => {
+      logger.debug(`execute_tool ${tool.name}`);
+      const functionArgs = functionCall.args ?? {};
+      let functionResponseEvent: Event | null = null;
+      let caughtExecutionError: unknown = undefined;
 
-    // Step 1: Check if plugin before_tool_callback overrides the function
-    // response.
-    let functionResponse = null;
-    let functionResponseError: string | unknown | undefined;
-    functionResponse =
-      await invocationContext.pluginManager.runBeforeToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-      });
-
-    // Step 2: If no overrides are provided from the plugins, further run the
-    // canonical callback.
-    // TODO - b/425992518: validate the callback response type matches.
-    if (functionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of beforeToolCallbacks) {
-        functionResponse = await callback({
-          tool: tool,
-          args: functionArgs,
-          context: toolContext,
-        });
-        if (functionResponse) {
-          break;
-        }
-      }
-    }
-
-    // Step 3: Otherwise, proceed calling the tool normally.
-    if (functionResponse == null) {
-      // Cover both null and undefined
       try {
-        functionResponse = await callToolAsync(tool, functionArgs, toolContext);
-      } catch (e: unknown) {
-        if (e instanceof Error) {
-          const onToolErrorResponse =
-            await invocationContext.pluginManager.runOnToolErrorCallback({
+        // Step 1: Check if plugin before_tool_callback overrides the function
+        // response.
+        let functionResponse = null;
+        let functionResponseError: string | unknown | undefined;
+        functionResponse =
+          await invocationContext.pluginManager.runBeforeToolCallback({
+            tool: tool,
+            toolArgs: functionArgs,
+            toolContext: toolContext,
+          });
+
+        // Step 2: If no overrides are provided from the plugins, further run the
+        // canonical callback.
+        // TODO - b/425992518: validate the callback response type matches.
+        if (functionResponse == null) {
+          // Cover both null and undefined
+          for (const callback of beforeToolCallbacks) {
+            functionResponse = await callback({
               tool: tool,
-              toolArgs: functionArgs,
-              toolContext: toolContext,
-              error: e,
+              args: functionArgs,
+              context: toolContext,
             });
-
-          // Set function response to the result of the error callback and
-          // continue execution, do not shortcut
-          if (onToolErrorResponse) {
-            functionResponse = onToolErrorResponse;
-          } else {
-            // If the error callback returns undefined, use the error message
-            // as the function response error.
-            functionResponseError = e.message;
+            if (functionResponse) {
+              break;
+            }
           }
-        } else {
-          // If the error is not an Error, use the error object as the function
-          // response error.
-          functionResponseError = e;
         }
-      }
-    }
 
-    // Step 4: Check if plugin after_tool_callback overrides the function
-    // response.
-    let alteredFunctionResponse =
-      await invocationContext.pluginManager.runAfterToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-        result: functionResponse,
-      });
+        // Step 3: Otherwise, proceed calling the tool normally.
+        if (functionResponse == null) {
+          // Cover both null and undefined
+          try {
+            functionResponse = await callToolAsync(
+              tool,
+              functionArgs,
+              toolContext,
+            );
+          } catch (e: unknown) {
+            caughtExecutionError = e;
+            if (e instanceof Error) {
+              const onToolErrorResponse =
+                await invocationContext.pluginManager.runOnToolErrorCallback({
+                  tool: tool,
+                  toolArgs: functionArgs,
+                  toolContext: toolContext,
+                  error: e,
+                });
 
-    // Step 5: If no overrides are provided from the plugins, further run the
-    // canonical after_tool_callbacks.
-    if (alteredFunctionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of afterToolCallbacks) {
-        alteredFunctionResponse = await callback({
-          tool: tool,
-          args: functionArgs,
-          context: toolContext,
-          response: functionResponse,
+              // Set function response to the result of the error callback and
+              // continue execution, do not shortcut
+              if (onToolErrorResponse) {
+                functionResponse = onToolErrorResponse;
+              } else {
+                // If the error callback returns undefined, use the error message
+                // as the function response error.
+                functionResponseError = e.message;
+              }
+            } else {
+              // If the error is not an Error, use the error object as the function
+              // response error.
+              functionResponseError = e;
+            }
+          }
+        }
+
+        // Step 4: Check if plugin after_tool_callback overrides the function
+        // response.
+        let alteredFunctionResponse =
+          await invocationContext.pluginManager.runAfterToolCallback({
+            tool: tool,
+            toolArgs: functionArgs,
+            toolContext: toolContext,
+            result: functionResponse,
+          });
+
+        // Step 5: If no overrides are provided from the plugins, further run the
+        // canonical after_tool_callbacks.
+        if (alteredFunctionResponse == null) {
+          // Cover both null and undefined
+          for (const callback of afterToolCallbacks) {
+            alteredFunctionResponse = await callback({
+              tool: tool,
+              args: functionArgs,
+              context: toolContext,
+              response: functionResponse,
+            });
+            if (alteredFunctionResponse) {
+              break;
+            }
+          }
+        }
+
+        // Step 6: If alternative response exists from after_tool_callback, use it
+        // instead of the original function response.
+        if (alteredFunctionResponse != null) {
+          functionResponse = alteredFunctionResponse;
+        }
+
+        // TODO - b/425992518: state event polluting runtime, consider fix.
+        // Allow long running function to return None as response.
+        if (tool.isLongRunning && !functionResponse) {
+          return;
+        }
+
+        if (functionResponseError) {
+          functionResponse = {error: functionResponseError};
+        } else if (
+          typeof functionResponse !== 'object' ||
+          functionResponse == null
+        ) {
+          functionResponse = {result: functionResponse};
+        } else if (Array.isArray(functionResponse)) {
+          functionResponse = {results: functionResponse};
+        }
+
+        // Builds the function response event.
+        functionResponseEvent = createEvent({
+          invocationId: invocationContext.invocationId,
+          author: invocationContext.agent.name,
+          content: createUserContent({
+            functionResponse: {
+              id: toolContext.functionCallId,
+              name: tool.name,
+              response: functionResponse,
+            },
+          }),
+          actions: toolContext.actions,
+          branch: invocationContext.branch,
         });
-        if (alteredFunctionResponse) {
-          break;
+
+        logger.debug('traceToolCall', {
+          tool: tool.name,
+          args: functionArgs,
+          functionResponseEvent: functionResponseEvent.id,
+        });
+        functionResponseEvents.push(functionResponseEvent);
+      } catch (e: unknown) {
+        caughtExecutionError = e;
+        throw e;
+      } finally {
+        if (
+          functionResponseEvent ||
+          caughtExecutionError ||
+          !(tool.isLongRunning && !functionResponseEvent)
+        ) {
+          traceToolCall({
+            tool,
+            args: functionArgs,
+            functionResponseEvent,
+            error: caughtExecutionError,
+            span,
+            invocationContext,
+          });
         }
+        span.end();
       }
-    }
-
-    // Step 6: If alternative response exists from after_tool_callback, use it
-    // instead of the original function response.
-    if (alteredFunctionResponse != null) {
-      functionResponse = alteredFunctionResponse;
-    }
-
-    // TODO - b/425992518: state event polluting runtime, consider fix.
-    // Allow long running function to return None as response.
-    if (tool.isLongRunning && !functionResponse) {
-      continue;
-    }
-
-    if (functionResponseError) {
-      functionResponse = {error: functionResponseError};
-    } else if (
-      typeof functionResponse !== 'object' ||
-      functionResponse == null
-    ) {
-      functionResponse = {result: functionResponse};
-    } else if (Array.isArray(functionResponse)) {
-      functionResponse = {results: functionResponse};
-    }
-
-    // Builds the function response event.
-    const functionResponseEvent = createEvent({
-      invocationId: invocationContext.invocationId,
-      author: invocationContext.agent.name,
-      content: createUserContent({
-        functionResponse: {
-          id: toolContext.functionCallId,
-          name: tool.name,
-          response: functionResponse,
-        },
-      }),
-      actions: toolContext.actions,
-      branch: invocationContext.branch,
     });
-
-    // TODO - b/436079721: implement [traceToolCall]
-    logger.debug('traceToolCall', {
-      tool: tool.name,
-      args: functionArgs,
-      functionResponseEvent: functionResponseEvent.id,
-    });
-    functionResponseEvents.push(functionResponseEvent);
   }
 
   if (!functionResponseEvents.length) {
@@ -506,7 +480,6 @@ export async function handleFunctionCallList({
     tracer.startActiveSpan('execute_tool (merged)', (span) => {
       try {
         logger.debug('execute_tool (merged)');
-        // TODO - b/436079721: implement [traceMergedToolCalls]
         logger.debug('traceMergedToolCalls', {
           responseEventId: mergedEvent.id,
           functionResponseEvent: mergedEvent.id,
@@ -514,6 +487,7 @@ export async function handleFunctionCallList({
         traceMergedToolCalls({
           responseEventId: mergedEvent.id,
           functionResponseEvent: mergedEvent,
+          invocationContext,
         });
       } finally {
         span.end();

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -291,4 +291,7 @@ export * from './artifacts/base_artifact_service.js';
 export * from './features/feature_registry.js';
 export * from './memory/base_memory_service.js';
 export * from './sessions/base_session_service.js';
+export * from './telemetry/google_cloud.js';
+export * from './telemetry/setup.js';
+export * from './telemetry/tracing.js';
 export * from './tools/base_tool.js';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -52,6 +52,7 @@ export {RunSkillScriptTool} from './tools/skill/run_skill_script_tool.js';
 export * from './integrations/agent_registry/agent_registry.js';
 export * from './telemetry/google_cloud.js';
 export * from './telemetry/setup.js';
+export * from './telemetry/tracing.js';
 export * from './tools/mcp/mcp_session_manager.js';
 export * from './tools/mcp/mcp_tool.js';
 export * from './tools/mcp/mcp_toolset.js';

--- a/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
+++ b/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
@@ -119,14 +119,11 @@ export class AgentRegistrySingleMCPToolset extends BaseToolset {
       );
 
       // Inject gcp.mcp.server.destination.id telemetry key for tracing tools execution
-      const toolWithMetadata = mcpTool as unknown as {
-        customMetadata?: Record<string, string>;
-      };
       if (this.destinationResourceId) {
-        if (!toolWithMetadata.customMetadata) {
-          toolWithMetadata.customMetadata = {};
+        if (!mcpTool.customMetadata) {
+          mcpTool.customMetadata = {};
         }
-        toolWithMetadata.customMetadata[GCP_MCP_SERVER_DESTINATION_ID] =
+        mcpTool.customMetadata[GCP_MCP_SERVER_DESTINATION_ID] =
           this.destinationResourceId;
       }
       return mcpTool;

--- a/core/src/telemetry/tracing.ts
+++ b/core/src/telemetry/tracing.ts
@@ -96,7 +96,6 @@ export interface TraceToolCallParams {
   args: Record<string, unknown>;
   functionResponseEvent?: Event | null;
   error?: unknown;
-  errorType?: string;
   span?: Span;
   invocationContext?: InvocationContext;
 }
@@ -111,7 +110,6 @@ export function traceToolCall({
   args,
   functionResponseEvent,
   error,
-  errorType,
   span,
   invocationContext,
 }: TraceToolCallParams): void {
@@ -135,57 +133,28 @@ export function traceToolCall({
       : '{}',
   });
 
-  if (error !== undefined && error !== null) {
-    if (
-      typeof error === 'object' &&
-      'errorType' in error &&
-      error.errorType != null
-    ) {
-      activeSpan.setAttribute('error.type', String(error.errorType));
-    } else if (typeof error === 'object') {
-      activeSpan.setAttribute('error.type', error.constructor.name);
-    } else {
-      activeSpan.setAttribute('error.type', typeof error);
-    }
-  } else if (errorType != null) {
-    activeSpan.setAttribute('error.type', errorType);
+  if (error != null) {
+    const errorTypeAttr =
+      (error as Record<string, unknown>).errorType ??
+      (typeof error === 'object' ? error.constructor.name : typeof error);
+    activeSpan.setAttribute('error.type', String(errorTypeAttr));
   }
 
-  try {
-    if (
-      tool.customMetadata &&
-      GCP_MCP_SERVER_DESTINATION_ID in tool.customMetadata
-    ) {
-      const destinationId = tool.customMetadata[GCP_MCP_SERVER_DESTINATION_ID];
-      if (destinationId !== undefined && destinationId !== null) {
-        activeSpan.setAttribute(
-          GCP_MCP_SERVER_DESTINATION_ID,
-          String(destinationId),
-        );
-      }
-    }
-  } catch (_e: unknown) {
-    // Never break tool execution on metadata inspection failures
+  const destinationId = tool.customMetadata?.[GCP_MCP_SERVER_DESTINATION_ID];
+  if (destinationId != null) {
+    activeSpan.setAttribute(
+      GCP_MCP_SERVER_DESTINATION_ID,
+      String(destinationId),
+    );
   }
 
   // Tracing tool response
   let toolCallId = '<not specified>';
   let toolResponse: unknown = '<not specified>';
-
-  try {
-    if (functionResponseEvent?.content?.parts) {
-      const responseParts = functionResponseEvent.content.parts;
-      const functionResponse = responseParts[0]?.functionResponse;
-      if (functionResponse?.id) {
-        toolCallId = functionResponse.id;
-      }
-      if (functionResponse?.response) {
-        toolResponse = functionResponse.response;
-      }
-    }
-  } catch (_e: unknown) {
-    // Ignore errors extracting tool response
-  }
+  const functionResponse =
+    functionResponseEvent?.content?.parts?.[0]?.functionResponse;
+  if (functionResponse?.id) toolCallId = functionResponse.id;
+  if (functionResponse?.response) toolResponse = functionResponse.response;
 
   if (typeof toolResponse !== 'object' || toolResponse === null) {
     toolResponse = {result: toolResponse};
@@ -240,14 +209,12 @@ export function traceMergedToolCalls({
     // applicable for tool_response.
     'gcp.vertex.agent.llm_request': '{}',
     'gcp.vertex.agent.llm_response': '{}',
-  });
-
-  span.setAttribute(
-    'gcp.vertex.agent.tool_response',
-    shouldAddRequestResponseToSpans(invocationContext)
+    'gcp.vertex.agent.tool_response': shouldAddRequestResponseToSpans(
+      invocationContext,
+    )
       ? safeJsonSerialize(functionResponseEvent)
       : '{}',
-  );
+  });
 }
 
 export interface TraceCallLlmParams {
@@ -288,6 +255,11 @@ export function traceCallLlm({
     )
       ? safeJsonSerialize(buildLlmRequestForTrace(llmRequest))
       : '{}',
+    'gcp.vertex.agent.llm_response': shouldAddRequestResponseToSpans(
+      invocationContext,
+    )
+      ? safeJsonSerialize(llmResponse)
+      : '{}',
   });
 
   // Consider removing once GenAI SDK provides a way to record this info.
@@ -301,13 +273,6 @@ export function traceCallLlm({
       llmRequest.config.maxOutputTokens,
     );
   }
-
-  span.setAttribute(
-    'gcp.vertex.agent.llm_response',
-    shouldAddRequestResponseToSpans(invocationContext)
-      ? safeJsonSerialize(llmResponse)
-      : '{}',
-  );
 
   if (llmResponse.usageMetadata) {
     span.setAttribute(
@@ -361,17 +326,10 @@ export function traceSendData({
   span.setAttributes({
     'gcp.vertex.agent.invocation_id': invocationContext.invocationId,
     'gcp.vertex.agent.event_id': eventId,
-  });
-
-  // Once instrumentation is added to the GenAI SDK, consider whether this
-  // information still needs to be recorded by the Agent Development Kit.
-
-  span.setAttribute(
-    'gcp.vertex.agent.data',
-    shouldAddRequestResponseToSpans(invocationContext)
+    'gcp.vertex.agent.data': shouldAddRequestResponseToSpans(invocationContext)
       ? safeJsonSerialize(data)
       : '{}',
-  );
+  });
 }
 
 /**
@@ -468,31 +426,25 @@ export function runAsyncGeneratorWithOtelContext<TThis, T>(
  *
  * @returns false only when ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS is explicitly set to 'false' or '0'
  */
+
 function shouldAddRequestResponseToSpans(
   invocationContext?: InvocationContext,
 ): boolean {
-  if (
-    invocationContext?.runConfig &&
-    'telemetry' in invocationContext.runConfig
-  ) {
-    const telemetry = (invocationContext.runConfig as Record<string, unknown>)
-      .telemetry;
-    if (typeof telemetry === 'object' && telemetry !== null) {
-      if ('shouldAddContentToLegacySpans' in telemetry) {
-        const val = (telemetry as Record<string, unknown>)
-          .shouldAddContentToLegacySpans;
-        return typeof val === 'function' ? val() : Boolean(val);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const telemetry = (invocationContext?.runConfig as any)?.telemetry;
+  if (telemetry) {
+    if (telemetry.shouldAddContentToLegacySpans !== undefined) {
+      return typeof telemetry.shouldAddContentToLegacySpans === 'function'
+        ? telemetry.shouldAddContentToLegacySpans()
+        : Boolean(telemetry.shouldAddContentToLegacySpans);
+    }
+    if (telemetry.captureMessageContent !== undefined) {
+      if (typeof telemetry.captureMessageContent === 'boolean') {
+        return telemetry.captureMessageContent;
       }
-      if ('captureMessageContent' in telemetry) {
-        const val = (telemetry as Record<string, unknown>)
-          .captureMessageContent;
-        if (typeof val === 'boolean') {
-          return val;
-        }
-        if (typeof val === 'string') {
-          const upper = val.toUpperCase();
-          return upper === 'SPAN_ONLY' || upper === 'SPAN_AND_EVENT';
-        }
+      if (typeof telemetry.captureMessageContent === 'string') {
+        const upper = telemetry.captureMessageContent.toUpperCase();
+        return upper === 'SPAN_ONLY' || upper === 'SPAN_AND_EVENT';
       }
     }
   }

--- a/core/src/telemetry/tracing.ts
+++ b/core/src/telemetry/tracing.ts
@@ -16,11 +16,12 @@
  */
 
 import {Content} from '@google/genai';
-import {context, Context, trace} from '@opentelemetry/api';
+import {context, Context, Span, trace} from '@opentelemetry/api';
 
 import {BaseAgent} from '../agents/base_agent.js';
 import {InvocationContext} from '../agents/invocation_context.js';
 import {Event} from '../events/event.js';
+import {GCP_MCP_SERVER_DESTINATION_ID} from '../integrations/agent_registry/types.js';
 import {LlmRequest} from '../models/llm_request.js';
 import {LlmResponse} from '../models/llm_response.js';
 import {BaseTool} from '../tools/base_tool.js';
@@ -93,7 +94,11 @@ export function traceAgentInvocation({
 export interface TraceToolCallParams {
   tool: BaseTool;
   args: Record<string, unknown>;
-  functionResponseEvent: Event;
+  functionResponseEvent?: Event | null;
+  error?: unknown;
+  errorType?: string;
+  span?: Span;
+  invocationContext?: InvocationContext;
 }
 
 /**
@@ -105,11 +110,15 @@ export function traceToolCall({
   tool,
   args,
   functionResponseEvent,
+  error,
+  errorType,
+  span,
+  invocationContext,
 }: TraceToolCallParams): void {
-  const span = trace.getActiveSpan();
-  if (!span) return;
+  const activeSpan = span || trace.getActiveSpan();
+  if (!activeSpan) return;
 
-  span.setAttributes({
+  activeSpan.setAttributes({
     [GEN_AI_OPERATION_NAME]: 'execute_tool',
     [GEN_AI_TOOL_DESCRIPTION]: tool.description || '',
     [GEN_AI_TOOL_NAME]: tool.name,
@@ -119,41 +128,89 @@ export function traceToolCall({
     // applicable for tool_response.
     'gcp.vertex.agent.llm_request': '{}',
     'gcp.vertex.agent.llm_response': '{}',
-    'gcp.vertex.agent.tool_call_args': shouldAddRequestResponseToSpans()
+    'gcp.vertex.agent.tool_call_args': shouldAddRequestResponseToSpans(
+      invocationContext,
+    )
       ? safeJsonSerialize(args)
       : '{}',
   });
+
+  if (error !== undefined && error !== null) {
+    if (
+      typeof error === 'object' &&
+      'errorType' in error &&
+      error.errorType != null
+    ) {
+      activeSpan.setAttribute('error.type', String(error.errorType));
+    } else if (typeof error === 'object') {
+      activeSpan.setAttribute('error.type', error.constructor.name);
+    } else {
+      activeSpan.setAttribute('error.type', typeof error);
+    }
+  } else if (errorType != null) {
+    activeSpan.setAttribute('error.type', errorType);
+  }
+
+  try {
+    if (
+      tool.customMetadata &&
+      GCP_MCP_SERVER_DESTINATION_ID in tool.customMetadata
+    ) {
+      const destinationId = tool.customMetadata[GCP_MCP_SERVER_DESTINATION_ID];
+      if (destinationId !== undefined && destinationId !== null) {
+        activeSpan.setAttribute(
+          GCP_MCP_SERVER_DESTINATION_ID,
+          String(destinationId),
+        );
+      }
+    }
+  } catch (_e: unknown) {
+    // Never break tool execution on metadata inspection failures
+  }
 
   // Tracing tool response
   let toolCallId = '<not specified>';
   let toolResponse: unknown = '<not specified>';
 
-  if (functionResponseEvent.content?.parts) {
-    const responseParts = functionResponseEvent.content.parts;
-    const functionResponse = responseParts[0]?.functionResponse;
-    if (functionResponse?.id) {
-      toolCallId = functionResponse.id;
+  try {
+    if (functionResponseEvent?.content?.parts) {
+      const responseParts = functionResponseEvent.content.parts;
+      const functionResponse = responseParts[0]?.functionResponse;
+      if (functionResponse?.id) {
+        toolCallId = functionResponse.id;
+      }
+      if (functionResponse?.response) {
+        toolResponse = functionResponse.response;
+      }
     }
-    if (functionResponse?.response) {
-      toolResponse = functionResponse.response;
-    }
+  } catch (_e: unknown) {
+    // Ignore errors extracting tool response
   }
+
   if (typeof toolResponse !== 'object' || toolResponse === null) {
     toolResponse = {result: toolResponse};
   }
 
-  span.setAttributes({
+  const attributesToSet: Record<string, string> = {
     [GEN_AI_TOOL_CALL_ID]: toolCallId,
-    'gcp.vertex.agent.event_id': functionResponseEvent.id,
-    'gcp.vertex.agent.tool_response': shouldAddRequestResponseToSpans()
+    'gcp.vertex.agent.tool_response': shouldAddRequestResponseToSpans(
+      invocationContext,
+    )
       ? safeJsonSerialize(toolResponse)
       : '{}',
-  });
+  };
+
+  if (functionResponseEvent?.id) {
+    attributesToSet['gcp.vertex.agent.event_id'] = functionResponseEvent.id;
+  }
+
+  activeSpan.setAttributes(attributesToSet);
 }
 
 export interface TraceMergedToolCallsParams {
   responseEventId: string;
   functionResponseEvent: Event;
+  invocationContext?: InvocationContext;
 }
 
 /**
@@ -167,6 +224,7 @@ export interface TraceMergedToolCallsParams {
 export function traceMergedToolCalls({
   responseEventId,
   functionResponseEvent,
+  invocationContext,
 }: TraceMergedToolCallsParams): void {
   const span = trace.getActiveSpan();
   if (!span) return;
@@ -186,7 +244,7 @@ export function traceMergedToolCalls({
 
   span.setAttribute(
     'gcp.vertex.agent.tool_response',
-    shouldAddRequestResponseToSpans()
+    shouldAddRequestResponseToSpans(invocationContext)
       ? safeJsonSerialize(functionResponseEvent)
       : '{}',
   );
@@ -225,7 +283,9 @@ export function traceCallLlm({
     'gcp.vertex.agent.session_id': invocationContext.session.id,
     'gcp.vertex.agent.event_id': eventId,
     // Consider removing once GenAI SDK provides a way to record this info.
-    'gcp.vertex.agent.llm_request': shouldAddRequestResponseToSpans()
+    'gcp.vertex.agent.llm_request': shouldAddRequestResponseToSpans(
+      invocationContext,
+    )
       ? safeJsonSerialize(buildLlmRequestForTrace(llmRequest))
       : '{}',
   });
@@ -244,7 +304,9 @@ export function traceCallLlm({
 
   span.setAttribute(
     'gcp.vertex.agent.llm_response',
-    shouldAddRequestResponseToSpans() ? safeJsonSerialize(llmResponse) : '{}',
+    shouldAddRequestResponseToSpans(invocationContext)
+      ? safeJsonSerialize(llmResponse)
+      : '{}',
   );
 
   if (llmResponse.usageMetadata) {
@@ -306,7 +368,9 @@ export function traceSendData({
 
   span.setAttribute(
     'gcp.vertex.agent.data',
-    shouldAddRequestResponseToSpans() ? safeJsonSerialize(data) : '{}',
+    shouldAddRequestResponseToSpans(invocationContext)
+      ? safeJsonSerialize(data)
+      : '{}',
   );
 }
 
@@ -404,7 +468,34 @@ export function runAsyncGeneratorWithOtelContext<TThis, T>(
  *
  * @returns false only when ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS is explicitly set to 'false' or '0'
  */
-function shouldAddRequestResponseToSpans(): boolean {
+function shouldAddRequestResponseToSpans(
+  invocationContext?: InvocationContext,
+): boolean {
+  if (
+    invocationContext?.runConfig &&
+    'telemetry' in invocationContext.runConfig
+  ) {
+    const telemetry = (invocationContext.runConfig as Record<string, unknown>)
+      .telemetry;
+    if (typeof telemetry === 'object' && telemetry !== null) {
+      if ('shouldAddContentToLegacySpans' in telemetry) {
+        const val = (telemetry as Record<string, unknown>)
+          .shouldAddContentToLegacySpans;
+        return typeof val === 'function' ? val() : Boolean(val);
+      }
+      if ('captureMessageContent' in telemetry) {
+        const val = (telemetry as Record<string, unknown>)
+          .captureMessageContent;
+        if (typeof val === 'boolean') {
+          return val;
+        }
+        if (typeof val === 'string') {
+          const upper = val.toUpperCase();
+          return upper === 'SPAN_ONLY' || upper === 'SPAN_AND_EVENT';
+        }
+      }
+    }
+  }
   const envValue = process.env.ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS || 'true';
   return envValue === 'true' || envValue === '1';
 }

--- a/core/src/tools/base_tool.ts
+++ b/core/src/tools/base_tool.ts
@@ -34,6 +34,7 @@ export interface BaseToolParams {
   name: string;
   description: string;
   isLongRunning?: boolean;
+  customMetadata?: Record<string, unknown>;
 }
 
 /**
@@ -66,6 +67,7 @@ export abstract class BaseTool {
   readonly name: string;
   readonly description: string;
   readonly isLongRunning: boolean;
+  customMetadata?: Record<string, unknown>;
 
   /**
    * Base constructor for a tool.
@@ -76,6 +78,7 @@ export abstract class BaseTool {
     this.name = params.name;
     this.description = params.description;
     this.isLongRunning = params.isLongRunning ?? false;
+    this.customMetadata = params.customMetadata;
   }
 
   /**

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -29,6 +29,7 @@ import {
   populateClientFunctionCallId,
   removeClientFunctionCallId,
 } from '../../src/agents/functions.js';
+import * as tracing from '../../src/telemetry/tracing.js';
 
 // Get the test target function
 const {
@@ -360,6 +361,61 @@ describe('handleFunctionCallList', () => {
         toolContext: expect.objectContaining({
           abortSignal: signal,
         }),
+      }),
+    );
+  });
+
+  it('should create execute_tool span and call traceToolCall enclosing the tool execution', async () => {
+    const startActiveSpanSpy = vi.spyOn(tracing.tracer, 'startActiveSpan');
+    const traceToolCallSpy = vi.spyOn(tracing, 'traceToolCall');
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call-1', name: 'testTool', args: {}}],
+      toolsDict: {'testTool': testTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    expect(startActiveSpanSpy).toHaveBeenCalledWith(
+      'execute_tool testTool',
+      expect.any(Function),
+    );
+    expect(traceToolCallSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: testTool,
+        args: {},
+        invocationContext,
+      }),
+    );
+  });
+
+  it('should trace parallel tool calls and create execute_tool (merged) span when multiple responses are merged', async () => {
+    const startActiveSpanSpy = vi.spyOn(tracing.tracer, 'startActiveSpan');
+    const traceMergedToolCallsSpy = vi.spyOn(tracing, 'traceMergedToolCalls');
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [
+        {id: 'call-1', name: 'testTool', args: {}},
+        {id: 'call-2', name: 'testTool', args: {}},
+      ],
+      toolsDict: {'testTool': testTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    expect(startActiveSpanSpy).toHaveBeenCalledWith(
+      'execute_tool testTool',
+      expect.any(Function),
+    );
+    expect(startActiveSpanSpy).toHaveBeenCalledWith(
+      'execute_tool (merged)',
+      expect.any(Function),
+    );
+    expect(traceMergedToolCallsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invocationContext,
       }),
     );
   });

--- a/core/test/telemetry/tracing_test.ts
+++ b/core/test/telemetry/tracing_test.ts
@@ -11,6 +11,7 @@ import {
   BaseAgent,
   BaseTool,
   Event,
+  GCP_MCP_SERVER_DESTINATION_ID,
   InvocationContext,
   LlmRequest,
   LlmResponse,
@@ -185,6 +186,113 @@ describe('Telemetry Tracing Functions', () => {
           expect.stringContaining('not specified'),
       });
     });
+
+    it('should set error.type when an Error instance is passed', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      traceToolCall({
+        tool: mockTool,
+        args: {},
+        functionResponseEvent: mockEvent,
+        error: new TypeError('Type error occurred'),
+      });
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        'error.type',
+        'TypeError',
+      );
+    });
+
+    it('should set error.type when custom error object with errorType is passed', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      traceToolCall({
+        tool: mockTool,
+        args: {},
+        functionResponseEvent: mockEvent,
+        error: {errorType: 'HTTP_ERROR', message: 'Not found'},
+      });
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        'error.type',
+        'HTTP_ERROR',
+      );
+    });
+
+    it('should set error.type when only errorType parameter is provided', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      traceToolCall({
+        tool: mockTool,
+        args: {},
+        functionResponseEvent: mockEvent,
+        errorType: 'TIMEOUT_ERROR',
+      });
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        'error.type',
+        'TIMEOUT_ERROR',
+      );
+    });
+
+    it('should ensure error takes precedence over errorType parameter', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      traceToolCall({
+        tool: mockTool,
+        args: {},
+        functionResponseEvent: mockEvent,
+        error: new RangeError('Out of range'),
+        errorType: 'OTHER_ERROR',
+      });
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        'error.type',
+        'RangeError',
+      );
+    });
+
+    it('should set gcp.mcp.server.destination.id when present in tool customMetadata', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      const toolWithMcp = {
+        ...mockTool,
+        customMetadata: {
+          [GCP_MCP_SERVER_DESTINATION_ID]: 'mcp-server-123',
+        },
+      } as BaseTool;
+
+      traceToolCall({
+        tool: toolWithMcp,
+        args: {},
+        functionResponseEvent: mockEvent,
+      });
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        GCP_MCP_SERVER_DESTINATION_ID,
+        'mcp-server-123',
+      );
+    });
+
+    it('should not set gcp.mcp.server.destination.id when not in customMetadata', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      traceToolCall({
+        tool: mockTool,
+        args: {},
+        functionResponseEvent: mockEvent,
+      });
+      expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+        GCP_MCP_SERVER_DESTINATION_ID,
+        expect.anything(),
+      );
+    });
+
+    it('should handle null or undefined functionResponseEvent gracefully without throwing', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      expect(() => {
+        traceToolCall({
+          tool: mockTool,
+          args: {},
+          functionResponseEvent: null,
+        });
+      }).not.toThrow();
+
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'gen_ai.tool.call.id': '<not specified>',
+        }),
+      );
+    });
   });
 
   describe('traceMergedToolCalls', () => {
@@ -228,6 +336,29 @@ describe('Telemetry Tracing Functions', () => {
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         'gcp.vertex.agent.tool_response',
         expect.any(String),
+      );
+    });
+
+    it('should respect optional invocationContext for legacy span content capture', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      const ctxWithNoCapture = {
+        ...mockInvocationContext,
+        runConfig: {
+          telemetry: {
+            captureMessageContent: 'NO_CONTENT',
+          },
+        },
+      } as unknown as InvocationContext;
+
+      traceMergedToolCalls({
+        responseEventId: 'merged-event-id',
+        functionResponseEvent: mockEvent,
+        invocationContext: ctxWithNoCapture,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        'gcp.vertex.agent.tool_response',
+        '{}',
       );
     });
   });

--- a/core/test/telemetry/tracing_test.ts
+++ b/core/test/telemetry/tracing_test.ts
@@ -215,35 +215,6 @@ describe('Telemetry Tracing Functions', () => {
       );
     });
 
-    it('should set error.type when only errorType parameter is provided', () => {
-      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
-      traceToolCall({
-        tool: mockTool,
-        args: {},
-        functionResponseEvent: mockEvent,
-        errorType: 'TIMEOUT_ERROR',
-      });
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        'error.type',
-        'TIMEOUT_ERROR',
-      );
-    });
-
-    it('should ensure error takes precedence over errorType parameter', () => {
-      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
-      traceToolCall({
-        tool: mockTool,
-        args: {},
-        functionResponseEvent: mockEvent,
-        error: new RangeError('Out of range'),
-        errorType: 'OTHER_ERROR',
-      });
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        'error.type',
-        'RangeError',
-      );
-    });
-
     it('should set gcp.mcp.server.destination.id when present in tool customMetadata', () => {
       vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
       const toolWithMcp = {
@@ -320,7 +291,7 @@ describe('Telemetry Tracing Functions', () => {
         functionResponseEvent: mockEventWithJson as unknown as Event,
       });
 
-      // Assert - setAttributes is called without tool_response
+      // Assert - setAttributes is called with tool_response merged
       expect(mockSpan.setAttributes).toHaveBeenCalledWith({
         'gen_ai.operation.name': 'execute_tool',
         'gen_ai.tool.name': '(merged tools)',
@@ -330,13 +301,8 @@ describe('Telemetry Tracing Functions', () => {
         'gcp.vertex.agent.event_id': 'merged-event-id',
         'gcp.vertex.agent.llm_request': '{}',
         'gcp.vertex.agent.llm_response': '{}',
+        'gcp.vertex.agent.tool_response': expect.any(String),
       });
-
-      // tool_response is set separately via setAttribute
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        'gcp.vertex.agent.tool_response',
-        expect.any(String),
-      );
     });
 
     it('should respect optional invocationContext for legacy span content capture', () => {
@@ -356,9 +322,10 @@ describe('Telemetry Tracing Functions', () => {
         invocationContext: ctxWithNoCapture,
       });
 
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        'gcp.vertex.agent.tool_response',
-        '{}',
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'gcp.vertex.agent.tool_response': '{}',
+        }),
       );
     });
   });
@@ -384,6 +351,8 @@ describe('Telemetry Tracing Functions', () => {
         'gcp.vertex.agent.session_id': 'test-session-id',
         'gcp.vertex.agent.event_id': 'test-event-id',
         'gcp.vertex.agent.llm_request': expect.stringContaining('test-model'),
+        'gcp.vertex.agent.llm_response':
+          expect.stringContaining('test-response'),
       });
 
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: #issue_number
Related: #issue_number

2. Or, if no issue exists, describe the change:

**Problem**: OpenTelemetry tool call tracing in TypeScript (`adk-js`) lacked full feature parity with Python (`adk-python`). Specifically, tool executions in `handleFunctionCallList` (`functions.ts`) were not enclosed in canonical `execute_tool <name>` or `execute_tool (merged)` spans, `TraceToolCallParams` did not record semantic `error.type` or remote MCP server destination IDs (`gcp.mcp.server.destination.id`), and `BaseTool` lacked a first-class `customMetadata` property.

**Solution**: A clear and concise description of what you want to happen and why you choose this solution.
- Enclosed individual and merged tool executions inside `tracer.startActiveSpan('execute_tool ' + tool.name)` and `traceMergedToolCalls` in `handleFunctionCallList` (`functions.ts`) to guarantee exact span enclosure enclosing before/after callbacks and error execution.
- Added first-class `customMetadata?: Record<string, unknown>` to `BaseTool` and `BaseToolParams` (`base_tool.ts`) and injected `GCP_MCP_SERVER_DESTINATION_ID` without type casting in `agent_registry_mcp_toolset.ts`.
- Updated `traceToolCall` and `traceMergedToolCalls` (`tracing.ts`) to record OpenTelemetry semantic error attributes (`error.type`), inspect tool `customMetadata` for remote destination IDs (`gcp.mcp.server.destination.id`), handle nullable function response events gracefully, and respect per-invocation telemetry config overrides.
- Re-exported `tracing.ts` in `index.ts` and `common.ts` so `TraceToolCallParams`, `traceToolCall`, and `traceMergedToolCalls` are publicly accessible across package boundaries.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
 [x] I have added or updated unit tests for my change.
 [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Ran end-to-end and integration tests (`npx vitest run --project integration tests/integration/agent_registry/agent_registry_test.ts` and `npx vitest run --project unit:core core/test/integrations/agent_registry_mcp_toolset_test.ts`) without mocks to verify that OpenTelemetry spans and custom metadata propagation work cleanly and accurately across tool execution workflows. Also verified all 43 unit tests across `core/test/telemetry/tracing_test.ts` and `core/test/agents/functions_test.ts` pass locally.

### Checklist
 [x] I have read the CONTRIBUTING.md document.
 [x] I have performed a self-review of my own code.
 [x] I have commented my code, particularly in hard-to-understand areas.
 [x] I have added tests that prove my fix is effective or that my feature works.
 [x] New and existing unit tests pass locally with my changes.
