### PR TITLE
fix(tools): persist exchanged OpenAPI credentials via the State API

### DIFF
--- a/core/src/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.ts
@@ -28,23 +28,18 @@ class ToolContextCredentialStore {
     authScheme?: OpenAPIV3.SecuritySchemeObject,
   ): AuthCredential | undefined {
     const key = this.getCredentialKey(authScheme);
-    const state = (this.context as unknown as {state: Record<string, unknown>})
-      .state;
-    if (state) {
-      const serialized = state[key];
-      if (serialized) {
-        return serialized as AuthCredential;
-      }
-    }
-    return undefined;
+    // Read through the State API so we see values persisted from previous
+    // tool calls. `context.state` is a `State` instance, not a plain object;
+    // bracket access would bypass its value/delta store and always miss.
+    return this.context.state.get<AuthCredential>(key);
   }
 
   storeCredential(key: string, credential: AuthCredential) {
-    const state = (this.context as unknown as {state: Record<string, unknown>})
-      .state;
-    if (state) {
-      state[key] = credential;
-    }
+    // Use State.set so the credential is recorded in the state delta and
+    // persisted to the session. A plain assignment (`state[key] = ...`) sets
+    // an own property on the State instance that is never committed, so the
+    // exchanged credential would be re-created on every tool invocation.
+    this.context.state.set(key, credential);
   }
 }
 

--- a/core/test/tools/openapi_tool/tool_auth_handler_test.ts
+++ b/core/test/tools/openapi_tool/tool_auth_handler_test.ts
@@ -6,6 +6,7 @@
 
 import {AuthCredentialTypes, Context, ToolAuthHandler} from '@google/adk';
 import {describe, expect, it, vi} from 'vitest';
+import {State} from '../../../src/sessions/state.js';
 
 // Mock AutoAuthCredentialExchanger
 vi.mock(
@@ -38,6 +39,7 @@ describe('ToolAuthHandler', () => {
 
   it('should return done after exchange if credential in context', async () => {
     const mockContext = {
+      state: new State(),
       getAuthResponse: vi.fn().mockReturnValue({
         authType: AuthCredentialTypes.API_KEY,
         apiKey: 'key',
@@ -56,6 +58,7 @@ describe('ToolAuthHandler', () => {
 
   it('should return pending and request credential if not in context', async () => {
     const mockContext = {
+      state: new State(),
       getAuthResponse: vi.fn().mockReturnValue(undefined),
       requestCredential: vi.fn(),
     } as unknown as Context;
@@ -70,12 +73,12 @@ describe('ToolAuthHandler', () => {
 
   it('should return cached credential if available', async () => {
     const mockContext = {
-      state: {
+      state: new State({
         'apiKey_existing_exchanged_credential': {
           authType: AuthCredentialTypes.HTTP,
           http: {scheme: 'bearer', credentials: {token: 'cached-token'}},
         },
-      },
+      }),
     } as unknown as Context;
 
     const handler = new ToolAuthHandler(mockContext, {type: 'apiKey'});
@@ -86,9 +89,10 @@ describe('ToolAuthHandler', () => {
     expect(result.authCredential?.http?.credentials.token).toBe('cached-token');
   });
 
-  it('should store exchanged credential in state', async () => {
+  it('should store exchanged credential in state and record it in the delta', async () => {
+    const state = new State();
     const mockContext = {
-      state: {},
+      state,
       getAuthResponse: vi.fn().mockReturnValue({
         authType: AuthCredentialTypes.API_KEY,
         apiKey: 'key',
@@ -100,10 +104,47 @@ describe('ToolAuthHandler', () => {
     const result = await handler.prepareAuthCredentials();
 
     expect(result.state).toBe('done');
-    expect(
-      (mockContext as unknown as {state: Record<string, unknown>}).state[
-        'apiKey_existing_exchanged_credential'
-      ],
-    ).toBeTruthy();
+    // Stored via the State API so it is readable back through State.get...
+    const stored = state.get<{http?: {credentials: {token: string}}}>(
+      'apiKey_existing_exchanged_credential',
+    );
+    expect(stored?.http?.credentials.token).toBe('exchanged-token');
+    // ...and recorded in the delta so it is persisted to the session (rather
+    // than being re-exchanged on every subsequent tool call).
+    expect(state.hasDelta()).toBe(true);
+  });
+
+  it('re-uses a credential persisted by a previous tool call instead of re-exchanging', async () => {
+    // First invocation: exchange and store the credential.
+    const firstState = new State();
+    const firstContext = {
+      state: firstState,
+      getAuthResponse: vi.fn().mockReturnValue({
+        authType: AuthCredentialTypes.API_KEY,
+        apiKey: 'key',
+      }),
+    } as unknown as Context;
+    await new ToolAuthHandler(firstContext, {
+      type: 'apiKey',
+    }).prepareAuthCredentials();
+
+    // Each tool call gets a fresh Context whose State is rebuilt from the
+    // values persisted to the session. Only what was recorded in the state
+    // delta/value survives this round-trip (a stray own-property would not).
+    const secondState = new State(firstState.toRecord());
+    const secondContext = {
+      state: secondState,
+      getAuthResponse: vi.fn(),
+    } as unknown as Context;
+    const result = await new ToolAuthHandler(secondContext, {
+      type: 'apiKey',
+    }).prepareAuthCredentials();
+
+    expect(result.state).toBe('done');
+    expect(result.authCredential?.http?.credentials.token).toBe(
+      'exchanged-token',
+    );
+    // The cached credential was reused; no second exchange was triggered.
+    expect(secondContext.getAuthResponse).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

`ToolContextCredentialStore` (used by `OPENAPIToolset` tools to cache an exchanged auth credential) cast `context.state` to a plain object and used bracket access:

```ts
const state = (this.context as unknown as {state: Record<string, unknown>}).state;
state[key] = credential;   // store
const serialized = state[key]; // load
```

But `context.state` is a `State` instance that keeps its data in a **private** value/delta store, reachable only via `get()` / `set()`. As a result:

- **`storeCredential`** set an *own property* on the `State` object. It was never recorded in the state delta, so it was never committed to the session.
- **`getCredential`** read that own property, never the value/delta store.

Because a fresh `Context`/`State` is created for every tool call (`functions.ts`), the stored own-property was discarded before the next call. So an `OpenAPIToolset` tool secured with **OAuth2 or a service account re-ran the token exchange on every single invocation**, and the exchanged credential was never persisted — the cache was effectively dead.

This is a mis-port: in adk-python, `tool_context.state[key] = ...` records a delta and persists.

## Fix

Use the `State` API — `context.state.get()` / `context.state.set()` — so the exchanged credential is recorded in the delta, persisted to the session, and read back on subsequent calls.

## Why the tests didn't catch it

The existing tests passed a plain `{state: {}}` object instead of a real `State`, so bracket access "worked" and the tests were green while real usage was broken. This PR updates them to use a real `State`, and adds coverage that:

- the stored credential is recorded in the delta (`State.hasDelta()`), and
- a credential persisted by one tool call is reused by the next — the second call's `State` is rebuilt from `State.toRecord()` (mirroring the per-call `State` reconstruction), and no re-exchange is triggered.

I verified all three credential-cache tests **fail** against the old bracket-access implementation and **pass** with the fix.

## Test plan

- [x] `core/test/tools/openapi_tool/tool_auth_handler_test.ts` updated + extended (6 tests).
- [x] Confirmed the new tests fail without the fix, pass with it.
- [x] Full core unit suite green (`npx vitest run --project unit:core`): 2082 passing.
- [x] `tsc --noEmit`, ESLint, and Prettier all clean.
