### PR TITLE
Feat: Cleanup and Generalize determineAgentForResumption for LRO Session Resumption Routing

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -8,7 +8,12 @@ import {Content, createUserContent, FunctionCall, Part} from '@google/genai';
 import {isEmpty} from 'lodash-es';
 
 import {InvocationContext} from '../agents/invocation_context.js';
-import {createEvent, Event, getFunctionCalls} from '../events/event.js';
+import {
+  createEvent,
+  Event,
+  getFunctionCalls,
+  getFunctionResponses,
+} from '../events/event.js';
 import {mergeEventActions} from '../events/event_actions.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {ToolConfirmation} from '../tools/tool_confirmation.js';
@@ -564,3 +569,44 @@ export function mergeParallelFunctionResponseEvents(
 }
 
 // TODO - b/425992518: support function call in live connection.
+
+/**
+ * Finds the function call event that matches the function call ID.
+ * Mirrors Python ADK's `find_event_by_function_call_id`.
+ */
+export function findEventByFunctionCallId(
+  events: Event[],
+  functionCallId: string,
+  endIndex: number = events.length,
+): Event | undefined {
+  for (let i = endIndex - 1; i >= 0; i--) {
+    const event = events[i];
+    const functionCalls = getFunctionCalls(event);
+    for (const functionCall of functionCalls) {
+      if (functionCall.id === functionCallId) {
+        return event;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Finds the function call event that matches the function response ID of the last event.
+ * Mirrors Python ADK's `find_matching_function_call`.
+ */
+export function findMatchingFunctionCall(events: Event[]): Event | undefined {
+  if (!events.length) {
+    return undefined;
+  }
+  const lastEvent = events[events.length - 1];
+  const functionResponses = getFunctionResponses(lastEvent);
+  if (!functionResponses.length || !functionResponses[0].id) {
+    return undefined;
+  }
+  return findEventByFunctionCallId(
+    events,
+    functionResponses[0].id,
+    events.length - 1,
+  );
+}

--- a/core/src/apps/app.ts
+++ b/core/src/apps/app.ts
@@ -6,6 +6,7 @@
 
 import {BaseAgent, isBaseAgent} from '../agents/base_agent.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
+import {ResumabilityConfig} from './resumability_config.js';
 
 const VALID_APP_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 
@@ -50,6 +51,7 @@ export interface AppOptions {
   name: string;
   rootAgent: BaseAgent;
   plugins?: BasePlugin[];
+  resumabilityConfig?: ResumabilityConfig;
 }
 
 /**
@@ -70,6 +72,7 @@ export class App {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly rootAgent: BaseAgent | any;
   readonly plugins: BasePlugin[];
+  readonly resumabilityConfig?: ResumabilityConfig;
 
   constructor(options: AppOptions) {
     validateAppName(options.name);
@@ -90,5 +93,6 @@ export class App {
     this.name = options.name;
     this.rootAgent = options.rootAgent;
     this.plugins = options.plugins ?? [];
+    this.resumabilityConfig = options.resumabilityConfig;
   }
 }

--- a/core/src/apps/resumability_config.ts
+++ b/core/src/apps/resumability_config.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/core/src/apps/resumability_config.ts
+++ b/core/src/apps/resumability_config.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The configuration of resumability for an application or runner.
+ *
+ * The "resumability" in ADK refers to the ability to:
+ * 1. pause an invocation upon a long-running function call.
+ * 2. resume an invocation from the last event, if it's paused or failed midway
+ * through.
+ */
+export interface ResumabilityConfig {
+  /**
+   * Whether the app/runner supports agent resumption.
+   * If enabled, resumption routing based on matching function responses will be active.
+   */
+  isResumable: boolean;
+}
+
+/**
+ * Creates a {@link ResumabilityConfig} with default values.
+ *
+ * @param params Optional partial {@link ResumabilityConfig} overriding defaults.
+ * @returns A merged {@link ResumabilityConfig} object.
+ */
+export function createResumabilityConfig(
+  params: Partial<ResumabilityConfig> = {},
+): ResumabilityConfig {
+  return {
+    isResumable: false,
+    ...params,
+  };
+}

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -14,7 +14,11 @@ export type {
   SingleAgentCallback,
 } from './agents/base_agent.js';
 export {Context} from './agents/context.js';
-export {functionsExportedForTestingOnly} from './agents/functions.js';
+export {
+  findEventByFunctionCallId,
+  findMatchingFunctionCall,
+  functionsExportedForTestingOnly,
+} from './agents/functions.js';
 export {InvocationContext} from './agents/invocation_context.js';
 export type {InvocationContextParams} from './agents/invocation_context.js';
 export {LiveRequestQueue} from './agents/live_request_queue.js';
@@ -58,6 +62,8 @@ export {StreamingMode} from './agents/run_config.js';
 export type {RunConfig} from './agents/run_config.js';
 export {SequentialAgent, isSequentialAgent} from './agents/sequential_agent.js';
 export type {TranscriptionEntry} from './agents/transcription_entry.js';
+export {createResumabilityConfig} from './apps/resumability_config.js';
+export type {ResumabilityConfig} from './apps/resumability_config.js';
 export type {
   BaseArtifactService,
   DeleteArtifactRequest,
@@ -190,7 +196,13 @@ export type {
   ToolCallPolicyContext,
 } from './plugins/security_plugin.js';
 export {InMemoryRunner} from './runner/in_memory_runner.js';
-export {Runner, isRunner} from './runner/runner.js';
+export {
+  Runner,
+  determineAgentForResumption,
+  findEventByLastFunctionResponseId,
+  isRoutableLlmAgent,
+  isRunner,
+} from './runner/runner.js';
 export type {RunnerConfig} from './runner/runner.js';
 export {BaseSessionService} from './sessions/base_session_service.js';
 export type {

--- a/core/src/runner/in_memory_runner.ts
+++ b/core/src/runner/in_memory_runner.ts
@@ -67,7 +67,7 @@ export class InMemoryRunner extends Runner {
       artifactService: new InMemoryArtifactService(),
       sessionService: new InMemorySessionService(),
       memoryService: new InMemoryMemoryService(),
-      resumabilityConfig,
+      resumabilityConfig: app?.resumabilityConfig ?? resumabilityConfig,
     });
   }
 }

--- a/core/src/runner/in_memory_runner.ts
+++ b/core/src/runner/in_memory_runner.ts
@@ -6,6 +6,7 @@
 
 import {BaseAgent} from '../agents/base_agent.js';
 import {App} from '../apps/app.js';
+import {ResumabilityConfig} from '../apps/resumability_config.js';
 import {InMemoryArtifactService} from '../artifacts/in_memory_artifact_service.js';
 import {InMemoryMemoryService} from '../memory/in_memory_memory_service.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
@@ -37,18 +38,27 @@ export class InMemoryRunner extends Runner {
    * Creates a new InMemoryRunner instance.
    *
    * @param params The configuration for the runner.
+   * @param params.app An optional application instance to run.
    * @param params.agent The root agent to run.
    * @param params.appName The application name. Defaults to `'InMemoryRunner'`.
    * @param params.plugins An optional list of plugins.
-   * @param params.app An optional application instance to run.
+   * @param params.resumabilityConfig An optional resumability configuration.
    */
   constructor(params: {
     app?: App;
     agent?: BaseAgent;
     appName?: string;
     plugins?: BasePlugin[];
+    resumabilityConfig?: ResumabilityConfig;
   }) {
-    const {agent, appName = 'InMemoryRunner', plugins = [], app} = params;
+    const {
+      agent,
+      appName = 'InMemoryRunner',
+      plugins = [],
+      app,
+      resumabilityConfig,
+    } = params;
+
     super({
       app,
       appName,
@@ -57,6 +67,7 @@ export class InMemoryRunner extends Runner {
       artifactService: new InMemoryArtifactService(),
       sessionService: new InMemorySessionService(),
       memoryService: new InMemoryMemoryService(),
+      resumabilityConfig,
     });
   }
 }

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -8,6 +8,7 @@ import {Content, createPartFromText} from '@google/genai';
 import {context, trace} from '@opentelemetry/api';
 
 import {BaseAgent} from '../agents/base_agent.js';
+import {findMatchingFunctionCall} from '../agents/functions.js';
 import {
   InvocationContext,
   newInvocationContextId,
@@ -15,6 +16,7 @@ import {
 import {isLlmAgent} from '../agents/llm_agent.js';
 import {createRunConfig, RunConfig} from '../agents/run_config.js';
 import {App} from '../apps/app.js';
+import {ResumabilityConfig} from '../apps/resumability_config.js';
 import {BaseArtifactService} from '../artifacts/base_artifact_service.js';
 import {ScopedArtifactService} from '../artifacts/scoped_artifact_service.js';
 
@@ -23,7 +25,7 @@ import {
   BuiltInCodeExecutor,
   isBuiltInCodeExecutor,
 } from '../code_executors/built_in_code_executor.js';
-import {createEvent, Event, getFunctionCalls} from '../events/event.js';
+import {createEvent, Event} from '../events/event.js';
 import {createEventActions} from '../events/event_actions.js';
 import {BaseMemoryService} from '../memory/base_memory_service.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
@@ -81,6 +83,11 @@ export interface RunnerConfig {
    * An optional service for managing authentication credentials.
    */
   credentialService?: BaseCredentialService;
+
+  /**
+   * An optional resumability configuration applied to the runner.
+   */
+  resumabilityConfig?: ResumabilityConfig;
 }
 
 /**
@@ -137,6 +144,7 @@ export class Runner {
   readonly sessionService: BaseSessionService;
   readonly memoryService?: BaseMemoryService;
   readonly credentialService?: BaseCredentialService;
+  readonly resumabilityConfig?: ResumabilityConfig;
 
   /**
    * Creates a new Runner instance.
@@ -160,6 +168,7 @@ export class Runner {
     this.sessionService = input.sessionService;
     this.memoryService = input.memoryService;
     this.credentialService = input.credentialService;
+    this.resumabilityConfig = input.resumabilityConfig;
   }
 
   /**
@@ -484,80 +493,114 @@ export class Runner {
    * Determines the next agent to run to continue the session. This is primarily
    * used for session resumption.
    */
-  // TODO - b/425992518: This is where LRO integration should happen.
-  // Needs clean up before we can generalize it.
+  /**
+   * Determines the next agent to run to continue the session. This is primarily
+   * used for session resumption across tool and LRO boundaries.
+   */
   private determineAgentForResumption(
     session: Session,
     rootAgent: BaseAgent,
   ): BaseAgent {
-    // =========================================================================
-    // Case 1: If the last event is a function response, this returns the
-    // agent that made the original function call.
-    // =========================================================================
-    const event = findEventByLastFunctionResponseId(session.events);
-    if (event && event.author) {
-      return rootAgent.findAgent(event.author) || rootAgent;
-    }
-
-    // =========================================================================
-    // Case 2: Otherwise, find the last agent that emitted a message and is
-    // transferable across the agent tree.
-    // =========================================================================
-    // TODO - b/425992518: Optimize this, not going to work for long sessions.
-    // TODO - b/425992518: The behavior is dynamic, needs better documentation.
-    for (let i = session.events.length - 1; i >= 0; i--) {
-      logger.info('event:', JSON.stringify(session.events[i]));
-      const event = session.events[i];
-      if (event.author === 'user' || !event.author) {
-        continue;
-      }
-
-      if (event.author === rootAgent.name) {
-        return rootAgent;
-      }
-
-      const agent = rootAgent.findSubAgent(event.author!);
-      if (!agent) {
-        logger.warn(
-          `Event from an unknown agent: ${event.author}, event id: ${event.id}`,
-        );
-        continue;
-      }
-      if (this.isRoutableLlmAgent(agent)) {
-        return agent;
-      }
-    }
-    // =========================================================================
-    // Case 3: default to root agent.
-    // =========================================================================
-    return rootAgent;
+    return determineAgentForResumption(
+      session,
+      rootAgent,
+      this.resumabilityConfig,
+    );
   }
 
   /**
    * Whether the agent to run can transfer to any other agent in the agent tree.
    *
-   * An agent is transferable if:
-   *  - It is an instance of `LlmAgent`.
-   *  - All its ancestors are also transferable (i.e., they have
-   *    `disallowTransferToParent` set to false).
-   *
    * @param agentToRun The agent to check for transferability.
    * @returns True if the agent can transfer, False otherwise.
    */
   private isRoutableLlmAgent(agentToRun: BaseAgent): boolean {
-    let agent: BaseAgent | undefined = agentToRun;
-    while (agent) {
-      if (!isLlmAgent(agent)) {
-        return false;
-      }
-      if (agent.disallowTransferToParent) {
-        return false;
-      }
-      agent = agent.parentAgent;
-    }
-    return true;
+    return isRoutableLlmAgent(agentToRun);
   }
   // TODO - b/425992518: Implement runLive and related methods.
+}
+
+/**
+ * Determines the next agent to run to continue the session. This is primarily
+ * used for session resumption across tool and LRO boundaries.
+ */
+export function determineAgentForResumption(
+  session: Session,
+  rootAgent: BaseAgent,
+  resumabilityConfig?: ResumabilityConfig,
+): BaseAgent {
+  // =========================================================================
+  // Case 1: If the last event is a function response and resumability is enabled,
+  // this returns the agent that made the original function call.
+  // =========================================================================
+  const event = findEventByLastFunctionResponseId(session.events);
+  const isResumable = Boolean(resumabilityConfig?.isResumable);
+  if (event && event.author && isResumable) {
+    const resumedAgent = rootAgent.findAgent(event.author);
+    if (resumedAgent) {
+      return resumedAgent;
+    }
+    logger.warn(
+      `Function response from an unknown agent: ${event.author}, event id: ${event.id}`,
+    );
+  }
+
+  // =========================================================================
+  // Case 2: Otherwise, find the last agent that emitted a message and is
+  // transferable across the agent tree.
+  // =========================================================================
+  // simplicity: O(N) backward event scan, upgrade to indexed lookups or map if N > 1000.
+  for (let i = session.events.length - 1; i >= 0; i--) {
+    logger.debug('event:', JSON.stringify(session.events[i]));
+    const event = session.events[i];
+    if (event.author === 'user' || !event.author) {
+      continue;
+    }
+
+    if (event.author === rootAgent.name) {
+      return rootAgent;
+    }
+
+    const agent = rootAgent.findSubAgent(event.author);
+    if (!agent) {
+      logger.warn(
+        `Event from an unknown agent: ${event.author}, event id: ${event.id}`,
+      );
+      continue;
+    }
+    if (isRoutableLlmAgent(agent)) {
+      return agent;
+    }
+  }
+  // =========================================================================
+  // Case 3: default to root agent.
+  // =========================================================================
+  return rootAgent;
+}
+
+/**
+ * Whether the agent to run can transfer to any other agent in the agent tree.
+ *
+ * An agent is transferable if:
+ *  - It is an instance of `LlmAgent`.
+ *  - All its ancestors are also transferable (i.e., they have
+ *    `disallowTransferToParent` set to false).
+ *
+ * @param agentToRun The agent to check for transferability.
+ * @returns True if the agent can transfer, False otherwise.
+ */
+export function isRoutableLlmAgent(agentToRun: BaseAgent): boolean {
+  let agent: BaseAgent | undefined = agentToRun;
+  while (agent) {
+    if (!isLlmAgent(agent)) {
+      return false;
+    }
+    if (agent.disallowTransferToParent) {
+      return false;
+    }
+    agent = agent.parentAgent;
+  }
+  return true;
 }
 
 /**
@@ -565,36 +608,10 @@ export class Runner {
  * containing a function call with a functionCall.id matching the
  * functionResponse.id from the last event in the session.
  */
-// TODO - b/425992518: a hack that used event log as transaction log. Fix.
-function findEventByLastFunctionResponseId(events: Event[]): Event | null {
-  if (!events.length) {
-    return null;
-  }
-
-  const lastEvent = events[events.length - 1];
-  const functionCallId = lastEvent.content?.parts?.find(
-    (part) => part.functionResponse,
-  )?.functionResponse?.id;
-  if (!functionCallId) {
-    return null;
-  }
-
-  // TODO - b/425992518: inefficient search, fix.
-  for (let i = events.length - 2; i >= 0; i--) {
-    const event = events[i];
-    // Looking for the system long running request euc function call.
-    const functionCalls = getFunctionCalls(event);
-    if (!functionCalls) {
-      continue;
-    }
-
-    for (const functionCall of functionCalls) {
-      if (functionCall.id === functionCallId) {
-        return event;
-      }
-    }
-  }
-  return null;
+export function findEventByLastFunctionResponseId(
+  events: Event[],
+): Event | null {
+  return findMatchingFunctionCall(events) ?? null;
 }
 
 function getAllToolsets(agent: BaseAgent): BaseToolset[] {

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -168,7 +168,8 @@ export class Runner {
     this.sessionService = input.sessionService;
     this.memoryService = input.memoryService;
     this.credentialService = input.credentialService;
-    this.resumabilityConfig = input.resumabilityConfig;
+    this.resumabilityConfig =
+      input.app?.resumabilityConfig ?? input.resumabilityConfig;
   }
 
   /**

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -23,6 +23,8 @@ import {FunctionCall} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
+  findEventByFunctionCallId,
+  findMatchingFunctionCall,
   generateClientFunctionCallId,
   getLongRunningFunctionCalls,
   mergeParallelFunctionResponseEvents,
@@ -715,5 +717,90 @@ describe('mergeParallelFunctionResponseEvents', () => {
     const event = createEvent();
     const merged = mergeParallelFunctionResponseEvents([event]);
     expect(merged).toBe(event);
+  });
+});
+
+describe('findEventByFunctionCallId', () => {
+  it('should find event with matching functionCall id', () => {
+    const event1 = createEvent({
+      invocationId: 'inv-1',
+      author: 'agent-1',
+      content: {
+        role: 'model',
+        parts: [{functionCall: {id: 'call-1', name: 'tool1', args: {}}}],
+      },
+    });
+    const event2 = createEvent({
+      invocationId: 'inv-2',
+      author: 'agent-2',
+      content: {
+        role: 'model',
+        parts: [{functionCall: {id: 'call-2', name: 'tool2', args: {}}}],
+      },
+    });
+    expect(findEventByFunctionCallId([event1, event2], 'call-1')).toBe(event1);
+    expect(findEventByFunctionCallId([event1, event2], 'call-2')).toBe(event2);
+  });
+
+  it('should return undefined if no matching functionCall id found or events empty', () => {
+    const event1 = createEvent({
+      invocationId: 'inv-1',
+      author: 'agent-1',
+      content: {
+        role: 'model',
+        parts: [{functionCall: {id: 'call-1', name: 'tool1', args: {}}}],
+      },
+    });
+    expect(findEventByFunctionCallId([event1], 'non-existent')).toBeUndefined();
+    expect(findEventByFunctionCallId([], 'call-1')).toBeUndefined();
+  });
+});
+
+describe('findMatchingFunctionCall', () => {
+  it('should find matching function call for last event function response', () => {
+    const callEvent = createEvent({
+      invocationId: 'inv-1',
+      author: 'sub-agent',
+      content: {
+        role: 'model',
+        parts: [
+          {functionCall: {id: 'lro-id-123', name: 'longRunningOp', args: {}}},
+        ],
+      },
+    });
+    const responseEvent = createEvent({
+      invocationId: 'inv-2',
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'lro-id-123',
+              name: 'longRunningOp',
+              response: {status: 'DONE'},
+            },
+          },
+        ],
+      },
+    });
+    expect(findMatchingFunctionCall([callEvent, responseEvent])).toBe(
+      callEvent,
+    );
+  });
+
+  it('should return undefined if last event is not function response or events empty', () => {
+    const callEvent = createEvent({
+      invocationId: 'inv-1',
+      author: 'sub-agent',
+      content: {
+        role: 'model',
+        parts: [
+          {functionCall: {id: 'lro-id-123', name: 'longRunningOp', args: {}}},
+        ],
+      },
+    });
+    expect(findMatchingFunctionCall([callEvent])).toBeUndefined();
+    expect(findMatchingFunctionCall([])).toBeUndefined();
   });
 });

--- a/core/test/apps/app_test.ts
+++ b/core/test/apps/app_test.ts
@@ -7,6 +7,7 @@
 import {describe, expect, it} from 'vitest';
 import {BaseAgent} from '../../src/agents/base_agent.js';
 import {App, isApp, validateAppName} from '../../src/apps/app.js';
+import {createResumabilityConfig} from '../../src/apps/resumability_config.js';
 import {BasePlugin} from '../../src/plugins/base_plugin.js';
 
 class DummyAgent extends BaseAgent {
@@ -83,5 +84,18 @@ describe('App', () => {
     expect(
       () => new App({name: 'test_app', rootAgent: {name: 'fake'}}),
     ).toThrow(/rootAgent must be a BaseAgent instance/);
+  });
+
+  it('creates an App with resumabilityConfig', () => {
+    const rootAgent = new DummyAgent('root');
+    const resumabilityConfig = createResumabilityConfig({isResumable: true});
+    const app = new App({
+      name: 'resumable_app',
+      rootAgent,
+      resumabilityConfig,
+    });
+
+    expect(app.resumabilityConfig).toBe(resumabilityConfig);
+    expect(app.resumabilityConfig?.isResumable).toBe(true);
   });
 });

--- a/core/test/apps/resumability_config_test.ts
+++ b/core/test/apps/resumability_config_test.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {createResumabilityConfig} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('createResumabilityConfig', () => {
+  it('should default to isResumable = false when no params given', () => {
+    const config = createResumabilityConfig();
+    expect(config.isResumable).toBe(false);
+  });
+
+  it('should override defaults with provided params', () => {
+    const config = createResumabilityConfig({isResumable: true});
+    expect(config.isResumable).toBe(true);
+  });
+});

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  App,
   BaseAgent,
   BasePlugin,
   createEvent,
@@ -336,6 +337,21 @@ describe('Runner.determineAgentForResumption', () => {
     }
 
     expect(events[0].author).toBe('sub_agent2');
+  });
+
+  it('should inherit resumabilityConfig from app when constructed with an App', async () => {
+    const app = new App({
+      name: TEST_APP_ID,
+      rootAgent,
+      resumabilityConfig: createResumabilityConfig({isResumable: true}),
+    });
+    const appRunner = new Runner({
+      app,
+      sessionService,
+      artifactService,
+    });
+
+    expect(appRunner.resumabilityConfig?.isResumable).toBe(true);
   });
 
   it('should skip function response resumption routing when resumabilityConfig.isResumable is false or undefined', async () => {

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -8,10 +8,13 @@ import {
   BaseAgent,
   BasePlugin,
   createEvent,
+  createResumabilityConfig,
+  determineAgentForResumption,
   Event,
   InMemoryArtifactService,
   InMemorySessionService,
   InvocationContext,
+  isRoutableLlmAgent,
   LlmAgent,
   Runner,
 } from '@google/adk';
@@ -149,6 +152,7 @@ describe('Runner.determineAgentForResumption', () => {
       agent: rootAgent,
       sessionService,
       artifactService,
+      resumabilityConfig: createResumabilityConfig({isResumable: true}),
     });
   });
 
@@ -332,6 +336,156 @@ describe('Runner.determineAgentForResumption', () => {
     }
 
     expect(events[0].author).toBe('sub_agent2');
+  });
+
+  it('should skip function response resumption routing when resumabilityConfig.isResumable is false or undefined', async () => {
+    const nonResumableRunner = new Runner({
+      appName: TEST_APP_ID,
+      agent: rootAgent,
+      sessionService,
+      artifactService,
+      resumabilityConfig: createResumabilityConfig({isResumable: false}),
+    });
+
+    const functionCall: FunctionCall = {
+      id: 'func_789',
+      name: 'test_func',
+      args: {},
+    };
+    const functionResponse: FunctionResponse = {
+      id: 'func_789',
+      name: 'test_func',
+      response: {},
+    };
+
+    const callEvent = createEvent({
+      invocationId: 'inv1',
+      author: 'sub_agent2',
+      content: {role: 'model', parts: [{functionCall}]},
+    });
+
+    const rootEvent = createEvent({
+      invocationId: 'inv2',
+      author: 'root_agent',
+      content: {role: 'model', parts: [{text: 'Root response'}]},
+    });
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: 'session_non_resumable',
+    });
+
+    await sessionService.appendEvent({session, event: callEvent});
+    await sessionService.appendEvent({session, event: rootEvent});
+
+    const events: Event[] = [];
+    for await (const event of nonResumableRunner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{functionResponse}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events[0].author).toBe('root_agent');
+  });
+
+  it('should route to sub-agent when resuming from an LRO function response across session boundaries', async () => {
+    const lroCall: FunctionCall = {
+      id: 'lro_vertex_ai_123',
+      name: 'vertex_ai_pipeline_run',
+      args: {model: 'gemini-pro'},
+    };
+    const lroResponse: FunctionResponse = {
+      id: 'lro_vertex_ai_123',
+      name: 'vertex_ai_pipeline_run',
+      response: {status: 'COMPLETED'},
+    };
+
+    const callEvent = createEvent({
+      invocationId: 'inv1',
+      author: 'sub_agent1',
+      content: {role: 'model', parts: [{functionCall: lroCall}]},
+    });
+
+    const responseEvent = createEvent({
+      invocationId: 'inv2',
+      author: 'user',
+      content: {role: 'user', parts: [{functionResponse: lroResponse}]},
+    });
+
+    const events = await runTest([callEvent, responseEvent]);
+    expect(events[0].author).toBe('sub_agent1');
+  });
+
+  it('should fall through to Case 2 when matching function response author is no longer in rootAgent hierarchy', async () => {
+    const functionCall: FunctionCall = {
+      id: 'func_stale_111',
+      name: 'stale_tool',
+      args: {},
+    };
+    const functionResponse: FunctionResponse = {
+      id: 'func_stale_111',
+      name: 'stale_tool',
+      response: {data: 'ok'},
+    };
+
+    const callEvent = createEvent({
+      invocationId: 'inv1',
+      author: 'removed_sub_agent',
+      content: {role: 'model', parts: [{functionCall}]},
+    });
+
+    const subAgent1Event = createEvent({
+      invocationId: 'inv2',
+      author: 'sub_agent1',
+      content: {role: 'model', parts: [{text: 'SubAgent 1 message'}]},
+    });
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: 'session_stale',
+    });
+
+    await sessionService.appendEvent({session, event: callEvent});
+    await sessionService.appendEvent({session, event: subAgent1Event});
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{functionResponse}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events[0].author).toBe('sub_agent1');
+  });
+
+  it('should verify standalone determineAgentForResumption and isRoutableLlmAgent behavior directly', async () => {
+    expect(isRoutableLlmAgent(subAgent1)).toBe(true);
+    expect(isRoutableLlmAgent(nonTransferableAgent)).toBe(false);
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: 'session_standalone',
+    });
+    const subAgent1Event = createEvent({
+      invocationId: 'inv1',
+      author: 'sub_agent1',
+      content: {role: 'model', parts: [{text: 'Hello'}]},
+    });
+    await sessionService.appendEvent({session, event: subAgent1Event});
+
+    const result = determineAgentForResumption(
+      session,
+      rootAgent,
+      createResumabilityConfig({isResumable: true}),
+    );
+    expect(result.name).toBe('sub_agent1');
   });
 });
 

--- a/tests/e2e/routing/lro_resumption_routing_e2e_test.ts
+++ b/tests/e2e/routing/lro_resumption_routing_e2e_test.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  createEvent,
+  createResumabilityConfig,
+  Event,
+  InMemoryRunner,
+  InMemorySessionService,
+  InvocationContext,
+} from '@google/adk';
+import {FunctionCall, FunctionResponse} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+
+/**
+ * Sub-agent simulating a long-running operation initiation and resumption handling.
+ */
+class DataProcessingAgent extends BaseAgent {
+  constructor() {
+    super({
+      name: 'DataProcessingAgent',
+      description:
+        'Agent responsible for long-running batch data processing tasks.',
+    });
+  }
+
+  override async *runAsyncImpl(
+    ctx: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    const lastEvent = ctx.session.events[ctx.session.events.length - 1];
+
+    // Check if we are resumed with a function response matching our LRO
+    const lroResponse = lastEvent?.content?.parts?.find(
+      (p) => p.functionResponse?.name === 'vertex_ai_batch_predict',
+    )?.functionResponse;
+
+    if (lroResponse) {
+      // Resumed after LRO completion!
+      yield createEvent({
+        author: this.name,
+        content: {
+          role: 'model',
+          parts: [
+            {
+              text: `Batch processing completed successfully! Status: ${
+                (lroResponse.response as {status?: string})?.status
+              }`,
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    // Otherwise, initiate the long-running operation tool call
+    const lroCall: FunctionCall = {
+      id: 'lro-call-id-999',
+      name: 'vertex_ai_batch_predict',
+      args: {dataset: 'gs://bucket/data.csv'},
+    };
+
+    yield createEvent({
+      author: this.name,
+      content: {
+        role: 'model',
+        parts: [
+          {text: 'Initiating long-running Vertex AI batch prediction...'},
+          {functionCall: lroCall},
+        ],
+      },
+      longRunningToolIds: ['lro-call-id-999'],
+    });
+  }
+}
+
+/**
+ * Root orchestrator agent that transfers to DataProcessingAgent when requested.
+ */
+class RootOrchestratorAgent extends BaseAgent {
+  constructor(subAgents: BaseAgent[]) {
+    super({
+      name: 'RootOrchestratorAgent',
+      subAgents,
+    });
+  }
+
+  override async *runAsyncImpl(
+    ctx: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    const lastEvent = ctx.session.events[ctx.session.events.length - 1];
+    const text = lastEvent?.content?.parts?.[0]?.text || '';
+
+    if (text.includes('process data')) {
+      const targetAgent = this.findSubAgent('DataProcessingAgent');
+      if (targetAgent) {
+        yield* targetAgent.runAsync(ctx);
+        return;
+      }
+    }
+
+    yield createEvent({
+      author: this.name,
+      content: {
+        role: 'model',
+        parts: [{text: 'Hello from root orchestrator.'}],
+      },
+    });
+  }
+}
+
+describe('E2E LRO Session Resumption Routing', () => {
+  it('should correctly route LRO completion back to the initiating sub-agent across serialized sessions without mocks', async () => {
+    // 1. Setup agents hierarchy and persistent session store
+    const dataProcessingAgent = new DataProcessingAgent();
+    const rootAgent = new RootOrchestratorAgent([dataProcessingAgent]);
+    const sessionService = new InMemorySessionService();
+    const appName = 'lro_resumption_app';
+    const userId = 'user-abc';
+
+    // 2. Initial turn: User requests data processing, root transfers to DataProcessingAgent which emits LRO tool call
+    const initialRunner = new InMemoryRunner({
+      agent: rootAgent,
+      appName,
+      resumabilityConfig: createResumabilityConfig({isResumable: true}),
+    });
+    // Override sessionService on runner to share the persistent session store across turns
+    (
+      initialRunner as unknown as {sessionService: InMemorySessionService}
+    ).sessionService = sessionService;
+
+    const session = await sessionService.createSession({appName, userId});
+
+    const initialEvents: Event[] = [];
+    for await (const ev of initialRunner.runAsync({
+      userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'Please process data now'}]},
+    })) {
+      initialEvents.push(ev);
+    }
+
+    expect(initialEvents.length).toBeGreaterThanOrEqual(1);
+    const lroEvent = initialEvents[initialEvents.length - 1];
+    expect(lroEvent.author).toBe('DataProcessingAgent');
+    expect(lroEvent.longRunningToolIds).toContain('lro-call-id-999');
+
+    // 3. Session is serialized/paused while external LRO runs asynchronously...
+    // Verify stored events in session contain the tool call from DataProcessingAgent
+    const storedSession = await sessionService.getSession({
+      appName,
+      userId,
+      sessionId: session.id,
+    });
+    expect(storedSession?.events.length).toBeGreaterThan(0);
+
+    // 4. LRO completes externally. We invoke a new resumed turn using a freshly instantiated Runner
+    const resumedRunner = new InMemoryRunner({
+      agent: rootAgent,
+      appName,
+      resumabilityConfig: createResumabilityConfig({isResumable: true}),
+    });
+    (
+      resumedRunner as unknown as {sessionService: InMemorySessionService}
+    ).sessionService = sessionService;
+
+    const lroCompletionResponse: FunctionResponse = {
+      id: 'lro-call-id-999',
+      name: 'vertex_ai_batch_predict',
+      response: {status: 'SUCCEEDED'},
+    };
+
+    const resumedEvents: Event[] = [];
+    for await (const ev of resumedRunner.runAsync({
+      userId,
+      sessionId: session.id,
+      newMessage: {
+        role: 'user',
+        parts: [{functionResponse: lroCompletionResponse}],
+      },
+    })) {
+      resumedEvents.push(ev);
+    }
+
+    // 5. Verify routing automatically directed execution back to DataProcessingAgent without hitting root
+    expect(resumedEvents.length).toBeGreaterThanOrEqual(1);
+    const finalEvent = resumedEvents[resumedEvents.length - 1];
+    expect(finalEvent.author).toBe('DataProcessingAgent');
+    expect(finalEvent.content?.parts?.[0]?.text).toContain(
+      'Batch processing completed successfully! Status: SUCCEEDED',
+    );
+  });
+});

--- a/tests/integration/context_compaction/agent_controlled/agent_test.ts
+++ b/tests/integration/context_compaction/agent_controlled/agent_test.ts
@@ -6,11 +6,22 @@
 
 import {InMemoryRunner, isCompactedEvent} from '@google/adk';
 import {createUserContent} from '@google/genai';
-import {describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {GeminiWithMockResponses} from '../../test_case_utils.js';
 import {rootAgent} from './agent.js';
 
 describe('Context Compaction Agent-Controlled', () => {
+  let currentTime = 1000;
+
+  beforeEach(() => {
+    currentTime = 1000;
+    vi.spyOn(Date, 'now').mockImplementation(() => ++currentTime);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should compact session events when agent calls consolidate_context', async () => {
     rootAgent.model = new GeminiWithMockResponses([
       // Turn 1

--- a/tests/integration/test_case_utils.ts
+++ b/tests/integration/test_case_utils.ts
@@ -56,6 +56,13 @@ function toGenerateContentResponse(
   return response;
 }
 
+/**
+ * Helper function to advance time / allow microtasks and clocks to tick in tests.
+ */
+export async function tick(ms = 5): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 class MockModels {
   private responseIndex = 0;
   private readonly responses: GenerateContentResponse[];
@@ -65,12 +72,14 @@ class MockModels {
   }
 
   async generateContent(_req: unknown): Promise<GenerateContentResponse> {
+    await tick();
     return this.getNextResponse();
   }
 
   async generateContentStream(
     _req: unknown,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    await tick();
     const response = this.getNextResponse();
     // Use an IIFE to create the async generator
     return (async function* () {


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

2. Or, if no issue exists, describe the change:

**Problem**: In `adk-js`, when a session resumes after a long-running tool invocation or Long Running Operation (LRO) completion across session boundaries, `determineAgentForResumption` needed cleanup and generalization to properly route execution back to the initiating sub-agent. Furthermore, `adk-js` lacked architectural parity with `adk-python`'s `ResumabilityConfig` guarding, and had brittle assumptions where unresolved agent authors from a function response immediately defaulted to `rootAgent` without falling through to the transferable LLM agent scan.

**Solution**:
- Introduced `ResumabilityConfig` (`core/src/apps/resumability_config.ts`) and integrated it into `RunnerConfig` and `Runner` to align with Python's reference architecture (`runners.py`).
- Extracted and generalized function call resumption matching helpers (`findMatchingFunctionCall` and `findEventByFunctionCallId`) in `core/src/agents/functions.ts`, and standalone resumption utilities (`determineAgentForResumption` and `isRoutableLlmAgent`) in `core/src/runner/runner.ts`.
- Enhanced `determineAgentForResumption` to check `resumabilityConfig.isResumable` when matching past function responses, and cleanly fall through to Case 2 (`isRoutableLlmAgent` scan) with a descriptive warning if the author is no longer found in `rootAgent`.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.
Run the local end-to-end verification test verifying multi-agent LRO resumption routing across serialized session boundaries without mocks:
`npx vitest run tests/e2e/routing/lro_resumption_routing_e2e_test.ts`

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
