### PR TITLE
Feat: Port LoopAgent live streaming support (runLiveImpl) to TypeScript

### DIFF
--- a/core/src/agents/loop_agent.ts
+++ b/core/src/agents/loop_agent.ts
@@ -94,11 +94,8 @@ export class LoopAgent extends BaseAgent {
   protected async *runLiveImpl(
     context: InvocationContext,
   ): AsyncGenerator<Event, void, void> {
-    let iteration = 0;
-
-    while (iteration < this.maxIterations) {
+    for (let iteration = 0; iteration < this.maxIterations; iteration++) {
       for (const subAgent of this.subAgents) {
-        let shouldExit = false;
         for await (const event of subAgent.runLive(context)) {
           if (context.abortSignal?.aborted) {
             return;
@@ -107,19 +104,10 @@ export class LoopAgent extends BaseAgent {
           yield event;
 
           if (event.actions?.escalate) {
-            shouldExit = true;
-            break;
+            return;
           }
         }
-
-        if (shouldExit) {
-          return;
-        }
       }
-
-      iteration++;
     }
-
-    return;
   }
 }

--- a/core/src/agents/loop_agent.ts
+++ b/core/src/agents/loop_agent.ts
@@ -91,10 +91,35 @@ export class LoopAgent extends BaseAgent {
     return;
   }
 
-  // eslint-disable-next-line require-yield
   protected async *runLiveImpl(
-    _context: InvocationContext,
+    context: InvocationContext,
   ): AsyncGenerator<Event, void, void> {
-    throw new Error('This is not supported yet for LoopAgent.');
+    let iteration = 0;
+
+    while (iteration < this.maxIterations) {
+      for (const subAgent of this.subAgents) {
+        let shouldExit = false;
+        for await (const event of subAgent.runLive(context)) {
+          if (context.abortSignal?.aborted) {
+            return;
+          }
+
+          yield event;
+
+          if (event.actions?.escalate) {
+            shouldExit = true;
+            break;
+          }
+        }
+
+        if (shouldExit) {
+          return;
+        }
+      }
+
+      iteration++;
+    }
+
+    return;
   }
 }

--- a/core/test/agents/loop_agent_test.ts
+++ b/core/test/agents/loop_agent_test.ts
@@ -42,9 +42,18 @@ class MockSubAgent extends BaseAgent {
   }
 
   protected async *runLiveImpl(
-    _context: InvocationContext,
+    context: InvocationContext,
   ): AsyncGenerator<Event, void, void> {
-    // Not needed for this test
+    for (const event of this.eventsToYield) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Ensure the event has the correct invocationId and branch from context
+      yield {
+        ...event,
+        invocationId: context.invocationId,
+        branch: context.branch,
+      };
+    }
   }
 }
 
