### PR TITLE
fix(tools): treat an empty toolFilter array as no filter in BaseToolset

### DIFF
--- a/core/src/tools/base_toolset.ts
+++ b/core/src/tools/base_toolset.ts
@@ -77,7 +77,11 @@ export abstract class BaseToolset {
    * @return Whether the tool should be exposed to LLM.
    */
   protected isToolSelected(tool: BaseTool, context: ReadonlyContext): boolean {
-    if (!this.toolFilter) {
+    // An empty tool filter means no filtering: all tools are selected.
+    if (
+      !this.toolFilter ||
+      (Array.isArray(this.toolFilter) && this.toolFilter.length === 0)
+    ) {
       return true;
     }
 

--- a/core/test/tools/base_toolset_test.ts
+++ b/core/test/tools/base_toolset_test.ts
@@ -10,6 +10,8 @@ import {
   Context,
   InvocationContext,
   LlmRequest,
+  ReadonlyContext,
+  ToolPredicate,
 } from '@google/adk';
 import {describe, expect, it} from 'vitest';
 
@@ -42,6 +44,44 @@ class DummyToolset extends BaseToolset {
 
   async close(): Promise<void> {}
 }
+
+class FilteringToolset extends BaseToolset {
+  constructor(toolFilter: ToolPredicate | string[]) {
+    super(toolFilter);
+  }
+
+  async getTools(context?: ReadonlyContext): Promise<BaseTool[]> {
+    const rawTools = [new DummyTool('tool1'), new DummyTool('tool2')];
+    if (!context) {
+      return rawTools;
+    }
+    return rawTools.filter((tool) => this.isToolSelected(tool, context));
+  }
+
+  async close(): Promise<void> {}
+}
+
+describe('BaseToolset.isToolSelected', () => {
+  const context = {} as unknown as ReadonlyContext;
+
+  it('selects all tools when the toolFilter is an empty array', async () => {
+    const toolset = new FilteringToolset([]);
+    const tools = await toolset.getTools(context);
+    expect(tools.map((tool) => tool.name)).toEqual(['tool1', 'tool2']);
+  });
+
+  it('selects only the named tools for a non-empty string[] filter', async () => {
+    const toolset = new FilteringToolset(['tool2']);
+    const tools = await toolset.getTools(context);
+    expect(tools.map((tool) => tool.name)).toEqual(['tool2']);
+  });
+
+  it('applies a ToolPredicate filter', async () => {
+    const toolset = new FilteringToolset((tool) => tool.name === 'tool1');
+    const tools = await toolset.getTools(context);
+    expect(tools.map((tool) => tool.name)).toEqual(['tool1']);
+  });
+});
 
 describe('BaseToolset integration with LLM Request', () => {
   it('No prefix means the tool names match original names', async () => {

--- a/core/test/tools/openapi_tool/openapi_toolset_test.ts
+++ b/core/test/tools/openapi_tool/openapi_toolset_test.ts
@@ -125,6 +125,37 @@ describe('OpenAPIToolset', () => {
     ).toEqual({api_key: 'my-key'});
   });
 
+  it('should return all tools when no toolFilter is set and a context is provided', async () => {
+    const toolset = new OpenAPIToolset({specDict: mockSpec});
+    const tools = await toolset.getTools({} as unknown as ReadonlyContext);
+
+    expect(tools.length).toBe(2);
+    expect(tools[0].name).toBe('get_users');
+    expect(tools[1].name).toBe('create_user');
+  });
+
+  it('should apply a string[] toolFilter when a context is provided', async () => {
+    const toolset = new OpenAPIToolset({
+      specDict: mockSpec,
+      toolFilter: ['create_user'],
+    });
+    const tools = await toolset.getTools({} as unknown as ReadonlyContext);
+
+    expect(tools.length).toBe(1);
+    expect(tools[0].name).toBe('create_user');
+  });
+
+  it('should apply a predicate toolFilter when a context is provided', async () => {
+    const toolset = new OpenAPIToolset({
+      specDict: mockSpec,
+      toolFilter: (tool) => tool.name === 'get_users',
+    });
+    const tools = await toolset.getTools({} as unknown as ReadonlyContext);
+
+    expect(tools.length).toBe(1);
+    expect(tools[0].name).toBe('get_users');
+  });
+
   it('should handle context in getTools', async () => {
     const toolset = new OpenAPIToolset({specDict: mockSpec});
     const mockContext = {};


### PR DESCRIPTION
## Summary

An `OpenAPIToolset` constructed without an explicit `toolFilter` silently contributes **zero tools** to the agent.

`BaseToolset` defaults `toolFilter` to `[]`, and `isToolSelected` ports adk-python's

```python
if not self.tool_filter:
    return True
```

— but an empty array is **truthy** in JavaScript, so the empty-filter case falls through to `[].includes(tool.name)`, which is `false` for every tool. Since the framework always passes a `ReadonlyContext` when collecting canonical tools (`tool_filter_request_processor`, `auth_preprocessor`), every `OpenAPIToolset` created without a filter ends up filtering out all of its tools — no error, no warning, the agent just never sees them.

### Repro

```ts
const toolset = new OpenAPIToolset({specDict: spec}); // no toolFilter
const agent = new LlmAgent({model, tools: [toolset], ...});
// agent runs with zero OpenAPI tools
```

`MCPToolset` and `AgentRegistryMcpToolset` already work around this with explicit empty-array guards in their `getTools`; `OpenAPIToolset` relied on `isToolSelected` and was broken.

## Fix

Treat an empty `toolFilter` array as "no filter" in `BaseToolset.isToolSelected` itself, restoring adk-python parity for all current and future subclasses. No public API change.

The bug was masked in tests: the existing `getTools`-with-context test stubbed `isToolSelected = () => true`, so the real filter path was never exercised.

## Tests

- New `BaseToolset.isToolSelected` tests: empty-array filter selects all tools; non-empty `string[]` filter selects only named tools; `ToolPredicate` filter is applied.
- New `OpenAPIToolset.getTools(context)` tests through the **real** filter path (no stubbing): no filter → all tools (regression test, fails without this fix), `string[]` filter, and predicate filter.
- [x] `npx vitest run --project unit:core` — 2087 passed
- [x] `tsc --noEmit -p core/tsconfig.json`
- [x] prettier + eslint on changed files