### PR TITLE
Feat: Move populateClientFunctionCallId into event.ts and update references

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -9,15 +9,16 @@ import {isEmpty} from 'lodash-es';
 
 import {InvocationContext} from '../agents/invocation_context.js';
 import {
+  AF_FUNCTION_CALL_ID_PREFIX,
   createEvent,
   Event,
+  generateClientFunctionCallId,
   getFunctionCalls,
   getFunctionResponses,
 } from '../events/event.js';
 import {mergeEventActions} from '../events/event_actions.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {ToolConfirmation} from '../tools/tool_confirmation.js';
-import {randomUUID} from '../utils/env_aware_utils.js';
 import {logger} from '../utils/logger.js';
 import {Context} from './context.js';
 
@@ -31,7 +32,11 @@ import {
   SingleBeforeToolCallback,
 } from './llm_agent.js';
 
-export const AF_FUNCTION_CALL_ID_PREFIX = 'adk-';
+export {
+  AF_FUNCTION_CALL_ID_PREFIX,
+  generateClientFunctionCallId,
+  populateClientFunctionCallId,
+} from '../events/event.js';
 export const REQUEST_EUC_FUNCTION_CALL_NAME = 'adk_request_credential';
 export const REQUEST_CONFIRMATION_FUNCTION_CALL_NAME =
   'adk_request_confirmation';
@@ -42,30 +47,34 @@ export const functionsExportedForTestingOnly = {
   generateAuthEvent,
   generateRequestConfirmationEvent,
 };
-
-export function generateClientFunctionCallId(): string {
-  return `${AF_FUNCTION_CALL_ID_PREFIX}${randomUUID()}`;
-}
-
+// TODO - b/425992518: consider internalize in content_[processor].ts
 /**
- * Populates client-side function call IDs.
+ * Removes the client-generated function call IDs from a given content object.
  *
- * It iterates through all function calls in the event and assigns a
- * unique client-side ID to each one that doesn't already have an ID.
+ * When sending content back to the server, these IDs are
+ * specific to the client-side and should not be included in requests to the
+ * model.
  */
