### PR TITLE
fix(auth): prevent SSRF credential leak via OAuth2 redirects and block IPv6 [::]

### DIFF
--- a/core/src/auth/oauth2/oauth2_discovery.ts
+++ b/core/src/auth/oauth2/oauth2_discovery.ts
@@ -82,6 +82,10 @@ export class OAuth2DiscoveryManager {
           headers: {
             Accept: 'application/json',
           },
+          // Never follow redirects: validateDiscoveryUrl only checks the
+          // initial URL, so following a 3xx would let a validated host
+          // redirect discovery to a private/cloud-metadata address (CWE-918).
+          redirect: 'error',
         });
 
         if (!response.ok) {
@@ -144,6 +148,10 @@ export class OAuth2DiscoveryManager {
         headers: {
           Accept: 'application/json',
         },
+        // Never follow redirects: validateDiscoveryUrl only checks the
+        // initial URL, so following a 3xx would let a validated host
+        // redirect discovery to a private/cloud-metadata address (CWE-918).
+        redirect: 'error',
       });
 
       if (!response.ok) {
@@ -208,6 +216,7 @@ export function validateDiscoveryUrl(urlStr: string): boolean {
       host === 'metadata.goog' ||
       host.startsWith('127.') ||
       host === '[::1]' ||
+      host === '[::]' ||
       host === '0.0.0.0' ||
       host.startsWith('10.') ||
       host.startsWith('192.168.') ||

--- a/core/src/auth/oauth2/oauth2_utils.ts
+++ b/core/src/auth/oauth2/oauth2_utils.ts
@@ -65,6 +65,11 @@ export async function fetchOAuth2Tokens(
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: body.toString(),
+      // Never follow redirects: the SSRF blocklist only validates `endpoint`,
+      // so a validated host that responds with a 3xx could otherwise redirect
+      // this credential-bearing POST (client_secret/refresh_token) to a
+      // private/cloud-metadata address (CWE-918).
+      redirect: 'error',
     });
 
     if (!response.ok) {

--- a/core/test/auth/oauth2/oauth2_discovery_test.ts
+++ b/core/test/auth/oauth2/oauth2_discovery_test.ts
@@ -393,6 +393,15 @@ describe('OAuth2DiscoveryManager', () => {
     it('blocks 0.0.0.0', async () => {
       expect(await isBlocked('https://0.0.0.0/')).toBe(true);
     });
+    it('blocks [::] IPv6 unspecified (routes to loopback)', async () => {
+      expect(await isBlocked('https://[::]/')).toBe(true);
+    });
+    it('blocks [::0] IPv6 unspecified shorthand', async () => {
+      expect(await isBlocked('https://[::0]/')).toBe(true);
+    });
+    it('blocks [0:0:0:0:0:0:0:0] IPv6 unspecified expanded', async () => {
+      expect(await isBlocked('https://[0:0:0:0:0:0:0:0]/')).toBe(true);
+    });
     it('blocks [::ffff:7f00:1] IPv4-mapped 127.0.0.1', async () => {
       expect(await isBlocked('https://[::ffff:7f00:1]/')).toBe(true);
     });
@@ -461,6 +470,43 @@ describe('OAuth2DiscoveryManager', () => {
     });
     it('blocks non-https scheme', async () => {
       expect(await isBlocked('http://example.com/')).toBe(true);
+    });
+  });
+
+  describe('discovery requests do not follow redirects', () => {
+    it('passes redirect: error to the auth-server discovery fetch', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          issuer: 'https://accounts.example.com',
+          authorization_endpoint: 'https://accounts.example.com/auth',
+          token_endpoint: 'https://accounts.example.com/token',
+        }),
+      } as Response);
+
+      await manager.discoverAuthServerMetadata('https://accounts.example.com');
+
+      expect(fetch).toHaveBeenCalled();
+      for (const call of (fetch as ReturnType<typeof vi.fn>).mock.calls) {
+        expect(call[1]).toMatchObject({redirect: 'error'});
+      }
+    });
+
+    it('passes redirect: error to the resource discovery fetch', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          resource: 'https://api.example.com',
+          authorization_servers: [],
+        }),
+      } as Response);
+
+      await manager.discoverResourceMetadata('https://api.example.com');
+
+      expect(fetch).toHaveBeenCalled();
+      for (const call of (fetch as ReturnType<typeof vi.fn>).mock.calls) {
+        expect(call[1]).toMatchObject({redirect: 'error'});
+      }
     });
   });
 });

