### PR TITLE
fix(core): format object state and Part artifact values as JSON or te…

### DIFF
--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -35,7 +35,7 @@ async function resolveKey(
       }
       throw new Error(`Artifact ${fileName} not found.`);
     }
-    return String(artifact);
+    return formatValue(artifact, true);
   }
 
   // Step 3: Handle state variable injection.
@@ -44,7 +44,7 @@ async function resolveKey(
   }
 
   if (key in invocationContext.session.state) {
-    return String(invocationContext.session.state[key]);
+    return formatValue(invocationContext.session.state[key], false);
   }
 
   if (isOptional) {
@@ -52,6 +52,38 @@ async function resolveKey(
   }
 
   throw new Error(`Context variable not found: \`${key}\`.`);
+}
+
+/**
+ * Formats a value for injection into an instruction template.
+ * If the value is an object or array, it converts it to a JSON string.
+ */
+function formatValue(value: unknown, isArtifact = false): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'object' && value !== null) {
+    if (
+      isArtifact &&
+      'text' in value &&
+      typeof (value as {text?: unknown}).text === 'string'
+    ) {
+      return (value as {text: string}).text;
+    }
+    try {
+      const json = JSON.stringify(value);
+      if (json !== undefined) {
+        return json;
+      }
+    } catch (e) {
+      throw new Error(
+        `Failed to serialize value for instruction template: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+    }
+  }
+  return String(value);
 }
 
 /**

--- a/core/test/agents/instructions_test.ts
+++ b/core/test/agents/instructions_test.ts
@@ -254,4 +254,54 @@ describe('injectSessionState', () => {
       await injectSessionState('Hello {invalid key?} and {invalid key}!', ctx),
     ).toBe('Hello {invalid key?} and {invalid key}!');
   });
+
+  it('serializes object state values to JSON string', async () => {
+    const ctx = makeContext({fruits: {apple: 'red', banana: 'yellow'}});
+    expect(
+      await injectSessionState(
+        'Please tell me all of the keys in `{fruits}`.',
+        ctx,
+      ),
+    ).toBe(
+      'Please tell me all of the keys in `{"apple":"red","banana":"yellow"}`.',
+    );
+  });
+
+  it('serializes array state values to JSON string', async () => {
+    const ctx = makeContext({list: ['apple', 'banana']});
+    expect(await injectSessionState('Fruits: {list}', ctx)).toBe(
+      'Fruits: ["apple","banana"]',
+    );
+  });
+
+  it('throws an error if object state value cannot be serialized', async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const ctx = makeContext({circular});
+    await expect(injectSessionState('Data: {circular}', ctx)).rejects.toThrow(
+      /Failed to serialize value for instruction template: Converting circular structure to JSON/,
+    );
+  });
+
+  it('extracts text property when artifact resolves to a Part object', async () => {
+    const mockArtifactService = {
+      loadArtifact: vi.fn().mockResolvedValue({text: 'report text content'}),
+    };
+    const ctx = makeContext({}, mockArtifactService);
+    expect(await injectSessionState('Data: {artifact.report.txt}', ctx)).toBe(
+      'Data: report text content',
+    );
+  });
+
+  it('serializes non-text Part artifact object to JSON string', async () => {
+    const mockArtifactService = {
+      loadArtifact: vi.fn().mockResolvedValue({
+        inlineData: {mimeType: 'text/plain', data: 'abc'},
+      }),
+    };
+    const ctx = makeContext({}, mockArtifactService);
+    expect(await injectSessionState('Data: {artifact.data.bin}', ctx)).toBe(
+      'Data: {"inlineData":{"mimeType":"text/plain","data":"abc"}}',
+    );
+  });
 });


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #494

**Problem:**
When an instruction template contains placeholders referencing state variables (`{variable_name}`) that store plain objects or arrays (e.g., `{fruits}` with value `{"apple": "red", "banana": "yellow"}`), the template renderer used standard JavaScript string coercion (`String(value)`). This resulted in sending `[object Object]` to the LLM instead of the actual object contents. Similarly, when resolving GenAI `Part` artifacts (`{artifact.filename}`), non-string values were coerced to `[object Object]` rather than extracting `.text` or serializing the payload.

**Solution:**
- Added a `formatValue(value: unknown, isArtifact?: boolean)` helper in [`core/src/agents/instructions.ts`](file:///Users/kalenkevich/projects/adk-js/core/src/agents/instructions.ts).
- For state variables (`{key}`), plain objects and arrays (`typeof value === 'object' && value !== null`) are now cleanly serialized using `JSON.stringify(value)` instead of falling back to `String()`.
- If an object cannot be serialized (e.g., circular references), a descriptive `Error` (`Failed to serialize value for instruction template: ...`) is raised immediately rather than silently rendering invalid instruction text.
- For artifacts (`{artifact.filename}`), when the artifact resolves to a GenAI `Part` object containing a `.text` string property, `artifact.text` is extracted directly; non-text parts are cleanly JSON serialized.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added new test cases to [`core/test/agents/instructions_test.ts`](file:///Users/kalenkevich/projects/adk-js/core/test/agents/instructions_test.ts) covering:
- Object state serialization (`{apple: 'red', banana: 'yellow'}` $\rightarrow$ `'{"apple":"red","banana":"yellow"}'`).
- Array state serialization (`['apple', 'banana']` $\rightarrow$ `'["apple","banana"]'`).
- Exception raising when serializing state objects with circular structures.
- Extracting `.text` when an artifact resolves to a GenAI `Part` object.
- JSON serialization of non-text (`inlineData`) `Part` artifact objects.

**Test Results Summary (`npm run test:unit`):**
```text
 RUN  v3.2.6 /Users/kalenkevich/projects/adk-js

 ✓ |unit:core| core/test/agents/instructions_test.ts (31 tests) 56ms

 Test Files  170 passed (170)
      Tests  2318 passed (2318)
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Achieves instruction template parity with the Python ADK SDK (`dict` representation directly usable in instructions templates).
