### PR TITLE
fix: gracefully handle missing function calls during context compaction

### DIFF
--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -400,11 +400,11 @@ function rearrangeEventsForLatestFunctionResponse(events: Event[]): Event[] {
   }
 
   if (!match) {
-    throw new Error(
-      `No function call event found for function responses ids: ${Array.from(
-        functionResponsesIds,
-      ).join(', ')}`,
-    );
+    // If the function call event cannot be found (e.g. due to context compaction
+    // rewriting the history before we parse it), we cannot safely include the
+    // function response event since the LLM inherently requires the call before
+    // the response. Drop the response event from the current request payload.
+    return events.slice(0, events.length - 1);
   }
 
   // Collect all function response events between the function call event

--- a/core/test/agents/processors/content_processor_utils_test.ts
+++ b/core/test/agents/processors/content_processor_utils_test.ts
@@ -275,10 +275,11 @@ describe('getContents', () => {
         ],
       },
     });
-
-    expect(() => getContents([e0, e1, e2], 'my_agent')).toThrowError(
-      'No function call event found for function responses ids: id2',
-    );
+    const result = getContents([e0, e1, e2], 'my_agent');
+    expect(result).toHaveLength(2);
+    // Should drop the last orphaned response event
+    expect(result[0].role).toBe('user');
+    expect(result[1].role).toBe('model');
   });
 
   it('should throw subset error when response is for an id from a call event, but contains other unexpected ids', () => {


### PR DESCRIPTION
This fixes an integration test regression introduced in PR #430 where a newly tightened safety check around `functionResponse` matching causes a crash if context compaction executes and strips away the parent `functionCall` from the history. By returning `events.slice(0, -1)`, we gracefully ignore the orphaned response instead of throwing a fatal error.