--- a/core/test/auth/oauth2/oauth2_utils_test.ts
+++ b/core/test/auth/oauth2/oauth2_utils_test.ts
@@ -130,6 +130,47 @@ describe('oauth2_utils', () => {
         fetchOAuth2Tokens('https://example.com/token', body),
       ).rejects.toThrow('Token request failed with status 401');
     });
+
+    it('does not follow redirects (redirect: error) to prevent SSRF credential leaks', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({access_token: 'acc-123'}),
+      } as Response);
+
+      await fetchOAuth2Tokens(
+        'https://example.com/token',
+        new URLSearchParams(),
+      );
+
+      // The blocklist only validates the initial endpoint, so redirects must
+      // not be followed or the credential-bearing POST could be redirected to
+      // a private/cloud-metadata address.
+      expect(fetch).toHaveBeenCalledWith(
+        'https://example.com/token',
+        expect.objectContaining({redirect: 'error'}),
+      );
+    });
+
+    it('propagates the error when the endpoint attempts a redirect', async () => {
+      // With redirect: 'error', the runtime's fetch rejects on any 3xx.
+      vi.mocked(fetch).mockRejectedValue(
+        new TypeError('fetch failed: unexpected redirect'),
+      );
+
+      await expect(
+        fetchOAuth2Tokens('https://example.com/token', new URLSearchParams()),
+      ).rejects.toThrow();
+    });
+
+    it('rejects a token endpoint that targets a blocked host before any fetch', async () => {
+      await expect(
+        fetchOAuth2Tokens(
+          'https://169.254.169.254/token',
+          new URLSearchParams(),
+        ),
+      ).rejects.toThrow('SSRF protection');
+      expect(fetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('parseAuthorizationCode', () => {


### PR DESCRIPTION
## Summary

The SSRF blocklist added in #465 / #431 validates only the **initial** URL string, but every OAuth2 `fetch()` uses the runtime default `redirect: 'follow'`. A token or discovery URL that passes `validateDiscoveryUrl()` can respond with a `3xx` that redirects the request to a private / cloud-metadata host — and on a `307`/`308` the **credential-bearing token POST** (`client_secret` / `refresh_token`) is re-sent to the redirect target. This fully bypasses the blocklist those PRs added (CWE-918).

Concretely, with the blocklist in place an attacker-supplied spec can no longer set `tokenUrl` directly to `169.254.169.254`, but it can set `tokenUrl = https://attacker.example/token` (which passes validation) and have that server reply `307 Location: http://169.254.169.254/…`. `fetchOAuth2Tokens` then forwards the full credential body to the metadata endpoint.

Separately, the blocklist covers the IPv4 unspecified address `0.0.0.0` and IPv6 loopback `[::1]`, but not the IPv6 **unspecified** address `[::]`, which routes to loopback on Linux/macOS.

## Changes

- Set `redirect: 'error'` on the token POST (`oauth2_utils.ts`) and both discovery GETs (`oauth2_discovery.ts`). OAuth token and RFC 8414 / RFC 9728 `.well-known` discovery endpoints have no legitimate reason to redirect, and a credential-bearing request must never follow one.
- Add `[::]` to the `validateDiscoveryUrl` blocklist, alongside the existing `0.0.0.0` and `[::1]` entries. The WHATWG URL parser normalizes `[::0]` and `[0:0:0:0:0:0:0:0]` to `[::]`, so a single entry covers every form.

## Test plan

- [x] New tests assert `redirect: 'error'` is passed on the token POST and both discovery fetches.
- [x] New blocklist cases for `[::]`, `[::0]`, and `[0:0:0:0:0:0:0:0]`.
- [x] New test confirms a token endpoint targeting a blocked host is rejected before any `fetch`.
- [x] Full core unit suite green (`npx vitest run --project unit:core`): 2049 passing.
- [x] `tsc --noEmit`, ESLint, and Prettier all clean.
