### PR TITLE
feat: Rethinking ForwardingArtifactService Interface (Part 1/2)

### DIFF
--- a/core/src/artifacts/scoped_artifact_service.ts
+++ b/core/src/artifacts/scoped_artifact_service.ts
@@ -13,9 +13,25 @@ import {
 } from './session_artifact_service.js';
 
 /**
+ * A unique symbol to identify session-scoped artifact services.
+ *
+ * Resolves to the same symbol as the one used by `isSessionArtifactService` in
+ * `session_artifact_service.ts` because `Symbol.for` looks up the global
+ * symbol registry.
+ */
+const SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.sessionArtifactService',
+);
+
+/**
  * A wrapper that scopes a BaseArtifactService to a specific session.
  */
 export class ScopedArtifactService implements SessionArtifactService {
+  /**
+   * Brands this class as a session-scoped artifact service.
+   */
+  readonly [SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL] = true;
+
   constructor(
     private readonly delegate: BaseArtifactService,
     private readonly appName: string,

--- a/core/src/artifacts/session_artifact_service.ts
+++ b/core/src/artifacts/session_artifact_service.ts
@@ -5,7 +5,7 @@
  */
 
 import {Part} from '@google/genai';
-import {ArtifactVersion} from './base_artifact_service.js';
+import {ArtifactVersion, BaseArtifactService} from './base_artifact_service.js';
 
 export interface SessionSaveArtifactRequest {
   filename: string;
@@ -28,4 +28,34 @@ export interface SessionArtifactService {
   getArtifactVersion(
     request: SessionLoadArtifactRequest,
   ): Promise<ArtifactVersion | undefined>;
+}
+
+/**
+ * A unique symbol to identify session-scoped artifact services.
+ *
+ * Implementations of {@link SessionArtifactService} brand themselves with this
+ * symbol so they can be told apart from a `BaseArtifactService` at runtime.
+ * The symbol is intentionally not exported: implementations living in other
+ * modules declare their own module-private constant with the same key, which
+ * the global symbol registry (`Symbol.for`) guarantees to be the same symbol.
+ */
+const SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.sessionArtifactService',
+);
+
+/**
+ * Type guard to check if an object implements SessionArtifactService.
+ *
+ * @param service The artifact service to check.
+ * @returns True if the service is a session-scoped artifact service.
+ */
+export function isSessionArtifactService(
+  service: BaseArtifactService | SessionArtifactService,
+): service is SessionArtifactService {
+  return (
+    typeof service === 'object' &&
+    service !== null &&
+    SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL in service &&
+    service[SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL] === true
+  );
 }

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -88,6 +88,8 @@ export type {
   SaveArtifactRequest,
 } from './artifacts/base_artifact_service.js';
 export {InMemoryArtifactService} from './artifacts/in_memory_artifact_service.js';
+export {ScopedArtifactService} from './artifacts/scoped_artifact_service.js';
+export {isSessionArtifactService} from './artifacts/session_artifact_service.js';
 export type {
   SessionArtifactService,
   SessionLoadArtifactRequest,
@@ -269,6 +271,7 @@ export {
   FINISH_TASK_TOOL_NAME,
   FinishTaskTool,
 } from './tools/finish_task_tool.js';
+export {ForwardingArtifactService} from './tools/forwarding_artifact_service.js';
 export {FunctionTool, isFunctionTool} from './tools/function_tool.js';
 export type {
   RequireConfirmation,

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -20,6 +20,10 @@ import {App} from '../apps/app.js';
 import {ResumabilityConfig} from '../apps/resumability_config.js';
 import {BaseArtifactService} from '../artifacts/base_artifact_service.js';
 import {ScopedArtifactService} from '../artifacts/scoped_artifact_service.js';
+import {
+  isSessionArtifactService,
+  SessionArtifactService,
+} from '../artifacts/session_artifact_service.js';
 
 import {BaseCredentialService} from '../auth/credential_service/base_credential_service.js';
 import {
@@ -32,7 +36,7 @@ import {BaseMemoryService} from '../memory/base_memory_service.js';
 import {BasePlugin} from '../plugins/base_plugin.js';
 import {PluginManager} from '../plugins/plugin_manager.js';
 import {BaseSessionService} from '../sessions/base_session_service.js';
-import {CompositeSessionKey, Session} from '../sessions/session.js';
+import {Session} from '../sessions/session.js';
 import {
   runAsyncGeneratorWithOtelContext,
   tracer,
@@ -80,7 +84,7 @@ export interface RunnerConfig {
   /**
    * An optional service for storing and retrieving artifacts.
    */
-  artifactService?: BaseArtifactService;
+  artifactService?: BaseArtifactService | SessionArtifactService;
 
   /**
    * The service for managing sessions.
@@ -157,7 +161,7 @@ export class Runner {
    */
   readonly agent: RunnableRoot;
   readonly pluginManager: PluginManager;
-  readonly artifactService?: BaseArtifactService;
+  readonly artifactService?: BaseArtifactService | SessionArtifactService;
   readonly sessionService: BaseSessionService;
   readonly memoryService?: BaseMemoryService;
   readonly credentialService?: BaseCredentialService;
@@ -305,12 +309,14 @@ export class Runner {
 
           const invocationContext = new InvocationContext({
             artifactService: this.artifactService
-              ? new ScopedArtifactService(
-                  this.artifactService,
-                  this.appName,
-                  userId,
-                  sessionId,
-                )
+              ? isSessionArtifactService(this.artifactService)
+                ? this.artifactService
+                : new ScopedArtifactService(
+                    this.artifactService,
+                    this.appName,
+                    userId,
+                    sessionId,
+                  )
               : undefined,
             sessionService: this.sessionService,
             memoryService: this.memoryService,
@@ -351,12 +357,10 @@ export class Runner {
 
             // Directly saves the artifacts (if applicable) in the user message and
             // replaces the artifact data with a file name placeholder.
-            // TODO - b/425992518: fix Runner<>>ArtifactService leaky abstraction.
             if (runConfig.saveInputBlobsAsArtifacts) {
               newMessage = await this.saveArtifacts(
+                invocationContext.artifactService,
                 invocationContext.invocationId,
-                session.userId,
-                session.id,
                 newMessage,
               );
               if (params.abortSignal?.aborted) {
@@ -506,26 +510,19 @@ export class Runner {
    * Saves artifacts from the message parts and replaces the inline data with
    * a file name placeholder and optional file reference.
    *
+   * @param artifactService The session-scoped artifact service to save to.
    * @param invocationId The current invocation ID.
-   * @param userId The user ID of the session.
-   * @param sessionId The session ID of the session.
    * @param message The message containing parts to process.
    */
   private async saveArtifacts(
+    artifactService: SessionArtifactService | undefined,
     invocationId: string,
-    userId: string,
-    sessionId: string,
     message: Content,
   ): Promise<Content> {
-    if (!this.artifactService || !message.parts?.length) {
+    if (!artifactService || !message.parts?.length) {
       return message;
     }
 
-    const sessionKey: CompositeSessionKey = {
-      appName: this.appName,
-      userId,
-      sessionId,
-    };
     const newParts: Part[] = [];
     let modified = false;
 
@@ -542,8 +539,7 @@ export class Runner {
           (inlineData as {displayName?: string}).displayName ||
           `artifact_${invocationId}_${i}`;
 
-        const version = await this.artifactService.saveArtifact({
-          ...sessionKey,
+        const version = await artifactService.saveArtifact({
           filename: fileName,
           artifact: part,
         });
@@ -551,13 +547,10 @@ export class Runner {
         newParts.push(createPartFromText(`[Uploaded Artifact: "${fileName}"]`));
 
         try {
-          const artifactVersion = await this.artifactService.getArtifactVersion(
-            {
-              ...sessionKey,
-              filename: fileName,
-              version,
-            },
-          );
+          const artifactVersion = await artifactService.getArtifactVersion({
+            filename: fileName,
+            version,
+          });
           if (
             artifactVersion?.canonicalUri &&
             /^(gs|https?):/i.test(artifactVersion.canonicalUri)

--- a/core/src/tools/forwarding_artifact_service.ts
+++ b/core/src/tools/forwarding_artifact_service.ts
@@ -6,70 +6,75 @@
 
 import {Part} from '@google/genai';
 
-import {InvocationContext} from '../agents/invocation_context.js';
+import {ArtifactVersion} from '../artifacts/base_artifact_service.js';
 import {
-  ArtifactVersion,
-  BaseArtifactService,
-  DeleteArtifactRequest,
-  ListArtifactKeysRequest,
-  ListVersionsRequest,
-  LoadArtifactRequest,
-  SaveArtifactRequest,
-} from '../artifacts/base_artifact_service.js';
-import {SessionArtifactService} from '../artifacts/session_artifact_service.js';
+  SessionArtifactService,
+  SessionLoadArtifactRequest,
+  SessionSaveArtifactRequest,
+} from '../artifacts/session_artifact_service.js';
 
 import {Context} from '../agents/context.js';
 
 /**
+ * A unique symbol to identify session-scoped artifact services.
+ *
+ * Resolves to the same symbol as the one used by `isSessionArtifactService` in
+ * `session_artifact_service.ts` because `Symbol.for` looks up the global
+ * symbol registry.
+ */
+const SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.sessionArtifactService',
+);
+
+/**
  * Artifact service that forwards to the parent tool context.
  */
-export class ForwardingArtifactService implements BaseArtifactService {
-  private readonly invocationContext: InvocationContext;
+export class ForwardingArtifactService implements SessionArtifactService {
+  /**
+   * Brands this class as a session-scoped artifact service.
+   */
+  readonly [SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL] = true;
 
-  constructor(private readonly toolContext: Context) {
-    this.invocationContext = toolContext.invocationContext;
-  }
+  constructor(private readonly toolContext: Context) {}
 
-  async saveArtifact(request: SaveArtifactRequest): Promise<number> {
+  async saveArtifact(request: SessionSaveArtifactRequest): Promise<number> {
     return this.toolContext.saveArtifact(request.filename, request.artifact);
   }
 
-  async loadArtifact(request: LoadArtifactRequest): Promise<Part | undefined> {
+  async loadArtifact(
+    request: SessionLoadArtifactRequest,
+  ): Promise<Part | undefined> {
     return this.toolContext.loadArtifact(request.filename, request.version);
   }
 
-  async listArtifactKeys(_request: ListArtifactKeysRequest): Promise<string[]> {
+  async listArtifactKeys(): Promise<string[]> {
     return this.toolContext.listArtifacts();
   }
 
   private getArtifactService(): SessionArtifactService {
-    const service = this.invocationContext.artifactService;
+    const service = this.toolContext.invocationContext.artifactService;
+
     if (!service) {
       throw new Error('Artifact service is not initialized.');
     }
     return service;
   }
 
-  async deleteArtifact(request: DeleteArtifactRequest): Promise<void> {
-    return this.getArtifactService().deleteArtifact(request.filename);
+  async deleteArtifact(filename: string): Promise<void> {
+    return this.getArtifactService().deleteArtifact(filename);
   }
 
-  async listVersions(request: ListVersionsRequest): Promise<number[]> {
-    return this.getArtifactService().listVersions(request.filename);
+  async listVersions(filename: string): Promise<number[]> {
+    return this.getArtifactService().listVersions(filename);
   }
 
-  async listArtifactVersions(
-    request: ListVersionsRequest,
-  ): Promise<ArtifactVersion[]> {
-    return this.getArtifactService().listArtifactVersions(request.filename);
+  async listArtifactVersions(filename: string): Promise<ArtifactVersion[]> {
+    return this.getArtifactService().listArtifactVersions(filename);
   }
 
   async getArtifactVersion(
-    request: LoadArtifactRequest,
+    request: SessionLoadArtifactRequest,
   ): Promise<ArtifactVersion | undefined> {
-    return this.getArtifactService().getArtifactVersion({
-      filename: request.filename,
-      version: request.version,
-    });
+    return this.getArtifactService().getArtifactVersion(request);
   }
 }

--- a/core/test/artifacts/session_artifact_service_test.ts
+++ b/core/test/artifacts/session_artifact_service_test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {BaseArtifactService} from '../../src/artifacts/base_artifact_service.js';
+import {InMemoryArtifactService} from '../../src/artifacts/in_memory_artifact_service.js';
+import {ScopedArtifactService} from '../../src/artifacts/scoped_artifact_service.js';
+import {
+  isSessionArtifactService,
+  SessionArtifactService,
+} from '../../src/artifacts/session_artifact_service.js';
+import {ForwardingArtifactService} from '../../src/tools/forwarding_artifact_service.js';
+
+/**
+ * The signature symbol carried by session-scoped artifact services. It is
+ * module-private in `session_artifact_service.ts`; `Symbol.for` resolves to the
+ * very same symbol through the global symbol registry.
+ */
+const SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.sessionArtifactService',
+);
+
+function makeBaseArtifactServiceStub(): BaseArtifactService {
+  return {
+    saveArtifact: vi.fn(),
+    loadArtifact: vi.fn(),
+    listArtifactKeys: vi.fn(),
+    deleteArtifact: vi.fn(),
+    listVersions: vi.fn(),
+    listArtifactVersions: vi.fn(),
+    getArtifactVersion: vi.fn(),
+  };
+}
+
+describe('isSessionArtifactService', () => {
+  it('detects ScopedArtifactService', () => {
+    const service = new ScopedArtifactService(
+      makeBaseArtifactServiceStub(),
+      'test-app',
+      'test-user',
+      'test-session',
+    );
+
+    expect(isSessionArtifactService(service)).toBe(true);
+  });
+
+  it('detects ForwardingArtifactService', () => {
+    const toolContext = {
+      saveArtifact: vi.fn(),
+      loadArtifact: vi.fn(),
+      listArtifacts: vi.fn(),
+      invocationContext: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    expect(
+      isSessionArtifactService(new ForwardingArtifactService(toolContext)),
+    ).toBe(true);
+  });
+
+  it('detects any object carrying the signature symbol', () => {
+    const branded: SessionArtifactService & Record<symbol, unknown> = {
+      [SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL]: true,
+      saveArtifact: vi.fn(),
+      loadArtifact: vi.fn(),
+      listArtifactKeys: vi.fn(),
+      deleteArtifact: vi.fn(),
+      listVersions: vi.fn(),
+      listArtifactVersions: vi.fn(),
+      getArtifactVersion: vi.fn(),
+    };
+
+    expect(isSessionArtifactService(branded)).toBe(true);
+  });
+
+  it('does not detect a BaseArtifactService implementation', () => {
+    expect(isSessionArtifactService(new InMemoryArtifactService())).toBe(false);
+  });
+
+  it('does not detect a BaseArtifactService stub', () => {
+    expect(isSessionArtifactService(makeBaseArtifactServiceStub())).toBe(false);
+  });
+
+  it('does not detect an unbranded object with a session-scoped shape', () => {
+    const unbranded = {
+      saveArtifact: vi.fn(),
+      loadArtifact: vi.fn(),
+      listArtifactKeys: vi.fn(),
+      deleteArtifact: vi.fn(),
+      listVersions: vi.fn(),
+      listArtifactVersions: vi.fn(),
+      getArtifactVersion: vi.fn(),
+    } as unknown as SessionArtifactService;
+
+    expect(isSessionArtifactService(unbranded)).toBe(false);
+  });
+
+  it('does not detect an object whose signature symbol is not true', () => {
+    const notBranded = {
+      [SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL]: 'yes',
+    } as unknown as SessionArtifactService;
+
+    expect(isSessionArtifactService(notBranded)).toBe(false);
+  });
+});

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -18,6 +18,8 @@ import {
   isRoutableLlmAgent,
   LlmAgent,
   Runner,
+  ScopedArtifactService,
+  SessionArtifactService,
 } from '@google/adk';
 import {Content, FunctionCall, FunctionResponse} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
@@ -1077,6 +1079,109 @@ describe('Runner customMetadata support', () => {
     const userEvent = updatedSession!.events[0];
     expect(userEvent.author).toBe('user');
     expect(userEvent.content?.role).toBe('user');
+  });
+});
+
+describe('Runner artifactService handling', () => {
+  const SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL = Symbol.for(
+    'google.adk.sessionArtifactService',
+  );
+
+  it('should wrap BaseArtifactService in ScopedArtifactService when constructing InvocationContext', async () => {
+    const baseArtifactService = new InMemoryArtifactService();
+    const agent = new MockLlmAgent('agent_base_artifact');
+    const sessionService = new InMemorySessionService();
+    const runner = new Runner({
+      appName: TEST_APP_ID,
+      agent,
+      sessionService,
+      artifactService: baseArtifactService,
+    });
+
+    let capturedInvocationContext: InvocationContext | undefined;
+    const plugin = new (class extends BasePlugin {
+      constructor() {
+        super('capture_context_plugin');
+      }
+      override async onUserMessageCallback({
+        invocationContext,
+      }: {
+        invocationContext: InvocationContext;
+        userMessage: Content;
+      }) {
+        capturedInvocationContext = invocationContext;
+        return undefined;
+      }
+    })();
+    runner.pluginManager.registerPlugin(plugin);
+
+    for await (const _ of runner.runEphemeral({
+      userId: TEST_USER_ID,
+      newMessage: {role: 'user', parts: [{text: 'Hello'}]},
+    })) {
+      // iterate
+    }
+
+    expect(capturedInvocationContext).toBeDefined();
+    expect(capturedInvocationContext!.artifactService).toBeInstanceOf(
+      ScopedArtifactService,
+    );
+  });
+
+  it('should pass SessionArtifactService directly to InvocationContext without wrapping in ScopedArtifactService', async () => {
+    const sessionArtifactService: SessionArtifactService &
+      Record<symbol, unknown> = {
+      // Brands the stub the same way ScopedArtifactService and
+      // ForwardingArtifactService brand themselves.
+      [SESSION_ARTIFACT_SERVICE_SIGNATURE_SYMBOL]: true,
+      saveArtifact: vi.fn().mockResolvedValue(1),
+      loadArtifact: vi.fn().mockResolvedValue(undefined),
+      listArtifactKeys: vi.fn().mockResolvedValue([]),
+      deleteArtifact: vi.fn().mockResolvedValue(undefined),
+      listVersions: vi.fn().mockResolvedValue([]),
+      listArtifactVersions: vi.fn().mockResolvedValue([]),
+      getArtifactVersion: vi.fn().mockResolvedValue(undefined),
+    };
+    const agent = new MockLlmAgent('agent_session_artifact');
+    const sessionService = new InMemorySessionService();
+    const runner = new Runner({
+      appName: TEST_APP_ID,
+      agent,
+      sessionService,
+      artifactService: sessionArtifactService,
+    });
+
+    let capturedInvocationContext: InvocationContext | undefined;
+    const plugin = new (class extends BasePlugin {
+      constructor() {
+        super('capture_context_plugin_session');
+      }
+      override async onUserMessageCallback({
+        invocationContext,
+      }: {
+        invocationContext: InvocationContext;
+        userMessage: Content;
+      }) {
+        capturedInvocationContext = invocationContext;
+        return undefined;
+      }
+    })();
+    runner.pluginManager.registerPlugin(plugin);
+
+    for await (const _ of runner.runEphemeral({
+      userId: TEST_USER_ID,
+      newMessage: {role: 'user', parts: [{text: 'Hello'}]},
+    })) {
+      // iterate
+    }
+
+    expect(capturedInvocationContext).toBeDefined();
+    expect(capturedInvocationContext!.artifactService).toBe(
+      sessionArtifactService,
+    );
+    expect(capturedInvocationContext!.artifactService).not.toBeInstanceOf(
+      ScopedArtifactService,
+    );
   });
 });
 

--- a/core/test/tools/forwarding_artifact_service_test.ts
+++ b/core/test/tools/forwarding_artifact_service_test.ts
@@ -7,12 +7,9 @@
 import {Part} from '@google/genai';
 import {describe, expect, it, vi} from 'vitest';
 import {
-  DeleteArtifactRequest,
-  ListArtifactKeysRequest,
-  ListVersionsRequest,
-  LoadArtifactRequest,
-  SaveArtifactRequest,
-} from '../../src/artifacts/base_artifact_service.js';
+  SessionLoadArtifactRequest,
+  SessionSaveArtifactRequest,
+} from '../../src/artifacts/session_artifact_service.js';
 import {ForwardingArtifactService} from '../../src/tools/forwarding_artifact_service.js';
 
 function makeArtifactServiceStub() {
@@ -48,10 +45,7 @@ describe('ForwardingArtifactService', () => {
       toolContext.saveArtifact.mockResolvedValue(0);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: SaveArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+      const request: SessionSaveArtifactRequest = {
         filename: 'file.txt',
         artifact: {text: 'hello'},
       };
@@ -71,10 +65,7 @@ describe('ForwardingArtifactService', () => {
       toolContext.loadArtifact.mockResolvedValue(part);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+      const request: SessionLoadArtifactRequest = {
         filename: 'file.txt',
         version: 2,
       };
@@ -89,10 +80,7 @@ describe('ForwardingArtifactService', () => {
       toolContext.loadArtifact.mockResolvedValue(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+      const request: SessionLoadArtifactRequest = {
         filename: 'file.txt',
       };
 
@@ -110,13 +98,7 @@ describe('ForwardingArtifactService', () => {
       toolContext.listArtifacts.mockResolvedValue(['a.txt', 'b.txt']);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: ListArtifactKeysRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
-      };
-
-      const result = await service.listArtifactKeys(request);
+      const result = await service.listArtifactKeys();
       expect(toolContext.listArtifacts).toHaveBeenCalled();
       expect(result).toEqual(['a.txt', 'b.txt']);
     });
@@ -129,14 +111,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(artifactService);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: DeleteArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
-        filename: 'file.txt',
-      };
-
-      await service.deleteArtifact(request);
+      await service.deleteArtifact('file.txt');
       expect(artifactService.deleteArtifact).toHaveBeenCalledWith('file.txt');
     });
 
@@ -144,14 +119,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: DeleteArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
-        filename: 'file.txt',
-      };
-
-      await expect(service.deleteArtifact(request)).rejects.toThrow(
+      await expect(service.deleteArtifact('file.txt')).rejects.toThrow(
         'Artifact service is not initialized.',
       );
     });
@@ -164,14 +132,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(artifactService);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
-        filename: 'file.txt',
-      };
-
-      const result = await service.listVersions(request);
+      const result = await service.listVersions('file.txt');
       expect(artifactService.listVersions).toHaveBeenCalledWith('file.txt');
       expect(result).toEqual([0, 1, 2]);
     });
@@ -180,14 +141,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
-        filename: 'file.txt',
-      };
-
-      await expect(service.listVersions(request)).rejects.toThrow(
+      await expect(service.listVersions('file.txt')).rejects.toThrow(
         'Artifact service is not initialized.',
       );
     });
@@ -201,14 +155,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(artifactService);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
-        filename: 'file.txt',
-      };
-
-      const result = await service.listArtifactVersions(request);
+      const result = await service.listArtifactVersions('file.txt');
       expect(artifactService.listArtifactVersions).toHaveBeenCalledWith(
         'file.txt',
       );
@@ -219,14 +166,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
-        filename: 'file.txt',
-      };
-
-      await expect(service.listArtifactVersions(request)).rejects.toThrow(
+      await expect(service.listArtifactVersions('file.txt')).rejects.toThrow(
         'Artifact service is not initialized.',
       );
     });
@@ -240,10 +180,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(artifactService);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+      const request: SessionLoadArtifactRequest = {
         filename: 'file.txt',
         version: 1,
       };
@@ -260,10 +197,7 @@ describe('ForwardingArtifactService', () => {
       const toolContext = makeToolContext(undefined);
       const service = new ForwardingArtifactService(toolContext);
 
-      const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+      const request: SessionLoadArtifactRequest = {
         filename: 'file.txt',
         version: 0,
       };


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

2. Or, if no issue exists, describe the change:

**Problem**: `ForwardingArtifactService` previously implemented `BaseArtifactService`, requiring every artifact operation (`saveArtifact`, `loadArtifact`, `deleteArtifact`, `listVersions`, etc.) to accept session identifiers (`appName`, `userId`, `sessionId`). Because `ForwardingArtifactService` is instantiated per tool execution and bound directly to a parent `ToolContext` (which already encapsulates the active session's `InvocationContext`), forcing callers and sub-agent tools to provide these session parameters was redundant, error-prone, and represented a leaky abstraction.

**Solution**: Redesigned `ForwardingArtifactService` to implement `SessionArtifactService` (`SessionSaveArtifactRequest`, `SessionLoadArtifactRequest`, etc.) without `appName`, `userId`, and `sessionId`. Updated `RunnerConfig` and `Runner` to accept `BaseArtifactService` | `SessionArtifactService`, cleanly distinguishing session-scoped services via a new exported `isSessionArtifactService` type guard, avoiding double-wrapping in `ScopedArtifactService`. Added `ScopedArtifactService`, `ForwardingArtifactService`, and `isSessionArtifactService` to package exports in `common.ts`.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.

1. Build the package locally using `npm run build`.
2. Run the standalone E2E test verifying sub-agent artifact saving and parent agent loading across `ForwardingArtifactService` and `AgentTool`:
   ```bash
   npx vitest run --project e2e tests/e2e/tools/forwarding_artifact_service_e2e_test.ts
   ```
3. Run the integration test suite:
   ```bash
   npx vitest run --project integration tests/integration/tools/agent_tool_test.ts
   ```

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

