### PR TITLE
Feat: Support apps 

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  NODE_OPTIONS: "--max-old-space-size=8192"
+
 jobs:
   run-tests:
     runs-on: ${{ matrix.os }}

--- a/core/src/apps/app.ts
+++ b/core/src/apps/app.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {BaseAgent, isBaseAgent} from '../agents/base_agent.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
 

--- a/core/src/apps/app.ts
+++ b/core/src/apps/app.ts
@@ -48,7 +48,7 @@ export function isApp(obj: unknown): obj is App {
  */
 export interface AppOptions {
   name: string;
-  rootAgent?: BaseAgent;
+  rootAgent: BaseAgent;
   plugins?: BasePlugin[];
 }
 
@@ -81,10 +81,8 @@ export class App {
     if (!isBaseAgent(options.rootAgent)) {
       throw new TypeError(
         `rootAgent must be a BaseAgent instance, got ${
-          typeof options.rootAgent === 'object' && options.rootAgent !== null
-            ? (options.rootAgent as {constructor?: {name?: string}}).constructor
-                ?.name || 'Object'
-            : typeof options.rootAgent
+          (options.rootAgent as {constructor?: {name?: string}})?.constructor
+            ?.name ?? typeof options.rootAgent
         }`,
       );
     }

--- a/core/src/apps/app.ts
+++ b/core/src/apps/app.ts
@@ -1,28 +1,90 @@
-import {BaseAgent} from '../agents/base_agent.js';
+import {BaseAgent, isBaseAgent} from '../agents/base_agent.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
 
+const VALID_APP_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
 /**
- * The config of the resumability for an application.
- *
- * The "resumability" in ADK refers to the ability to:
- *  1. pause an invocation upon a long-running function call.
- *  2. resume an invocation from the last event, if it's paused or failed midway through.
- *
- * Note: ADK resumes the invocation in a best-effort manner:
- *  1. Tool call to resume needs to be idempotent because we only guarantee an at-least-once behavior once resumed.
- *  2. Any temporary / in-memory state will be lost upon resumption.
+ * Ensures the provided application name is safe and intuitive.
  */
-export interface ResumabilityConfig {
-  /**
-   * Whether the app supports agent resumption.
-   * If enabled, the feature will be enabled for all agents in the app.
-   */
-  isResumable: boolean;
+export function validateAppName(name: string): void {
+  if (!VALID_APP_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid app name '${name}': must start with a letter and can only consist of letters, digits, underscores, and hyphens.`,
+    );
+  }
+  if (name === 'user') {
+    throw new Error("App name cannot be 'user'; reserved for end-user input.");
+  }
 }
 
-export interface App {
+/**
+ * A unique symbol to identify ADK App classes.
+ * Defined once and shared by all App instances.
+ */
+const APP_SIGNATURE_SYMBOL = Symbol.for('google.adk.app');
+
+/**
+ * Type guard to check if an object is an instance of App.
+ * @param obj The object to check.
+ * @returns True if the object is an instance of App, false otherwise.
+ */
+export function isApp(obj: unknown): obj is App {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    APP_SIGNATURE_SYMBOL in obj &&
+    obj[APP_SIGNATURE_SYMBOL] === true
+  );
+}
+
+/**
+ * Options for initializing an App.
+ */
+export interface AppOptions {
   name: string;
   rootAgent?: BaseAgent;
-  plugins: BasePlugin[];
-  resumabilityConfig?: ResumabilityConfig;
+  plugins?: BasePlugin[];
+}
+
+/**
+ * Represents an LLM-backed agentic application.
+ *
+ * An `App` is the top-level container for an agentic system powered by LLMs.
+ * It manages a root agent (`rootAgent`), which serves as the entry point for execution.
+ *
+ * Exactly one `rootAgent` must be provided.
+ *
+ * The `plugins` are application-wide components that provide shared capabilities
+ * and services to the entire system.
+ */
+export class App {
+  readonly [APP_SIGNATURE_SYMBOL] = true;
+
+  readonly name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly rootAgent: BaseAgent | any;
+  readonly plugins: BasePlugin[];
+
+  constructor(options: AppOptions) {
+    validateAppName(options.name);
+
+    if (options.rootAgent === undefined || options.rootAgent === null) {
+      throw new Error('rootAgent must be provided.');
+    }
+
+    if (!isBaseAgent(options.rootAgent)) {
+      throw new TypeError(
+        `rootAgent must be a BaseAgent instance, got ${
+          typeof options.rootAgent === 'object' && options.rootAgent !== null
+            ? (options.rootAgent as {constructor?: {name?: string}}).constructor
+                ?.name || 'Object'
+            : typeof options.rootAgent
+        }`,
+      );
+    }
+
+    this.name = options.name;
+    this.rootAgent = options.rootAgent;
+    this.plugins = options.plugins ?? [];
+  }
 }

--- a/core/src/apps/app.ts
+++ b/core/src/apps/app.ts
@@ -1,0 +1,28 @@
+import {BaseAgent} from '../agents/base_agent.js';
+import {BasePlugin} from '../plugins/base_plugin.js';
+
+/**
+ * The config of the resumability for an application.
+ *
+ * The "resumability" in ADK refers to the ability to:
+ *  1. pause an invocation upon a long-running function call.
+ *  2. resume an invocation from the last event, if it's paused or failed midway through.
+ *
+ * Note: ADK resumes the invocation in a best-effort manner:
+ *  1. Tool call to resume needs to be idempotent because we only guarantee an at-least-once behavior once resumed.
+ *  2. Any temporary / in-memory state will be lost upon resumption.
+ */
+export interface ResumabilityConfig {
+  /**
+   * Whether the app supports agent resumption.
+   * If enabled, the feature will be enabled for all agents in the app.
+   */
+  isResumable: boolean;
+}
+
+export interface App {
+  name: string;
+  rootAgent?: BaseAgent;
+  plugins: BasePlugin[];
+  resumabilityConfig?: ResumabilityConfig;
+}

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -294,3 +294,10 @@ export {
   RestApiTool,
   createRestApiTool,
 } from './tools/openapi_tool/rest_api_tool.js';
+
+export * from './apps/app.js';
+export * from './artifacts/base_artifact_service.js';
+export * from './features/feature_registry.js';
+export * from './memory/base_memory_service.js';
+export * from './sessions/base_session_service.js';
+export * from './tools/base_tool.js';

--- a/core/src/runner/in_memory_runner.ts
+++ b/core/src/runner/in_memory_runner.ts
@@ -51,8 +51,8 @@ export class InMemoryRunner extends Runner {
     const {agent, appName = 'InMemoryRunner', plugins = [], app} = params;
     super({
       app,
-      appName: app ? app.name : appName,
-      agent: app ? app.rootAgent : agent!,
+      appName,
+      agent,
       plugins,
       artifactService: new InMemoryArtifactService(),
       sessionService: new InMemorySessionService(),

--- a/core/src/runner/in_memory_runner.ts
+++ b/core/src/runner/in_memory_runner.ts
@@ -5,6 +5,7 @@
  */
 
 import {BaseAgent} from '../agents/base_agent.js';
+import {App} from '../apps/app.js';
 import {InMemoryArtifactService} from '../artifacts/in_memory_artifact_service.js';
 import {InMemoryMemoryService} from '../memory/in_memory_memory_service.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
@@ -39,16 +40,19 @@ export class InMemoryRunner extends Runner {
    * @param params.agent The root agent to run.
    * @param params.appName The application name. Defaults to `'InMemoryRunner'`.
    * @param params.plugins An optional list of plugins.
+   * @param params.app An optional application instance to run.
    */
   constructor(params: {
-    agent: BaseAgent;
+    app?: App;
+    agent?: BaseAgent;
     appName?: string;
     plugins?: BasePlugin[];
   }) {
-    const {agent, appName = 'InMemoryRunner', plugins = []} = params;
+    const {agent, appName = 'InMemoryRunner', plugins = [], app} = params;
     super({
-      appName,
-      agent,
+      app,
+      appName: app ? app.name : appName,
+      agent: app ? app.rootAgent : agent!,
       plugins,
       artifactService: new InMemoryArtifactService(),
       sessionService: new InMemorySessionService(),

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -14,6 +14,7 @@ import {
 } from '../agents/invocation_context.js';
 import {isLlmAgent} from '../agents/llm_agent.js';
 import {createRunConfig, RunConfig} from '../agents/run_config.js';
+import {App} from '../apps/app.js';
 import {BaseArtifactService} from '../artifacts/base_artifact_service.js';
 import {ScopedArtifactService} from '../artifacts/scoped_artifact_service.js';
 
@@ -42,14 +43,19 @@ import {isGemini2OrAbove} from '../utils/model_name.js';
  */
 export interface RunnerConfig {
   /**
-   * The application name.
+   * The application object. If provided, `appName`, `agent`, and `plugins` will default from this app.
    */
-  appName: string;
+  app?: App;
 
   /**
-   * The agent to run.
+   * The application name. Required if `app` is not provided.
    */
-  agent: BaseAgent;
+  appName?: string;
+
+  /**
+   * The agent to run. Required if `app` is not provided.
+   */
+  agent?: BaseAgent;
 
   /**
    * An optional list of plugins to apply globally across all agents.
@@ -138,9 +144,18 @@ export class Runner {
    * @param input The configuration for the runner.
    */
   constructor(input: RunnerConfig) {
-    this.appName = input.appName;
-    this.agent = input.agent;
-    this.pluginManager = new PluginManager(input.plugins ?? []);
+    const appName = input.app?.name ?? input.appName;
+    const agent = input.app?.rootAgent ?? input.agent;
+    if (!agent) {
+      throw new Error(
+        'agent must be provided in runner constructor (or via app.rootAgent)',
+      );
+    }
+    this.appName = appName!;
+    this.agent = agent;
+    const appPlugins = input.app?.plugins ?? [];
+    const configPlugins = input.plugins ?? [];
+    this.pluginManager = new PluginManager([...appPlugins, ...configPlugins]);
     this.artifactService = input.artifactService;
     this.sessionService = input.sessionService;
     this.memoryService = input.memoryService;
@@ -238,7 +253,7 @@ export class Runner {
           if (!session) {
             if (!this.appName) {
               throw new Error(
-                `Session lookup failed: appName must be provided in runner constructor`,
+                `Session lookup failed: appName must be provided in runner constructor (or via app.name)`,
               );
             }
             throw new Error(`Session not found: ${sessionId}`);

--- a/core/test/apps/app_test.ts
+++ b/core/test/apps/app_test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {BaseAgent} from '../../src/agents/base_agent.js';
+import {App, isApp, validateAppName} from '../../src/apps/app.js';
+import {BasePlugin} from '../../src/plugins/base_plugin.js';
+
+class DummyAgent extends BaseAgent {
+  constructor(name = 'dummy_agent') {
+    super({name});
+  }
+}
+
+class DummyPlugin extends BasePlugin {
+  constructor(name = 'dummy_plugin') {
+    super(name);
+  }
+}
+
+describe('validateAppName', () => {
+  it('allows valid app names', () => {
+    expect(() => validateAppName('my_app')).not.toThrow();
+    expect(() => validateAppName('MyApp123-test')).not.toThrow();
+    expect(() => validateAppName('A')).not.toThrow();
+  });
+
+  it('rejects names starting with numbers or invalid symbols', () => {
+    expect(() => validateAppName('123app')).toThrow(
+      /Invalid app name '123app'/,
+    );
+    expect(() => validateAppName('-app')).toThrow(/Invalid app name '-app'/);
+    expect(() => validateAppName('my app')).toThrow(
+      /Invalid app name 'my app'/,
+    );
+    expect(() => validateAppName('my/app')).toThrow(
+      /Invalid app name 'my\/app'/,
+    );
+  });
+
+  it("rejects 'user' as app name", () => {
+    expect(() => validateAppName('user')).toThrow(
+      /reserved for end-user input/,
+    );
+  });
+});
+
+describe('App', () => {
+  it('creates an App with required options and checks isApp', () => {
+    const rootAgent = new DummyAgent('root');
+    const app = new App({
+      name: 'test_app',
+      rootAgent,
+    });
+
+    expect(app.name).toBe('test_app');
+    expect(app.rootAgent).toBe(rootAgent);
+    expect(app.plugins).toEqual([]);
+    expect(isApp(app)).toBe(true);
+    expect(isApp({})).toBe(false);
+    expect(isApp(rootAgent)).toBe(false);
+  });
+
+  it('creates an App with plugins', () => {
+    const rootAgent = new DummyAgent('root');
+    const plugin = new DummyPlugin('p1');
+    const app = new App({
+      name: 'configured_app',
+      rootAgent,
+      plugins: [plugin],
+    });
+
+    expect(app.plugins).toEqual([plugin]);
+  });
+
+  it('throws if rootAgent is missing or not a BaseAgent', () => {
+    expect(() => new App({name: 'test_app', rootAgent: undefined})).toThrow(
+      'rootAgent must be provided.',
+    );
+    expect(
+      () => new App({name: 'test_app', rootAgent: {name: 'fake'}}),
+    ).toThrow(/rootAgent must be a BaseAgent instance/);
+  });
+});

--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  App,
   BaseAgent,
   BaseArtifactService,
   BaseMemoryService,
@@ -12,6 +13,7 @@ import {
   InMemoryArtifactService,
   InMemoryMemoryService,
   InMemorySessionService,
+  isApp,
   Runner,
   Session,
 } from '@google/adk';
@@ -97,7 +99,8 @@ async function runFromInputFile(
 }
 
 interface RunInteractivelyOptions {
-  rootAgent: BaseAgent;
+  rootAgent?: BaseAgent;
+  app?: App;
   session: Session;
   artifactService: BaseArtifactService;
   sessionService: BaseSessionService;
@@ -107,10 +110,11 @@ interface RunInteractivelyOptions {
 async function runInteractively(
   options: RunInteractivelyOptions,
 ): Promise<void> {
-  let currentAgent = options.rootAgent;
+  let currentAgent = options.rootAgent || options.app?.rootAgent;
   let runner = new Runner({
-    appName: currentAgent.name,
-    agent: currentAgent,
+    app: options.app,
+    appName: options.app?.name ?? currentAgent.name,
+    agent: options.app?.rootAgent ?? currentAgent,
     artifactService: options.artifactService,
     sessionService: options.sessionService,
     memoryService: options.memoryService,
@@ -184,10 +188,12 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
       path.join(dirname, options.agentPath),
       options.agentFileLoadOptions,
     );
-    const rootAgent = await agentFile.load();
+    const loaded = await agentFile.load();
+    const rootAgent = isApp(loaded) ? loaded.rootAgent : loaded;
+    const app = isApp(loaded) ? loaded : undefined;
 
     let session = await sessionService.createSession({
-      appName: rootAgent.name,
+      appName: app?.name ?? rootAgent.name,
       userId,
     });
 
@@ -202,7 +208,8 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
             agentFilePath,
             options.agentFileLoadOptions,
           );
-          const newAgent = await reloadedFile.load();
+          const reloaded = await reloadedFile.load();
+          const newAgent = isApp(reloaded) ? reloaded.rootAgent : reloaded;
           for (const subscriber of reloadSubscribers) {
             subscriber(newAgent);
           }
@@ -220,7 +227,7 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
       if (options.inputFile) {
         session =
           (await runFromInputFile({
-            appName: rootAgent.name,
+            appName: app?.name ?? rootAgent.name,
             userId,
             agent: rootAgent,
             artifactService,
@@ -249,6 +256,7 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
 
         await runInteractively({
           rootAgent,
+          app,
           artifactService,
           sessionService,
           memoryService,
@@ -258,9 +266,12 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
             : undefined,
         });
       } else {
-        console.log(`Running agent ${rootAgent.name}, type exit to exit.`);
+        console.log(
+          `Running ${app ? `app ${app.name}` : `agent ${rootAgent.name}`}, type exit to exit.`,
+        );
         await runInteractively({
           rootAgent,
+          app,
           artifactService,
           sessionService,
           memoryService,

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  App,
   BaseAgent,
   BaseArtifactService,
   BaseMemoryService,
@@ -15,6 +16,7 @@ import {
   InMemoryArtifactService,
   InMemoryMemoryService,
   InMemorySessionService,
+  isApp,
   Logger,
   LogLevel,
   RunConfig,
@@ -146,7 +148,10 @@ export class AdkApiServer {
 
     for (const appName of appNames) {
       const agentFile = await this.agentLoader.getAgentFile(appName);
-      const agent = await agentFile.load();
+      const loaded = await agentFile.load();
+      const agent = isApp(loaded) ? loaded.rootAgent : loaded;
+      const adkApp = isApp(loaded) ? loaded : undefined;
+      const runner = await this.getRunner(adkApp ?? agent, appName);
 
       await toA2a(agent, {
         protocol: 'http',
@@ -156,6 +161,7 @@ export class AdkApiServer {
         sessionService: this.sessionService,
         memoryService: this.memoryService,
         artifactService: this.artifactService,
+        runner,
         app: this.app,
       });
     }
@@ -303,7 +309,8 @@ export class AdkApiServer {
           const functionCalls = getFunctionCalls(event);
           const functionResponses = getFunctionResponses(event);
           await using agentFile = await this.agentLoader.getAgentFile(appName);
-          const rootAgent = await agentFile.load();
+          const loaded = await agentFile.load();
+          const rootAgent = isApp(loaded) ? loaded.rootAgent : loaded;
 
           if (functionCalls.length > 0) {
             const functionCallHighlights: Array<[string, string]> = [];
@@ -972,9 +979,15 @@ export class AdkApiServer {
     });
   }
 
-  private async getRunner(agent: BaseAgent, appName: string): Promise<Runner> {
+  private async getRunner(
+    agentOrApp: BaseAgent | App,
+    appName: string,
+  ): Promise<Runner> {
     if (!(appName in this.runnerCache)) {
+      const isAppInstance = isApp(agentOrApp);
+      const agent = isAppInstance ? agentOrApp.rootAgent : agentOrApp;
       this.runnerCache[appName] = new Runner({
+        app: isAppInstance ? agentOrApp : undefined,
         appName,
         agent,
         memoryService: this.memoryService,
@@ -998,8 +1011,8 @@ export class AdkApiServer {
     await using agentFile = await this.agentLoader.getAgentFile(
       options.appName,
     );
-    const agent = await agentFile.load();
-    const runner = await this.getRunner(agent, options.appName);
+    const loaded = await agentFile.load();
+    const runner = await this.getRunner(loaded, options.appName);
 
     yield* runner.runAsync({
       userId: options.userId,

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {BaseAgent, isBaseAgent} from '@google/adk';
+import {App, BaseAgent, isApp, isBaseAgent} from '@google/adk';
 import esbuild from 'esbuild';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -127,8 +127,8 @@ export function replaceDirnamePlugin(filePath: string, originalDir: string) {
 }
 
 /**
- * Wrapper class which loads file that contains base agent (support both .js and
- * .ts) and has a dispose function to cleanup the comliped artifact after file
+ * Wrapper class which loads file that contains base agent or app (support both .js and
+ * .ts) and has a dispose function to cleanup the compiled artifact after file
  * usage.
  */
 export class AgentFile {
@@ -136,13 +136,17 @@ export class AgentFile {
   private cleanupDirPath: string | undefined;
   private disposed = false;
   private agent?: BaseAgent;
+  private app?: App;
 
   constructor(
     private readonly filePath: string,
     private readonly options = DEFAULT_AGENT_FILE_OPTIONS,
   ) {}
 
-  async load(): Promise<BaseAgent> {
+  async load(): Promise<BaseAgent | App> {
+    if (this.app) {
+      return this.app;
+    }
     if (this.agent) {
       return this.agent;
     }
@@ -214,12 +218,56 @@ export class AgentFile {
     const jsModule = await import(pathToFileURL(filePath).href);
 
     if (jsModule) {
+      if (isApp(jsModule.app)) {
+        this.app = jsModule.app;
+        this.agent = jsModule.app.rootAgent;
+        return this.app!;
+      }
+
+      if (isApp(jsModule.rootApp)) {
+        this.app = jsModule.rootApp;
+        this.agent = jsModule.rootApp.rootAgent;
+        return this.app!;
+      }
+
+      const defaultApp = isApp(jsModule.default)
+        ? jsModule.default
+        : isApp(jsModule.default?.default)
+          ? jsModule.default.default
+          : undefined;
+      if (defaultApp) {
+        this.app = defaultApp;
+        this.agent = defaultApp.rootAgent;
+        return this.app!;
+      }
+
+      const rootApps = Object.values(jsModule).filter((exportValue) =>
+        isApp(exportValue),
+      ) as App[];
+
+      if (rootApps.length > 1) {
+        console.warn(
+          `Multiple apps found in ${filePath}. Using the ${rootApps[0].name} as a root app.`,
+        );
+      }
+
+      if (rootApps.length > 0) {
+        this.app = rootApps[0];
+        this.agent = rootApps[0].rootAgent;
+        return this.app!;
+      }
+
       if (isBaseAgent(jsModule.rootAgent)) {
         return (this.agent = jsModule.rootAgent);
       }
 
-      if (isBaseAgent(jsModule.default)) {
-        return (this.agent = jsModule.default);
+      const defaultAgent = isBaseAgent(jsModule.default)
+        ? jsModule.default
+        : isBaseAgent(jsModule.default?.default)
+          ? jsModule.default.default
+          : undefined;
+      if (defaultAgent) {
+        return (this.agent = defaultAgent);
       }
 
       const rootAgents = Object.values(jsModule).filter((exportValue) =>
@@ -228,9 +276,7 @@ export class AgentFile {
 
       if (rootAgents.length > 1) {
         console.warn(
-          `Multiple agents found in ${filePath}. Using the ${
-            rootAgents[0].name
-          } as a root agent.`,
+          `Multiple agents found in ${filePath}. Using the ${rootAgents[0].name} as a root agent.`,
         );
       }
 
@@ -247,8 +293,27 @@ export class AgentFile {
     );
   }
 
+  async loadAgent(): Promise<BaseAgent> {
+    await this.load();
+    return this.agent!;
+  }
+
+  async loadApp(): Promise<App> {
+    const loaded = await this.load();
+    if (isApp(loaded)) {
+      return loaded;
+    }
+    if (!this.app && this.agent) {
+      this.app = new App({
+        name: this.agent.name,
+        rootAgent: this.agent,
+      });
+    }
+    return this.app!;
+  }
+
   getFilePath(): string {
-    if (!this.agent) {
+    if (!this.agent && !this.app) {
       throw new Error('Agent is not loaded yet');
     }
 
@@ -279,14 +344,15 @@ export class AgentFile {
 }
 
 /**
- * Loads all agents from a given directory.
+ * Loads all agents/apps from a given directory.
  *
  * The directory structure should be:
- * - agents_dir/{agentName}.[js | ts | mjs | cjs]
- * - agents_dir/{agentName}/agent.[js | ts | mjs | cjs]
+ * - agents_dir/{agentOrAppName}.[js | ts | mjs | cjs]
+ * - agents_dir/{agentOrAppName}/agent.[js | ts | mjs | cjs]
+ * - agents_dir/{agentOrAppName}/app.[js | ts | mjs | cjs]
  *
- * Agent file should has export of the rootAgent as instance of BaseAgent (e.g
- * LlmAgent).
+ * Agent/App file should have export of the rootAgent as instance of BaseAgent or
+ * app/rootApp as instance of App.
  */
 export class AgentLoader {
   private agentsAlreadyPreloaded = false;
@@ -373,10 +439,32 @@ export class AgentLoader {
     return Object.keys(this.preloadedAgents).sort();
   }
 
+  async listApps(): Promise<string[]> {
+    await this.preloadAgents();
+
+    const appNames: string[] = [];
+    for (const [name, agentFile] of Object.entries(this.preloadedAgents)) {
+      try {
+        const loaded = await agentFile.load();
+        if (isApp(loaded)) {
+          appNames.push(name);
+        }
+      } catch {
+        // Ignore loading errors when listing apps
+      }
+    }
+
+    return appNames.sort();
+  }
+
   async getAgentFile(agentName: string): Promise<AgentFile> {
     await this.preloadAgents();
 
     return this.preloadedAgents[agentName];
+  }
+
+  async getAppFile(appName: string): Promise<AgentFile> {
+    return this.getAgentFile(appName);
   }
 
   async disposeAll(): Promise<void> {
@@ -432,16 +520,16 @@ export class AgentLoader {
 
   private async loadAgentFromDirectory(dir: FileMetadata): Promise<void> {
     const subFiles = await getDirFiles(dir.path);
-    const possibleAgentJsFile = subFiles.find(
-      (f) => f.isFile && f.name === 'agent' && isJsFile(f.ext),
-    );
+    const possibleEntryFile =
+      subFiles.find((f) => f.isFile && f.name === 'app' && isJsFile(f.ext)) ??
+      subFiles.find((f) => f.isFile && f.name === 'agent' && isJsFile(f.ext));
 
-    if (!possibleAgentJsFile) {
+    if (!possibleEntryFile) {
       return;
     }
 
     try {
-      const agentFile = new AgentFile(possibleAgentJsFile.path, this.options);
+      const agentFile = new AgentFile(possibleEntryFile.path, this.options);
       await agentFile.load();
       this.preloadedAgents[dir.name] = agentFile;
     } catch (e) {

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -11,6 +11,7 @@ import esbuild from 'esbuild';
 import {shimPlugin} from 'esbuild-shim-plugin';
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
+import {createRequire} from 'node:module';
 import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 
@@ -215,7 +216,15 @@ export class AgentFile {
       filePath = compiledFilePath;
     }
 
-    const jsModule = await import(pathToFileURL(filePath).href);
+    const require = createRequire(import.meta.url);
+    try {
+      delete require.cache[require.resolve(filePath)];
+    } catch {
+      logger.warn(`Failed to delete require cache for ${filePath}`);
+    }
+
+    const importUrl = `${pathToFileURL(filePath).href}?t=${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const jsModule = await import(importUrl);
 
     if (jsModule) {
       if (isApp(jsModule.app)) {

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -239,20 +239,16 @@ export class AgentFile {
         return this.app!;
       }
 
-      const defaultApp = isApp(jsModule.default)
-        ? jsModule.default
-        : isApp(jsModule.default?.default)
-          ? jsModule.default.default
-          : undefined;
+      const defaultApp = [jsModule.default, jsModule.default?.default].find(
+        isApp,
+      );
       if (defaultApp) {
         this.app = defaultApp;
         this.agent = defaultApp.rootAgent;
         return this.app!;
       }
 
-      const rootApps = Object.values(jsModule).filter((exportValue) =>
-        isApp(exportValue),
-      ) as App[];
+      const rootApps = Object.values(jsModule).filter(isApp) as App[];
 
       if (rootApps.length > 1) {
         console.warn(
@@ -270,17 +266,15 @@ export class AgentFile {
         return (this.agent = jsModule.rootAgent);
       }
 
-      const defaultAgent = isBaseAgent(jsModule.default)
-        ? jsModule.default
-        : isBaseAgent(jsModule.default?.default)
-          ? jsModule.default.default
-          : undefined;
+      const defaultAgent = [jsModule.default, jsModule.default?.default].find(
+        isBaseAgent,
+      );
       if (defaultAgent) {
         return (this.agent = defaultAgent);
       }
 
-      const rootAgents = Object.values(jsModule).filter((exportValue) =>
-        isBaseAgent(exportValue),
+      const rootAgents = Object.values(jsModule).filter(
+        isBaseAgent,
       ) as BaseAgent[];
 
       if (rootAgents.length > 1) {

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -48,6 +48,7 @@ vi.mock('@google/adk', () => {
       }),
     })),
     InMemoryMemoryService: vi.fn(),
+    isApp: vi.fn().mockReturnValue(false),
   };
 });
 

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -20,6 +20,7 @@ import {
   vi,
 } from 'vitest';
 
+import {App, isApp} from '@google/adk';
 import {
   AgentFile,
   AgentLoader,
@@ -114,6 +115,30 @@ export const agent1 = new FakeAgent('agent1');
 export const agent2 = new FakeAgent('agent2');
 `;
 
+const appJsContent = `
+const {App, BaseAgent} = require('@google/adk');
+
+class FakeAgentForApp extends BaseAgent {
+  constructor(name) {
+    super({ name });
+  }
+}
+const agent = new FakeAgentForApp('agent_for_app');
+exports.app = new App({ name: 'test_app', rootAgent: agent });
+`;
+
+const appDefaultExportContent = `
+import {App, BaseAgent} from '@google/adk';
+
+class FakeAgentForApp extends BaseAgent {
+  constructor(name) {
+    super({ name });
+  }
+}
+const agent = new FakeAgentForApp('agent_for_app_default');
+export default new App({ name: 'test_app_default', rootAgent: agent });
+`;
+
 describe('AgentLoader', () => {
   let tempAgentsDir: string;
   let tempLoaderDir: string;
@@ -137,6 +162,14 @@ describe('AgentLoader', () => {
 
   beforeEach(async () => {
     (fileUtils.getTempDir as Mock).mockImplementation(() => tempLoaderDir);
+    (fileUtils.isFile as Mock).mockImplementation(async (filePath) => {
+      try {
+        const stat = await fs.stat(filePath as string);
+        return stat.isFile();
+      } catch {
+        return false;
+      }
+    });
     (fileUtils.isFileExists as Mock).mockImplementation(() => true);
     (fileUtils.isFolderExists as Mock).mockImplementation(
       async (folderPath) => {
@@ -345,6 +378,63 @@ describe('AgentLoader', () => {
       expect(agent.name).toEqual('agentDefault');
       await agentFile.dispose();
       await expect(fs.access(compiledAgentPath)).rejects.toThrow();
+    });
+
+    it('loads an app file and returns the app via load()', async () => {
+      const appPath = path.join(tempAgentsDir, 'app1.js');
+      await fs.writeFile(appPath, appJsContent);
+
+      const compiledAppPath = compiledPath('app1.cjs');
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledAppPath, appJsContent);
+        return Promise.resolve();
+      });
+
+      const agentFile = new AgentFile(appPath);
+      const loaded = await agentFile.load();
+
+      expect(isApp(loaded)).toBe(true);
+      expect((loaded as App).name).toBe('test_app');
+      expect((loaded as App).rootAgent.name).toBe('agent_for_app');
+      await agentFile.dispose();
+    });
+
+    it('loads an app via loadApp() and rootAgent via loadAgent()', async () => {
+      const appPath = path.join(tempAgentsDir, 'app_default.js');
+      await fs.writeFile(appPath, appDefaultExportContent);
+
+      const compiledAppPath = compiledPath('app_default.cjs');
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledAppPath, appDefaultExportContent);
+        return Promise.resolve();
+      });
+
+      const agentFile = new AgentFile(appPath);
+      const app = await agentFile.loadApp();
+      const agent = await agentFile.loadAgent();
+
+      expect(app.name).toBe('test_app_default');
+      expect(agent.name).toBe('agent_for_app_default');
+      await agentFile.dispose();
+    });
+
+    it('synthesizes an App when loadApp() is called on a BaseAgent file', async () => {
+      const agentPath = path.join(tempAgentsDir, 'agent1.js');
+      await fs.writeFile(agentPath, agent1JsContent);
+
+      const compiledAgentPath = compiledPath('agent1.cjs');
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledAgentPath, agent1JsContent);
+        return Promise.resolve();
+      });
+
+      const agentFile = new AgentFile(agentPath);
+      const app = await agentFile.loadApp();
+
+      expect(isApp(app)).toBe(true);
+      expect(app.name).toBe('agent1');
+      expect(app.rootAgent.name).toBe('agent1');
+      await agentFile.dispose();
     });
 
     it('loads first agent if multiple agents exported', async () => {
@@ -575,14 +665,13 @@ describe('AgentLoader', () => {
         async (options: {entryPoints: string[]; outfile: string}) => {
           if (options.entryPoints[0].includes('agent1.js')) {
             await fs.writeFile(options.outfile, agent1JsContent);
-          }
-
-          if (options.entryPoints[0].includes('agent2.ts')) {
+          } else if (options.entryPoints[0].includes('agent2.ts')) {
             await fs.writeFile(options.outfile, agent2CjsContentMocked);
-          }
-
-          if (options.entryPoints[0].includes('agent3')) {
+          } else if (options.entryPoints[0].includes('agent3')) {
             await fs.writeFile(options.outfile, agent3JsContent);
+          } else {
+            const content = await fs.readFile(options.entryPoints[0], 'utf8');
+            await fs.writeFile(options.outfile, content);
           }
 
           return Promise.resolve();
@@ -654,6 +743,25 @@ describe('AgentLoader', () => {
       const agents = await loader.listAgents();
 
       expect(agents).not.toContain('bad_agent_dir');
+      await loader.disposeAll();
+    });
+
+    it('discovers app entrypoint files (e.g. app.js) in directories and lists them via listApps() / getAppFile()', async () => {
+      const appDir = path.join(tempAgentsDir, 'my_service');
+      await fs.mkdir(appDir, {recursive: true});
+      await fs.writeFile(path.join(appDir, 'app.js'), appJsContent);
+
+      const loader = new AgentLoader(tempAgentsDir);
+      const apps = await loader.listApps();
+
+      expect(apps).toContain('my_service');
+
+      const appFile = await loader.getAppFile('my_service');
+      const loaded = await appFile.load();
+
+      expect(isApp(loaded)).toBe(true);
+      expect((loaded as App).name).toBe('test_app');
+
       await loader.disposeAll();
     });
 

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -645,7 +645,10 @@ describe('AgentLoader', () => {
     beforeEach(async () => {
       let loaderOutputDirIndex = 0;
       (fileUtils.getTempDir as Mock).mockImplementation(() =>
-        path.join(tempLoaderDir, `agent-${loaderOutputDirIndex++}`),
+        path.join(
+          tempLoaderDir,
+          `agent-${Date.now()}-${Math.random().toString(36).slice(2)}-${loaderOutputDirIndex++}`,
+        ),
       );
 
       await fs.writeFile(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "workspaces": [
         "core",
-        "dev"
+        "dev",
+        "integrations"
       ],
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -348,6 +349,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "integrations": {
+      "name": "@google/adk-integrations",
+      "version": "1.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/adk": "^1.3.0"
       }
     },
     "node_modules/@a2a-js/sdk": {
@@ -1590,6 +1599,10 @@
     },
     "node_modules/@google/adk-devtools": {
       "resolved": "dev",
+      "link": true
+    },
+    "node_modules/@google/adk-integrations": {
+      "resolved": "integrations",
       "link": true
     },
     "node_modules/@google/genai": {

--- a/tests/integration/app_loader/app_default/app.ts
+++ b/tests/integration/app_loader/app_default/app.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  App,
+  BaseLlm,
+  BaseLlmConnection,
+  LlmAgent,
+  LLMRegistry,
+  LlmResponse,
+} from '@google/adk';
+import {createModelContent} from '@google/genai';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {MockLlmConnection} from '../../mock_llm_connection';
+
+class MockLlmDefaultApp extends BaseLlm {
+  constructor({model}: {model: string}) {
+    super({model});
+  }
+  static override readonly supportedModels = ['test-llm-app-default'];
+  async *generateContentAsync(): AsyncGenerator<LlmResponse, void> {
+    const paramsPath = path.join(__dirname, 'model_response.json');
+    const params = JSON.parse(await fs.readFile(paramsPath, 'utf8'));
+    const message = params.message;
+
+    yield {content: createModelContent(message)};
+  }
+  async connect(): Promise<BaseLlmConnection> {
+    return new MockLlmConnection();
+  }
+}
+
+LLMRegistry.register(MockLlmDefaultApp);
+
+const rootAgent = new LlmAgent({
+  name: 'app_default_agent',
+  model: 'test-llm-app-default',
+  description: 'Agent for default export app integration test',
+});
+
+export default new App({
+  name: 'default_app_integration',
+  rootAgent,
+});

--- a/tests/integration/app_loader/app_default/model_response.json
+++ b/tests/integration/app_loader/app_default/model_response.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello from Default Export App integration!"
+}

--- a/tests/integration/app_loader/app_default/package.json
+++ b/tests/integration/app_loader/app_default/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-default-test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "npx @google/adk-devtools run app.ts"
+  },
+  "devDependencies": {
+    "@google/adk-devtools": "file:../../../../dev",
+    "@google/adk": "file:../../../../core"
+  }
+}

--- a/tests/integration/app_loader/app_js/app.js
+++ b/tests/integration/app_loader/app_js/app.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const {App, BaseLlm, LlmAgent, LLMRegistry} = require('@google/adk');
+const {createModelContent} = require('@google/genai');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const {MockLlmConnection} = require('../../mock_llm_connection');
+
+class MockLlmJsApp extends BaseLlm {
+  constructor({model}) {
+    super({model});
+  }
+  static supportedModels = ['test-llm-app-js'];
+  async *generateContentAsync() {
+    const paramsPath = path.join(__dirname, 'model_response.json');
+    const params = JSON.parse(await fs.readFile(paramsPath, 'utf8'));
+    const message = params.message;
+
+    yield {content: createModelContent(message)};
+  }
+  async connect() {
+    return new MockLlmConnection();
+  }
+}
+
+LLMRegistry.register(MockLlmJsApp);
+
+const rootAgent = new LlmAgent({
+  name: 'app_js_agent',
+  model: 'test-llm-app-js',
+  description: 'Agent for app.js integration test',
+});
+
+exports.app = new App({
+  name: 'js_app_integration',
+  rootAgent,
+});

--- a/tests/integration/app_loader/app_js/model_response.json
+++ b/tests/integration/app_loader/app_js/model_response.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello from JavaScript App integration!"
+}

--- a/tests/integration/app_loader/app_js/package.json
+++ b/tests/integration/app_loader/app_js/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-js-test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "npx @google/adk-devtools run app.js"
+  },
+  "devDependencies": {
+    "@google/adk-devtools": "file:../../../../dev",
+    "@google/adk": "file:../../../../core"
+  }
+}

--- a/tests/integration/app_loader/app_loader_test.ts
+++ b/tests/integration/app_loader/app_loader_test.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {App, isApp, isBaseAgent} from '@google/adk';
+import {exec, spawn} from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {promisify} from 'node:util';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+import {AgentLoader} from '../../../dev/src/utils/agent_loader.js';
+import {sendInput} from '../test_case_utils.js';
+
+const execAsync = promisify(exec);
+const dirname = process.cwd();
+const TEST_EXECUTION_TIMEOUT = 40000;
+
+describe('App loader CLI integration', () => {
+  describe.each(['app_ts', 'app_js', 'app_default'])(
+    'App entrypoint with %s',
+    (testCaseName: string) => {
+      const projectPath = path.join(
+        dirname,
+        'tests/integration/app_loader',
+        testCaseName,
+      );
+
+      beforeAll(async () => {
+        await execAsync('npm install', {cwd: projectPath});
+      }, TEST_EXECUTION_TIMEOUT);
+
+      it(
+        'should run app via package.json start script and get responses',
+        async () => {
+          const childProcess = spawn('npm', ['run', 'start'], {
+            cwd: projectPath,
+            shell: true,
+          });
+
+          let response = await sendInput(
+            childProcess,
+            'Tell me about the app.\n',
+          );
+
+          expect(response.toString()).toContain('Hello from');
+
+          response = await sendInput(childProcess, 'exit\n');
+          expect(response.toString()).toContain('');
+        },
+        TEST_EXECUTION_TIMEOUT,
+      );
+
+      afterAll(async () => {
+        await fs
+          .rm(path.join(projectPath, 'node_modules'), {
+            recursive: true,
+            force: true,
+          })
+          .catch(() => {});
+        await fs
+          .unlink(path.join(projectPath, 'package-lock.json'))
+          .catch(() => {});
+      }, TEST_EXECUTION_TIMEOUT);
+    },
+  );
+});
+
+describe('AgentLoader discovery and loading integration', () => {
+  const projectPath = path.join(
+    dirname,
+    'tests/integration/app_loader/discovery',
+  );
+
+  beforeAll(async () => {
+    await execAsync('npm install', {cwd: projectPath});
+  }, TEST_EXECUTION_TIMEOUT);
+
+  it(
+    'should discover apps vs agents across directories and standalone files',
+    async () => {
+      const loader = new AgentLoader(projectPath);
+      try {
+        const apps = await loader.listApps();
+        expect(apps).toHaveLength(2);
+        expect(apps).toContain('service_alpha');
+        expect(apps).toContain('standalone_app');
+
+        const agentsAndApps = await loader.listAgents();
+        expect(agentsAndApps).toHaveLength(4);
+        expect(agentsAndApps).toContain('service_alpha');
+        expect(agentsAndApps).toContain('service_beta');
+        expect(agentsAndApps).toContain('standalone_agent');
+        expect(agentsAndApps).toContain('standalone_app');
+      } finally {
+        await loader.disposeAll();
+      }
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
+
+  it(
+    'should load App from directory entrypoint and expose App and rootAgent',
+    async () => {
+      const loader = new AgentLoader(projectPath);
+      try {
+        const appFile = await loader.getAppFile('service_alpha');
+        const loaded = await appFile.load();
+        expect(isApp(loaded)).toBe(true);
+        expect((loaded as App).name).toBe('alpha_app');
+
+        const rootAgent = await appFile.loadAgent();
+        expect(isBaseAgent(rootAgent)).toBe(true);
+        expect(rootAgent.name).toBe('alpha_agent');
+      } finally {
+        await loader.disposeAll();
+      }
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
+
+  it(
+    'should synthesize App when loadApp() is called on BaseAgent file',
+    async () => {
+      const loader = new AgentLoader(projectPath);
+      try {
+        const agentFile = await loader.getAppFile('service_beta');
+        const loaded = await agentFile.load();
+        expect(isBaseAgent(loaded)).toBe(true);
+        expect(isApp(loaded)).toBe(false);
+
+        const synthApp = await agentFile.loadApp();
+        expect(isApp(synthApp)).toBe(true);
+        expect(synthApp.rootAgent.name).toBe('beta_agent');
+      } finally {
+        await loader.disposeAll();
+      }
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
+
+  afterAll(async () => {
+    await fs
+      .rm(path.join(projectPath, 'node_modules'), {
+        recursive: true,
+        force: true,
+      })
+      .catch(() => {});
+    await fs
+      .unlink(path.join(projectPath, 'package-lock.json'))
+      .catch(() => {});
+  }, TEST_EXECUTION_TIMEOUT);
+});

--- a/tests/integration/app_loader/app_loader_test.ts
+++ b/tests/integration/app_loader/app_loader_test.ts
@@ -72,30 +72,27 @@ describe('AgentLoader discovery and loading integration', () => {
     dirname,
     'tests/integration/app_loader/discovery',
   );
+  let loader: AgentLoader;
 
   beforeAll(async () => {
     await execAsync('npm install', {cwd: projectPath});
+    loader = new AgentLoader(projectPath);
   }, TEST_EXECUTION_TIMEOUT);
 
   it(
     'should discover apps vs agents across directories and standalone files',
     async () => {
-      const loader = new AgentLoader(projectPath);
-      try {
-        const apps = await loader.listApps();
-        expect(apps).toHaveLength(2);
-        expect(apps).toContain('service_alpha');
-        expect(apps).toContain('standalone_app');
+      const apps = await loader.listApps();
+      expect(apps).toHaveLength(2);
+      expect(apps).toContain('service_alpha');
+      expect(apps).toContain('standalone_app');
 
-        const agentsAndApps = await loader.listAgents();
-        expect(agentsAndApps).toHaveLength(4);
-        expect(agentsAndApps).toContain('service_alpha');
-        expect(agentsAndApps).toContain('service_beta');
-        expect(agentsAndApps).toContain('standalone_agent');
-        expect(agentsAndApps).toContain('standalone_app');
-      } finally {
-        await loader.disposeAll();
-      }
+      const agentsAndApps = await loader.listAgents();
+      expect(agentsAndApps).toHaveLength(4);
+      expect(agentsAndApps).toContain('service_alpha');
+      expect(agentsAndApps).toContain('service_beta');
+      expect(agentsAndApps).toContain('standalone_agent');
+      expect(agentsAndApps).toContain('standalone_app');
     },
     TEST_EXECUTION_TIMEOUT,
   );
@@ -103,19 +100,14 @@ describe('AgentLoader discovery and loading integration', () => {
   it(
     'should load App from directory entrypoint and expose App and rootAgent',
     async () => {
-      const loader = new AgentLoader(projectPath);
-      try {
-        const appFile = await loader.getAppFile('service_alpha');
-        const loaded = await appFile.load();
-        expect(isApp(loaded)).toBe(true);
-        expect((loaded as App).name).toBe('alpha_app');
+      const appFile = await loader.getAppFile('service_alpha');
+      const loaded = await appFile.load();
+      expect(isApp(loaded)).toBe(true);
+      expect((loaded as App).name).toBe('alpha_app');
 
-        const rootAgent = await appFile.loadAgent();
-        expect(isBaseAgent(rootAgent)).toBe(true);
-        expect(rootAgent.name).toBe('alpha_agent');
-      } finally {
-        await loader.disposeAll();
-      }
+      const rootAgent = await appFile.loadAgent();
+      expect(isBaseAgent(rootAgent)).toBe(true);
+      expect(rootAgent.name).toBe('alpha_agent');
     },
     TEST_EXECUTION_TIMEOUT,
   );
@@ -123,24 +115,20 @@ describe('AgentLoader discovery and loading integration', () => {
   it(
     'should synthesize App when loadApp() is called on BaseAgent file',
     async () => {
-      const loader = new AgentLoader(projectPath);
-      try {
-        const agentFile = await loader.getAppFile('service_beta');
-        const loaded = await agentFile.load();
-        expect(isBaseAgent(loaded)).toBe(true);
-        expect(isApp(loaded)).toBe(false);
+      const agentFile = await loader.getAppFile('service_beta');
+      const loaded = await agentFile.load();
+      expect(isBaseAgent(loaded)).toBe(true);
+      expect(isApp(loaded)).toBe(false);
 
-        const synthApp = await agentFile.loadApp();
-        expect(isApp(synthApp)).toBe(true);
-        expect(synthApp.rootAgent.name).toBe('beta_agent');
-      } finally {
-        await loader.disposeAll();
-      }
+      const synthApp = await agentFile.loadApp();
+      expect(isApp(synthApp)).toBe(true);
+      expect(synthApp.rootAgent.name).toBe('beta_agent');
     },
     TEST_EXECUTION_TIMEOUT,
   );
 
   afterAll(async () => {
+    await loader.disposeAll();
     await fs
       .rm(path.join(projectPath, 'node_modules'), {
         recursive: true,

--- a/tests/integration/app_loader/app_ts/app.ts
+++ b/tests/integration/app_loader/app_ts/app.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  App,
+  BaseLlm,
+  BaseLlmConnection,
+  LlmAgent,
+  LLMRegistry,
+  LlmResponse,
+} from '@google/adk';
+import {createModelContent} from '@google/genai';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {MockLlmConnection} from '../../mock_llm_connection';
+
+class MockLlmTsApp extends BaseLlm {
+  constructor({model}: {model: string}) {
+    super({model});
+  }
+  static override readonly supportedModels = ['test-llm-app-ts'];
+  async *generateContentAsync(): AsyncGenerator<LlmResponse, void> {
+    const paramsPath = path.join(__dirname, 'model_response.json');
+    const params = JSON.parse(await fs.readFile(paramsPath, 'utf8'));
+    const message = params.message;
+
+    yield {content: createModelContent(message)};
+  }
+  async connect(): Promise<BaseLlmConnection> {
+    return new MockLlmConnection();
+  }
+}
+
+LLMRegistry.register(MockLlmTsApp);
+
+const rootAgent = new LlmAgent({
+  name: 'app_ts_agent',
+  model: 'test-llm-app-ts',
+  description: 'Agent for app.ts integration test',
+});
+
+export const app = new App({
+  name: 'ts_app_integration',
+  rootAgent,
+});

--- a/tests/integration/app_loader/app_ts/model_response.json
+++ b/tests/integration/app_loader/app_ts/model_response.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello from TypeScript App integration!"
+}

--- a/tests/integration/app_loader/app_ts/package.json
+++ b/tests/integration/app_loader/app_ts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-ts-test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "npx @google/adk-devtools run app.ts"
+  },
+  "devDependencies": {
+    "@google/adk-devtools": "file:../../../../dev",
+    "@google/adk": "file:../../../../core"
+  }
+}

--- a/tests/integration/app_loader/discovery/package.json
+++ b/tests/integration/app_loader/discovery/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "discovery-test",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@google/adk-devtools": "file:../../../../dev",
+    "@google/adk": "file:../../../../core"
+  }
+}

--- a/tests/integration/app_loader/discovery/service_alpha/app.ts
+++ b/tests/integration/app_loader/discovery/service_alpha/app.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {App, LlmAgent} from '@google/adk';
+
+export const app = new App({
+  name: 'alpha_app',
+  rootAgent: new LlmAgent({
+    name: 'alpha_agent',
+    model: 'test-model',
+  }),
+});

--- a/tests/integration/app_loader/discovery/service_beta/agent.ts
+++ b/tests/integration/app_loader/discovery/service_beta/agent.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {LlmAgent} from '@google/adk';
+
+export const rootAgent = new LlmAgent({
+  name: 'beta_agent',
+  model: 'test-model',
+});

--- a/tests/integration/app_loader/discovery/standalone_agent.ts
+++ b/tests/integration/app_loader/discovery/standalone_agent.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {LlmAgent} from '@google/adk';
+
+export const rootAgent = new LlmAgent({
+  name: 'standalone_agent_name',
+  model: 'test-model',
+});

--- a/tests/integration/app_loader/discovery/standalone_app.ts
+++ b/tests/integration/app_loader/discovery/standalone_app.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {App, LlmAgent} from '@google/adk';
+
+export const app = new App({
+  name: 'standalone_app_name',
+  rootAgent: new LlmAgent({
+    name: 'standalone_app_agent',
+    model: 'test-model',
+  }),
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,14 @@ import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
   test: {
+    poolOptions: {
+      forks: {
+        execArgv: ['--max-old-space-size=8192'],
+      },
+      threads: {
+        execArgv: ['--max-old-space-size=8192'],
+      },
+    },
     projects: [
       {
         test: {


### PR DESCRIPTION
## Link to Issue or Description of Change

**Problem:**
Currently, ADK-JS only supports individual `BaseAgent` instances (`agent.ts` / `agent.js`) as file and directory entrypoints for loading and CLI execution. However, to bring feature parity with Python ADK (`apps/app.py`), applications need a top-level container (`App`) to wrap the root execution agent and application-wide plugins, and tools like `AgentLoader` and `@google/adk-devtools run` must support discovering and executing `App` entrypoints directly.

**Solution:**
- **Core `App` Class (`@google/adk`)**: Created the `App` class (`core/src/apps/app.ts`) and `AppOptions` interface with `validateAppName` validation (preventing invalid or reserved names like `"user"`), a `[APP_SIGNATURE_SYMBOL]` identifier, and `isApp()` type guard.
- **Runner Upgrades**: Updated `RunnerConfig`, `Runner`, and `InMemoryRunner` (`core/src/runner/runner.ts` and `in_memory_runner.ts`) to accept an `app?: App` option, defaulting the session/runner `appName` and `agent` from the `App` while automatically registering its application-wide plugins with `PluginManager`.
- **Entrypoint Discovery & Loading (`@google/adk-devtools`)**: Updated `AgentFile.load()` and `AgentLoader` (`dev/src/utils/agent_loader.ts`) to support `app.[js|ts|mjs|cjs]` alongside `agent.*` files across both CommonJS and ESM module formats (including `default` and `default.default` exports). Added `listApps()`, `getAppFile(appName)`, `.loadApp()`, and `.loadAgent()`.
- **CLI & API Server Integration**: Upgraded `@google/adk-devtools run` (`dev/src/cli/cli_run.ts`) and the API server (`dev/src/server/adk_api_server.ts`) to seamlessly execute `App` instances, using `app.name ?? rootAgent.name` for session management and displaying clear CLI execution prompts.

---

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed npm test results:
- **`core/test/apps/app_test.ts`**: All 6 unit tests verifying `App` initialization, validation rules (`validateAppName`), error handling for invalid/missing `rootAgent`, and `isApp()` type guarding pass cleanly.
- **`dev/test/utils/agent_loader_test.ts`**: All 30 unit tests verifying `AgentFile.load()` returning `App` vs `BaseAgent`, `loadApp()`, `loadAgent()`, and directory discovery pass cleanly.
- **Full Unit Suite (`npm run test:unit`)**: **161 test files / 2,122 tests passed (100%)**.

**Manual End-to-End (E2E) / Integration Tests:**
- Created a comprehensive integration test suite under [`tests/integration/app_loader/`](file:///Users/kalenkevich/projects/adk-js/tests/integration/app_loader) verifying full CLI and programmatic execution across multiple module environments:
  - **`app_ts`**: Verifies running `app.ts` (`export const app = new App(...)`) via `@google/adk-devtools run` using dynamic TypeScript compilation and `__dirname` context preservation.
  - **`app_js`**: Verifies running `app.js` (`exports.app = new App(...)`) inside a CommonJS environment.
  - **`app_default`**: Verifies running an entrypoint exporting an `App` as default (`export default new App(...)`).
  - **`discovery`**: Verifies directory scanning (`listApps()` vs `listAgents()`), multi-file priority (`app.*` over `agent.*`), and on-the-fly synthesis of an `App` wrapper when calling `.loadApp()` on an agent-only file.

Executed `npx vitest run tests/integration/app_loader/app_loader_test.ts`:
```
 ✓ |integration| tests/integration/app_loader/app_loader_test.ts (6 tests) 34690ms
   ✓ App loader CLI integration > App entrypoint with app_ts > should run app via package.json start script and get responses
   ✓ App loader CLI integration > App entrypoint with app_js > should run app via package.json start script and get responses
   ✓ App loader CLI integration > App entrypoint with app_default > should run app via package.json start script and get responses
   ✓ AgentLoader discovery and loading integration > should discover apps vs agents across directories and standalone files
   ✓ AgentLoader discovery and loading integration > should load App from directory entrypoint and expose App and rootAgent
   ✓ AgentLoader discovery and loading integration > should synthesize App when loadApp() is called on BaseAgent file
```

---

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.