### PR TITLE
Revert "fix: gracefully handle missing function calls during context compaction (#496)"

### DIFF
--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -400,11 +400,11 @@ function rearrangeEventsForLatestFunctionResponse(events: Event[]): Event[] {
   }
 
   if (!match) {
-    // If the function call event cannot be found (e.g. due to context compaction
-    // rewriting the history before we parse it), we cannot safely include the
-    // function response event since the LLM inherently requires the call before
-    // the response. Drop the response event from the current request payload.
-    return events.slice(0, events.length - 1);
+    throw new Error(
+      `No function call event found for function responses ids: ${Array.from(
+        functionResponsesIds,
+      ).join(', ')}`,
+    );
   }
 
   // Collect all function response events between the function call event

--- a/core/test/agents/processors/content_processor_utils_test.ts
+++ b/core/test/agents/processors/content_processor_utils_test.ts
@@ -275,11 +275,10 @@ describe('getContents', () => {
         ],
       },
     });
-    const result = getContents([e0, e1, e2], 'my_agent');
-    expect(result).toHaveLength(2);
-    // Should drop the last orphaned response event
-    expect(result[0].role).toBe('user');
-    expect(result[1].role).toBe('model');
+
+    expect(() => getContents([e0, e1, e2], 'my_agent')).toThrowError(
+      'No function call event found for function responses ids: id2',
+    );
   });
 
   it('should throw subset error when response is for an id from a call event, but contains other unexpected ids', () => {


### PR DESCRIPTION
Reverts google/adk-js#496. We should fix compaction upstream, rather than silently dropping orphaned responses.