### PR TITLE
Feat: Validate tool callback response types and prevent state event pollution

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -364,8 +364,8 @@ export async function handleFunctionCallList({
       }
     }
 
-    // An override from step 1 or 2 skips the tool, so normalize it here rather
-    // than only at event construction: the after-tool callbacks observe it too.
+    // An override from step 1 or 2 bypasses the tool call and is handed to the
+    // after-tool callbacks as-is, so normalize it before they see it.
     functionResponse = normalizeCallbackResponse(functionResponse);
 
     // Step 3: Otherwise, proceed calling the tool normally.

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -365,9 +365,7 @@ export async function handleFunctionCallList({
       }
     }
 
-    if (functionResponse != null) {
-      functionResponse = normalizeCallbackResponse(functionResponse);
-    }
+    functionResponse = normalizeCallbackResponse(functionResponse);
 
     // Step 3: Otherwise, proceed calling the tool normally.
     if (functionResponse == null) {

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -365,6 +365,8 @@ export async function handleFunctionCallList({
       }
     }
 
+    // An override from step 1 or 2 skips the tool, so normalize it here rather
+    // than only at event construction: the after-tool callbacks observe it too.
     functionResponse = normalizeCallbackResponse(functionResponse);
 
     // Step 3: Otherwise, proceed calling the tool normally.

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -45,6 +45,7 @@ export const functionsExportedForTestingOnly = {
   handleFunctionCallList,
   generateAuthEvent,
   generateRequestConfirmationEvent,
+  normalizeCallbackResponse,
 };
 // TODO - b/425992518: consider internalize as part of llm_agent's runtime.
 /**
@@ -274,6 +275,24 @@ export async function handleFunctionCallsAsync({
 }
 
 /**
+ * Normalizes callback and tool responses into a Record<string, unknown> or undefined.
+ */
+function normalizeCallbackResponse(
+  response: unknown,
+): Record<string, unknown> | undefined {
+  if (response == null) {
+    return undefined;
+  }
+  if (typeof response !== 'object') {
+    return {result: response};
+  }
+  if (Array.isArray(response)) {
+    return {results: response};
+  }
+  return response as Record<string, unknown>;
+}
+
+/**
  * The underlying implementation of handleFunctionCalls, but takes a list of
  * function calls instead of an event.
  * This is also used by llm_agent execution flow in preprocessing.
@@ -332,7 +351,6 @@ export async function handleFunctionCallList({
 
     // Step 2: If no overrides are provided from the plugins, further run the
     // canonical callback.
-    // TODO - b/425992518: validate the callback response type matches.
     if (functionResponse == null) {
       // Cover both null and undefined
       for (const callback of beforeToolCallbacks) {
@@ -345,6 +363,10 @@ export async function handleFunctionCallList({
           break;
         }
       }
+    }
+
+    if (functionResponse != null) {
+      functionResponse = normalizeCallbackResponse(functionResponse);
     }
 
     // Step 3: Otherwise, proceed calling the tool normally.
@@ -364,8 +386,8 @@ export async function handleFunctionCallList({
 
           // Set function response to the result of the error callback and
           // continue execution, do not shortcut
-          if (onToolErrorResponse) {
-            functionResponse = onToolErrorResponse;
+          if (onToolErrorResponse != null) {
+            functionResponse = normalizeCallbackResponse(onToolErrorResponse);
           } else {
             // If the error callback returns undefined, use the error message
             // as the function response error.
@@ -409,24 +431,20 @@ export async function handleFunctionCallList({
     // Step 6: If alternative response exists from after_tool_callback, use it
     // instead of the original function response.
     if (alteredFunctionResponse != null) {
-      functionResponse = alteredFunctionResponse;
+      functionResponse = normalizeCallbackResponse(alteredFunctionResponse);
     }
 
-    // TODO - b/425992518: state event polluting runtime, consider fix.
     // Allow long running function to return None as response.
-    if (tool.isLongRunning && !functionResponse) {
+    if (tool.isLongRunning && functionResponse == null) {
       continue;
     }
 
     if (functionResponseError) {
       functionResponse = {error: functionResponseError};
-    } else if (
-      typeof functionResponse !== 'object' ||
-      functionResponse == null
-    ) {
+    } else if (functionResponse == null) {
       functionResponse = {result: functionResponse};
-    } else if (Array.isArray(functionResponse)) {
-      functionResponse = {results: functionResponse};
+    } else {
+      functionResponse = normalizeCallbackResponse(functionResponse);
     }
 
     // Builds the function response event.

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -434,6 +434,10 @@ export async function handleFunctionCallList({
     }
 
     // Allow long running function to return None as response.
+    // Only a nullish response defers the event. A falsy-but-present response
+    // ('', 0, false) is a real result and still emits one, so long-running
+    // tools that return such a value now produce a response event where they
+    // previously produced none.
     if (tool.isLongRunning && functionResponse == null) {
       continue;
     }

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -45,7 +45,6 @@ export const functionsExportedForTestingOnly = {
   handleFunctionCallList,
   generateAuthEvent,
   generateRequestConfirmationEvent,
-  normalizeCallbackResponse,
 };
 // TODO - b/425992518: consider internalize as part of llm_agent's runtime.
 /**

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -4,20 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
-  BaseLlm,
-  BaseLlmConnection,
   BasePlugin,
   BaseTool,
   createEvent,
   createEventActions,
-  createSession,
   Event,
   functionsExportedForTestingOnly,
   FunctionTool,
   InvocationContext,
   LlmAgent,
-  LlmRequest,
-  LlmResponse,
   PluginManager,
   Session,
   SingleAfterToolCallback,
@@ -98,6 +93,26 @@ class TestPlugin extends BasePlugin {
 
 function randomIdForTestingOnly(): string {
   return (Math.random() * 100).toString();
+}
+
+const silentLongRunningTool = new FunctionTool({
+  name: 'silentLongRunningTool',
+  description: 'long running tool returning nullish',
+  parameters: z.object({}),
+  execute: async () => null,
+  isLongRunning: true,
+});
+
+const falsyLongRunningTool = new FunctionTool({
+  name: 'falsyLongRunningTool',
+  description: 'long running tool returning an empty string',
+  parameters: z.object({}),
+  execute: async () => '',
+  isLongRunning: true,
+});
+
+function longRunningCallFor(tool: BaseTool): FunctionCall {
+  return {id: randomIdForTestingOnly(), name: tool.name, args: {}};
 }
 
 describe('normalizeCallbackResponse', () => {
@@ -425,22 +440,10 @@ describe('handleFunctionCallList', () => {
   });
 
   it('should cleanly return null and emit no event when long-running tool returns null or undefined', async () => {
-    const longRunningTool = new FunctionTool({
-      name: 'longRunningTool',
-      description: 'long running tool returning nullish',
-      parameters: z.object({}),
-      execute: async () => null,
-      isLongRunning: true,
-    });
-    const longRunningCall: FunctionCall = {
-      id: randomIdForTestingOnly(),
-      name: 'longRunningTool',
-      args: {},
-    };
     const event = await handleFunctionCallList({
       invocationContext,
-      functionCalls: [longRunningCall],
-      toolsDict: {'longRunningTool': longRunningTool},
+      functionCalls: [longRunningCallFor(silentLongRunningTool)],
+      toolsDict: {silentLongRunningTool},
       beforeToolCallbacks: [],
       afterToolCallbacks: [],
     });
@@ -448,100 +451,36 @@ describe('handleFunctionCallList', () => {
   });
 
   it('should emit an event when long-running tool returns a falsy but present response', async () => {
-    const longRunningToolWithResponse = new FunctionTool({
-      name: 'longRunningToolWithResponse',
-      description: 'long running tool returning an empty string',
-      parameters: z.object({}),
-      execute: async () => '',
-      isLongRunning: true,
-    });
-    const longRunningCall: FunctionCall = {
-      id: randomIdForTestingOnly(),
-      name: 'longRunningToolWithResponse',
-      args: {},
-    };
     const event = await handleFunctionCallList({
       invocationContext,
-      functionCalls: [longRunningCall],
-      toolsDict: {'longRunningToolWithResponse': longRunningToolWithResponse},
+      functionCalls: [longRunningCallFor(falsyLongRunningTool)],
+      toolsDict: {falsyLongRunningTool},
       beforeToolCallbacks: [],
       afterToolCallbacks: [],
     });
-    expect(event).not.toBeNull();
     expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
       result: '',
     });
   });
-});
 
-describe('LlmAgent turn with long-running tools', () => {
   it('should emit a response part only for the long-running tool that returned something', async () => {
-    const silentTool = new FunctionTool({
-      name: 'silentTool',
-      description: 'long running tool returning nullish',
-      parameters: z.object({}),
-      execute: async () => null,
-      isLongRunning: true,
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [
+        longRunningCallFor(silentLongRunningTool),
+        longRunningCallFor(falsyLongRunningTool),
+      ],
+      toolsDict: {silentLongRunningTool, falsyLongRunningTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
     });
-    const falsyTool = new FunctionTool({
-      name: 'falsyTool',
-      description: 'long running tool returning an empty string',
-      parameters: z.object({}),
-      execute: async () => '',
-      isLongRunning: true,
-    });
-
-    class MockLlm extends BaseLlm {
-      private toolsRequested = false;
-
-      async *generateContentAsync(
-        _request: LlmRequest,
-      ): AsyncGenerator<LlmResponse, void, void> {
-        if (this.toolsRequested) {
-          yield {content: {role: 'model', parts: [{text: 'done'}]}};
-          return;
-        }
-        this.toolsRequested = true;
-        yield {
-          content: {
-            role: 'model',
-            parts: [
-              {functionCall: {name: 'silentTool', args: {}}},
-              {functionCall: {name: 'falsyTool', args: {}}},
-            ],
-          },
-        };
-      }
-      async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
-        throw new Error('Method not implemented.');
-      }
-    }
-
-    const agent = new LlmAgent({
-      name: 'test_agent_long_running',
-      tools: [silentTool, falsyTool],
-      model: new MockLlm({model: 'mock-model'}),
-    });
-
-    const events: Event[] = [];
-    for await (const event of agent.runAsync(
-      new InvocationContext({
-        invocationId: 'inv_long_running_123',
-        session: createSession({id: 'sess_123', appName: 'test_app'}),
-        agent,
-        pluginManager: new PluginManager(),
+    expect(event?.content?.parts).toEqual([
+      expect.objectContaining({
+        functionResponse: expect.objectContaining({
+          name: 'falsyLongRunningTool',
+          response: {result: ''},
+        }),
       }),
-    )) {
-      events.push(event);
-    }
-
-    const responses = events.flatMap(
-      (event) =>
-        event.content?.parts?.flatMap((part) => part.functionResponse ?? []) ??
-        [],
-    );
-    expect(responses).toEqual([
-      expect.objectContaining({name: 'falsyTool', response: {result: ''}}),
     ]);
   });
 });

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -448,6 +448,33 @@ describe('handleFunctionCallList', () => {
     });
   });
 
+  it('should still emit an event when a regular tool returns nothing', async () => {
+    const nullTool = new FunctionTool({
+      name: 'nullTool',
+      description: 'tool returning nullish',
+      parameters: z.object({}),
+      execute: async () => null,
+    });
+    const nullCall: FunctionCall = {
+      id: randomIdForTestingOnly(),
+      name: 'nullTool',
+      args: {},
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [nullCall],
+      toolsDict: {'nullTool': nullTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+    expect(event).not.toBeNull();
+    expect(event?.content?.parts?.[0].functionResponse?.response).toStrictEqual(
+      {
+        result: null,
+      },
+    );
+  });
+
   it('should cleanly return null and emit no event when long-running tool returns null or undefined', async () => {
     const longRunningTool = new FunctionTool({
       name: 'longRunningTool',

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -4,22 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
+  BaseLlm,
+  BaseLlmConnection,
   BasePlugin,
   BaseTool,
   createEvent,
   createEventActions,
+  createSession,
   Event,
   functionsExportedForTestingOnly,
   FunctionTool,
   InvocationContext,
   LlmAgent,
+  LlmRequest,
+  LlmResponse,
   PluginManager,
   Session,
   SingleAfterToolCallback,
   SingleBeforeToolCallback,
   ToolConfirmation,
 } from '@google/adk';
-import {FunctionCall} from '@google/genai';
+import {Content, FunctionCall, Blob as GenaiBlob} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
@@ -35,6 +40,7 @@ const {
   handleFunctionCallList,
   generateAuthEvent,
   generateRequestConfirmationEvent,
+  normalizeCallbackResponse,
 } = functionsExportedForTestingOnly;
 
 // Tool for testing
@@ -93,6 +99,42 @@ class TestPlugin extends BasePlugin {
 function randomIdForTestingOnly(): string {
   return (Math.random() * 100).toString();
 }
+
+/**
+ * Casts a value that the tool callback return type forbids. Untyped JavaScript
+ * callers can still return such values at runtime, which is exactly what
+ * `normalizeCallbackResponse` exists to absorb.
+ */
+function outOfContractResponse(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+describe('normalizeCallbackResponse', () => {
+  it('should return undefined when input is null or undefined', () => {
+    expect(normalizeCallbackResponse(null)).toBeUndefined();
+    expect(normalizeCallbackResponse(undefined)).toBeUndefined();
+  });
+
+  it('should wrap primitive values into a {result: value} object', () => {
+    expect(normalizeCallbackResponse('primitive string')).toEqual({
+      result: 'primitive string',
+    });
+    expect(normalizeCallbackResponse(123)).toEqual({result: 123});
+    expect(normalizeCallbackResponse(true)).toEqual({result: true});
+  });
+
+  it('should wrap arrays into a {results: array} object', () => {
+    expect(normalizeCallbackResponse(['a', 'b'])).toEqual({
+      results: ['a', 'b'],
+    });
+  });
+
+  it('should return object records unchanged', () => {
+    expect(normalizeCallbackResponse({custom: 'record'})).toEqual({
+      custom: 'record',
+    });
+  });
+});
 
 describe('handleFunctionCallList', () => {
   let invocationContext: InvocationContext;
@@ -362,6 +404,177 @@ describe('handleFunctionCallList', () => {
         }),
       }),
     );
+  });
+
+  it('should normalize primitive string returned by beforeToolCallback', async () => {
+    const beforeToolCallback: SingleBeforeToolCallback = async () => {
+      return outOfContractResponse('primitive before response');
+    };
+    let passedResponseToAfterCallback: unknown;
+    const afterToolCallback: SingleAfterToolCallback = async ({response}) => {
+      passedResponseToAfterCallback = response;
+      return undefined;
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [functionCall],
+      toolsDict,
+      beforeToolCallbacks: [beforeToolCallback],
+      afterToolCallbacks: [afterToolCallback],
+    });
+    expect(passedResponseToAfterCallback).toEqual({
+      result: 'primitive before response',
+    });
+    expect(event).not.toBeNull();
+    expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
+      result: 'primitive before response',
+    });
+  });
+
+  it('should normalize array returned by afterToolCallback', async () => {
+    const afterToolCallback: SingleAfterToolCallback = async () => {
+      return outOfContractResponse(['item1', 'item2']);
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [functionCall],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [afterToolCallback],
+    });
+    expect(event).not.toBeNull();
+    expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
+      results: ['item1', 'item2'],
+    });
+  });
+
+  it('should cleanly return null and emit no event when long-running tool returns null or undefined', async () => {
+    const longRunningTool = new FunctionTool({
+      name: 'longRunningTool',
+      description: 'long running tool returning nullish',
+      parameters: z.object({}),
+      execute: async () => null,
+      isLongRunning: true,
+    });
+    const longRunningCall: FunctionCall = {
+      id: randomIdForTestingOnly(),
+      name: 'longRunningTool',
+      args: {},
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [longRunningCall],
+      toolsDict: {'longRunningTool': longRunningTool},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+    expect(event).toBeNull();
+  });
+
+  it('should create and return FunctionResponseEvent when long-running tool explicitly returns a response record', async () => {
+    const longRunningToolWithResponse = new FunctionTool({
+      name: 'longRunningToolWithResponse',
+      description: 'long running tool with response',
+      parameters: z.object({}),
+      execute: async () => ({status: 'initiated', jobId: '123'}),
+      isLongRunning: true,
+    });
+    const longRunningCall: FunctionCall = {
+      id: randomIdForTestingOnly(),
+      name: 'longRunningToolWithResponse',
+      args: {},
+    };
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [longRunningCall],
+      toolsDict: {'longRunningToolWithResponse': longRunningToolWithResponse},
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+    expect(event).not.toBeNull();
+    expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
+      status: 'initiated',
+      jobId: '123',
+    });
+  });
+});
+
+describe('LlmAgent long-running tool integration', () => {
+  it('should complete turn cleanly without emitting empty function response parts when long-running tool returns nullish', async () => {
+    const longRunningTool = new FunctionTool({
+      name: 'longRunningIntegrationTool',
+      description: 'long running integration tool',
+      parameters: z.object({}),
+      execute: async () => null,
+      isLongRunning: true,
+    });
+
+    const functionCallResponse: LlmResponse = {
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'longRunningIntegrationTool',
+              args: {},
+            },
+          },
+        ],
+      },
+    };
+
+    class MockConnection implements BaseLlmConnection {
+      sendHistory(_history: Content[]): Promise<void> {
+        return Promise.resolve();
+      }
+      sendContent(_content: Content): Promise<void> {
+        return Promise.resolve();
+      }
+      sendRealtime(_blob: GenaiBlob): Promise<void> {
+        return Promise.resolve();
+      }
+      async *receive(): AsyncGenerator<LlmResponse, void, void> {}
+      async close(): Promise<void> {
+        return Promise.resolve();
+      }
+    }
+
+    class MockIntegrationLlm extends BaseLlm {
+      async *generateContentAsync(
+        _request: LlmRequest,
+      ): AsyncGenerator<LlmResponse, void, void> {
+        yield functionCallResponse;
+      }
+      async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+        return new MockConnection();
+      }
+    }
+
+    const agent = new LlmAgent({
+      name: 'test_agent_long_running',
+      tools: [longRunningTool],
+      model: new MockIntegrationLlm({model: 'mock-model'}),
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'inv_integration_123',
+      session: createSession({id: 'sess_123', appName: 'test_app'}),
+      agent,
+      pluginManager: new PluginManager(),
+    });
+
+    const events: Event[] = [];
+    for await (const event of agent.runAsync(invocationContext)) {
+      events.push(event);
+    }
+
+    expect(events.length).toBe(1);
+    expect(events[0].content?.parts?.[0].functionCall?.name).toBe(
+      'longRunningIntegrationTool',
+    );
+    expect(
+      events.some((e) => e.content?.parts?.some((p) => p.functionResponse)),
+    ).toBe(false);
   });
 });
 

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -35,7 +35,6 @@ const {
   handleFunctionCallList,
   generateAuthEvent,
   generateRequestConfirmationEvent,
-  normalizeCallbackResponse,
 } = functionsExportedForTestingOnly;
 
 // Tool for testing
