### PR TITLE
Feat: Scope global instructions using GlobalInstructionPlugin (Parity with adk-python)

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -215,6 +215,8 @@ export interface LlmAgentConfig extends BaseAgentConfig {
    *
    * For example: use globalInstruction to make all agents have a stable
    * identity or personality.
+   *
+   * @deprecated Use GlobalInstructionPlugin instead.
    */
   globalInstruction?: string | InstructionProvider;
 
@@ -352,6 +354,7 @@ export class LlmAgent extends BaseAgent {
 
   model?: string | BaseLlm;
   instruction: string | InstructionProvider;
+  /** @deprecated Use GlobalInstructionPlugin instead. */
   globalInstruction: string | InstructionProvider;
   tools: ToolUnion[];
   generateContentConfig?: GenerateContentConfig;
@@ -522,6 +525,7 @@ export class LlmAgent extends BaseAgent {
    * This method is only for use by Agent Development Kit.
    * @param context The context to retrieve the session state.
    * @returns The resolved globalInstruction field.
+   * @deprecated Use GlobalInstructionPlugin instead.
    */
   async canonicalGlobalInstruction(
     context: ReadonlyContext,

--- a/core/src/agents/processors/instructions_llm_request_processor.ts
+++ b/core/src/agents/processors/instructions_llm_request_processor.ts
@@ -26,8 +26,8 @@ export class InstructionsLlmRequestProcessor extends BaseLlmRequestProcessor {
       return;
     }
     const rootAgent = agent.rootAgent;
-    // TODO - b/425992518: unexpected and buggy for performance.
-    // Global instruction should be explicitly scoped.
+    // DEPRECATED: use GlobalInstructionPlugin instead.
+    // TODO: Remove this code block when globalInstruction field is removed.
     // Step 1: Appends global instructions if set by RootAgent.
     if (isLlmAgent(rootAgent) && rootAgent.globalInstruction) {
       const {instruction, requireStateInjection} =

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -174,6 +174,7 @@ export type {BaseLlmType} from './models/registry.js';
 export {RoutedLlm} from './models/routed_llm.js';
 export type {LlmRouter} from './models/routed_llm.js';
 export {BasePlugin, ContextCompactionTrigger} from './plugins/base_plugin.js';
+export {GlobalInstructionPlugin} from './plugins/global_instruction_plugin.js';
 export {LoggingPlugin} from './plugins/logging_plugin.js';
 export {PluginManager} from './plugins/plugin_manager.js';
 export {

--- a/core/src/plugins/global_instruction_plugin.ts
+++ b/core/src/plugins/global_instruction_plugin.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context} from '../agents/context.js';
+import {injectSessionState} from '../agents/instructions.js';
+import {InstructionProvider} from '../agents/llm_agent.js';
+import {ReadonlyContext} from '../agents/readonly_context.js';
+import {LlmRequest} from '../models/llm_request.js';
+import {LlmResponse} from '../models/llm_response.js';
+import {BasePlugin} from './base_plugin.js';
+
+/**
+ * Plugin that provides global instructions functionality at the App level.
+ *
+ * This plugin replaces the deprecated globalInstruction field on LlmAgent.
+ * Global instructions are applied to all agents in the application, providing
+ * a consistent way to set application-wide instructions, identity, or
+ * personality.
+ *
+ * The plugin operates through the beforeModelCallback, allowing it to modify
+ * LLM requests before they are sent to the model.
+ */
+export class GlobalInstructionPlugin extends BasePlugin {
+  private readonly globalInstruction?: string | InstructionProvider;
+
+  /**
+   * Initializes the GlobalInstructionPlugin.
+   *
+   * @param globalInstruction The instruction to apply globally. Can be a string
+   *     or an InstructionProvider function that takes ReadonlyContext and
+   *     returns a string (sync or async).
+   * @param name The name of the plugin (defaults to 'global_instruction').
+   */
+  constructor(
+    globalInstruction?: string | InstructionProvider,
+    name = 'global_instruction',
+  ) {
+    super(name);
+    this.globalInstruction = globalInstruction;
+  }
+
+  override async beforeModelCallback(params: {
+    callbackContext: Context;
+    llmRequest: LlmRequest;
+  }): Promise<LlmResponse | undefined> {
+    if (!this.globalInstruction) {
+      return;
+    }
+
+    const readonlyContext = new ReadonlyContext(
+      params.callbackContext.invocationContext,
+    );
+    const finalGlobalInstruction =
+      await this.resolveGlobalInstruction(readonlyContext);
+
+    if (!finalGlobalInstruction) {
+      return;
+    }
+
+    if (!params.llmRequest.config) {
+      params.llmRequest.config = {};
+    }
+
+    const existingInstruction = params.llmRequest.config.systemInstruction;
+
+    if (
+      !existingInstruction ||
+      (Array.isArray(existingInstruction) && existingInstruction.length === 0)
+    ) {
+      params.llmRequest.config.systemInstruction = finalGlobalInstruction;
+      return;
+    }
+
+    if (typeof existingInstruction === 'string') {
+      params.llmRequest.config.systemInstruction = `${finalGlobalInstruction}\n\n${existingInstruction}`;
+    } else if (Array.isArray(existingInstruction)) {
+      params.llmRequest.config.systemInstruction = [
+        finalGlobalInstruction,
+        ...existingInstruction,
+      ];
+    } else {
+      params.llmRequest.config.systemInstruction = [
+        finalGlobalInstruction,
+        existingInstruction,
+      ] as unknown as string[];
+    }
+
+    return;
+  }
+
+  private async resolveGlobalInstruction(
+    readonlyContext: ReadonlyContext,
+  ): Promise<string> {
+    if (typeof this.globalInstruction === 'string') {
+      return await injectSessionState(this.globalInstruction, readonlyContext);
+    }
+    return await this.globalInstruction!(readonlyContext);
+  }
+}

--- a/core/test/plugins/global_instruction_plugin_test.ts
+++ b/core/test/plugins/global_instruction_plugin_test.ts
@@ -1,0 +1,315 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseLlm,
+  Context,
+  GlobalInstructionPlugin,
+  InMemoryRunner,
+  InvocationContext,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+  ReadonlyContext,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+class MockLlm extends BaseLlm {
+  lastRequest?: LlmRequest;
+
+  constructor() {
+    super({model: 'mock-llm'});
+  }
+
+  async *generateContentAsync(
+    request: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    this.lastRequest = request;
+    yield {
+      content: {parts: [{text: 'Hello from mock LLM'}]},
+    };
+  }
+}
+
+describe('GlobalInstructionPlugin', () => {
+  const mockSession = {
+    id: 'session-1',
+    state: {
+      user_id: 'test_user_123',
+    },
+  } as unknown as InvocationContext['session'];
+
+  const mockInvocationContext = {
+    invocationId: 'inv-1',
+    session: mockSession,
+    userId: 'user-1',
+    appName: 'test-app',
+  } as unknown as InvocationContext;
+
+  const mockCallbackContext = {
+    agentName: 'test_agent',
+    invocationId: 'inv-1',
+    invocationContext: mockInvocationContext,
+  } as unknown as Context;
+
+  it('should initialize with default name "global_instruction"', () => {
+    const plugin = new GlobalInstructionPlugin('instruction');
+    expect(plugin.name).toBe('global_instruction');
+  });
+
+  it('should accept custom name', () => {
+    const plugin = new GlobalInstructionPlugin('instruction', 'custom_name');
+    expect(plugin.name).toBe('custom_name');
+  });
+
+  it('should apply string global instruction to system instruction', async () => {
+    const plugin = new GlobalInstructionPlugin(
+      'You are a helpful assistant with a friendly personality.',
+    );
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: ''},
+    };
+
+    const result = await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest,
+    });
+
+    expect(result).toBeUndefined();
+    expect(llmRequest.config?.systemInstruction).toBe(
+      'You are a helpful assistant with a friendly personality.',
+    );
+  });
+
+  it('should apply InstructionProvider global instruction', async () => {
+    const provider = async (readonlyContext: ReadonlyContext) => {
+      return `You are assistant for user ${readonlyContext.invocationContext.session.state['user_id']}.`;
+    };
+    const plugin = new GlobalInstructionPlugin(provider);
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: ''},
+    };
+
+    const result = await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest,
+    });
+
+    expect(result).toBeUndefined();
+    expect(llmRequest.config?.systemInstruction).toBe(
+      'You are assistant for user test_user_123.',
+    );
+  });
+
+  it('should not modify system instruction when global instruction is empty or undefined', async () => {
+    const pluginEmpty = new GlobalInstructionPlugin('');
+    const pluginUndefined = new GlobalInstructionPlugin();
+    const pluginProviderEmpty = new GlobalInstructionPlugin(async () => '');
+
+    const llmRequest1: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: 'Original instruction'},
+    };
+    const llmRequest2: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: 'Original instruction'},
+    };
+    const llmRequest3: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: 'Original instruction'},
+    };
+
+    await pluginEmpty.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: llmRequest1,
+    });
+    await pluginUndefined.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: llmRequest2,
+    });
+    await pluginProviderEmpty.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: llmRequest3,
+    });
+
+    expect(llmRequest1.config?.systemInstruction).toBe('Original instruction');
+    expect(llmRequest2.config?.systemInstruction).toBe('Original instruction');
+    expect(llmRequest3.config?.systemInstruction).toBe('Original instruction');
+  });
+
+  it('should prepend global instruction to existing string system instruction', async () => {
+    const plugin = new GlobalInstructionPlugin('You are a helpful assistant.');
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: 'Existing instructions.'},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest,
+    });
+
+    expect(llmRequest.config?.systemInstruction).toBe(
+      'You are a helpful assistant.\n\nExisting instructions.',
+    );
+  });
+
+  it('should prepend global instruction to existing array system instruction', async () => {
+    const plugin = new GlobalInstructionPlugin('Global instruction.');
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: ['Existing instruction.']},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest,
+    });
+
+    expect(llmRequest.config?.systemInstruction).toEqual([
+      'Global instruction.',
+      'Existing instruction.',
+    ]);
+  });
+
+  it('should inject session state variables into string global instruction', async () => {
+    const plugin = new GlobalInstructionPlugin(
+      'Welcome back, user: {user_id}.',
+    );
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: ''},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest,
+    });
+
+    expect(llmRequest.config?.systemInstruction).toBe(
+      'Welcome back, user: test_user_123.',
+    );
+  });
+
+  it('should handle undefined config and empty existing instruction array or undefined', async () => {
+    const plugin = new GlobalInstructionPlugin('Global instruction.');
+    const llmRequestNoConfig: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+    const llmRequestEmptyArray: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: [] as string[]},
+    };
+    const llmRequestUndefinedInstruction: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: undefined},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: llmRequestNoConfig,
+    });
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: llmRequestEmptyArray,
+    });
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest: llmRequestUndefinedInstruction,
+    });
+
+    expect(llmRequestNoConfig.config?.systemInstruction).toBe(
+      'Global instruction.',
+    );
+    expect(llmRequestEmptyArray.config?.systemInstruction).toBe(
+      'Global instruction.',
+    );
+    expect(llmRequestUndefinedInstruction.config?.systemInstruction).toBe(
+      'Global instruction.',
+    );
+  });
+
+  it('should prepend global instruction to existing object (non-Iterable) system instruction', async () => {
+    const plugin = new GlobalInstructionPlugin('Global instruction.');
+    const existingObj = {text: 'Some object instruction'};
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+      config: {systemInstruction: existingObj as unknown as string},
+    };
+
+    await plugin.beforeModelCallback({
+      callbackContext: mockCallbackContext,
+      llmRequest,
+    });
+
+    expect(llmRequest.config?.systemInstruction).toEqual([
+      'Global instruction.',
+      existingObj,
+    ]);
+  });
+
+  it('should inject system instruction in an end-to-end InMemoryRunner simulation', async () => {
+    const mockLlm = new MockLlm();
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: mockLlm,
+      instruction: 'Agent specific instruction.',
+    });
+    const plugin = new GlobalInstructionPlugin(
+      'Global application instruction.',
+    );
+    const runner = new InMemoryRunner({
+      agent,
+      plugins: [plugin],
+    });
+
+    const session = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: 'test_user',
+    });
+
+    const events: unknown[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'test_user',
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'Hi'}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(mockLlm.lastRequest).toBeDefined();
+    expect(mockLlm.lastRequest?.config?.systemInstruction).toBe(
+      'Global application instruction.\n\nYou are an agent. Your internal name is "test_agent".\n\nAgent specific instruction.',
+    );
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

