### PR TITLE
fix(core): don't emit empty-parts model content from the stream aggregator (Vertex 400 on multi-turn tool use)

### DIFF
--- a/core/src/utils/streaming_utils.ts
+++ b/core/src/utils/streaming_utils.ts
@@ -450,10 +450,16 @@ export class StreamingResponseAggregator {
     const finishReason = this.finishReason ?? candidate?.finishReason;
 
     return {
-      content: {
-        role: 'model',
-        parts: finalParts ?? [],
-      },
+      // Only attach a model `content` when there are actual parts to emit. When
+      // the turn accumulated no parts (e.g. a function call that was already
+      // flushed, followed by a trailing STOP chunk that carries only usage
+      // metadata) we still surface that trailing metadata, but MUST NOT emit
+      // `content: { parts: [] }`. An empty-parts model turn corrupts the session
+      // history: on the next request the Vertex AI backend rejects the whole
+      // call with HTTP 400 "Unable to submit request because it must include at
+      // least one parts field", which breaks multi-turn tool-using sessions
+      // right after the first tool call (google/adk-js#21, #22).
+      content: finalParts ? {role: 'model', parts: finalParts} : undefined,
       groundingMetadata: this.groundingMetadata,
       citationMetadata: this.citationMetadata,
       errorCode: finishReason === FinishReason.STOP ? undefined : finishReason,

--- a/core/test/utils/streaming_utils_test.ts
+++ b/core/test/utils/streaming_utils_test.ts
@@ -853,10 +853,15 @@ describe('StreamingResponseAggregator', () => {
       }
       expect(results2).toHaveLength(0); // Suppressed early return
 
-      // 3. Call close() and verify metadata is returned and parts array is empty
+      // 3. Call close() and verify the trailing usage metadata is preserved
+      // WITHOUT emitting an empty-parts model content. Emitting
+      // `content: { parts: [] }` here corrupts the session history and makes the
+      // Vertex AI backend reject the next request with HTTP 400 "must include at
+      // least one parts field" (google/adk-js#21, #22); the metadata-only
+      // close() response therefore omits `content` entirely.
       const finalResponse = aggregator.close();
       expect(finalResponse).toBeDefined();
-      expect(finalResponse?.content?.parts).toEqual([]);
+      expect(finalResponse?.content).toBeUndefined();
       expect(finalResponse?.usageMetadata).toEqual({
         promptTokenCount: 15,
         candidatesTokenCount: 25,


### PR DESCRIPTION
## Summary

`StreamingResponseAggregator.close()` emits a model turn with an empty `parts` array (`content: { parts: [] }`) whenever a turn accumulated no parts but a trailing chunk carried usage metadata — e.g. a function call that was already flushed during streaming, followed by a `STOP` chunk that carries only usage data. That empty-parts model turn is appended to the session history, and on the **next** request the Vertex AI backend rejects the whole call with:

> HTTP 400 `Unable to submit request because it must include at least one parts field, which describes the prompt input.`

This is the root cause behind **#21** ("Multi-turn sessions return empty response after first tool call") and **#22** ("Unable to submit request because it must include at least one parts field"). The user-visible symptom is a multi-turn tool-using session that breaks right after the first tool call: the follow-up turn returns an empty response, and the turn after that hard-fails with the 400.

It reproduces only on the **Vertex AI** backend (`GOOGLE_GENAI_USE_VERTEXAI=TRUE`); the Gemini API backend and the Python ADK are unaffected — matching the reports in #21.

## Root cause

`core/src/utils/streaming_utils.ts`, `StreamingResponseAggregator.close()`:

```ts
return {
  content: { role: 'model', parts: finalParts ?? [] },  // <-- parts: [] when finalParts is empty but metadata is present
  ...
};
```

When the turn's only content was a function call (already flushed in `processResponse`) and the stream ends with a metadata-only `STOP` chunk, `strategy.close()` returns `undefined` while `hasMetadata` is `true` — so `close()` returns a response whose `content.parts` is `[]`. The runner appends that empty model turn to history, and Vertex rejects the following request.

## Fix

Attach a model `content` only when there are actual parts to emit; otherwise omit `content` entirely (`LlmResponse.content` is optional). Trailing usage metadata is still surfaced, so nothing is lost:

```ts
content: finalParts ? { role: 'model', parts: finalParts } : undefined,
```

## Tests

- Updated the existing `should preserve metadata in close() when no text parts are accumulated in non-progressive mode` test to assert the metadata-only response **omits `content`** (instead of emitting `parts: []`), so it doubles as a regression guard for the Vertex 400.
- Full `core` `streaming_utils` suite passes (25/25).

## Notes

- No behavior change for turns that produce content.
- `LlmResponse.content` is already optional, so this is type-safe.
