### PR TITLE
Fix: Fix Artifact Saving Message Part Replacement & LLM Exposure (TODO b/425992518)

### DIFF
--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Content, createPartFromText} from '@google/genai';
+import {Content, createPartFromText, Part} from '@google/genai';
 import {context, trace} from '@opentelemetry/api';
 
 import {BaseAgent} from '../agents/base_agent.js';
@@ -334,7 +334,7 @@ export class Runner {
             // replaces the artifact data with a file name placeholder.
             // TODO - b/425992518: fix Runner<>>ArtifactService leaky abstraction.
             if (runConfig.saveInputBlobsAsArtifacts) {
-              await this.saveArtifacts(
+              newMessage = await this.saveArtifacts(
                 invocationContext.invocationId,
                 session.userId,
                 session.id,
@@ -449,7 +449,7 @@ export class Runner {
 
   /**
    * Saves artifacts from the message parts and replaces the inline data with
-   * a file name placeholder.
+   * a file name placeholder and optional file reference.
    *
    * @param invocationId The current invocation ID.
    * @param userId The user ID of the session.
@@ -461,9 +461,9 @@ export class Runner {
     userId: string,
     sessionId: string,
     message: Content,
-  ): Promise<void> {
+  ): Promise<Content> {
     if (!this.artifactService || !message.parts?.length) {
-      return;
+      return message;
     }
 
     const sessionKey: CompositeSessionKey = {
@@ -471,23 +471,72 @@ export class Runner {
       userId,
       sessionId,
     };
+    const newParts: Part[] = [];
+    let modified = false;
 
     for (let i = 0; i < message.parts.length; i++) {
       const part = message.parts[i];
       if (!part.inlineData) {
+        newParts.push(part);
         continue;
       }
-      const fileName = `artifact_${invocationId}_${i}`;
-      await this.artifactService.saveArtifact({
-        ...sessionKey,
-        filename: fileName,
-        artifact: part,
-      });
-      // TODO - b/425992518: potentially buggy if accidentally exposed to LLM.
-      message.parts[i] = createPartFromText(
-        `Uploaded file: ${fileName}. It is saved into artifacts`,
-      );
+
+      try {
+        const inlineData = part.inlineData;
+        const fileName =
+          (inlineData as {displayName?: string}).displayName ||
+          `artifact_${invocationId}_${i}`;
+
+        const version = await this.artifactService.saveArtifact({
+          ...sessionKey,
+          filename: fileName,
+          artifact: part,
+        });
+
+        newParts.push(createPartFromText(`[Uploaded Artifact: "${fileName}"]`));
+
+        try {
+          const artifactVersion = await this.artifactService.getArtifactVersion(
+            {
+              ...sessionKey,
+              filename: fileName,
+              version,
+            },
+          );
+          if (
+            artifactVersion?.canonicalUri &&
+            /^(gs|https?):/i.test(artifactVersion.canonicalUri)
+          ) {
+            newParts.push({
+              fileData: {
+                fileUri: artifactVersion.canonicalUri,
+                mimeType: artifactVersion.mimeType || inlineData.mimeType || '',
+                displayName: fileName,
+              },
+            });
+          }
+        } catch (error) {
+          logger.warn(
+            `Failed to resolve artifact version for ${fileName}:`,
+            error,
+          );
+        }
+        modified = true;
+        logger.info(`Successfully saved artifact: ${fileName}`);
+      } catch (error) {
+        logger.error(`Failed to save artifact for part ${i}:`, error);
+        newParts.push(part);
+      }
     }
+
+    if (!modified) {
+      return message;
+    }
+
+    return {
+      ...message,
+      parts: newParts,
+    };
   }
 
   /**

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -887,3 +887,357 @@ describe('Runner customMetadata support', () => {
     expect(userEvent.content?.role).toBe('user');
   });
 });
+
+describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
+  let sessionService: InMemorySessionService;
+  let artifactService: InMemoryArtifactService;
+  let agent: MockLlmAgent;
+  let runner: Runner;
+
+  beforeEach(() => {
+    sessionService = new InMemorySessionService();
+    artifactService = new InMemoryArtifactService();
+    agent = new MockLlmAgent('test_agent');
+    runner = new Runner({
+      appName: TEST_APP_ID,
+      agent: agent,
+      sessionService,
+      artifactService,
+    });
+  });
+
+  it('testSaveArtifacts_modelAccessibleUri_attachesFileData', async () => {
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    vi.spyOn(artifactService, 'getArtifactVersion').mockResolvedValue({
+      version: 0,
+      canonicalUri: 'gs://test-bucket/file.pdf/versions/0',
+      mimeType: 'application/pdf',
+    });
+
+    const newMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'JVBERi0xLjQ...',
+            displayName: 'file.pdf',
+          },
+        } as unknown as Content['parts']![0],
+      ],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(updatedSession!.events).toHaveLength(2);
+    const userEvent = updatedSession!.events[0];
+    expect(userEvent.content!.parts).toEqual([
+      {text: '[Uploaded Artifact: "file.pdf"]'},
+      {
+        fileData: {
+          fileUri: 'gs://test-bucket/file.pdf/versions/0',
+          mimeType: 'application/pdf',
+          displayName: 'file.pdf',
+        },
+      },
+    ]);
+  });
+
+  it('testSaveArtifacts_nonAccessibleUri_onlyAttachesPlaceholder', async () => {
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    vi.spyOn(artifactService, 'getArtifactVersion').mockResolvedValue({
+      version: 0,
+      canonicalUri: 'file:///tmp/file.pdf',
+      mimeType: 'application/pdf',
+    });
+
+    const newMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'JVBERi0xLjQ...',
+            displayName: 'file.pdf',
+          },
+        } as unknown as Content['parts']![0],
+      ],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const userEvent = updatedSession!.events[0];
+    expect(userEvent.content!.parts).toEqual([
+      {text: '[Uploaded Artifact: "file.pdf"]'},
+    ]);
+  });
+
+  it('testSaveArtifacts_immutability_doesNotMutateInput', async () => {
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const inlineDataObj = {
+      mimeType: 'application/pdf',
+      data: 'JVBERi0xLjQ...',
+      displayName: 'file.pdf',
+    };
+
+    const newMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: inlineDataObj,
+        } as unknown as Content['parts']![0],
+      ],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    expect(newMessage.parts![0].inlineData).toBeDefined();
+    expect(newMessage.parts![0].inlineData).toEqual(inlineDataObj);
+    expect(newMessage.parts![0].text).toBeUndefined();
+  });
+
+  it('testSaveArtifacts_displayNameResolution', async () => {
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    vi.spyOn(artifactService, 'getArtifactVersion').mockResolvedValue({
+      version: 0,
+      canonicalUri: 'gs://test-bucket/doc/versions/0',
+    });
+
+    // Test with displayName and without displayName
+    const newMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'JVBERi0xLjQ...',
+            displayName: 'named_doc.pdf',
+          },
+        } as unknown as Content['parts']![0],
+        {
+          inlineData: {
+            mimeType: 'image/png',
+            data: 'iVBOR...',
+          },
+        },
+      ],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const parts = updatedSession!.events[0].content!.parts!;
+    expect(parts[0]).toEqual({text: '[Uploaded Artifact: "named_doc.pdf"]'});
+    expect(parts[1].fileData?.displayName).toBe('named_doc.pdf');
+
+    expect(parts[2].text).toMatch(/\[Uploaded Artifact: "artifact_.+_1"\]/);
+    expect(parts[3].fileData?.displayName).toMatch(/artifact_.+_1/);
+  });
+
+  it('testSaveArtifacts_errorResiliency_retainsOriginalPart', async () => {
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    vi.spyOn(artifactService, 'saveArtifact').mockImplementation(
+      async (req) => {
+        if (req.filename === 'good.pdf') {
+          return 0;
+        }
+        throw new Error('simulated save error for bad.png');
+      },
+    );
+
+    const newMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'JVBERi0xLjQ...',
+            displayName: 'good.pdf',
+          },
+        } as unknown as Content['parts']![0],
+        {
+          inlineData: {
+            mimeType: 'image/png',
+            data: 'bad_data',
+            displayName: 'bad.png',
+          },
+        } as unknown as Content['parts']![0],
+      ],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    const updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const parts = updatedSession!.events[0].content!.parts!;
+    expect(parts[0]).toEqual({text: '[Uploaded Artifact: "good.pdf"]'});
+    expect(parts[1].inlineData).toEqual({
+      mimeType: 'image/png',
+      data: 'bad_data',
+      displayName: 'bad.png',
+    });
+  });
+
+  it('should handle getArtifactVersion errors and missing version metadata gracefully during saveArtifacts', async () => {
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    // Case 1: getArtifactVersion throws an error
+    vi.spyOn(artifactService, 'getArtifactVersion').mockRejectedValueOnce(
+      new Error('version lookup failure'),
+    );
+
+    const newMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'data',
+            displayName: 'file1.pdf',
+          },
+        } as unknown as Content['parts']![0],
+      ],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    let updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+    let userEvents = updatedSession!.events.filter((e) => e.author === 'user');
+    expect(userEvents[0].content!.parts).toEqual([
+      {text: '[Uploaded Artifact: "file1.pdf"]'},
+    ]);
+
+    // Case 2: getArtifactVersion returns undefined or no canonicalUri
+    vi.spyOn(artifactService, 'getArtifactVersion').mockResolvedValueOnce(
+      undefined,
+    );
+
+    const newMessage2: Content = {
+      role: 'user',
+      parts: [
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'data',
+            displayName: 'file2.pdf',
+          },
+        } as unknown as Content['parts']![0],
+      ],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: newMessage2,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    updatedSession = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+    userEvents = updatedSession!.events.filter((e) => e.author === 'user');
+    expect(userEvents[1].content!.parts).toEqual([
+      {text: '[Uploaded Artifact: "file2.pdf"]'},
+    ]);
+  });
+});

--- a/tests/integration/runner/runner_artifacts_test.ts
+++ b/tests/integration/runner/runner_artifacts_test.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createEvent,
+  Event,
+  InMemoryArtifactService,
+  InMemorySessionService,
+  InvocationContext,
+  LlmAgent,
+  Runner,
+} from '@google/adk';
+import {Content, Part} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+
+class SimulatedGcsArtifactService extends InMemoryArtifactService {
+  override async getArtifactVersion(request: {
+    appName: string;
+    userId: string;
+    sessionId: string;
+    filename: string;
+    version?: number;
+  }) {
+    const versionMeta = await super.getArtifactVersion(request);
+    if (!versionMeta) {
+      return undefined;
+    }
+    return {
+      ...versionMeta,
+      canonicalUri: `gs://simulated-gcs-bucket/${request.appName}/${request.userId}/${request.sessionId}/${request.filename}/v${versionMeta.version}`,
+    };
+  }
+}
+
+class RecordingMockAgent extends LlmAgent {
+  public receivedHistory: Content[] = [];
+
+  constructor(name: string) {
+    super({
+      name,
+      model: 'gemini-2.5-flash',
+    });
+  }
+
+  protected override async *runAsyncImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    // Record what history was in the session when this agent ran
+    this.receivedHistory = (context.session?.events || [])
+      .map((e) => e.content)
+      .filter((c): c is Content => !!c);
+
+    yield createEvent({
+      invocationId: context.invocationId,
+      author: this.name,
+      content: {role: 'model', parts: [{text: `Response from ${this.name}`}]},
+    });
+  }
+}
+
+describe('Integration: Runner Artifact Saving & LLM Exposure', () => {
+  it('should save inline blobs, replace with bracketed token and fileData, and maintain clean conversation history across turns', async () => {
+    const sessionService = new InMemorySessionService();
+    const artifactService = new SimulatedGcsArtifactService();
+    const agent = new RecordingMockAgent('test_agent');
+    const runner = new Runner({
+      appName: 'test_app',
+      agent,
+      sessionService,
+      artifactService,
+    });
+
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'test_user',
+      sessionId: 'test_session',
+    });
+
+    // Turn 1: User sends message with inline PDF document
+    const turn1Message: Content = {
+      role: 'user',
+      parts: [
+        {text: 'Here is the quarterly financial report:'},
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'JVBERi0xLjQ...',
+            displayName: 'quarterly_report.pdf',
+          },
+        } as unknown as Part,
+      ],
+    };
+
+    const turn1Events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: turn1Message,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      turn1Events.push(event);
+    }
+
+    // Check session events right after Turn 1
+    const updatedSession = await sessionService.getSession({
+      appName: 'test_app',
+      userId: 'test_user',
+      sessionId: 'test_session',
+    });
+
+    expect(updatedSession).not.toBeNull();
+    const userEvent = updatedSession!.events.find((e) => e.author === 'user');
+    expect(userEvent).toBeDefined();
+
+    // Verify the parts in session event
+    const userParts = userEvent!.content!.parts!;
+    expect(userParts[0]).toEqual({
+      text: 'Here is the quarterly financial report:',
+    });
+    expect(userParts[1]).toEqual({
+      text: '[Uploaded Artifact: "quarterly_report.pdf"]',
+    });
+    expect(userParts[2]).toEqual({
+      fileData: {
+        fileUri:
+          'gs://simulated-gcs-bucket/test_app/test_user/test_session/quarterly_report.pdf/v0',
+        mimeType: 'application/pdf',
+        displayName: 'quarterly_report.pdf',
+      },
+    });
+
+    // Verify no legacy "It is saved into artifacts" strings exist anywhere in session history
+    const sessionHistoryText = JSON.stringify(updatedSession!.events);
+    expect(sessionHistoryText).not.toContain('It is saved into artifacts');
+
+    // Turn 2: User asks follow-up question
+    const turn2Message: Content = {
+      role: 'user',
+      parts: [{text: 'What was the revenue mentioned in the report above?'}],
+    };
+
+    for await (const _ of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: turn2Message,
+      runConfig: {saveInputBlobsAsArtifacts: true},
+    })) {
+      // Consume stream
+    }
+
+    // Check the history that the agent received during Turn 2
+    expect(agent.receivedHistory.length).toBeGreaterThanOrEqual(2);
+    const firstTurnHistory = agent.receivedHistory.find(
+      (c) =>
+        c.role === 'user' &&
+        c.parts?.some((p) => p.text?.includes('quarterly_report.pdf')),
+    );
+    expect(firstTurnHistory).toBeDefined();
+
+    const historyParts = firstTurnHistory!.parts!;
+    expect(historyParts[1]).toEqual({
+      text: '[Uploaded Artifact: "quarterly_report.pdf"]',
+    });
+    expect(historyParts[2].fileData?.fileUri).toContain(
+      'gs://simulated-gcs-bucket/',
+    );
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: #issue_number
Related: #issue_number

2. Or, if no issue exists, describe the change:

**Problem**: When `Runner` saves message parts containing `inlineData` blobs as artifacts (`saveInputBlobsAsArtifacts: true`), it mutates caller-provided `message.parts[i]` objects in place and replaces them with an informal string (`Uploaded file: ${fileName}. It is saved into artifacts`). When exposed to the LLM, this causes instructions confusion/hallucination risks (TODO b/425992518) and renders multimodal models blind to file contents due to missing `fileData` reference parts.

**Solution**: Update `Runner.saveArtifacts` to construct and return a new `Content` object (preventing caller message mutation) and replace `inlineData` parts with a standardized `[Uploaded Artifact: "${fileName}"]` bracketed placeholder text part. Additionally, if `ArtifactService.getArtifactVersion` returns a canonical URI with a model-accessible scheme (`gs://`, `https://`, `http://`), attach a `fileData` part alongside the placeholder so multimodal LLMs can inspect cloud-hosted files cleanly.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.

Run the unit and integration tests locally using vitest:
```bash
npm test -- core/test/runner/runner_test.ts
npx vitest run --project integration tests/integration/runner/runner_artifacts_test.ts
```

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
