### PR TITLE
Fix: enforce session ownership in VertexAiSessionService.deleteSession

### DIFF
--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -333,10 +333,26 @@ export class VertexAiSessionService extends BaseSessionService {
 
   async deleteSession({
     appName,
-    userId: _userId,
+    userId,
     sessionId,
   }: DeleteSessionRequest): Promise<void> {
     const reasoningEngineId = this.getReasoningEngineId(appName);
+
+    // A session may only be deleted by the user it belongs to. getSession
+    // already enforces this and throws when the stored session's userId does
+    // not match, so load the session first and stop if it is missing or not
+    // owned by this user. This keeps deleteSession consistent with getSession
+    // and with InMemorySessionService.deleteSession.
+    const session = await this.getSession({
+      appName,
+      userId,
+      sessionId,
+      config: {numRecentEvents: 0},
+    });
+    if (!session) {
+      return;
+    }
+
     await this.sessions.delete({
       name: `reasoningEngines/${reasoningEngineId}/sessions/${sessionId}`,
     });

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -820,6 +820,62 @@ describe('VertexAiSessionService', () => {
         name: `reasoningEngines/12345/sessions/delete-session`,
       });
     });
+
+    it('does not delete a session that belongs to another user', async () => {
+      mockClient.get.mockResolvedValue({
+        name: 'reasoningEngines/12345/sessions/victim-session',
+        userId: 'victimUser',
+        sessionState: {},
+        updateTime: new Date().toISOString(),
+      });
+      const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+      await expect(
+        service.deleteSession({
+          appName: '12345',
+          userId: 'attackerUser',
+          sessionId: 'victim-session',
+        }),
+      ).rejects.toThrow(
+        'Session victim-session does not belong to user attackerUser',
+      );
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
+      loggerSpy.mockRestore();
+    });
+
+    it("does not delete another user's session when userId is omitted", async () => {
+      mockClient.get.mockResolvedValue({
+        name: 'reasoningEngines/12345/sessions/victim-session',
+        userId: 'victimUser',
+        sessionState: {},
+        updateTime: new Date().toISOString(),
+      });
+      const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+      await expect(
+        service.deleteSession({
+          appName: '12345',
+          userId: undefined as unknown as string,
+          sessionId: 'victim-session',
+        }),
+      ).rejects.toThrow('does not belong to user');
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
+      loggerSpy.mockRestore();
+    });
+
+    it('does not call delete when the session does not exist', async () => {
+      mockClient.get.mockRejectedValue({code: 5});
+
+      await service.deleteSession({
+        appName: '12345',
+        userId: 'testUser',
+        sessionId: 'missing-session',
+      });
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
+    });
   });
 
   describe('appendEvent', () => {


### PR DESCRIPTION
### Link to Issue or Description of Change

**Description of change:**

**Problem:**

`VertexAiSessionService.deleteSession` ignored its `userId` argument. It was destructured as `userId: _userId` and thrown away, and the session was deleted by `sessionId` alone.

That is out of step with the rest of the sessions code. `getSession` refuses to return a session that does not belong to the supplied user and throws `Session <id> does not belong to user <user>`. `InMemorySessionService.deleteSession` loads the session through `getSession` first and returns early if it is not there. The Vertex delete path did neither.

It matters here because on the Vertex AI Agent Engine backend sessions live under a shared reasoning engine and are addressed by `sessionId`, so a delete by `sessionId` alone can cross users. A caller that has another user's `sessionId` could delete that user's session.

**Solution:**

In `core/src/sessions/vertex_ai_session_service.ts`, stop discarding `userId`. Load the session with `getSession` first (with `numRecentEvents: 0`, so it is a single lookup and skips event listing), return early if it is absent, and only then call the backend delete. This reuses the ownership check already in `getSession` instead of adding a second copy of it, so it stays in sync with `getSession` and matches `InMemorySessionService.deleteSession`.

Deleting your own session, or a session that does not exist, behaves as before. Deleting a session that belongs to another user now throws the same `does not belong to user` error `getSession` raises, instead of removing it.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added three cases to the `deleteSession` block in `core/test/sessions/vertex_ai_session_service_test.ts`:

- a session that belongs to another user is not deleted (the call rejects and `sessions.delete` is never invoked)
- omitting `userId` does not delete another user's session
- deleting a non-existent session is a no-op and does not call `sessions.delete`

The existing "deletes an existing session" case still passes, so the owner path is unchanged.

`npx vitest run core/test/sessions/vertex_ai_session_service_test.ts --project unit:core` reports 46 passed. `npm run lint` and `prettier --check` are clean on the two changed files. I also checked that the two ownership tests fail against the current `deleteSession` and pass with this change, so they guard the behavior rather than just asserting it.

**Manual End-to-End (E2E) Tests:**

The change is covered by unit tests against a mocked `Sessions` client. A live end-to-end run needs a GCP project with an Agent Engine reasoning engine, which I did not have set up. The path it exercises is the `sessions.get` ownership check that `getSession` already relies on.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The fix is about ten lines and does not change the delete behavior for a session's owner. It only adds the ownership check that `getSession` and the in-memory service already perform.
