### PR TITLE
fix(sessions/vertexai): quote userId in AIP-160 list filter

### DIFF
--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -48,6 +48,18 @@ export function isVertexAiConnectionString(uri?: string): boolean {
   return uri?.startsWith('vertexai://') || false;
 }
 
+/**
+ * Quotes a value for safe use as a Google AIP-160 filter string literal.
+ *
+ * Backslashes are escaped first, then double quotes, so that caller-controlled
+ * input stays inside the quoted value and cannot break out to inject additional
+ * filter predicates. See https://google.aip.dev/160.
+ */
+export function quoteFilterLiteral(value: string): string {
+  const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
 export interface VertexAiSessionServiceOptions {
   projectId?: string;
   location?: string;
@@ -260,7 +272,7 @@ export class VertexAiSessionService extends BaseSessionService {
       const response = await this.sessions.listInternal({
         name: `reasoningEngines/${reasoningEngineId}`,
         config: {
-          ...(userId ? {filter: `user_id="${userId}"`} : {}),
+          ...(userId ? {filter: `user_id=${quoteFilterLiteral(userId)}`} : {}),
           ...(pageToken ? {pageToken} : {}),
         },
       });

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -516,6 +516,23 @@ describe('VertexAiSessionService', () => {
       expect(response.sessions[1].id).toBe('malformed_name');
     });
 
+    it('escapes double quotes in userId to prevent AIP-160 filter injection', async () => {
+      // A double quote in userId must not break out of the quoted filter
+      // literal and append an `OR user_id!=""` predicate that would return
+      // every user's sessions (cross-user session enumeration).
+      mockClient.listInternal.mockResolvedValue({sessions: []});
+
+      await service.listSessions({
+        appName: '12345',
+        userId: 'attacker" OR user_id!="',
+      });
+
+      expect(mockClient.listInternal).toHaveBeenCalledWith({
+        name: 'reasoningEngines/12345',
+        config: {filter: 'user_id="attacker\\" OR user_id!=\\""'},
+      });
+    });
+
     it('lists sessions without filter if userId is missing', async () => {
       await service.listSessions({
         appName: '12345',

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -20,7 +20,10 @@ vi.mock('nodejs-vertexai', () => ({
   },
 }));
 
-import {isVertexAiConnectionString} from '@google/adk/sessions/vertex_ai_session_service.js';
+import {
+  isVertexAiConnectionString,
+  quoteFilterLiteral,
+} from '@google/adk/sessions/vertex_ai_session_service.js';
 import {logger} from '@google/adk/utils/logger.js';
 
 describe('isVertexAiConnectionString', () => {
@@ -33,6 +36,28 @@ describe('isVertexAiConnectionString', () => {
     expect(isVertexAiConnectionString('memory:/')).toBe(false);
     expect(isVertexAiConnectionString('')).toBe(false);
     expect(isVertexAiConnectionString(undefined)).toBe(false);
+  });
+});
+
+describe('quoteFilterLiteral', () => {
+  it('quotes a plain value', () => {
+    expect(quoteFilterLiteral('alice')).toBe('"alice"');
+  });
+
+  it('neutralizes quote injection', () => {
+    // Must not break out of the literal and append an OR predicate that would
+    // return every user's sessions.
+    expect(quoteFilterLiteral('attacker" OR user_id!="')).toBe(
+      '"attacker\\" OR user_id!=\\""',
+    );
+  });
+
+  it('escapes a lone backslash', () => {
+    expect(quoteFilterLiteral('\\')).toBe('"\\\\"');
+  });
+
+  it('quotes an empty string', () => {
+    expect(quoteFilterLiteral('')).toBe('""');
   });
 });
 


### PR DESCRIPTION
## Link to Issue or Description of Change

**Problem**

`VertexAiSessionService.listSessions` in `core/src/sessions/vertex_ai_session_service.ts` builds the Vertex AI Agent Engine list filter by interpolating the raw `userId` directly into a quoted [AIP-160](https://google.aip.dev/160) string literal:

```ts
...(userId ? {filter: `user_id="${userId}"`} : {}),
```

A double-quote character in `userId` breaks out of the quoted value and lets a caller append arbitrary AIP-160 predicates. For example a `userId` of `attacker" OR user_id!="` produces the filter:

```
user_id="attacker" OR user_id!=""
```

Since `user_id!=""` matches every session with a non-empty user id, this returns sessions belonging to **all** users of the same Agent Engine deployment (cross-user session enumeration). Each returned session exposes its id, user id, update time, and state.

This is reachable from the dev API server: the route `GET /apps/:appName/users/:userId/sessions` (`dev/src/server/adk_api_server.ts`) reads `req.params.userId` and passes it straight to `sessionService.listSessions({appName, userId})`, so the attacker only needs to URL-encode `"` in the path.

This is the JS/TS counterpart of an issue previously reported and fixed in adk-python — see google/adk-python#5270 / PR google/adk-python#5273 (merged as `bdece00`), where the same unescaped-`user_id` interpolation was fixed with a filter-literal quoting helper. I noticed the same pattern here while reviewing the sibling port and am proposing the equivalent fix.

**Solution**

Add a small `quoteFilterLiteral` helper that escapes backslashes first, then double-quotes, so the whole value stays inside the AIP-160 string literal regardless of what is passed in, and use it when building the filter:

```ts
...(userId ? {filter: `user_id=${quoteFilterLiteral(userId)}`} : {}),
```

## Testing Plan

**Unit tests**

Added a regression test to the existing `listSessions` suite in `core/test/sessions/vertex_ai_session_service_test.ts` that passes a quote-injection `userId` and asserts the exact (escaped) filter forwarded to the client:

```ts
userId: 'attacker" OR user_id!="'
// asserts: config: {filter: 'user_id="attacker\\" OR user_id!=\\""'}
```

The pre-existing `listSessions` test (`userId: 'testUser'` -> `filter: 'user_id="testUser"'`) continues to hold, since the helper is a no-op for values without metacharacters.

**Manual validation (filter-string transformation)**

- On `main`, a `userId` of `attacker" OR user_id!="` produces the filter `user_id="attacker" OR user_id!=""` — the injected `OR user_id!=""` predicate is live and returns every user's sessions.
- With this change, the same input produces `user_id="attacker\" OR user_id!=\""` — the metacharacters stay inside the quoted literal and the filter matches only the literal (non-existent) user.

## Additional context

Small, focused fix that keeps the current filter-construction approach but ensures `userId` remains data instead of altering the filter expression. Mirrors the escaping order used in the merged adk-python fix (backslashes first, then double quotes).
