### PR TITLE
Feat: Refactor Runner<>ArtifactService Leaky Abstraction via SaveFilesAsArtifactsPlugin (Part 2/2)

### DIFF
--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -39,6 +39,8 @@ export interface RunConfig {
 
   /**
    * Whether or not to save the input blobs as artifacts.
+   *
+   * @deprecated Use `SaveFilesAsArtifactsPlugin` instead for better control and flexibility.
    */
   saveInputBlobsAsArtifacts?: boolean;
 

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -185,6 +185,8 @@ export type {LlmRouter} from './models/routed_llm.js';
 export {BasePlugin, ContextCompactionTrigger} from './plugins/base_plugin.js';
 export {LoggingPlugin} from './plugins/logging_plugin.js';
 export {PluginManager} from './plugins/plugin_manager.js';
+export {SaveFilesAsArtifactsPlugin} from './plugins/save_files_as_artifacts_plugin.js';
+export type {SaveFilesAsArtifactsPluginOptions} from './plugins/save_files_as_artifacts_plugin.js';
 export {
   InMemoryPolicyEngine,
   PolicyOutcome,

--- a/core/src/plugins/save_files_as_artifacts_plugin.ts
+++ b/core/src/plugins/save_files_as_artifacts_plugin.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Content, createPartFromText, Part} from '@google/genai';
+
+import {BaseAgent} from '../agents/base_agent.js';
+import {Context} from '../agents/context.js';
+import {InvocationContext} from '../agents/invocation_context.js';
+import {logger} from '../utils/logger.js';
+import {BasePlugin} from './base_plugin.js';
+
+function isModelAccessibleUri(uri: string): boolean {
+  return /^(gs|https?):\/\//i.test(uri);
+}
+
+async function buildFileReferencePart(
+  invocationContext: InvocationContext,
+  filename: string,
+  version: number,
+  mimeType: string | undefined,
+  displayName: string,
+): Promise<Part | undefined> {
+  const artifactService = invocationContext.artifactService!;
+  try {
+    const artifactVersion = await artifactService.getArtifactVersion({
+      filename,
+      version,
+    });
+    if (
+      !artifactVersion?.canonicalUri ||
+      !isModelAccessibleUri(artifactVersion.canonicalUri)
+    ) {
+      return undefined;
+    }
+    return {
+      fileData: {
+        fileUri: artifactVersion.canonicalUri,
+        mimeType: mimeType || artifactVersion.mimeType,
+        displayName,
+      },
+    };
+  } catch (exc) {
+    logger.warn(`Failed to resolve artifact version for ${filename}: ${exc}`);
+    return undefined;
+  }
+}
+
+export interface SaveFilesAsArtifactsPluginOptions {
+  name?: string;
+  attachFileReference?: boolean;
+}
+
+export class SaveFilesAsArtifactsPlugin extends BasePlugin {
+  private readonly attachFileReference: boolean;
+
+  constructor(options: SaveFilesAsArtifactsPluginOptions = {}) {
+    super(options.name || 'save_files_as_artifacts_plugin');
+    this.attachFileReference = options.attachFileReference ?? true;
+  }
+
+  override async onUserMessageCallback({
+    invocationContext,
+    userMessage,
+  }: {
+    invocationContext: InvocationContext;
+    userMessage: Content;
+  }): Promise<Content | undefined> {
+    if (!invocationContext.artifactService) {
+      logger.warn(
+        'Artifact service is not set. SaveFilesAsArtifactsPlugin will not be enabled.',
+      );
+      return undefined;
+    }
+
+    if (!userMessage.parts || userMessage.parts.length === 0) {
+      return undefined;
+    }
+
+    const newParts: Part[] = [];
+    const pendingDelta: Record<string, number> = {};
+
+    for (let i = 0; i < userMessage.parts.length; i++) {
+      const part = userMessage.parts[i];
+      if (!part.inlineData) {
+        newParts.push(part);
+        continue;
+      }
+
+      try {
+        const inlineData = part.inlineData;
+        let filename = inlineData.displayName;
+        if (!filename) {
+          filename = `artifact_${invocationContext.invocationId}_${i}`;
+          logger.info(
+            `No displayName found, using generated filename: ${filename}`,
+          );
+        }
+
+        const version = await invocationContext.artifactService.saveArtifact({
+          filename,
+          artifact: {...part},
+        });
+
+        newParts.push(createPartFromText(`[Uploaded Artifact: "${filename}"]`));
+
+        if (this.attachFileReference) {
+          const filePart = await buildFileReferencePart(
+            invocationContext,
+            filename,
+            version,
+            inlineData.mimeType,
+            filename,
+          );
+          if (filePart) {
+            newParts.push(filePart);
+          }
+        }
+        pendingDelta[filename] = version;
+        logger.info(`Successfully saved artifact: ${filename}`);
+      } catch (e) {
+        logger.error(`Failed to save artifact for part ${i}: ${e}`);
+        newParts.push(part);
+      }
+    }
+
+    if (Object.keys(pendingDelta).length > 0) {
+      const state = invocationContext.session.state;
+      const key = `${this.name}:pending_delta`;
+      state[key] = Object.assign(
+        (state[key] as Record<string, number>) || {},
+        pendingDelta,
+      );
+      return {
+        role: userMessage.role,
+        parts: newParts,
+      };
+    }
+
+    return undefined;
+  }
+
+  override async beforeAgentCallback({
+    callbackContext,
+  }: {
+    agent: BaseAgent;
+    callbackContext: Context;
+  }): Promise<Content | undefined> {
+    const key = `${this.name}:pending_delta`;
+    const pendingDelta = callbackContext.state.get<Record<string, number>>(key);
+    if (pendingDelta && Object.keys(pendingDelta).length > 0) {
+      Object.assign(callbackContext.actions.artifactDelta, pendingDelta);
+      callbackContext.state.set(key, {});
+    }
+    return undefined;
+  }
+}

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -334,6 +334,9 @@ export class Runner {
             // replaces the artifact data with a file name placeholder.
             // TODO - b/425992518: fix Runner<>>ArtifactService leaky abstraction.
             if (runConfig.saveInputBlobsAsArtifacts) {
+              logger.warn(
+                "The 'saveInputBlobsAsArtifacts' setting is deprecated. Use SaveFilesAsArtifactsPlugin instead for better control and flexibility.",
+              );
               await this.saveArtifacts(
                 invocationContext.invocationId,
                 session.userId,
@@ -450,6 +453,8 @@ export class Runner {
   /**
    * Saves artifacts from the message parts and replaces the inline data with
    * a file name placeholder.
+   *
+   * @deprecated Directly saving artifacts from Runner is deprecated. Use `SaveFilesAsArtifactsPlugin` instead.
    *
    * @param invocationId The current invocation ID.
    * @param userId The user ID of the session.

--- a/core/test/plugins/save_files_as_artifacts_plugin_test.ts
+++ b/core/test/plugins/save_files_as_artifacts_plugin_test.ts
@@ -1,0 +1,488 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  createEvent,
+  createSession,
+  DeleteArtifactRequest,
+  Event,
+  InMemoryArtifactService,
+  InvocationContext,
+  ListArtifactKeysRequest,
+  ListVersionsRequest,
+  LlmAgent,
+  LoadArtifactRequest,
+  PluginManager,
+  SaveArtifactRequest,
+  SaveFilesAsArtifactsPlugin,
+  Session,
+} from '@google/adk';
+import {Content, Part} from '@google/genai';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ScopedArtifactService} from '../../src/artifacts/scoped_artifact_service.js';
+import {resetLogger, setLogger} from '../../src/utils/logger.js';
+
+function makeMockLogger() {
+  const infoCalls: string[] = [];
+  const warnCalls: string[] = [];
+  const errorCalls: string[] = [];
+  const mockLogger = {
+    setLogLevel: () => {},
+    log: () => {},
+    debug: () => {},
+    info: (...args: unknown[]) => {
+      infoCalls.push(args.map((a) => String(a)).join(' '));
+    },
+    warn: (...args: unknown[]) => {
+      warnCalls.push(args.map((a) => String(a)).join(' '));
+    },
+    error: (...args: unknown[]) => {
+      errorCalls.push(args.map((a) => String(a)).join(' '));
+    },
+  };
+  return {mockLogger, infoCalls, warnCalls, errorCalls};
+}
+
+class MockAgent extends LlmAgent {
+  constructor(name = 'mock_agent') {
+    super({
+      name,
+      model: 'gemini-2.5-flash',
+    });
+  }
+
+  protected override async *runAsyncImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    yield createEvent({
+      invocationId: context.invocationId,
+      author: this.name,
+      content: {role: 'model', parts: [{text: 'Done'}]},
+    });
+  }
+}
+
+describe('SaveFilesAsArtifactsPlugin', () => {
+  let infoCalls: string[];
+  let warnCalls: string[];
+  let errorCalls: string[];
+
+  const mockAgent = new MockAgent('test_agent');
+  let mockSession: Session;
+
+  let baseArtifactService: InMemoryArtifactService;
+  let scopedArtifactService: ScopedArtifactService;
+  let invocationContext: InvocationContext;
+  let callbackContext: Context;
+
+  beforeEach(() => {
+    const {
+      mockLogger,
+      infoCalls: callsInfo,
+      warnCalls: callsWarn,
+      errorCalls: callsError,
+    } = makeMockLogger();
+    infoCalls = callsInfo;
+    warnCalls = callsWarn;
+    errorCalls = callsError;
+    setLogger(mockLogger);
+
+    mockSession = createSession({
+      id: 'session-1',
+      appName: 'test-app',
+      userId: 'user-1',
+    });
+
+    baseArtifactService = new InMemoryArtifactService();
+    const wrappedArtifactService = {
+      saveArtifact: (req: SaveArtifactRequest) =>
+        baseArtifactService.saveArtifact(req),
+      loadArtifact: (req: LoadArtifactRequest) =>
+        baseArtifactService.loadArtifact(req),
+      listArtifactKeys: (req: ListArtifactKeysRequest) =>
+        baseArtifactService.listArtifactKeys(req),
+      deleteArtifact: (req: DeleteArtifactRequest) =>
+        baseArtifactService.deleteArtifact(req),
+      listVersions: (req: ListVersionsRequest) =>
+        baseArtifactService.listVersions(req),
+      listArtifactVersions: (req: ListVersionsRequest) =>
+        baseArtifactService.listArtifactVersions(req),
+      getArtifactVersion: async (req: LoadArtifactRequest) => {
+        const v = await baseArtifactService.getArtifactVersion(req);
+        if (v) {
+          return {
+            ...v,
+            canonicalUri: `gs://bucket/${req.filename}/versions/${v.version}`,
+            mimeType: 'application/pdf',
+          };
+        }
+        return v;
+      },
+    } as unknown as InMemoryArtifactService;
+
+    scopedArtifactService = new ScopedArtifactService(
+      wrappedArtifactService,
+      'test-app',
+      'user-1',
+      'session-1',
+    );
+
+    invocationContext = new InvocationContext({
+      invocationId: 'inv-1',
+      session: mockSession,
+      agent: mockAgent,
+      pluginManager: new PluginManager(),
+      artifactService: scopedArtifactService,
+    });
+
+    callbackContext = new Context({
+      invocationContext,
+    });
+  });
+
+  afterEach(() => {
+    resetLogger();
+    vi.restoreAllMocks();
+  });
+
+  it('testSaveFilesWithDisplayName', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    const userMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'YmFzZTY0ZGF0YQ==',
+            displayName: 'report.pdf',
+          },
+        },
+      ],
+    };
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage,
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.role).toBe('user');
+    expect(result!.parts).toHaveLength(2);
+    expect(result!.parts![0]).toEqual({
+      text: '[Uploaded Artifact: "report.pdf"]',
+    });
+    expect(result!.parts![1].fileData).toEqual({
+      fileUri: 'gs://bucket/report.pdf/versions/0',
+      mimeType: 'application/pdf',
+      displayName: 'report.pdf',
+    });
+
+    const saved = await scopedArtifactService.loadArtifact({
+      filename: 'report.pdf',
+    });
+    expect(saved).toBeDefined();
+    expect(saved!.inlineData!.displayName).toBe('report.pdf');
+  });
+
+  it('testSaveFilesWithoutDisplayName', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    const userMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'image/png',
+            data: 'aW1hZ2VkYXRh',
+          },
+        },
+      ],
+    };
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage,
+    });
+
+    expect(result).toBeDefined();
+    const expectedFilename = 'artifact_inv-1_0';
+    expect(result!.parts![0]).toEqual({
+      text: `[Uploaded Artifact: "${expectedFilename}"]`,
+    });
+    expect(infoCalls.some((c) => c.includes('No displayName found'))).toBe(
+      true,
+    );
+
+    const saved = await scopedArtifactService.loadArtifact({
+      filename: expectedFilename,
+    });
+    expect(saved).toBeDefined();
+  });
+
+  it('testAttachFileReferenceFalse', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin({
+      attachFileReference: false,
+    });
+    const userMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'YmFzZTY0ZGF0YQ==',
+            displayName: 'report.pdf',
+          },
+        },
+      ],
+    };
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage,
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.parts).toHaveLength(1);
+    expect(result!.parts![0]).toEqual({
+      text: '[Uploaded Artifact: "report.pdf"]',
+    });
+  });
+
+  it('testMultipleFilesInMessage', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    const userMessage: Content = {
+      role: 'user',
+      parts: [
+        {text: 'Here is document 1 and 2:'},
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZG9jMQ==',
+            displayName: 'doc1.pdf',
+          },
+        },
+        {text: 'and'},
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZG9jMg==',
+            displayName: 'doc2.pdf',
+          },
+        },
+      ],
+    };
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage,
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.parts).toHaveLength(6);
+    expect(result!.parts![0]).toEqual({text: 'Here is document 1 and 2:'});
+    expect(result!.parts![1]).toEqual({
+      text: '[Uploaded Artifact: "doc1.pdf"]',
+    });
+    expect(result!.parts![2].fileData?.displayName).toBe('doc1.pdf');
+    expect(result!.parts![3]).toEqual({text: 'and'});
+    expect(result!.parts![4]).toEqual({
+      text: '[Uploaded Artifact: "doc2.pdf"]',
+    });
+    expect(result!.parts![5].fileData?.displayName).toBe('doc2.pdf');
+  });
+
+  it('testArtifactServiceMissing', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    const ctxNoArtifact = new InvocationContext({
+      invocationId: 'inv-1',
+      session: mockSession,
+      agent: mockAgent,
+      pluginManager: new PluginManager(),
+      artifactService: undefined,
+    });
+
+    const userMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZGF0YQ==',
+            displayName: 'doc.pdf',
+          },
+        },
+      ],
+    };
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext: ctxNoArtifact,
+      userMessage,
+    });
+
+    expect(result).toBeUndefined();
+    expect(
+      warnCalls.some((c) => c.includes('Artifact service is not set')),
+    ).toBe(true);
+  });
+
+  it('testSaveArtifactFailure', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    vi.spyOn(scopedArtifactService, 'saveArtifact').mockRejectedValueOnce(
+      new Error('Storage full'),
+    );
+
+    const inlinePart: Part = {
+      inlineData: {
+        mimeType: 'application/pdf',
+        data: 'ZGF0YQ==',
+        displayName: 'broken.pdf',
+      },
+    };
+    const userMessage: Content = {
+      role: 'user',
+      parts: [{text: 'file below'}, inlinePart],
+    };
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage,
+    });
+
+    expect(result).toBeUndefined();
+    expect(
+      errorCalls.some((c) =>
+        c.includes('Failed to save artifact for part 1: Error: Storage full'),
+      ),
+    ).toBe(true);
+  });
+
+  it('testBeforeAgentCallbackDeltaMerge', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    const userMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZGF0YQ==',
+            displayName: 'report.pdf',
+          },
+        },
+      ],
+    };
+
+    await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage,
+    });
+
+    const pendingKey = `${plugin.name}:pending_delta`;
+    expect(mockSession.state[pendingKey]).toEqual({'report.pdf': 0});
+
+    await plugin.beforeAgentCallback({
+      agent: mockAgent,
+      callbackContext,
+    });
+
+    expect(callbackContext.actions.artifactDelta).toEqual({'report.pdf': 0});
+    expect(mockSession.state[pendingKey]).toEqual({});
+  });
+
+  it('testEmptyOrMissingParts', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    const resEmpty = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage: {role: 'user', parts: []},
+    });
+    expect(resEmpty).toBeUndefined();
+
+    const resNoParts = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage: {role: 'user'} as unknown as Content,
+    });
+    expect(resNoParts).toBeUndefined();
+  });
+
+  it('testBuildFileReferencePartFailureAndInaccessibleUri', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    vi.spyOn(scopedArtifactService, 'getArtifactVersion')
+      .mockRejectedValueOnce(new Error('Resolve error'))
+      .mockResolvedValueOnce({
+        version: 0,
+        canonicalUri: 'file:///local/path',
+        mimeType: 'application/pdf',
+      })
+      .mockResolvedValueOnce({
+        version: 0,
+        canonicalUri: 'not-a-valid-url',
+        mimeType: 'application/pdf',
+      })
+      .mockResolvedValueOnce({
+        version: 0,
+      })
+      .mockResolvedValueOnce({
+        version: 0,
+        canonicalUri: 'gs://bucket/doc5.pdf/versions/0',
+        mimeType: 'application/octet-stream',
+      });
+
+    const userMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZGF0YQ==',
+            displayName: 'doc1.pdf',
+          },
+        },
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZGF0YQ==',
+            displayName: 'doc2.pdf',
+          },
+        },
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZGF0YQ==',
+            displayName: 'doc3.pdf',
+          },
+        },
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'ZGF0YQ==',
+            displayName: 'doc4.pdf',
+          },
+        },
+        {
+          inlineData: {
+            mimeType: '' as unknown as string,
+            data: 'ZGF0YQ==',
+            displayName: 'doc5.pdf',
+          },
+        },
+      ],
+    };
+
+    const result = await plugin.onUserMessageCallback({
+      invocationContext,
+      userMessage,
+    });
+    expect(result).toBeDefined();
+    expect(result!.parts).toHaveLength(6);
+    expect(result!.parts![5].fileData?.mimeType).toBe(
+      'application/octet-stream',
+    );
+    expect(
+      warnCalls.some((c) =>
+        c.includes('Failed to resolve artifact version for doc1.pdf'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/core/test/plugins/save_files_as_artifacts_plugin_test.ts
+++ b/core/test/plugins/save_files_as_artifacts_plugin_test.ts
@@ -11,12 +11,14 @@ import {
   DeleteArtifactRequest,
   Event,
   InMemoryArtifactService,
+  InMemorySessionService,
   InvocationContext,
   ListArtifactKeysRequest,
   ListVersionsRequest,
   LlmAgent,
   LoadArtifactRequest,
   PluginManager,
+  Runner,
   SaveArtifactRequest,
   SaveFilesAsArtifactsPlugin,
   Session,
@@ -389,6 +391,42 @@ describe('SaveFilesAsArtifactsPlugin', () => {
 
     expect(callbackContext.actions.artifactDelta).toEqual({'report.pdf': 0});
     expect(mockSession.state[pendingKey]).toEqual({});
+  });
+
+  it('testRunnerDeprecationWarning', async () => {
+    const sessionService = new InMemorySessionService();
+    await sessionService.createSession({
+      sessionId: 'session-1',
+      appName: 'test-app',
+      userId: 'user-1',
+    });
+
+    const runner = new Runner({
+      agent: mockAgent,
+      appName: 'test-app',
+      sessionService,
+      artifactService: new InMemoryArtifactService(),
+    });
+
+    const userMessage: Content = {
+      role: 'user',
+      parts: [{text: 'test message'}],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: 'user-1',
+      sessionId: 'session-1',
+      newMessage: userMessage,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume generator
+    }
+
+    expect(
+      warnCalls.some((c) =>
+        c.includes("The 'saveInputBlobsAsArtifacts' setting is deprecated."),
+      ),
+    ).toBe(true);
   });
 
   it('testEmptyOrMissingParts', async () => {

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -18,6 +18,7 @@ import {
   isRoutableLlmAgent,
   LlmAgent,
   Runner,
+  SaveFilesAsArtifactsPlugin,
 } from '@google/adk';
 import {Content, FunctionCall, FunctionResponse} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
@@ -885,5 +886,73 @@ describe('Runner customMetadata support', () => {
     const userEvent = updatedSession!.events[0];
     expect(userEvent.author).toBe('user');
     expect(userEvent.content?.role).toBe('user');
+  });
+
+  it('should execute a turn with SaveFilesAsArtifactsPlugin registered and make stored artifacts accessible', async () => {
+    const plugin = new SaveFilesAsArtifactsPlugin();
+    const runnerWithPlugin = new Runner({
+      appName: TEST_APP_ID,
+      agent: agent,
+      sessionService,
+      artifactService,
+      plugins: [plugin],
+    });
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const inlineDataPart = {
+      inlineData: {
+        mimeType: 'text/plain',
+        data: 'aGVsbG8gYXJ0aWZhY3Q=',
+        displayName: 'test_doc.txt',
+      },
+    };
+
+    const events: Event[] = [];
+    for await (const event of runnerWithPlugin.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {
+        role: 'user',
+        parts: [{text: 'Check this out'}, inlineDataPart],
+      },
+    })) {
+      events.push(event);
+    }
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(updatedSession).toBeDefined();
+    const userEvent = updatedSession!.events[0];
+    expect(userEvent.content!.parts).toBeDefined();
+    expect(
+      userEvent.content!.parts!.some((p) =>
+        p.text?.includes('[Uploaded Artifact: "test_doc.txt"]'),
+      ),
+    ).toBe(true);
+
+    const keys = await artifactService.listArtifactKeys({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+    expect(keys).toContain('test_doc.txt');
+
+    const loadedPart = await artifactService.loadArtifact({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+      filename: 'test_doc.txt',
+    });
+    expect(loadedPart).toBeDefined();
+    expect(loadedPart!.inlineData!.displayName).toBe('test_doc.txt');
   });
 });


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: b/425992518
Related: b/425992518

2. Or, if no issue exists, describe the change:

**Problem**: Directly saving incoming message part artifacts and mutating `newMessage` within `Runner` (`Runner.runAsync`) creates a leaky abstraction between `Runner` and `ArtifactService` (noted in TODO b/425992518). This violates single-responsibility and bypasses `ScopedArtifactService`.

**Solution**: Introduced `SaveFilesAsArtifactsPlugin` extending `BasePlugin` to intercept inline part blobs (`part.inlineData`), save them scoped to the session via `invocationContext.artifactService.saveArtifact(...)`, replace them with text placeholders (`[Uploaded Artifact: "filename"]`), and optionally attach model-accessible file references (`FileData`). Deprecated `saveArtifacts` in `Runner` and `saveInputBlobsAsArtifacts` in `RunConfig` with clear migration guidance (`logger.warn`), aligning `adk-js` with clean architecture parity in `adk-python`.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.
1. Initialize an `LlmAgent` and `Runner` with `SaveFilesAsArtifactsPlugin({ attachFileReference: true })` registered in `plugins`.
2. Send a user message containing `inlineData` (e.g., `application/pdf` or `image/png` base64 blob with `displayName: "report.pdf"`).
3. Verify that `SaveFilesAsArtifactsPlugin` saves `report.pdf` to the `ArtifactService`, replaces the inline blob with `[Uploaded Artifact: "report.pdf"]`, and appends a `FileData` part referencing the canonical URI when accessible.

### Checklist
- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