@@ -111,36 +110,9 @@ const falsyLongRunningTool = new FunctionTool({
   isLongRunning: true,
 });
 
-function longRunningCallFor(tool: BaseTool): FunctionCall {
+function callFor(tool: BaseTool): FunctionCall {
   return {id: randomIdForTestingOnly(), name: tool.name, args: {}};
 }
-
-describe('normalizeCallbackResponse', () => {
-  it('should return undefined when input is null or undefined', () => {
-    expect(normalizeCallbackResponse(null)).toBeUndefined();
-    expect(normalizeCallbackResponse(undefined)).toBeUndefined();
-  });
-
-  it('should wrap primitive values into a {result: value} object', () => {
-    expect(normalizeCallbackResponse('primitive string')).toEqual({
-      result: 'primitive string',
-    });
-    expect(normalizeCallbackResponse(123)).toEqual({result: 123});
-    expect(normalizeCallbackResponse(true)).toEqual({result: true});
-  });
-
-  it('should wrap arrays into a {results: array} object', () => {
-    expect(normalizeCallbackResponse(['a', 'b'])).toEqual({
-      results: ['a', 'b'],
-    });
-  });
-
-  it('should return object records unchanged', () => {
-    expect(normalizeCallbackResponse({custom: 'record'})).toEqual({
-      custom: 'record',
-    });
-  });
-});
 
 describe('handleFunctionCallList', () => {
   let invocationContext: InvocationContext;
@@ -419,14 +391,9 @@ describe('handleFunctionCallList', () => {
       parameters: z.object({}),
       execute: async () => null,
     });
-    const nullCall: FunctionCall = {
-      id: randomIdForTestingOnly(),
-      name: 'nullTool',
-      args: {},
-    };
     const event = await handleFunctionCallList({
       invocationContext,
-      functionCalls: [nullCall],
+      functionCalls: [callFor(nullTool)],
       toolsDict: {'nullTool': nullTool},
       beforeToolCallbacks: [],
       afterToolCallbacks: [],
@@ -442,7 +409,7 @@ describe('handleFunctionCallList', () => {
   it('should cleanly return null and emit no event when long-running tool returns null or undefined', async () => {
     const event = await handleFunctionCallList({
       invocationContext,
-      functionCalls: [longRunningCallFor(silentLongRunningTool)],
+      functionCalls: [callFor(silentLongRunningTool)],
       toolsDict: {silentLongRunningTool},
       beforeToolCallbacks: [],
       afterToolCallbacks: [],
@@ -450,25 +417,12 @@ describe('handleFunctionCallList', () => {
     expect(event).toBeNull();
   });
 
-  it('should emit an event when long-running tool returns a falsy but present response', async () => {
-    const event = await handleFunctionCallList({
-      invocationContext,
-      functionCalls: [longRunningCallFor(falsyLongRunningTool)],
-      toolsDict: {falsyLongRunningTool},
-      beforeToolCallbacks: [],
-      afterToolCallbacks: [],
-    });
-    expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
-      result: '',
-    });
-  });
-
   it('should emit a response part only for the long-running tool that returned something', async () => {
     const event = await handleFunctionCallList({
       invocationContext,
       functionCalls: [
-        longRunningCallFor(silentLongRunningTool),
-        longRunningCallFor(falsyLongRunningTool),
+        callFor(silentLongRunningTool),
+        callFor(falsyLongRunningTool),
       ],
       toolsDict: {silentLongRunningTool, falsyLongRunningTool},
       beforeToolCallbacks: [],

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -24,7 +24,7 @@ import {
   SingleBeforeToolCallback,
   ToolConfirmation,
 } from '@google/adk';
-import {Content, FunctionCall, Blob as GenaiBlob} from '@google/genai';
+import {FunctionCall} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
@@ -98,15 +98,6 @@ class TestPlugin extends BasePlugin {
 
 function randomIdForTestingOnly(): string {
   return (Math.random() * 100).toString();
-}
-
-/**
- * Casts a value that the tool callback return type forbids. Untyped JavaScript
- * callers can still return such values at runtime, which is exactly what
- * `normalizeCallbackResponse` exists to absorb.
- */
-function outOfContractResponse(value: unknown): Record<string, unknown> {
-  return value as Record<string, unknown>;
 }
 
 describe('normalizeCallbackResponse', () => {
@@ -408,7 +399,9 @@ describe('handleFunctionCallList', () => {
 
   it('should normalize primitive string returned by beforeToolCallback', async () => {
     const beforeToolCallback: SingleBeforeToolCallback = async () => {
-      return outOfContractResponse('primitive before response');
+      // The declared return type forbids a primitive, but an untyped JavaScript
+      // caller can still return one; that is what normalization absorbs.
+      return 'primitive before response' as unknown as Record<string, unknown>;
     };
     let passedResponseToAfterCallback: unknown;
     const afterToolCallback: SingleAfterToolCallback = async ({response}) => {
@@ -428,23 +421,6 @@ describe('handleFunctionCallList', () => {
     expect(event).not.toBeNull();
     expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
       result: 'primitive before response',
-    });
-  });
-
-  it('should normalize array returned by afterToolCallback', async () => {
-    const afterToolCallback: SingleAfterToolCallback = async () => {
-      return outOfContractResponse(['item1', 'item2']);
-    };
-    const event = await handleFunctionCallList({
-      invocationContext,
-      functionCalls: [functionCall],
-      toolsDict,
-      beforeToolCallbacks: [],
-      afterToolCallbacks: [afterToolCallback],
-    });
-    expect(event).not.toBeNull();
-    expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
-      results: ['item1', 'item2'],
     });
   });
 
@@ -550,22 +526,6 @@ describe('LlmAgent long-running tool integration', () => {
       },
     };
 
-    class MockConnection implements BaseLlmConnection {
-      sendHistory(_history: Content[]): Promise<void> {
-        return Promise.resolve();
-      }
-      sendContent(_content: Content): Promise<void> {
-        return Promise.resolve();
-      }
-      sendRealtime(_blob: GenaiBlob): Promise<void> {
-        return Promise.resolve();
-      }
-      async *receive(): AsyncGenerator<LlmResponse, void, void> {}
-      async close(): Promise<void> {
-        return Promise.resolve();
-      }
-    }
-
     class MockIntegrationLlm extends BaseLlm {
       async *generateContentAsync(
         _request: LlmRequest,
@@ -573,7 +533,7 @@ describe('LlmAgent long-running tool integration', () => {
         yield functionCallResponse;
       }
       async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
-        return new MockConnection();
+        throw new Error('Method not implemented.');
       }
     }
 

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -447,12 +447,12 @@ describe('handleFunctionCallList', () => {
     expect(event).toBeNull();
   });
 
-  it('should create and return FunctionResponseEvent when long-running tool explicitly returns a response record', async () => {
+  it('should emit an event when long-running tool returns a falsy but present response', async () => {
     const longRunningToolWithResponse = new FunctionTool({
       name: 'longRunningToolWithResponse',
-      description: 'long running tool with response',
+      description: 'long running tool returning an empty string',
       parameters: z.object({}),
-      execute: async () => ({status: 'initiated', jobId: '123'}),
+      execute: async () => '',
       isLongRunning: true,
     });
     const longRunningCall: FunctionCall = {
@@ -469,41 +469,48 @@ describe('handleFunctionCallList', () => {
     });
     expect(event).not.toBeNull();
     expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
-      status: 'initiated',
-      jobId: '123',
+      result: '',
     });
   });
 });
 
-describe('LlmAgent turn with a long-running tool', () => {
-  it('should complete turn cleanly without emitting empty function response parts when long-running tool returns nullish', async () => {
-    const longRunningTool = new FunctionTool({
-      name: 'longRunningTurnTool',
+describe('LlmAgent turn with long-running tools', () => {
+  it('should emit a response part only for the long-running tool that returned something', async () => {
+    const silentTool = new FunctionTool({
+      name: 'silentTool',
       description: 'long running tool returning nullish',
       parameters: z.object({}),
       execute: async () => null,
       isLongRunning: true,
     });
-
-    const functionCallResponse: LlmResponse = {
-      content: {
-        role: 'model',
-        parts: [
-          {
-            functionCall: {
-              name: 'longRunningTurnTool',
-              args: {},
-            },
-          },
-        ],
-      },
-    };
+    const falsyTool = new FunctionTool({
+      name: 'falsyTool',
+      description: 'long running tool returning an empty string',
+      parameters: z.object({}),
+      execute: async () => '',
+      isLongRunning: true,
+    });
 
     class MockLlm extends BaseLlm {
+      private toolsRequested = false;
+
       async *generateContentAsync(
         _request: LlmRequest,
       ): AsyncGenerator<LlmResponse, void, void> {
-        yield functionCallResponse;
+        if (this.toolsRequested) {
+          yield {content: {role: 'model', parts: [{text: 'done'}]}};
+          return;
+        }
+        this.toolsRequested = true;
+        yield {
+          content: {
+            role: 'model',
+            parts: [
+              {functionCall: {name: 'silentTool', args: {}}},
+              {functionCall: {name: 'falsyTool', args: {}}},
+            ],
+          },
+        };
       }
       async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
         throw new Error('Method not implemented.');
@@ -512,29 +519,30 @@ describe('LlmAgent turn with a long-running tool', () => {
 
     const agent = new LlmAgent({
       name: 'test_agent_long_running',
-      tools: [longRunningTool],
+      tools: [silentTool, falsyTool],
       model: new MockLlm({model: 'mock-model'}),
     });
 
-    const invocationContext = new InvocationContext({
-      invocationId: 'inv_long_running_123',
-      session: createSession({id: 'sess_123', appName: 'test_app'}),
-      agent,
-      pluginManager: new PluginManager(),
-    });
-
     const events: Event[] = [];
-    for await (const event of agent.runAsync(invocationContext)) {
+    for await (const event of agent.runAsync(
+      new InvocationContext({
+        invocationId: 'inv_long_running_123',
+        session: createSession({id: 'sess_123', appName: 'test_app'}),
+        agent,
+        pluginManager: new PluginManager(),
+      }),
+    )) {
       events.push(event);
     }
 
-    expect(events.length).toBe(1);
-    expect(events[0].content?.parts?.[0].functionCall?.name).toBe(
-      'longRunningTurnTool',
+    const responses = events.flatMap(
+      (event) =>
+        event.content?.parts?.flatMap((part) => part.functionResponse ?? []) ??
+        [],
     );
-    expect(
-      events.some((e) => e.content?.parts?.some((p) => p.functionResponse)),
-    ).toBe(false);
+    expect(responses).toEqual([
+      expect.objectContaining({name: 'falsyTool', response: {result: ''}}),
+    ]);
   });
 });
 

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -397,33 +397,6 @@ describe('handleFunctionCallList', () => {
     );
   });
 
-  it('should normalize primitive string returned by beforeToolCallback', async () => {
-    const beforeToolCallback: SingleBeforeToolCallback = async () => {
-      // The declared return type forbids a primitive, but an untyped JavaScript
-      // caller can still return one; that is what normalization absorbs.
-      return 'primitive before response' as unknown as Record<string, unknown>;
-    };
-    let passedResponseToAfterCallback: unknown;
-    const afterToolCallback: SingleAfterToolCallback = async ({response}) => {
-      passedResponseToAfterCallback = response;
-      return undefined;
-    };
-    const event = await handleFunctionCallList({
-      invocationContext,
-      functionCalls: [functionCall],
-      toolsDict,
-      beforeToolCallbacks: [beforeToolCallback],
-      afterToolCallbacks: [afterToolCallback],
-    });
-    expect(passedResponseToAfterCallback).toEqual({
-      result: 'primitive before response',
-    });
-    expect(event).not.toBeNull();
-    expect(event?.content?.parts?.[0].functionResponse?.response).toEqual({
-      result: 'primitive before response',
-    });
-  });
-
   it('should still emit an event when a regular tool returns nothing', async () => {
     const nullTool = new FunctionTool({
       name: 'nullTool',
@@ -502,11 +475,11 @@ describe('handleFunctionCallList', () => {
   });
 });
 
-describe('LlmAgent long-running tool integration', () => {
+describe('LlmAgent turn with a long-running tool', () => {
   it('should complete turn cleanly without emitting empty function response parts when long-running tool returns nullish', async () => {
     const longRunningTool = new FunctionTool({
-      name: 'longRunningIntegrationTool',
-      description: 'long running integration tool',
+      name: 'longRunningTurnTool',
+      description: 'long running tool returning nullish',
       parameters: z.object({}),
       execute: async () => null,
       isLongRunning: true,
@@ -518,7 +491,7 @@ describe('LlmAgent long-running tool integration', () => {
         parts: [
           {
             functionCall: {
-              name: 'longRunningIntegrationTool',
+              name: 'longRunningTurnTool',
               args: {},
             },
           },
@@ -526,7 +499,7 @@ describe('LlmAgent long-running tool integration', () => {
       },
     };
 
-    class MockIntegrationLlm extends BaseLlm {
+    class MockLlm extends BaseLlm {
       async *generateContentAsync(
         _request: LlmRequest,
       ): AsyncGenerator<LlmResponse, void, void> {
@@ -540,11 +513,11 @@ describe('LlmAgent long-running tool integration', () => {
     const agent = new LlmAgent({
       name: 'test_agent_long_running',
       tools: [longRunningTool],
-      model: new MockIntegrationLlm({model: 'mock-model'}),
+      model: new MockLlm({model: 'mock-model'}),
     });
 
     const invocationContext = new InvocationContext({
-      invocationId: 'inv_integration_123',
+      invocationId: 'inv_long_running_123',
       session: createSession({id: 'sess_123', appName: 'test_app'}),
       agent,
       pluginManager: new PluginManager(),
@@ -557,7 +530,7 @@ describe('LlmAgent long-running tool integration', () => {
 
     expect(events.length).toBe(1);
     expect(events[0].content?.parts?.[0].functionCall?.name).toBe(
-      'longRunningIntegrationTool',
+      'longRunningTurnTool',
     );
     expect(
       events.some((e) => e.content?.parts?.some((p) => p.functionResponse)),


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

2. Or, if no issue exists, describe the change:

**Problem**:
1. When `beforeToolCallback`, `afterToolCallback`, or a plugin's `onToolErrorCallback` returns a primitive value (string, number, boolean) or an array instead of a `Record<string, unknown>`, that value was passed straight down the callback chain and into `Event`. The declared callback types already forbid this, so it only happens for JavaScript consumers or code that escapes the type system via an assertion — but when it does happen the framework propagates the malformed value instead of containing it, causing downstream UI/consumer failures.
2. The long-running tool response check used a truthiness test whose behaviour did not match its own comment ("allow long running function to return None as response"), and both sites carried a stale `TODO - b/425992518`.

**Solution**:
1. Added a `normalizeCallbackResponse` helper and applied it to the step 2 (`beforeToolCallback`) override, the step 3 `onToolErrorCallback` result, the step 5 (`afterToolCallback`) override, and the final response construction. Non-nullish, non-object values become `{result: value}` and arrays become `{results: value}` at the point they enter the chain, rather than only at the end.
2. Tightened the long-running skip from `!functionResponse` to `functionResponse == null`, so that only a genuinely absent response defers event creation. Removed both `TODO` comments.

### Behavioural change / compatibility

Flagging this explicitly per review — this is a `Feat:`, not a `Fix:`, because it changes observable runtime behaviour:

- **Long-running tools returning a falsy-but-present value.** `BaseTool.runAsync()` is declared `Promise<unknown>`, so returning `''`, `0`, or `false` is fully within the type contract. Previously such a call emitted **no** function response event at all (the truthiness check swallowed it); it now emits `{result: ''}` / `{result: 0}` / `{result: false}`. Any long-running tool relying on a falsy return to mean "no response yet" will now surface an immediate response to the model. This change is silent — nothing throws — so it is called out here and in a comment at the check itself.
- **Callback overrides are normalized before later callbacks observe them.** An `afterToolCallback` now receives `{result: 'x'}` where it previously received `'x'` from a `beforeToolCallback` override. This only affects callbacks that were already returning values outside their declared `Record<string, unknown> | undefined` type, so typed consumers are unaffected; the final `Event` payload is unchanged in every case.
- Correction to an earlier revision of this description: the long-running change does **not** align with `adk-python`. `adk-python` uses `if (tool.is_long_running or tool._defers_response) and not function_response` (falsy), which matches the previous ADK TS behaviour. Happy to revert that one line to `!functionResponse` and keep only the normalization work if maintainers would rather preserve cross-language parity here.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Run the targeted unit test suite covering tool callbacks, long-running tool responses, and type validation:
`npx vitest run --project unit:core core/test/agents/functions_test.ts`
Verified all 30 tests in `functions_test.ts` pass cleanly.

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