2. Or, if no issue exists, describe the change:

**Problem**: In `adk-js`, `InstructionsLlmRequestProcessor.runAsync()` checks if `rootAgent.globalInstruction` is set and evaluates/appends it on every single LLM request made by any agent across the execution hierarchy. This results in unexpected performance degradation, redundant state injection, prompt bloat, and cache invalidation across nested agent trees (TODO b/425992518).

**Solution**: Following architectural parity with `adk-python`, this change introduces `GlobalInstructionPlugin` extending `BasePlugin` (`core/src/plugins/global_instruction_plugin.ts`) to scope global instructions at the application level via `beforeModelCallback`. It supports both static string instructions (with session state variable injection using `injectSessionState`) and dynamic `InstructionProvider` callbacks (`(context: ReadonlyContext) => string | Promise<string>`). When `beforeModelCallback` runs, if the resolved global instruction is non-empty, it is cleanly prepended to `llmRequest.config.systemInstruction` (handling string, array, and object formats). Additionally, the `globalInstruction` property on `LlmAgentConfig` and `LlmAgent` and `canonicalGlobalInstruction` are marked with `@deprecated` JSDoc tags, and `InstructionsLlmRequestProcessor` is updated with deprecation comments directing developers to use `GlobalInstructionPlugin`.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
We verified the end-to-end functionality by creating an `InMemoryRunner` simulation with an `LlmAgent` and `GlobalInstructionPlugin` attached. We executed `runner.runAsync()` with a user message session and verified that the model request received the global application instructions prepended as the leading system instruction (`Global application instruction.\n\nYou are an agent. Your internal name is "test_agent".\n\nAgent specific instruction.`). To run the unit tests locally:
`npx vitest run --project unit:core core/test/plugins/global_instruction_plugin_test.ts`

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.