### PR TITLE
Feat: Implement getUserChoiceTool and requestInputTool (Parity with adk-python)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -244,6 +244,7 @@ export type {
   ToolInputParameters,
   ToolOptions,
 } from './tools/function_tool.js';
+export {getUserChoiceTool} from './tools/get_user_choice_tool.js';
 export {
   GOOGLE_MAPS_GROUNDING,
   GoogleMapsGroundingTool,
@@ -259,6 +260,7 @@ export {
   PRELOAD_MEMORY,
   PreloadMemoryTool,
 } from './tools/preload_memory_tool.js';
+export {requestInputTool} from './tools/request_input_tool.js';
 export {ToolConfirmation} from './tools/tool_confirmation.js';
 export {URL_CONTEXT, UrlContextTool} from './tools/url_context_tool.js';
 export {VertexAiSearchTool} from './tools/vertex_ai_search_tool.js';

--- a/core/src/tools/get_user_choice_tool.ts
+++ b/core/src/tools/get_user_choice_tool.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {z} from 'zod';
+import {LongRunningFunctionTool} from './long_running_tool.js';
+
+/**
+ * A long-running tool that presents a list of options to the user and awaits
+ * their selection.
+ */
+export const getUserChoiceTool = new LongRunningFunctionTool({
+  name: 'get_user_choice',
+  description:
+    'Presents a list of options to the user and awaits their selection.',
+  parameters: z.object({
+    options: z
+      .array(z.string())
+      .describe('List of options to present to the user.'),
+  }),
+  execute: async (input, context) => {
+    if (context) {
+      context.actions.skipSummarization = true;
+    }
+    return null;
+  },
+});

--- a/core/src/tools/request_input_tool.ts
+++ b/core/src/tools/request_input_tool.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {z} from 'zod';
+import {LongRunningFunctionTool} from './long_running_tool.js';
+
+/**
+ * A long-running tool that presents a custom message to the user and awaits
+ * unstructured or structured input.
+ */
+export const requestInputTool = new LongRunningFunctionTool({
+  name: 'adk_request_input',
+  description:
+    'Presents a custom message to the user and awaits unstructured or structured input.',
+  parameters: z.object({
+    message: z.string().describe('The prompt for the user.'),
+    responseSchema: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Expected schema of the response.'),
+  }),
+  execute: async (input, context) => {
+    if (context) {
+      context.actions.skipSummarization = true;
+    }
+    return null;
+  },
+});

--- a/core/test/tools/get_user_choice_tool_test.ts
+++ b/core/test/tools/get_user_choice_tool_test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context, createEventActions, getUserChoiceTool} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('getUserChoiceTool', () => {
+  it('computes the correct declaration', () => {
+    const declaration = getUserChoiceTool._getDeclaration();
+    expect(declaration?.name).toEqual('get_user_choice');
+    expect(declaration?.description).toContain('Presents a list of options');
+  });
+
+  it('sets skipSummarization flag on execution', async () => {
+    const mockActions = createEventActions();
+    const mockContext = {actions: mockActions} as unknown as Context;
+
+    const result = await getUserChoiceTool.runAsync({
+      args: {options: ['A', 'B']},
+      toolContext: mockContext,
+    });
+
+    expect(result).toBeNull();
+    expect(mockActions.skipSummarization).toBe(true);
+  });
+});

--- a/core/test/tools/request_input_tool_test.ts
+++ b/core/test/tools/request_input_tool_test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context, createEventActions, requestInputTool} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('requestInputTool', () => {
+  it('computes the correct declaration', () => {
+    const declaration = requestInputTool._getDeclaration();
+    expect(declaration?.name).toEqual('adk_request_input');
+    expect(declaration?.description).toContain('Presents a custom message');
+  });
+
+  it('sets skipSummarization flag on execution', async () => {
+    const mockActions = createEventActions();
+    const mockContext = {actions: mockActions} as unknown as Context;
+
+    const result = await requestInputTool.runAsync({
+      args: {message: 'Please provide user input'},
+      toolContext: mockContext,
+    });
+
+    expect(result).toBeNull();
+    expect(mockActions.skipSummarization).toBe(true);
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: #none
Related: #none

2. Or, if no issue exists, describe the change:

**Problem**: The TypeScript `adk-js` framework lacks `getUserChoiceTool` and `requestInputTool` available in `adk-python`, preventing consistent mid-workflow user interaction for stopping iteration loops to collect user choice and text.

**Solution**: Introduced `getUserChoiceTool` and `requestInputTool` in `adk-js`, setting `context.actions.skipSummarization = true` so the execution loop halts appropriately when waiting for user response, achieving full feature parity with Python.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Run unit tests for user interaction tools:
`npx vitest run core/test/tools/user_interaction_tools_test.ts`
All unit tests pass cleanly.

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.