### PR TITLE
Feat: Internalize removeClientFunctionCallId into content processor in adk-js

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -26,7 +26,7 @@ import {
   SingleBeforeToolCallback,
 } from './llm_agent.js';
 
-const AF_FUNCTION_CALL_ID_PREFIX = 'adk-';
+export const AF_FUNCTION_CALL_ID_PREFIX = 'adk-';
 export const REQUEST_EUC_FUNCTION_CALL_NAME = 'adk_request_credential';
 export const REQUEST_CONFIRMATION_FUNCTION_CALL_NAME =
   'adk_request_confirmation';
@@ -60,34 +60,7 @@ export function populateClientFunctionCallId(modelResponseEvent: Event): void {
     }
   }
 }
-// TODO - b/425992518: consider internalize in content_[processor].ts
-/**
- * Removes the client-generated function call IDs from a given content object.
- *
- * When sending content back to the server, these IDs are
- * specific to the client-side and should not be included in requests to the
- * model.
- */
-export function removeClientFunctionCallId(content: Content): void {
-  if (content && content.parts) {
-    for (const part of content.parts) {
-      if (
-        part.functionCall &&
-        part.functionCall.id &&
-        part.functionCall.id.startsWith(AF_FUNCTION_CALL_ID_PREFIX)
-      ) {
-        part.functionCall.id = undefined;
-      }
-      if (
-        part.functionResponse &&
-        part.functionResponse.id &&
-        part.functionResponse.id.startsWith(AF_FUNCTION_CALL_ID_PREFIX)
-      ) {
-        part.functionResponse.id = undefined;
-      }
-    }
-  }
-}
+
 // TODO - b/425992518: consider internalize as part of llm_agent's runtime.
 /**
  * Returns a set of function call ids of the long running tools.

--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -18,10 +18,28 @@ import {
 } from '../../events/event.js';
 
 import {
-  removeClientFunctionCallId,
+  AF_FUNCTION_CALL_ID_PREFIX,
   REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
   REQUEST_EUC_FUNCTION_CALL_NAME,
 } from '../functions.js';
+
+/**
+ * Removes the client-generated function call IDs from a given content object.
+ *
+ * When sending content back to the server, these IDs are
+ * specific to the client-side and should not be included in requests to the
+ * model.
+ */
+export function removeClientFunctionCallId(content: Content): void {
+  for (const part of content?.parts ?? []) {
+    if (part.functionCall?.id?.startsWith(AF_FUNCTION_CALL_ID_PREFIX)) {
+      part.functionCall.id = undefined;
+    }
+    if (part.functionResponse?.id?.startsWith(AF_FUNCTION_CALL_ID_PREFIX)) {
+      part.functionResponse.id = undefined;
+    }
+  }
+}
 
 /**
  * Get the contents for the LLM request.

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -19,7 +19,7 @@ import {
   SingleBeforeToolCallback,
   ToolConfirmation,
 } from '@google/adk';
-import {Content, FunctionCall} from '@google/genai';
+import {FunctionCall} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
@@ -27,7 +27,6 @@ import {
   getLongRunningFunctionCalls,
   mergeParallelFunctionResponseEvents,
   populateClientFunctionCallId,
-  removeClientFunctionCallId,
 } from '../../src/agents/functions.js';
 
 // Get the test target function
@@ -648,37 +647,6 @@ describe('populateClientFunctionCallId', () => {
     });
     populateClientFunctionCallId(event);
     expect(event.content!.parts![0].text).toBe('hello');
-  });
-});
-
-describe('removeClientFunctionCallId', () => {
-  it('should remove client generated ID from functionCall', () => {
-    const content: Content = {
-      role: 'model',
-      parts: [{functionCall: {name: 'testTool', args: {}, id: 'adk-test-id'}}],
-    };
-    removeClientFunctionCallId(content);
-    expect(content.parts![0].functionCall!.id).toBeUndefined();
-  });
-
-  it('should remove client generated ID from functionResponse', () => {
-    const content: Content = {
-      role: 'user',
-      parts: [
-        {functionResponse: {name: 'testTool', response: {}, id: 'adk-test-id'}},
-      ],
-    };
-    removeClientFunctionCallId(content);
-    expect(content.parts![0].functionResponse!.id).toBeUndefined();
-  });
-
-  it('should not remove non-client generated ID', () => {
-    const content: Content = {
-      role: 'model',
-      parts: [{functionCall: {name: 'testTool', args: {}, id: 'server-id'}}],
-    };
-    removeClientFunctionCallId(content);
-    expect(content.parts![0].functionCall!.id).toBe('server-id');
   });
 });
 

--- a/core/test/agents/processors/content_processor_utils_test.ts
+++ b/core/test/agents/processors/content_processor_utils_test.ts
@@ -11,6 +11,7 @@ import {
   getContents,
   getCurrentTurnContents,
   mergeFunctionResponseEvents,
+  removeClientFunctionCallId,
 } from '../../../src/agents/processors/content_processor_utils.js';
 
 describe('getContents', () => {
@@ -1088,5 +1089,49 @@ describe('getContents', () => {
     const contents = getContents([e0], 'my_agent', 'main.agentA.subAgent');
     expect(contents).toHaveLength(1);
     expect(contents[0].parts?.[0].text).toBe('hello');
+  });
+});
+
+describe('removeClientFunctionCallId', () => {
+  it('should remove client generated ID from functionCall', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [{functionCall: {name: 'testTool', args: {}, id: 'adk-test-id'}}],
+    };
+    removeClientFunctionCallId(content);
+    expect(content.parts![0].functionCall!.id).toBeUndefined();
+  });
+
+  it('should remove client generated ID from functionResponse', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [
+        {functionResponse: {name: 'testTool', response: {}, id: 'adk-test-id'}},
+      ],
+    };
+    removeClientFunctionCallId(content);
+    expect(content.parts![0].functionResponse!.id).toBeUndefined();
+  });
+
+  it('should not remove non-client generated ID', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [{functionCall: {name: 'testTool', args: {}, id: 'server-id'}}],
+    };
+    removeClientFunctionCallId(content);
+    expect(content.parts![0].functionCall!.id).toBe('server-id');
+  });
+
+  it('should safely handle null, undefined, or empty content objects without throwing', () => {
+    expect(() =>
+      removeClientFunctionCallId(undefined as unknown as Content),
+    ).not.toThrow();
+    expect(() =>
+      removeClientFunctionCallId(null as unknown as Content),
+    ).not.toThrow();
+    const emptyContent: Content = {};
+    expect(() => removeClientFunctionCallId(emptyContent)).not.toThrow();
+    const noParts: Content = {role: 'user', parts: []};
+    expect(() => removeClientFunctionCallId(noParts)).not.toThrow();
   });
 });


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: b/425992518
Related: b/425992518

2. Or, if no issue exists, describe the change:

**Problem**: The `removeClientFunctionCallId` utility, which strips client-generated function call IDs (`adk-...`) from `Content` objects prior to sending requests to the LLM backend, was located inside general tool helpers (`core/src/agents/functions.ts`) along with a TODO comment to move it to the content processor utilities.

**Solution**: Moved `removeClientFunctionCallId` from `core/src/agents/functions.ts` to `core/src/agents/processors/content_processor_utils.ts`. Exported `AF_FUNCTION_CALL_ID_PREFIX` (`'adk-'`) from `functions.ts` so both modules can reference the prefix cleanly without duplicating magic strings. Simplified the loop and conditionals inside `removeClientFunctionCallId` using optional chaining (`content?.parts ?? []`), and relocated/expanded unit tests to achieve 100% line and branch coverage.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.

Run `npm run build` and `npm test` across unit and integration projects (`npx vitest run core/test/agents/functions_test.ts core/test/agents/processors/content_processor_utils_test.ts core/test/agents/processors/content_request_processor_test.ts core/test/agents/llm_agent_test.ts`). Verify in an interactive agent turn that function call IDs and response IDs starting with `'adk-'` are stripped before model invocation while server-generated IDs are preserved.

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
