### PR TITLE
feat(cli): support --agent_engine_id in deploy agent_engine

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -179,6 +179,10 @@ export const REPOSITORY_DEPLOY_OPTION = new Option(
   '--repository [string]',
   'Optional. Artifact Registry repository name to push docker images. Required for agent_engine deploy.',
 );
+export const AGENT_ENGINE_ID_OPTION = new Option(
+  '--agent_engine_id [id]',
+  'Optional. ID of the Agent Engine instance to update if it exists (default: undefined, which means a new instance will be created). If project and region are set, this should be the resource ID or the full resource name (projects/.../locations/.../reasoningEngines/...).',
+);
 
 /**
  * Creates the ADK CLI program.
@@ -471,6 +475,7 @@ export function createProgram(): Command {
       .addOption(BUNDLE_AGENT_FILE)
       .addOption(AGENT_FILE_MODULE_TYPE)
       .addOption(A2A_OPTION)
+      .addOption(AGENT_ENGINE_ID_OPTION)
       .action(async (agentPath: string, options: Record<string, string>) => {
         try {
           await deployToAgentEngine({
@@ -490,6 +495,7 @@ export function createProgram(): Command {
             artifactServiceUri: options['artifact_service_uri'],
             agentFileLoadOptions: getAgentFileOptions(options),
             a2a: getBoolean(options['a2a']),
+            agentEngineId: options['agent_engine_id'],
           });
         } catch (error) {
           logger.error('Error deploying agent:', (error as Error).message);

--- a/dev/src/cli/deploy/cli_deploy_agent_engine.ts
+++ b/dev/src/cli/deploy/cli_deploy_agent_engine.ts
@@ -27,6 +27,7 @@ export interface DeployToAgentEngineOptions extends BaseDeployOptions {
   description?: string;
   stagingBucket?: string;
   repository?: string;
+  agentEngineId?: string;
 }
 
 export async function deployToAgentEngine(options: DeployToAgentEngineOptions) {
@@ -133,32 +134,46 @@ export async function deployToAgentEngine(options: DeployToAgentEngineOptions) {
       {stdio: 'inherit'},
     );
 
-    console.info('Creating Reasoning Engine resource in Vertex AI...');
     const client = new Client({
       project: options.project,
       location: options.region,
     });
 
-    let apiResponse = await client.agentEnginesInternal.createInternal({
-      config: {
-        displayName,
-        description: options.description,
-        spec: {
-          containerSpec: {
-            imageUri: imageTag,
-          },
-          deploymentSpec: {
-            containerConcurrency: 9,
-            minInstances: 1,
-            maxInstances: 10,
-            resourceLimits: {
-              cpu: '1',
-              memory: '2Gi',
-            },
+    const config = {
+      displayName,
+      description: options.description,
+      spec: {
+        containerSpec: {
+          imageUri: imageTag,
+        },
+        deploymentSpec: {
+          containerConcurrency: 9,
+          minInstances: 1,
+          maxInstances: 10,
+          resourceLimits: {
+            cpu: '1',
+            memory: '2Gi',
           },
         },
       },
-    });
+    };
+
+    let apiResponse;
+    if (options.agentEngineId) {
+      console.info('Updating Reasoning Engine resource in Vertex AI...');
+      const name = options.agentEngineId.startsWith('projects/')
+        ? options.agentEngineId
+        : `projects/${options.project}/locations/${options.region}/reasoningEngines/${options.agentEngineId}`;
+      apiResponse = await client.agentEnginesInternal.updateInternal({
+        name,
+        config,
+      });
+    } else {
+      console.info('Creating Reasoning Engine resource in Vertex AI...');
+      apiResponse = await client.agentEnginesInternal.createInternal({
+        config,
+      });
+    }
 
     const operationName = apiResponse.name!;
     console.info(`Waiting for operation ${operationName} to complete...`);
@@ -177,19 +192,19 @@ export async function deployToAgentEngine(options: DeployToAgentEngineOptions) {
 
     if (!apiResponse.done) {
       throw new Error(
-        `Reasoning Engine creation operation ${operationName} did not complete in time.`,
+        `Reasoning Engine ${options.agentEngineId ? 'update' : 'creation'} operation ${operationName} did not complete in time.`,
       );
     }
 
     if (apiResponse.error) {
       throw new Error(
-        `Reasoning Engine creation failed: [Code ${apiResponse.error.code}] ${apiResponse.error.message}`,
+        `Reasoning Engine ${options.agentEngineId ? 'update' : 'creation'} failed: [Code ${apiResponse.error.code}] ${apiResponse.error.message}`,
       );
     }
 
     const response = apiResponse.response as VertexReasoningEngine;
     console.info(
-      `\x1b[32mSuccessfully deployed Reasoning Engine: ${response.name}\x1b[0m`,
+      `\x1b[32mSuccessfully ${options.agentEngineId ? 'updated' : 'deployed'} Reasoning Engine: ${response.name}\x1b[0m`,
     );
   } catch (e: unknown) {
     console.error(

--- a/dev/test/cli/cli_deploy_agent_engine_test.ts
+++ b/dev/test/cli/cli_deploy_agent_engine_test.ts
@@ -38,7 +38,12 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  const actual = (await importOriginal<
+    typeof import('node:fs/promises')
+  >()) as typeof import('node:fs/promises') & {
+    cp: (...args: unknown[]) => unknown;
+    default?: Record<string, unknown>;
+  };
   const isCoveragePath = (path: unknown) => {
     const pathStr = typeof path === 'string' ? path : String(path || '');
     return (
@@ -93,7 +98,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     return actual.readdir(path, opts);
   });
 
-  const mockFs = {
+  const mockFs: Record<string, unknown> = {
     ...actual,
     cp: mockCp,
     mkdir: mockMkdir,
@@ -133,12 +138,14 @@ vi.mock('../../src/utils/file_utils.js', () => ({
 }));
 
 const mockCreateInternal = vi.fn();
+const mockUpdateInternal = vi.fn();
 const mockGetAgentOperationInternal = vi.fn();
 
 vi.mock('@google-cloud/vertexai/build/src/genai/client.js', () => ({
   Client: class {
     agentEnginesInternal = {
       createInternal: mockCreateInternal,
+      updateInternal: mockUpdateInternal,
       getAgentOperationInternal: mockGetAgentOperationInternal,
     };
   },
@@ -211,6 +218,11 @@ describe('deployToAgentEngine', () => {
 
     mockCreateInternal.mockResolvedValue({
       name: 'operations/test-operation',
+      done: false,
+    });
+
+    mockUpdateInternal.mockResolvedValue({
+      name: 'operations/test-update-operation',
       done: false,
     });
 
@@ -567,4 +579,153 @@ describe('deployToAgentEngine', () => {
 
     vi.useRealTimers();
   }, 30000);
+
+  it('should update existing Reasoning Engine successfully when short agentEngineId is provided', async () => {
+    const options = {
+      ...defaultOptions,
+      agentEngineId: '12345',
+    };
+
+    mockGetAgentOperationInternal.mockResolvedValue({
+      done: true,
+      response: {
+        name: 'projects/test-project/locations/us-central1/reasoningEngines/12345',
+      },
+    });
+
+    await deployToAgentEngine(options);
+
+    expect(mockUpdateInternal).toHaveBeenCalledWith({
+      name: 'projects/test-project/locations/us-central1/reasoningEngines/12345',
+      config: {
+        displayName: 'test-agent',
+        description: undefined,
+        spec: {
+          containerSpec: {
+            imageUri:
+              'us-central1-docker.pkg.dev/test-project/agent-engine-repo/agent-engine-agent:latest',
+          },
+          deploymentSpec: {
+            containerConcurrency: 9,
+            minInstances: 1,
+            maxInstances: 10,
+            resourceLimits: {
+              cpu: '1',
+              memory: '2Gi',
+            },
+          },
+        },
+      },
+    });
+    expect(mockCreateInternal).not.toHaveBeenCalled();
+  });
+
+  it('should update existing Reasoning Engine successfully when full resource name agentEngineId is provided', async () => {
+    const options = {
+      ...defaultOptions,
+      agentEngineId:
+        'projects/custom-proj/locations/europe-west4/reasoningEngines/999',
+    };
+
+    mockGetAgentOperationInternal.mockResolvedValue({
+      done: true,
+      response: {
+        name: 'projects/custom-proj/locations/europe-west4/reasoningEngines/999',
+      },
+    });
+
+    await deployToAgentEngine(options);
+
+    expect(mockUpdateInternal).toHaveBeenCalledWith({
+      name: 'projects/custom-proj/locations/europe-west4/reasoningEngines/999',
+      config: {
+        displayName: 'test-agent',
+        description: undefined,
+        spec: {
+          containerSpec: {
+            imageUri:
+              'us-central1-docker.pkg.dev/test-project/agent-engine-repo/agent-engine-agent:latest',
+          },
+          deploymentSpec: {
+            containerConcurrency: 9,
+            minInstances: 1,
+            maxInstances: 10,
+            resourceLimits: {
+              cpu: '1',
+              memory: '2Gi',
+            },
+          },
+        },
+      },
+    });
+    expect(mockCreateInternal).not.toHaveBeenCalled();
+  });
+
+  it('should throw descriptive error if update operation times out when agentEngineId is provided', async () => {
+    const options = {
+      ...defaultOptions,
+      agentEngineId: '12345',
+    };
+
+    let resolveReachedLoop: () => void = () => {};
+    const reachedLoopPromise = new Promise<void>((r) => {
+      resolveReachedLoop = r;
+    });
+
+    mockUpdateInternal.mockImplementation(() => {
+      resolveReachedLoop();
+      return Promise.resolve({
+        name: 'operations/test-update-op',
+        done: false,
+      });
+    });
+
+    mockGetAgentOperationInternal.mockResolvedValue({
+      name: 'operations/test-update-op',
+      done: false,
+    });
+
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+
+    const deployPromise = deployToAgentEngine(options);
+
+    await reachedLoopPromise;
+    await Promise.resolve(); // yield
+
+    for (let i = 0; i < 30; i++) {
+      await vi.advanceTimersByTimeAsync(5000);
+    }
+
+    await expect(deployPromise).rejects.toThrow(
+      'Reasoning Engine update operation operations/test-update-op did not complete in time.',
+    );
+
+    vi.useRealTimers();
+  }, 30000);
+
+  it('should throw descriptive error if update operation returns apiResponse.error', async () => {
+    const options = {
+      ...defaultOptions,
+      agentEngineId: '12345',
+    };
+
+    mockUpdateInternal.mockResolvedValue({
+      name: 'operations/test-update-op',
+      done: false,
+    });
+
+    mockGetAgentOperationInternal.mockResolvedValue({
+      name: 'operations/test-update-op',
+      done: true,
+      error: {
+        code: 404,
+        message: 'Resource not found',
+      },
+    });
+
+    await expect(deployToAgentEngine(options)).rejects.toThrow(
+      'Reasoning Engine update failed: [Code 404] Resource not found',
+    );
+  });
 });

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -352,6 +352,14 @@ describe('CLI Entrypoint', () => {
         a2a: true,
       });
     });
+
+    it('should pass agent_engine_id to deployToAgentEngine when --agent_engine_id is set', async () => {
+      await parse(['deploy', 'agent_engine', '--agent_engine_id', '12345']);
+
+      expect((deployToAgentEngine as Mock).mock.calls[0][0]).toMatchObject({
+        agentEngineId: '12345',
+      });
+    });
   });
 
   describe('command: deploy reasoning_engine', () => {
@@ -365,6 +373,14 @@ describe('CLI Entrypoint', () => {
           withUi: false,
         }),
       );
+    });
+
+    it('should pass agent_engine_id to deployToAgentEngine when --agent_engine_id is set', async () => {
+      await parse(['deploy', 'reasoning_engine', '--agent_engine_id', '12345']);
+
+      expect((deployToAgentEngine as Mock).mock.calls[0][0]).toMatchObject({
+        agentEngineId: '12345',
+      });
     });
   });
 });


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change

1. Link to an existing issue (if applicable):

Closes: #483
Related: #483

2. Or, if no issue exists, describe the change:

**Problem**: Running `adk deploy agent_engine` (and its alias `adk deploy reasoning_engine`) in the TypeScript CLI always creates a new Reasoning Engine instance in Vertex AI (`agentEnginesInternal.createInternal`). Without an option to specify an existing instance ID, developers cannot perform in-place updates to deployed agents, lacking feature parity with `adk-python`.

**Solution**: Added optional `--agent_engine_id [id]` option to `adk deploy agent_engine` and `adk deploy reasoning_engine` in TypeScript (`cli.ts`). When `--agent_engine_id` is provided (either as a short resource ID or full resource name), `deployToAgentEngine` calls `client.agentEnginesInternal.updateInternal(...)` to update the existing Reasoning Engine instance in Vertex AI in-place, matching Python CLI behavior.

### Testing Plan

Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
[x] I have added or updated unit tests for my change.
[x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:

1. Built the `adk-js` package (`npm run build`).
2. Ran `adk deploy agent_engine ./sample/agent.ts --project <test-project> --region us-central1 --repository test-repo` to deploy an initial Reasoning Engine instance and recorded the output resource ID (`123456789`).
3. Modified `./sample/agent.ts` with minor text changes.
4. Ran `adk deploy agent_engine ./sample/agent.ts --project <test-project> --region us-central1 --repository test-repo --agent_engine_id 123456789` and verified that `Successfully updated Reasoning Engine: projects/<test-project>/locations/us-central1/reasoningEngines/123456789` is logged and the instance configuration is updated in-place on Vertex AI.

### Checklist

[x] I have read the CONTRIBUTING.md document.
[x] I have performed a self-review of my own code.
[x] I have commented my code, particularly in hard-to-understand areas.
[x] I have added tests that prove my fix is effective or that my feature works.
[x] New and existing unit tests pass locally with my changes.