@@ -215,6 +224,173 @@ describe('LoopAgent', () => {
 
     const yieldedEvents: Event[] = [];
     for await (const event of loopAgent.runAsync(parentContext)) {
+      yieldedEvents.push(event);
+    }
+
+    expect(yieldedEvents.length).toBe(0);
+  });
+
+  it('should loop through sub-agents and yield events in live mode', async () => {
+    const event1 = createEvent({
+      author: 'sub1',
+      content: {role: 'model', parts: [{text: 'hello'}]},
+    });
+    const event2 = createEvent({
+      author: 'sub2',
+      content: {role: 'model', parts: [{text: 'world'}]},
+    });
+
+    const sub1 = new MockSubAgent({name: 'sub1'}, [event1]);
+    const sub2 = new MockSubAgent({name: 'sub2'}, [event2]);
+
+    const loopAgent = new LoopAgent({
+      name: 'loop',
+      subAgents: [sub1, sub2],
+      maxIterations: 1,
+    });
+
+    const parentContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: loopAgent,
+      session: {
+        id: 'test-session',
+        appName: 'test-app',
+        userId: 'test-user',
+        state: {},
+        events: [],
+        lastUpdateTime: Date.now(),
+      } as unknown as Session,
+      pluginManager: new PluginManager(),
+    });
+
+    const yieldedEvents: Event[] = [];
+    for await (const event of loopAgent.runLive(parentContext)) {
+      yieldedEvents.push(event);
+    }
+
+    expect(yieldedEvents.length).toBe(2);
+    expect(yieldedEvents[0].author).toBe('sub1');
+    expect(yieldedEvents[1].author).toBe('sub2');
+  });
+
+  it('should stop after maxIterations in live mode', async () => {
+    const event = createEvent({
+      author: 'sub',
+      content: {role: 'model', parts: [{text: 'hello'}]},
+    });
+
+    const sub = new MockSubAgent({name: 'sub'}, [event]);
+
+    const loopAgent = new LoopAgent({
+      name: 'loop',
+      subAgents: [sub],
+      maxIterations: 2,
+    });
+
+    const parentContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: loopAgent,
+      session: {
+        id: 'test-session',
+        appName: 'test-app',
+        userId: 'test-user',
+        state: {},
+        events: [],
+        lastUpdateTime: Date.now(),
+      } as unknown as Session,
+      pluginManager: new PluginManager(),
+    });
+
+    const yieldedEvents: Event[] = [];
+    for await (const event of loopAgent.runLive(parentContext)) {
+      yieldedEvents.push(event);
+    }
+
+    expect(yieldedEvents.length).toBe(2);
+  });
+
+  it('should stop on escalation in live mode', async () => {
+    const event1 = createEvent({
+      author: 'sub1',
+      content: {role: 'model', parts: [{text: 'hello'}]},
+    });
+    const event2 = createEvent({
+      author: 'sub2',
+      content: {role: 'model', parts: [{text: 'world'}]},
+      actions: createEventActions({escalate: true}),
+    });
+    const event3 = createEvent({
+      author: 'sub1',
+      content: {role: 'model', parts: [{text: 'should not reach'}]},
+    });
+
+    const sub1 = new MockSubAgent({name: 'sub1'}, [event1, event3]);
+    const sub2 = new MockSubAgent({name: 'sub2'}, [event2]);
+
+    const loopAgent = new LoopAgent({
+      name: 'loop',
+      subAgents: [sub1, sub2],
+      maxIterations: 5,
+    });
+
+    const parentContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: loopAgent,
+      session: {
+        id: 'test-session',
+        appName: 'test-app',
+        userId: 'test-user',
+        state: {},
+        events: [],
+        lastUpdateTime: Date.now(),
+      } as unknown as Session,
+      pluginManager: new PluginManager(),
+    });
+
+    const yieldedEvents: Event[] = [];
+    for await (const event of loopAgent.runLive(parentContext)) {
+      yieldedEvents.push(event);
+    }
+
+    expect(yieldedEvents.length).toBe(3);
+    expect(yieldedEvents[2].actions?.escalate).toBe(true);
+  });
+
+  it('should stop on abort signal in live mode', async () => {
+    const event = createEvent({
+      author: 'sub',
+      content: {role: 'model', parts: [{text: 'hello'}]},
+    });
+
+    const sub = new MockSubAgent({name: 'sub'}, [event]);
+
+    const loopAgent = new LoopAgent({
+      name: 'loop',
+      subAgents: [sub],
+      maxIterations: 5,
+    });
+
+    const controller = new AbortController();
+
+    const parentContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: loopAgent,
+      session: {
+        id: 'test-session',
+        appName: 'test-app',
+        userId: 'test-user',
+        state: {},
+        events: [],
+        lastUpdateTime: Date.now(),
+      } as unknown as Session,
+      pluginManager: new PluginManager(),
+      abortSignal: controller.signal,
+    });
+
+    controller.abort();
+
+    const yieldedEvents: Event[] = [];
+    for await (const event of loopAgent.runLive(parentContext)) {
       yieldedEvents.push(event);
     }
 

--- a/core/test/agents/loop_agent_test.ts
+++ b/core/test/agents/loop_agent_test.ts
@@ -44,16 +44,7 @@ class MockSubAgent extends BaseAgent {
   protected async *runLiveImpl(
     context: InvocationContext,
   ): AsyncGenerator<Event, void, void> {
-    for (const event of this.eventsToYield) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Ensure the event has the correct invocationId and branch from context
-      yield {
-        ...event,
-        invocationId: context.invocationId,
-        branch: context.branch,
-      };
-    }
+    yield* this.runAsyncImpl(context);
   }
 }
 

