### PR TITLE
Fix: Clean up eventActions from CallbackContext

### DIFF
--- a/core/src/agents/context.ts
+++ b/core/src/agents/context.ts
@@ -17,6 +17,13 @@ import {ToolConfirmation} from '../tools/tool_confirmation.js';
 import {InvocationContext} from './invocation_context.js';
 import {ReadonlyContext} from './readonly_context.js';
 
+interface WritableContext {
+  eventActions?: EventActions;
+  invocationContext?: InvocationContext;
+  _state?: State;
+  toolConfirmation?: ToolConfirmation;
+}
+
 /**
  * The context of various callbacks within an agent run.
  *
@@ -181,5 +188,13 @@ export class Context extends ReadonlyContext {
         confirmed: false,
         payload: payload,
       });
+  }
+
+  cleanup() {
+    const writable = this as unknown as WritableContext;
+    writable.eventActions = undefined;
+    writable.invocationContext = undefined;
+    writable._state = undefined;
+    writable.toolConfirmation = undefined;
   }
 }

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -335,142 +335,150 @@ export async function handleFunctionCallList({
       toolConfirmation,
     });
 
-    // TODO - b/436079721: implement [tracer.start_as_current_span]
-    logger.debug(`execute_tool ${tool.name}`);
-    const functionArgs = functionCall.args ?? {};
+    try {
+      // TODO - b/436079721: implement [tracer.start_as_current_span]
+      logger.debug(`execute_tool ${tool.name}`);
+      const functionArgs = functionCall.args ?? {};
 
-    // Step 1: Check if plugin before_tool_callback overrides the function
-    // response.
-    let functionResponse = null;
-    let functionResponseError: string | unknown | undefined;
-    functionResponse =
-      await invocationContext.pluginManager.runBeforeToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-      });
-
-    // Step 2: If no overrides are provided from the plugins, further run the
-    // canonical callback.
-    // TODO - b/425992518: validate the callback response type matches.
-    if (functionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of beforeToolCallbacks) {
-        functionResponse = await callback({
+      // Step 1: Check if plugin before_tool_callback overrides the function
+      // response.
+      let functionResponse = null;
+      let functionResponseError: string | unknown | undefined;
+      functionResponse =
+        await invocationContext.pluginManager.runBeforeToolCallback({
           tool: tool,
-          args: functionArgs,
-          context: toolContext,
+          toolArgs: functionArgs,
+          toolContext: toolContext,
         });
-        if (functionResponse) {
-          break;
-        }
-      }
-    }
 
-    // Step 3: Otherwise, proceed calling the tool normally.
-    if (functionResponse == null) {
-      // Cover both null and undefined
-      try {
-        functionResponse = await callToolAsync(tool, functionArgs, toolContext);
-      } catch (e: unknown) {
-        if (e instanceof Error) {
-          const onToolErrorResponse =
-            await invocationContext.pluginManager.runOnToolErrorCallback({
-              tool: tool,
-              toolArgs: functionArgs,
-              toolContext: toolContext,
-              error: e,
-            });
-
-          // Set function response to the result of the error callback and
-          // continue execution, do not shortcut
-          if (onToolErrorResponse) {
-            functionResponse = onToolErrorResponse;
-          } else {
-            // If the error callback returns undefined, use the error message
-            // as the function response error.
-            functionResponseError = e.message;
+      // Step 2: If no overrides are provided from the plugins, further run the
+      // canonical callback.
+      // TODO - b/425992518: validate the callback response type matches.
+      if (functionResponse == null) {
+        // Cover both null and undefined
+        for (const callback of beforeToolCallbacks) {
+          functionResponse = await callback({
+            tool: tool,
+            args: functionArgs,
+            context: toolContext,
+          });
+          if (functionResponse) {
+            break;
           }
-        } else {
-          // If the error is not an Error, use the error object as the function
-          // response error.
-          functionResponseError = e;
         }
       }
-    }
 
-    // Step 4: Check if plugin after_tool_callback overrides the function
-    // response.
-    let alteredFunctionResponse =
-      await invocationContext.pluginManager.runAfterToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-        result: functionResponse,
+      // Step 3: Otherwise, proceed calling the tool normally.
+      if (functionResponse == null) {
+        // Cover both null and undefined
+        try {
+          functionResponse = await callToolAsync(
+            tool,
+            functionArgs,
+            toolContext,
+          );
+        } catch (e: unknown) {
+          if (e instanceof Error) {
+            const onToolErrorResponse =
+              await invocationContext.pluginManager.runOnToolErrorCallback({
+                tool: tool,
+                toolArgs: functionArgs,
+                toolContext: toolContext,
+                error: e,
+              });
+
+            // Set function response to the result of the error callback and
+            // continue execution, do not shortcut
+            if (onToolErrorResponse) {
+              functionResponse = onToolErrorResponse;
+            } else {
+              // If the error callback returns undefined, use the error message
+              // as the function response error.
+              functionResponseError = e.message;
+            }
+          } else {
+            // If the error is not an Error, use the error object as the function
+            // response error.
+            functionResponseError = e;
+          }
+        }
+      }
+
+      // Step 4: Check if plugin after_tool_callback overrides the function
+      // response.
+      let alteredFunctionResponse =
+        await invocationContext.pluginManager.runAfterToolCallback({
+          tool: tool,
+          toolArgs: functionArgs,
+          toolContext: toolContext,
+          result: functionResponse,
+        });
+
+      // Step 5: If no overrides are provided from the plugins, further run the
+      // canonical after_tool_callbacks.
+      if (alteredFunctionResponse == null) {
+        // Cover both null and undefined
+        for (const callback of afterToolCallbacks) {
+          alteredFunctionResponse = await callback({
+            tool: tool,
+            args: functionArgs,
+            context: toolContext,
+            response: functionResponse,
+          });
+          if (alteredFunctionResponse) {
+            break;
+          }
+        }
+      }
+
+      // Step 6: If alternative response exists from after_tool_callback, use it
+      // instead of the original function response.
+      if (alteredFunctionResponse != null) {
+        functionResponse = alteredFunctionResponse;
+      }
+
+      // TODO - b/425992518: state event polluting runtime, consider fix.
+      // Allow long running function to return None as response.
+      if (tool.isLongRunning && !functionResponse) {
+        continue;
+      }
+
+      if (functionResponseError) {
+        functionResponse = {error: functionResponseError};
+      } else if (
+        typeof functionResponse !== 'object' ||
+        functionResponse == null
+      ) {
+        functionResponse = {result: functionResponse};
+      } else if (Array.isArray(functionResponse)) {
+        functionResponse = {results: functionResponse};
+      }
+
+      // Builds the function response event.
+      const functionResponseEvent = createEvent({
+        invocationId: invocationContext.invocationId,
+        author: invocationContext.agent.name,
+        content: createUserContent({
+          functionResponse: {
+            id: toolContext.functionCallId,
+            name: tool.name,
+            response: functionResponse,
+          },
+        }),
+        actions: toolContext.actions,
+        branch: invocationContext.branch,
       });
 
-    // Step 5: If no overrides are provided from the plugins, further run the
-    // canonical after_tool_callbacks.
-    if (alteredFunctionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of afterToolCallbacks) {
-        alteredFunctionResponse = await callback({
-          tool: tool,
-          args: functionArgs,
-          context: toolContext,
-          response: functionResponse,
-        });
-        if (alteredFunctionResponse) {
-          break;
-        }
-      }
+      // TODO - b/436079721: implement [traceToolCall]
+      logger.debug('traceToolCall', {
+        tool: tool.name,
+        args: functionArgs,
+        functionResponseEvent: functionResponseEvent.id,
+      });
+      functionResponseEvents.push(functionResponseEvent);
+    } finally {
+      toolContext.cleanup();
     }
-
-    // Step 6: If alternative response exists from after_tool_callback, use it
-    // instead of the original function response.
-    if (alteredFunctionResponse != null) {
-      functionResponse = alteredFunctionResponse;
-    }
-
-    // TODO - b/425992518: state event polluting runtime, consider fix.
-    // Allow long running function to return None as response.
-    if (tool.isLongRunning && !functionResponse) {
-      continue;
-    }
-
-    if (functionResponseError) {
-      functionResponse = {error: functionResponseError};
-    } else if (
-      typeof functionResponse !== 'object' ||
-      functionResponse == null
-    ) {
-      functionResponse = {result: functionResponse};
-    } else if (Array.isArray(functionResponse)) {
-      functionResponse = {results: functionResponse};
-    }
-
-    // Builds the function response event.
-    const functionResponseEvent = createEvent({
-      invocationId: invocationContext.invocationId,
-      author: invocationContext.agent.name,
-      content: createUserContent({
-        functionResponse: {
-          id: toolContext.functionCallId,
-          name: tool.name,
-          response: functionResponse,
-        },
-      }),
-      actions: toolContext.actions,
-      branch: invocationContext.branch,
-    });
-
-    // TODO - b/436079721: implement [traceToolCall]
-    logger.debug('traceToolCall', {
-      tool: tool.name,
-      args: functionArgs,
-      functionResponseEvent: functionResponseEvent.id,
-    });
-    functionResponseEvents.push(functionResponseEvent);
   }
 
   if (!functionResponseEvents.length) {

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -1130,36 +1130,40 @@ export class LlmAgent extends BaseAgent {
       eventActions: modelResponseEvent.actions,
     });
 
-    // Plugin callbacks before canonical callbacks
-    const beforeModelCallbackResponse =
-      await invocationContext.pluginManager.runBeforeModelCallback({
-        callbackContext,
-        llmRequest,
-      });
-    if (invocationContext.abortSignal?.aborted) {
-      return;
-    }
-
-    if (beforeModelCallbackResponse) {
-      return beforeModelCallbackResponse;
-    }
-
-    // If no override was returned from the plugins, run the canonical callbacks
-    for (const callback of this.canonicalBeforeModelCallbacks) {
-      const callbackResponse = await callback({
-        context: callbackContext,
-        request: llmRequest,
-      });
-
+    try {
+      // Plugin callbacks before canonical callbacks
+      const beforeModelCallbackResponse =
+        await invocationContext.pluginManager.runBeforeModelCallback({
+          callbackContext,
+          llmRequest,
+        });
       if (invocationContext.abortSignal?.aborted) {
         return;
       }
 
-      if (callbackResponse) {
-        return callbackResponse;
+      if (beforeModelCallbackResponse) {
+        return beforeModelCallbackResponse;
       }
+
+      // If no override was returned from the plugins, run the canonical callbacks
+      for (const callback of this.canonicalBeforeModelCallbacks) {
+        const callbackResponse = await callback({
+          context: callbackContext,
+          request: llmRequest,
+        });
+
+        if (invocationContext.abortSignal?.aborted) {
+          return;
+        }
+
+        if (callbackResponse) {
+          return callbackResponse;
+        }
+      }
+      return undefined;
+    } finally {
+      callbackContext.cleanup();
     }
-    return undefined;
   }
 
   private async handleAfterModelCallback(
@@ -1172,32 +1176,36 @@ export class LlmAgent extends BaseAgent {
       eventActions: modelResponseEvent.actions,
     });
 
-    // Plugin callbacks before canonical callbacks
-    const afterModelCallbackResponse =
-      await invocationContext.pluginManager.runAfterModelCallback({
-        callbackContext,
-        llmResponse,
-      });
-    if (afterModelCallbackResponse) {
-      return afterModelCallbackResponse;
-    }
-
-    // If no override was returned from the plugins, run the canonical callbacks
-    for (const callback of this.canonicalAfterModelCallbacks) {
-      const callbackResponse = await callback({
-        context: callbackContext,
-        response: llmResponse,
-      });
-
-      if (invocationContext.abortSignal?.aborted) {
-        return;
+    try {
+      // Plugin callbacks before canonical callbacks
+      const afterModelCallbackResponse =
+        await invocationContext.pluginManager.runAfterModelCallback({
+          callbackContext,
+          llmResponse,
+        });
+      if (afterModelCallbackResponse) {
+        return afterModelCallbackResponse;
       }
 
-      if (callbackResponse) {
-        return callbackResponse;
+      // If no override was returned from the plugins, run the canonical callbacks
+      for (const callback of this.canonicalAfterModelCallbacks) {
+        const callbackResponse = await callback({
+          context: callbackContext,
+          response: llmResponse,
+        });
+
+        if (invocationContext.abortSignal?.aborted) {
+          return;
+        }
+
+        if (callbackResponse) {
+          return callbackResponse;
+        }
       }
+      return undefined;
+    } finally {
+      callbackContext.cleanup();
     }
-    return undefined;
   }
 
   protected async *runAndHandleError<T extends LlmResponse | Event>(
@@ -1222,54 +1230,58 @@ export class LlmAgent extends BaseAgent {
         eventActions: modelResponseEvent.actions,
       });
 
-      // Wrapped LLM should throw Error-typed errors
-      if (modelError instanceof Error) {
-        // Try plugins to recover from the error
-        const onModelErrorCallbackResponse =
-          await invocationContext.pluginManager.runOnModelErrorCallback({
-            callbackContext: callbackContext,
-            llmRequest: llmRequest,
-            error: modelError as Error,
-          });
+      try {
+        // Wrapped LLM should throw Error-typed errors
+        if (modelError instanceof Error) {
+          // Try plugins to recover from the error
+          const onModelErrorCallbackResponse =
+            await invocationContext.pluginManager.runOnModelErrorCallback({
+              callbackContext: callbackContext,
+              llmRequest: llmRequest,
+              error: modelError as Error,
+            });
 
-        if (onModelErrorCallbackResponse) {
-          yield onModelErrorCallbackResponse as T;
-        } else {
-          // If no plugins, just return the message.
-          let errorCode = 'UNKNOWN_ERROR';
-          let errorMessage = modelError.message;
-
-          try {
-            const errorResponse = JSON.parse(modelError.message) as {
-              error: {code: number; message: string};
-            };
-            if (errorResponse?.error) {
-              errorCode = String(errorResponse.error.code || 'UNKNOWN_ERROR');
-              errorMessage = errorResponse.error.message || errorMessage;
-            }
-          } catch {
-            // Ignore JSON parse error, use original message.
-          }
-
-          if (modelResponseEvent.actions) {
-            // We are yielding an Event
-            yield createEvent({
-              invocationId: invocationContext.invocationId,
-              author: this.name,
-              errorCode,
-              errorMessage,
-            }) as T;
+          if (onModelErrorCallbackResponse) {
+            yield onModelErrorCallbackResponse as T;
           } else {
-            // We are yielding an LlmResponse
-            yield {
-              errorCode,
-              errorMessage,
-            } as T;
+            // If no plugins, just return the message.
+            let errorCode = 'UNKNOWN_ERROR';
+            let errorMessage = modelError.message;
+
+            try {
+              const errorResponse = JSON.parse(modelError.message) as {
+                error: {code: number; message: string};
+              };
+              if (errorResponse?.error) {
+                errorCode = String(errorResponse.error.code || 'UNKNOWN_ERROR');
+                errorMessage = errorResponse.error.message || errorMessage;
+              }
+            } catch {
+              // Ignore JSON parse error, use original message.
+            }
+
+            if (modelResponseEvent.actions) {
+              // We are yielding an Event
+              yield createEvent({
+                invocationId: invocationContext.invocationId,
+                author: this.name,
+                errorCode,
+                errorMessage,
+              }) as T;
+            } else {
+              // We are yielding an LlmResponse
+              yield {
+                errorCode,
+                errorMessage,
+              } as T;
+            }
           }
+        } else {
+          logger.error('Unknown error during response generation', modelError);
+          throw modelError;
         }
-      } else {
-        logger.error('Unknown error during response generation', modelError);
-        throw modelError;
+      } finally {
+        callbackContext.cleanup();
       }
     }
   }

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -6,6 +6,7 @@
 import {
   BasePlugin,
   BaseTool,
+  Context,
   createEvent,
   createEventActions,
   Event,
@@ -363,6 +364,19 @@ describe('handleFunctionCallList', () => {
         }),
       }),
     );
+  });
+
+  it('should call cleanup on toolContext after tool execution', async () => {
+    const cleanupSpy = vi.spyOn(Context.prototype, 'cleanup');
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [functionCall],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+    expect(cleanupSpy).toHaveBeenCalled();
+    cleanupSpy.mockRestore();
   });
 });
 

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -27,7 +27,7 @@ import {
   ToolProcessLlmRequest,
 } from '@google/adk';
 import {Content, Schema, Type} from '@google/genai';
-import {beforeEach, describe, expect, it} from 'vitest';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
 
@@ -837,5 +837,127 @@ describe('LlmAgent Default Request Processors', () => {
       CONTENT_REQUEST_PROCESSOR,
     );
     expect(authIndex).toBeLessThan(contentIndex);
+  });
+});
+
+describe('Context Cleanup', () => {
+  it('should clear references when cleanup is called', () => {
+    const invocationContext = new InvocationContext({
+      invocationId: 'inv_123',
+      session: {
+        id: 'sess_123',
+        state: {
+          hasDelta: () => false,
+          get: () => undefined,
+          set: () => {},
+        },
+        events: [],
+      } as unknown as Session,
+      agent: {} as unknown as LlmAgent,
+      pluginManager: new PluginManager(),
+    });
+    const context = new Context({
+      invocationContext,
+    });
+
+    expect(context.eventActions).toBeDefined();
+    expect(context.invocationContext).toBeDefined();
+    expect(context.state).toBeDefined();
+
+    context.cleanup();
+
+    expect(context.eventActions).toBeUndefined();
+    expect(context.invocationContext).toBeUndefined();
+    expect((context as unknown as {_state: unknown})._state).toBeUndefined();
+    expect(() => context.userId).toThrow();
+  });
+});
+
+describe('LlmAgent Callback Context Cleanup', () => {
+  let agent: TestLlmAgent;
+  let invocationContext: InvocationContext;
+  let llmRequest: LlmRequest;
+  let modelResponseEvent: Event;
+
+  beforeEach(() => {
+    agent = new TestLlmAgent({name: 'test_agent'});
+    invocationContext = new InvocationContext({
+      invocationId: 'inv_123',
+      session: {
+        id: 'sess_123',
+        state: {
+          hasDelta: () => false,
+          get: () => undefined,
+          set: () => {},
+        },
+        events: [],
+      } as unknown as Session,
+      agent: agent,
+      pluginManager: new PluginManager(),
+    });
+    llmRequest = {contents: [], liveConnectConfig: {}, toolsDict: {}};
+    modelResponseEvent = {id: 'evt_123'} as Event;
+  });
+
+  it('should call cleanup on Context after beforeModelCallback', async () => {
+    const cleanupSpy = vi.spyOn(Context.prototype, 'cleanup');
+    agent.beforeModelCallback = async () => ({
+      content: {parts: [{text: 'before'}]},
+    });
+
+    const generator = agent.testCallLlmAsync(
+      invocationContext,
+      llmRequest,
+      modelResponseEvent,
+    );
+    await generator.next();
+
+    expect(cleanupSpy).toHaveBeenCalled();
+    cleanupSpy.mockRestore();
+  });
+
+  it('should call cleanup on Context after afterModelCallback', async () => {
+    const cleanupSpy = vi.spyOn(Context.prototype, 'cleanup');
+    agent.model = new MockLlm({content: {parts: [{text: 'model response'}]}});
+    agent.afterModelCallback = async () => ({
+      content: {parts: [{text: 'after'}]},
+    });
+
+    const generator = agent.testCallLlmAsync(
+      invocationContext,
+      llmRequest,
+      modelResponseEvent,
+    );
+    await generator.next();
+
+    // handleBeforeModelCallback runs first (cleanup called once)
+    // handleAfterModelCallback runs next (cleanup called twice)
+    expect(cleanupSpy).toHaveBeenCalledTimes(2);
+    cleanupSpy.mockRestore();
+  });
+
+  it('should call cleanup on Context during runAndHandleError when error occurs', async () => {
+    const cleanupSpy = vi.spyOn(Context.prototype, 'cleanup');
+
+    // eslint-disable-next-line require-yield
+    const errorGenerator = async function* () {
+      throw new Error('Test Error');
+    };
+
+    const generator = agent.testRunAndHandleError(
+      errorGenerator(),
+      invocationContext,
+      llmRequest,
+      modelResponseEvent,
+    );
+
+    const responses = [];
+    for await (const response of generator) {
+      responses.push(response);
+    }
+
+    expect(responses.length).toBe(1);
+    expect(cleanupSpy).toHaveBeenCalled();
+    cleanupSpy.mockRestore();
   });
 });

--- a/tests/integration/build_setup/build_setup_test.ts
+++ b/tests/integration/build_setup/build_setup_test.ts
@@ -43,7 +43,7 @@ describe('Build setup', () => {
         expect(buildResult.stderr).toBe('');
         expect(buildResult.stdout).toContain('\nBuild complete');
       }
-    });
+    }, 60000);
 
     it(
       'should build and run agent successfully',


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**
There was no cleanup of `eventActions` and `InvocationContext` references from `Context` instances after their execution in callbacks or tools, which could lead to memory leaks and state pollution.

**Solution:**
This PR implements the cleanup of these references.

## Changes:
- Added `cleanup()` method to `Context` class in `core/src/agents/context.ts` that sets references to `eventActions`, `invocationContext`, `_state`, and `toolConfirmation` to `undefined`.
- Updated `LlmAgent` in `core/src/agents/llm_agent.ts` to wrap callback executions (`handleBeforeModelCallback`, `handleAfterModelCallback`, `runAndHandleError`) in `try...finally` blocks and call `context.cleanup()` in `finally`.
- Updated `handleFunctionCallList` in `core/src/agents/functions.ts` to wrap tool execution in `try...finally` and call `toolContext.cleanup()` in `finally`.
- Added unit tests in `core/test/agents/llm_agent_test.ts` to verify `cleanup()` is called after callbacks and during error handling, and that `Context` properties are indeed cleared.
- Added unit test in `core/test/agents/functions_test.ts` to verify `cleanup()` is called on `toolContext` after tool execution.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**
Verified tests passed.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