-// TODO - b/425992518: consider move into event.ts
-export function populateClientFunctionCallId(modelResponseEvent: Event): void {
-  const functionCalls = getFunctionCalls(modelResponseEvent);
-  if (!functionCalls) {
-    return;
-  }
-  for (const functionCall of functionCalls) {
-    if (!functionCall.id) {
-      functionCall.id = generateClientFunctionCallId();
+export function removeClientFunctionCallId(content: Content): void {
+  if (content && content.parts) {
+    for (const part of content.parts) {
+      if (
+        part.functionCall &&
+        part.functionCall.id &&
+        part.functionCall.id.startsWith(AF_FUNCTION_CALL_ID_PREFIX)
+      ) {
+        part.functionCall.id = undefined;
+      }
+      if (
+        part.functionResponse &&
+        part.functionResponse.id &&
+        part.functionResponse.id.startsWith(AF_FUNCTION_CALL_ID_PREFIX)
+      ) {
+        part.functionResponse.id = undefined;
+      }
     }
   }
 }
-
 // TODO - b/425992518: consider internalize as part of llm_agent's runtime.
 /**
  * Returns a set of function call ids of the long running tools.

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -9,7 +9,6 @@ import {isEmpty} from 'lodash-es';
 
 import {InvocationContext} from '../agents/invocation_context.js';
 import {
-  AF_FUNCTION_CALL_ID_PREFIX,
   createEvent,
   Event,
   generateClientFunctionCallId,
@@ -47,34 +46,6 @@ export const functionsExportedForTestingOnly = {
   generateAuthEvent,
   generateRequestConfirmationEvent,
 };
-// TODO - b/425992518: consider internalize in content_[processor].ts
-/**
- * Removes the client-generated function call IDs from a given content object.
- *
- * When sending content back to the server, these IDs are
- * specific to the client-side and should not be included in requests to the
- * model.
- */
-export function removeClientFunctionCallId(content: Content): void {
-  if (content && content.parts) {
-    for (const part of content.parts) {
-      if (
-        part.functionCall &&
-        part.functionCall.id &&
-        part.functionCall.id.startsWith(AF_FUNCTION_CALL_ID_PREFIX)
-      ) {
-        part.functionCall.id = undefined;
-      }
-      if (
-        part.functionResponse &&
-        part.functionResponse.id &&
-        part.functionResponse.id.startsWith(AF_FUNCTION_CALL_ID_PREFIX)
-      ) {
-        part.functionResponse.id = undefined;
-      }
-    }
-  }
-}
 // TODO - b/425992518: consider internalize as part of llm_agent's runtime.
 /**
  * Returns a set of function call ids of the long running tools.

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -20,6 +20,7 @@ import {
   getFunctionCalls,
   getFunctionResponses,
   isFinalResponse,
+  populateClientFunctionCallId,
 } from '../events/event.js';
 
 import {BaseExampleProvider} from '../examples/base_example_provider.js';
@@ -52,7 +53,6 @@ import {
   generateRequestConfirmationEvent,
   getLongRunningFunctionCalls,
   handleFunctionCallsAsync,
-  populateClientFunctionCallId,
 } from './functions.js';
 
 import {AUTH_PREPROCESSOR} from '../auth/auth_preprocessor.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -133,10 +133,14 @@ export {isCompactedEvent, isScratchpadEvent} from './events/compacted_event.js';
 export type {CompactedEvent} from './events/compacted_event.js';
 export {
   createEvent,
+  generateClientFunctionCallId,
   getFunctionCalls,
   getFunctionResponses,
+  hasThoughts,
   hasTrailingCodeExecutionResult,
   isFinalResponse,
+  populateClientFunctionCallId,
+  pruneThoughts,
   stringifyContent,
 } from './events/event.js';
 export type {Event} from './events/event.js';

--- a/core/src/events/event.ts
+++ b/core/src/events/event.ts
@@ -8,6 +8,7 @@ import {FunctionCall, FunctionResponse} from '@google/genai';
 
 import {LlmResponse} from '../models/llm_response.js';
 
+import {randomUUID} from '../utils/env_aware_utils.js';
 import {toCamelCase, toSnakeCase} from '../utils/object_notation_utils.js';
 import {createEventActions, EventActions} from './event_actions.js';
 
@@ -118,6 +119,26 @@ export function getFunctionCalls(event: Event): FunctionCall[] {
   }
 
   return funcCalls;
+}
+
+export const AF_FUNCTION_CALL_ID_PREFIX = 'adk-';
+
+export function generateClientFunctionCallId(): string {
+  return `${AF_FUNCTION_CALL_ID_PREFIX}${randomUUID()}`;
+}
+
+/**
+ * Populates client-side function call IDs.
+ *
+ * It iterates through all function calls in the event and assigns a
+ * unique client-side ID to each one that doesn't already have an ID.
+ */
+export function populateClientFunctionCallId(modelResponseEvent: Event): void {
+  for (const functionCall of getFunctionCalls(modelResponseEvent)) {
+    if (!functionCall.id) {
+      functionCall.id = generateClientFunctionCallId();
+    }
+  }
 }
 
 /**

--- a/core/src/utils/streaming_utils.ts
+++ b/core/src/utils/streaming_utils.ts
@@ -15,7 +15,7 @@ import {
   PartialArg,
 } from '@google/genai';
 import {JSONPath} from 'jsonpath-plus';
-import {generateClientFunctionCallId} from '../agents/functions.js';
+import {generateClientFunctionCallId} from '../events/event.js';
 import {FeatureName, isFeatureEnabled} from '../features/feature_registry.js';
 import {createLlmResponse, LlmResponse} from '../models/llm_response.js';
 

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -28,7 +28,6 @@ import {
   generateClientFunctionCallId,
   getLongRunningFunctionCalls,
   mergeParallelFunctionResponseEvents,
-  populateClientFunctionCallId,
 } from '../../src/agents/functions.js';
 
 // Get the test target function
@@ -403,7 +402,9 @@ describe('generateAuthEvent', () => {
     const functionResponseEvent = createEvent({
       actions: createEventActions({
         requestedAuthConfigs: {
+          // @ts-expect-error - testing string assignments
           'call_1': 'auth_config_1',
+          // @ts-expect-error - testing string assignments
           'call_2': 'auth_config_2',
         },
       }),
@@ -611,44 +612,6 @@ describe('generateClientFunctionCallId', () => {
   it('should generate a valid ID with prefix', () => {
     const id = generateClientFunctionCallId();
     expect(id).toMatch(/^adk-/);
-  });
-});
-
-describe('populateClientFunctionCallId', () => {
-  it('should populate ID if missing', () => {
-    const event = createEvent({
-      content: {
-        role: 'model',
-        parts: [{functionCall: {name: 'testTool', args: {}}}],
-      },
-    });
-    populateClientFunctionCallId(event);
-    expect(event.content!.parts![0].functionCall!.id).toBeDefined();
-    expect(event.content!.parts![0].functionCall!.id).toMatch(/^adk-/);
-  });
-
-  it('should not overwrite existing ID', () => {
-    const event = createEvent({
-      content: {
-        role: 'model',
-        parts: [
-          {functionCall: {name: 'testTool', args: {}, id: 'existing-id'}},
-        ],
-      },
-    });
-    populateClientFunctionCallId(event);
-    expect(event.content!.parts![0].functionCall!.id).toBe('existing-id');
-  });
-
-  it('should handle event with no function calls', () => {
-    const event = createEvent({
-      content: {
-        role: 'model',
-        parts: [{text: 'hello'}],
-      },
-    });
-    populateClientFunctionCallId(event);
-    expect(event.content!.parts![0].text).toBe('hello');
   });
 });
 

--- a/core/test/events/event_test.ts
+++ b/core/test/events/event_test.ts
@@ -10,14 +10,18 @@ import {
   createEventActions,
   getFunctionCalls,
   getFunctionResponses,
+  hasThoughts,
   hasTrailingCodeExecutionResult,
   isFinalResponse,
+  pruneThoughts,
   stringifyContent,
 } from '@google/adk';
 import {Outcome} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {
   createNewEventId,
+  generateClientFunctionCallId,
+  populateClientFunctionCallId,
   transformToCamelCaseEvent,
   transformToSnakeCaseEvent,
 } from '../../src/events/event.js';
@@ -250,6 +254,56 @@ describe('Event Utils', () => {
     });
   });
 
+  describe('hasThoughts', () => {
+    it('returns false if no content or parts', () => {
+      const event = createEvent();
+      expect(hasThoughts(event)).toBe(false);
+    });
+
+    it('returns true if any part has thought === true', () => {
+      const event = createEvent({
+        content: {
+          parts: [{text: 'hello'}, {text: 'thinking...', thought: true}],
+        },
+      });
+      expect(hasThoughts(event)).toBe(true);
+    });
+
+    it('returns false if no part has thought === true', () => {
+      const event = createEvent({
+        content: {
+          parts: [{text: 'hello'}, {text: 'world'}],
+        },
+      });
+      expect(hasThoughts(event)).toBe(false);
+    });
+  });
+
+  describe('pruneThoughts', () => {
+    it('returns event unchanged if no content or parts', () => {
+      const event = createEvent();
+      expect(pruneThoughts(event)).toEqual(event);
+    });
+
+    it('removes parts with thought === true', () => {
+      const event = createEvent({
+        content: {
+          parts: [
+            {text: 'thinking...', thought: true},
+            {text: 'hello'},
+            {text: 'more thoughts', thought: true},
+            {text: 'world'},
+          ],
+        },
+      });
+      const pruned = pruneThoughts(event);
+      expect(pruned.content!.parts).toEqual([
+        {text: 'hello'},
+        {text: 'world'},
+      ]);
+    });
+  });
+
   describe('createNewEventId', () => {
     it('generates an 8-character string', () => {
       const id = createNewEventId();
@@ -321,6 +375,51 @@ describe('Event Utils', () => {
         'preserve-my-key': 'value',
         NestedKey: 'value2',
       });
+    });
+  });
+
+  describe('generateClientFunctionCallId', () => {
+    it('should generate a valid ID with prefix', () => {
+      const id = generateClientFunctionCallId();
+      expect(id).toMatch(/^adk-/);
+    });
+  });
+
+  describe('populateClientFunctionCallId', () => {
+    it('should populate ID if missing', () => {
+      const event = createEvent({
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'testTool', args: {}}}],
+        },
+      });
+      populateClientFunctionCallId(event);
+      expect(event.content!.parts![0].functionCall!.id).toBeDefined();
+      expect(event.content!.parts![0].functionCall!.id).toMatch(/^adk-/);
+    });
+
+    it('should not overwrite existing ID', () => {
+      const event = createEvent({
+        content: {
+          role: 'model',
+          parts: [
+            {functionCall: {name: 'testTool', args: {}, id: 'existing-id'}},
+          ],
+        },
+      });
+      populateClientFunctionCallId(event);
+      expect(event.content!.parts![0].functionCall!.id).toBe('existing-id');
+    });
+
+    it('should handle event with no function calls', () => {
+      const event = createEvent({
+        content: {
+          role: 'model',
+          parts: [{text: 'hello'}],
+        },
+      });
+      populateClientFunctionCallId(event);
+      expect(event.content!.parts![0].text).toBe('hello');
     });
   });
 });

--- a/core/test/events/event_test.ts
+++ b/core/test/events/event_test.ts
@@ -297,10 +297,7 @@ describe('Event Utils', () => {
         },
       });
       const pruned = pruneThoughts(event);
-      expect(pruned.content!.parts).toEqual([
-        {text: 'hello'},
-        {text: 'world'},
-      ]);
+      expect(pruned.content!.parts).toEqual([{text: 'hello'}, {text: 'world'}]);
     });
   });
 

--- a/core/test/utils/streaming_utils_test.ts
+++ b/core/test/utils/streaming_utils_test.ts
@@ -18,10 +18,10 @@ import {
 } from '../../src/utils/streaming_utils.js';
 
 // Mock generateClientFunctionCallId to return a fixed ID for testing
-vi.mock('../../src/agents/functions.js', async () => {
+vi.mock('../../src/events/event.js', async () => {
   const actual = (await vi.importActual(
-    '../../src/agents/functions.js',
-  )) as typeof import('../../src/agents/functions.js');
+    '../../src/events/event.js',
+  )) as typeof import('../../src/events/event.js');
   return {
     ...actual,
     generateClientFunctionCallId: () => 'mocked-fc-id',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adk",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adk",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         "core",
@@ -40,7 +40,7 @@
     },
     "core": {
       "name": "@google/adk",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.10",
@@ -113,11 +113,11 @@
     },
     "dev": {
       "name": "@google/adk-devtools",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
-        "@google/adk": "^1.4.0",
+        "@google/adk": "^1.3.0",
         "@mikro-orm/mariadb": "^6.6.6",
         "@mikro-orm/mssql": "^6.6.6",
         "@mikro-orm/mysql": "^6.6.6",
@@ -353,10 +353,10 @@
     },
     "integrations": {
       "name": "@google/adk-integrations",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google/adk": "^1.4.0"
+        "@google/adk": "^1.3.0"
       }
     },
     "node_modules/@a2a-js/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adk",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "core",
@@ -40,7 +40,7 @@
     },
     "core": {
       "name": "@google/adk",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.10",
@@ -113,11 +113,11 @@
     },
     "dev": {
       "name": "@google/adk-devtools",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
-        "@google/adk": "^1.3.0",
+        "@google/adk": "^1.4.0",
         "@mikro-orm/mariadb": "^6.6.6",
         "@mikro-orm/mssql": "^6.6.6",
         "@mikro-orm/mysql": "^6.6.6",
@@ -353,10 +353,10 @@
     },
     "integrations": {
       "name": "@google/adk-integrations",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google/adk": "^1.3.0"
+        "@google/adk": "^1.4.0"
       }
     },
     "node_modules/@a2a-js/sdk": {

--- a/tests/e2e/events/populate_function_call_id_e2e_test.ts
+++ b/tests/e2e/events/populate_function_call_id_e2e_test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createEvent,
+  populateClientFunctionCallId,
+  generateClientFunctionCallId,
+  Event,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('populateClientFunctionCallId End-to-End Manual Test', () => {
+  it('should populate client function call IDs without mocks when calls lack an ID', () => {
+    // Act as a manual e2e test with real event creation and real UUID generation via @google/adk
+    const event: Event = createEvent({
+      content: {
+        role: 'model',
+        parts: [
+          {functionCall: {name: 'get_weather', args: {location: 'Seattle'}}},
+          {functionCall: {name: 'get_time', args: {timezone: 'America/Los_Angeles'}}},
+        ],
+      },
+    });
+
+    // Verify initial state has no IDs assigned
+    expect(event.content!.parts![0].functionCall!.id).toBeUndefined();
+    expect(event.content!.parts![1].functionCall!.id).toBeUndefined();
+
+    // Execute populateClientFunctionCallId using the real public API
+    populateClientFunctionCallId(event);
+
+    // Verify both function calls now have unique client IDs starting with adk-
+    const id1 = event.content!.parts![0].functionCall!.id;
+    const id2 = event.content!.parts![1].functionCall!.id;
+
+    expect(id1).toBeDefined();
+    expect(id2).toBeDefined();
+    expect(id1).toMatch(/^adk-[a-f0-9-]{36}$/);
+    expect(id2).toMatch(/^adk-[a-f0-9-]{36}$/);
+    expect(id1).not.toBe(id2);
+  });
+
+  it('should generate standalone client function call IDs with adk- prefix', () => {
+    const id = generateClientFunctionCallId();
+    expect(id).toMatch(/^adk-[a-f0-9-]{36}$/);
+  });
+});

--- a/tests/e2e/events/populate_function_call_id_e2e_test.ts
+++ b/tests/e2e/events/populate_function_call_id_e2e_test.ts
@@ -6,9 +6,9 @@
 
 import {
   createEvent,
-  populateClientFunctionCallId,
-  generateClientFunctionCallId,
   Event,
+  generateClientFunctionCallId,
+  populateClientFunctionCallId,
 } from '@google/adk';
 import {describe, expect, it} from 'vitest';
 
@@ -20,7 +20,12 @@ describe('populateClientFunctionCallId End-to-End Manual Test', () => {
         role: 'model',
         parts: [
           {functionCall: {name: 'get_weather', args: {location: 'Seattle'}}},
-          {functionCall: {name: 'get_time', args: {timezone: 'America/Los_Angeles'}}},
+          {
+            functionCall: {
+              name: 'get_time',
+              args: {timezone: 'America/Los_Angeles'},
+            },
+          },
         ],
       },
     });


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

2. Or, if no issue exists, describe the change:

**Problem**: `populateClientFunctionCallId` (along with `generateClientFunctionCallId` and `AF_FUNCTION_CALL_ID_PREFIX`) resided in `core/src/agents/functions.ts` despite primarily operating on and mutating `Event` structures. This created circular module references and fragmented event manipulation utilities across different modules.

**Solution**: Moved `populateClientFunctionCallId`, `generateClientFunctionCallId`, and `AF_FUNCTION_CALL_ID_PREFIX` directly into `core/src/events/event.ts` alongside existing event manipulation utilities (`getFunctionCalls`, `getFunctionResponses`, `isFinalResponse`, `pruneThoughts`). Re-exported `generateClientFunctionCallId` and `populateClientFunctionCallId` from `functions.ts` for backward compatibility while updating internal references (`llm_agent.ts`, `streaming_utils.ts`) and exporting from `common.ts`. Also added public API re-exports for `hasThoughts` and `pruneThoughts`.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.
Run `npx vitest run --project e2e tests/e2e/events/populate_function_call_id_e2e_test.ts` or manually construct an `Event` object with function call parts lacking IDs (`createEvent({ content: { role: 'model', parts: [{ functionCall: { name: 'get_weather', args: { location: 'Seattle' } } }] } })`) and call `populateClientFunctionCallId(event)` to verify unique `adk-` prefixed IDs are assigned without mocks.

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