--- a/tests/e2e/loop_agent_run_live_e2e_test.ts
+++ b/tests/e2e/loop_agent_run_live_e2e_test.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseAgentConfig,
+  Context,
+  createEvent,
+  createEventActions,
+  Event,
+  EXIT_LOOP,
+  InvocationContext,
+  LoopAgent,
+  PluginManager,
+  Session,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+class GeneratorLiveAgent extends BaseAgent {
+  private iterationCount = 0;
+
+  constructor(config: BaseAgentConfig) {
+    super(config);
+  }
+
+  protected async *runAsyncImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    // Not used in live test
+  }
+
+  protected async *runLiveImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    this.iterationCount++;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    yield createEvent({
+      author: this.name,
+      invocationId: context.invocationId,
+      branch: context.branch,
+      content: {
+        role: 'model',
+        parts: [{text: `Live generation attempt ${this.iterationCount}`}],
+      },
+    });
+  }
+}
+
+class EvaluatorLiveAgent extends BaseAgent {
+  private evaluationThreshold: number;
+  private attemptCount = 0;
+
+  constructor(config: BaseAgentConfig & {threshold: number}) {
+    super(config);
+    this.evaluationThreshold = config.threshold;
+  }
+
+  protected async *runAsyncImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    // Not used in live test
+  }
+
+  protected async *runLiveImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    this.attemptCount++;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    if (this.attemptCount >= this.evaluationThreshold) {
+      const actions = createEventActions();
+      const toolContext = new Context({
+        invocationContext: context,
+        eventActions: actions,
+      });
+      await EXIT_LOOP.runAsync({
+        args: {},
+        toolContext,
+      });
+
+      yield createEvent({
+        author: this.name,
+        invocationId: context.invocationId,
+        branch: context.branch,
+        content: {
+          role: 'model',
+          parts: [
+            {text: 'Evaluation passed. Exiting loop via EXIT_LOOP tool.'},
+          ],
+        },
+        actions,
+      });
+    } else {
+      yield createEvent({
+        author: this.name,
+        invocationId: context.invocationId,
+        branch: context.branch,
+        content: {
+          role: 'model',
+          parts: [{text: 'Evaluation not satisfactory, requesting retry.'}],
+        },
+      });
+    }
+  }
+}
+
+describe('E2E LoopAgent Live Streaming Execution', () => {
+  it('should stream live events through generator and evaluator sub-agents until EXIT_LOOP terminates execution', async () => {
+    const generatorAgent = new GeneratorLiveAgent({name: 'live_generator'});
+    const evaluatorAgent = new EvaluatorLiveAgent({
+      name: 'live_evaluator',
+      threshold: 3, // Escalate on 3rd iteration via EXIT_LOOP
+    });
+
+    const loopAgent = new LoopAgent({
+      name: 'live_refinement_loop',
+      subAgents: [generatorAgent, evaluatorAgent],
+      maxIterations: 10,
+    });
+
+    const session = {
+      id: 'e2e-live-session',
+      appName: 'e2e-test-app',
+      userId: 'e2e-user',
+      state: {},
+      events: [],
+      lastUpdateTime: Date.now(),
+    } as unknown as Session;
+
+    const context = new InvocationContext({
+      invocationId: 'e2e-live-invocation',
+      agent: loopAgent,
+      session,
+      pluginManager: new PluginManager(),
+    });
+
+    const yieldedEvents: Event[] = [];
+    for await (const event of loopAgent.runLive(context)) {
+      yieldedEvents.push(event);
+    }
+
+    expect(yieldedEvents.length).toBe(6);
+
+    expect(yieldedEvents[0].author).toBe('live_generator');
+    expect(yieldedEvents[1].author).toBe('live_evaluator');
+    expect(yieldedEvents[2].author).toBe('live_generator');
+    expect(yieldedEvents[3].author).toBe('live_evaluator');
+    expect(yieldedEvents[4].author).toBe('live_generator');
+    expect(yieldedEvents[5].author).toBe('live_evaluator');
+
+    expect(yieldedEvents[4].content?.parts?.[0]?.text).toContain(
+      'Live generation attempt 3',
+    );
+    expect(yieldedEvents[5].content?.parts?.[0]?.text).toContain(
+      'Evaluation passed. Exiting loop via EXIT_LOOP tool.',
+    );
+    expect(yieldedEvents[5].actions?.escalate).toBe(true);
+    expect(yieldedEvents[5].actions?.skipSummarization).toBe(true);
+  });
+});

--- a/tests/e2e/loop_agent_run_live_e2e_test.ts
+++ b/tests/e2e/loop_agent_run_live_e2e_test.ts
@@ -22,10 +22,6 @@ import {describe, expect, it} from 'vitest';
 class GeneratorLiveAgent extends BaseAgent {
   private iterationCount = 0;
 
-  constructor(config: BaseAgentConfig) {
-    super(config);
-  }
-
   protected async *runAsyncImpl(
     _context: InvocationContext,
   ): AsyncGenerator<Event, void, void> {


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: #N/A
Related: #N/A

2. Or, if no issue exists, describe the change:

**Problem**: Invoking `runLive()` on a `LoopAgent` instance in TypeScript (`adk-js`) currently throws an unconditional runtime error (`This is not supported yet for LoopAgent.`).

**Solution**: Port `runLiveImpl` for `LoopAgent` to TypeScript (`core/src/agents/loop_agent.ts`), matching the Python reference implementation architecture. Iterates over sub-agents across `maxIterations` in live streaming mode, checking `context.abortSignal?.aborted` and `event.actions?.escalate` after each yielded event.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Run the standalone end-to-end verification test verifying multi-agent `LoopAgent` live streaming iterations:
`npx vitest run tests/e2e/loop_agent_run_live_e2e_test.ts`
This verifies that running generator and evaluator sub-agents in live streaming mode streams events across iterations and exits cleanly when `escalate` or `abortSignal` is triggered.

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.