### PR TITLE
Feat: Refactor LlmAgent and composite shell agents for global runtime interruption (Part 2/2)

### DIFF
--- a/core/src/agents/invocation_context.ts
+++ b/core/src/agents/invocation_context.ts
@@ -8,6 +8,11 @@ import {Content} from '@google/genai';
 
 import {SessionArtifactService} from '../artifacts/session_artifact_service.js';
 import {BaseCredentialService} from '../auth/credential_service/base_credential_service.js';
+import {
+  Event,
+  getFunctionCalls,
+  getFunctionResponses,
+} from '../events/event.js';
 import {BaseMemoryService} from '../memory/base_memory_service.js';
 import {PluginManager} from '../plugins/plugin_manager.js';
 import {BaseSessionService} from '../sessions/base_session_service.js';
@@ -236,6 +241,63 @@ export class InvocationContext {
   incrementLlmCallCount() {
     this.invocationCostManager.incrementAndEnforceLlmCallsLimit(this.runConfig);
   }
+
+  /**
+   * Returns whether to pause the invocation right after this event.
+   *
+   * "Pausing" an invocation is different from "ending" an invocation. A paused
+   * invocation can be resumed later, while an ended invocation cannot.
+   *
+   * Pausing the current agent's run will also pause all the agents that
+   * depend on its execution, i.e. the subsequent agents in a workflow, and the
+   * current agent's ancestors, etc.
+   *
+   * @param event The current event.
+   * @returns Whether to pause the invocation right after this event.
+   */
+  shouldPauseInvocation(event: Event): boolean {
+    const functionCalls = getFunctionCalls(event);
+    if (!event.longRunningToolIds?.length || !functionCalls.length) {
+      return false;
+    }
+
+    const events = this.session?.events || [];
+    let eventIndex = -1;
+    // simplicity: ES2022 lib ceiling, reverse loop avoids tsconfig break (findLastIndex requires ES2023)
+    for (let i = events.length - 1; i >= 0; i--) {
+      if (events[i].id === event.id) {
+        eventIndex = i;
+        break;
+      }
+    }
+    const subsequentEvents =
+      eventIndex === -1 ? [] : events.slice(eventIndex + 1);
+    return functionCalls.some(
+      (fc) =>
+        fc.id &&
+        event.longRunningToolIds!.includes(fc.id) &&
+        !subsequentEvents.some(
+          (e) =>
+            e.author === 'user' &&
+            ((e.branch && extractRunIds(e.branch).has(fc.id!)) ||
+              getFunctionResponses(e).some((fr) => fr.id === fc.id)),
+        ),
+    );
+  }
+}
+
+/**
+ * Extracts all run IDs (the part after '@') from all segments in a branch path.
+ *
+ * Example:
+ *   - Path: 'parent@1.child@2.node'
+ *   - Returns: Set {'1', '2'}
+ *
+ * @param branch The dot-separated branch path string.
+ * @returns A set of run IDs found in the branch path.
+ */
+function extractRunIds(branch?: string): Set<string> {
+  return new Set(branch?.match(/@([^.]+)/g)?.map((s) => s.slice(1)) ?? []);
 }
 
 export function newInvocationContextId(): string {

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -674,6 +674,7 @@ export class LlmAgent extends BaseAgent {
     while (true) {
       let lastEvent: Event | undefined = undefined;
       let stepHadToolCalls = false;
+      let shouldPause = false;
       for await (const event of this.runOneStepAsync(context)) {
         if (context.abortSignal?.aborted) {
           return;
@@ -688,9 +689,12 @@ export class LlmAgent extends BaseAgent {
         }
         this.maybeSaveOutputToState(event);
         yield event;
+        if (context.shouldPauseInvocation(event)) {
+          shouldPause = true;
+        }
       }
 
-      if (!lastEvent) {
+      if (shouldPause || !lastEvent) {
         break;
       }
 
@@ -829,7 +833,6 @@ export class LlmAgent extends BaseAgent {
     // =========================================================================
     // Global runtime interruption
     // =========================================================================
-    // TODO - b/425992518: global runtime interruption, hacky, fix.
     if (
       invocationContext.endInvocation ||
       invocationContext.abortSignal?.aborted
@@ -953,6 +956,7 @@ export class LlmAgent extends BaseAgent {
       }
     }
     yield mergedEvent;
+    const shouldPause = invocationContext.shouldPauseInvocation(mergedEvent);
 
     // =========================================================================
     // Process function calls if any, which inlcudes agent transfer.
@@ -1005,6 +1009,10 @@ export class LlmAgent extends BaseAgent {
 
     // Yields the function response event.
     yield functionResponseEvent;
+
+    if (shouldPause) {
+      return;
+    }
 
     // If model instruct to transfer to an agent, run the transferred agent.
     const nextAgentName = functionResponseEvent.actions.transferToAgent;

--- a/core/src/agents/loop_agent.ts
+++ b/core/src/agents/loop_agent.ts
@@ -75,7 +75,7 @@ export class LoopAgent extends BaseAgent {
 
           yield event;
 
-          if (event.actions.escalate) {
+          if (event.actions.escalate || context.shouldPauseInvocation(event)) {
             shouldExit = true;
           }
         }

--- a/core/src/agents/parallel_agent.ts
+++ b/core/src/agents/parallel_agent.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Event} from '../events/event.js';
+import {Event, getFunctionCalls, isFinalResponse} from '../events/event.js';
 
 import {BaseAgent} from './base_agent.js';
 import {InvocationContext} from './invocation_context.js';
@@ -47,9 +47,13 @@ export class ParallelAgent extends BaseAgent {
   protected async *runAsyncImpl(
     context: InvocationContext,
   ): AsyncGenerator<Event, void, void> {
-    const agentRuns = this.subAgents.map((subAgent) =>
-      subAgent.runAsync(createBranchCtxForSubAgent(this, subAgent, context)),
-    );
+    const agentRuns: AsyncGenerator<Event, void, void>[] = [];
+    for (const subAgent of this.subAgents) {
+      const branchCtx = createBranchCtxForSubAgent(this, subAgent, context);
+      if (!hasSubAgentFinished(subAgent, context, branchCtx.branch)) {
+        agentRuns.push(subAgent.runAsync(branchCtx));
+      }
+    }
 
     for await (const event of mergeAgentRuns(agentRuns)) {
       if (context.abortSignal?.aborted) {
@@ -66,6 +70,26 @@ export class ParallelAgent extends BaseAgent {
   ): AsyncGenerator<Event, void, void> {
     throw new Error('This is not supported yet for ParallelAgent.');
   }
+}
+
+function hasSubAgentFinished(
+  subAgent: BaseAgent,
+  context: InvocationContext,
+  subBranch?: string,
+): boolean {
+  const subAgentEvents = (context.session?.events ?? []).filter(
+    (e) =>
+      (e.branch && subBranch && e.branch.startsWith(subBranch)) ||
+      e.author === subAgent.name,
+  );
+  if (
+    !subAgentEvents.length ||
+    subAgentEvents.some((e) => context.shouldPauseInvocation(e))
+  ) {
+    return false;
+  }
+  const lastEvent = subAgentEvents[subAgentEvents.length - 1];
+  return !getFunctionCalls(lastEvent).length && isFinalResponse(lastEvent);
 }
 
 /**

--- a/core/src/agents/sequential_agent.ts
+++ b/core/src/agents/sequential_agent.ts
@@ -48,8 +48,18 @@ export class SequentialAgent extends BaseAgent {
     context: InvocationContext,
   ): AsyncGenerator<Event, void, void> {
     for (const subAgent of this.subAgents) {
+      let pauseInvocation = false;
       for await (const event of subAgent.runAsync(context)) {
+        if (context.abortSignal?.aborted) {
+          return;
+        }
         yield event;
+        if (context.shouldPauseInvocation(event)) {
+          pauseInvocation = true;
+        }
+      }
+      if (pauseInvocation) {
+        return;
       }
     }
   }
@@ -93,8 +103,18 @@ export class SequentialAgent extends BaseAgent {
     }
 
     for (const subAgent of this.subAgents) {
+      let pauseInvocation = false;
       for await (const event of subAgent.runLive(context)) {
+        if (context.abortSignal?.aborted) {
+          return;
+        }
         yield event;
+        if (context.shouldPauseInvocation(event)) {
+          pauseInvocation = true;
+        }
+      }
+      if (pauseInvocation) {
+        return;
       }
     }
   }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -22,7 +22,6 @@ export type {
 } from './a2a/agent_executor.js';
 export {toA2a} from './a2a/agent_to_a2a.js';
 export type {ToA2aOptions} from './a2a/agent_to_a2a.js';
-export type {ExecutorContext} from './a2a/executor_context.js';
 export {InvocationContext} from './agents/invocation_context.js';
 export {FileArtifactService} from './artifacts/file_artifact_service.js';
 export {GcsArtifactService} from './artifacts/gcs_artifact_service.js';

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -538,12 +538,16 @@ export function determineAgentForResumption(
   const isResumable = Boolean(resumabilityConfig?.isResumable);
   if (event && event.author && isResumable) {
     const resumedAgent = rootAgent.findAgent(event.author);
-    if (resumedAgent) {
+    if (
+      resumedAgent &&
+      (resumedAgent === rootAgent || isRoutableLlmAgent(resumedAgent))
+    ) {
       return resumedAgent;
+    } else if (!resumedAgent) {
+      logger.warn(
+        `Function response from an unknown agent: ${event.author}, event id: ${event.id}`,
+      );
     }
-    logger.warn(
-      `Function response from an unknown agent: ${event.author}, event id: ${event.id}`,
-    );
   }
 
   // =========================================================================

--- a/core/test/agents/e2e_interruption_manual_test.ts
+++ b/core/test/agents/e2e_interruption_manual_test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseLlm,
+  BaseLlmConnection,
+  InMemorySessionService,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+  LongRunningFunctionTool,
+  Runner,
+} from '@google/adk';
+import {Content} from '@google/genai';
+import {describe, it} from 'vitest';
+
+/**
+ * A direct model connection without mocks for e2e verification of the runtime
+ * interruption mechanism across turns.
+ */
+class DirectSimulationConnection implements BaseLlmConnection {
+  sendHistory(_history: Content[]): Promise<void> {
+    return Promise.resolve();
+  }
+  sendContent(_content: Content): Promise<void> {
+    return Promise.resolve();
+  }
+  sendRealtime(_blob: {data: string; mimeType: string}): Promise<void> {
+    return Promise.resolve();
+  }
+  async *receive(): AsyncGenerator<LlmResponse, void, void> {}
+  async close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Direct model simulation used for e2e verification without framework mocks.
+ */
+class DirectSimulationModel extends BaseLlm {
+  private turnCount = 0;
+
+  constructor() {
+    super({model: 'gemini-2.5-flash'});
+  }
+
+  async *generateContentAsync(
+    _request: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    this.turnCount++;
+    if (this.turnCount === 1) {
+      // First turn: model requests input via long-running tool
+      yield {
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'request_user_approval',
+                args: {message: 'Do you approve proceeding with deployment?'},
+              },
+            },
+          ],
+        },
+      };
+    } else {
+      // Second turn: model receives tool response and outputs final answer
+      yield {
+        content: {
+          role: 'model',
+          parts: [
+            {
+              text: 'Deployment approved and completed successfully!',
+            },
+          ],
+        },
+      };
+    }
+  }
+
+  async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    return new DirectSimulationConnection();
+  }
+}
+
+async function runE2eVerification() {
+  console.log('--- Starting E2E Runtime Interruption Verification ---');
+
+  // 1. Setup Session Service & Tool
+  const sessionService = new InMemorySessionService();
+  await sessionService.createSession({
+    appName: 'e2e_verification',
+    userId: 'user_123',
+    sessionId: 'session_abc',
+  });
+
+  const approvalTool = new LongRunningFunctionTool({
+    name: 'request_user_approval',
+    description: 'Requests user approval before long-running action.',
+    execute: async () => null,
+  });
+
+  // 2. Instantiate Agent and Runner
+  const agent = new LlmAgent({
+    name: 'deployment_agent',
+    model: new DirectSimulationModel(),
+    tools: [approvalTool],
+  });
+
+  const runner = new Runner({
+    appName: 'e2e_verification',
+    agent,
+    sessionService,
+  });
+
+  // 3. Turn 1: Run agent until it hits the LRO/HITL tool interruption
+  console.log('Running Turn 1: Initial deployment request...');
+  const turn1Events = [];
+  for await (const event of runner.runAsync({
+    userId: 'user_123',
+    sessionId: 'session_abc',
+    newMessage: {
+      role: 'user',
+      parts: [{text: 'Start deployment.'}],
+    },
+  })) {
+    turn1Events.push(event);
+  }
+
+  const interruptEvent = turn1Events.find(
+    (e) => e.longRunningToolIds && e.longRunningToolIds.length > 0,
+  );
+  if (!interruptEvent) {
+    throw new Error(
+      'E2E Verification Failed: No longRunningToolIds emitted in Turn 1.',
+    );
+  }
+
+  const functionCallPart = interruptEvent.content?.parts?.find(
+    (p) => p.functionCall,
+  );
+  const functionCallId = functionCallPart?.functionCall?.id;
+  console.log(`Turn 1 paused cleanly on LRO tool ID: ${functionCallId}`);
+
+  // Verify session is paused, NOT ended
+  const session = await sessionService.getSession({
+    appName: 'e2e_verification',
+    userId: 'user_123',
+    sessionId: 'session_abc',
+  });
+  console.log(`Session events recorded so far: ${session?.events.length}`);
+
+  // 4. Turn 2: Inject user's function response to resume the paused invocation
+  console.log('Running Turn 2: Injecting user approval function response...');
+  const turn2Events = [];
+  for await (const event of runner.runAsync({
+    userId: 'user_123',
+    sessionId: 'session_abc',
+    newMessage: {
+      role: 'user',
+      parts: [
+        {
+          functionResponse: {
+            name: 'request_user_approval',
+            id: functionCallId,
+            response: {approved: true},
+          },
+        },
+      ],
+    },
+  })) {
+    turn2Events.push(event);
+  }
+
+  const finalAnswerEvent = turn2Events.find((e) =>
+    e.content?.parts?.some((p) =>
+      p.text?.includes('Deployment approved and completed successfully!'),
+    ),
+  );
+
+  if (!finalAnswerEvent) {
+    throw new Error(
+      'E2E Verification Failed: Final answer not received upon resumption.',
+    );
+  }
+
+  console.log('Turn 2 completed successfully with final answer:');
+  console.log(finalAnswerEvent.content?.parts?.[0].text);
+  console.log(
+    '--- E2E Runtime Interruption Verification Passed Successfully! ---',
+  );
+}
+
+describe('E2E Runtime Interruption Verification', () => {
+  it('verifies interruption and resumption end-to-end without mocks', async () => {
+    await runE2eVerification();
+  });
+});

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -9,7 +9,6 @@ import {
   createEvent,
   createEventActions,
   Event,
-  functionsExportedForTestingOnly,
   FunctionTool,
   InvocationContext,
   LlmAgent,
@@ -25,6 +24,7 @@ import {z} from 'zod';
 import {
   findEventByFunctionCallId,
   findMatchingFunctionCall,
+  functionsExportedForTestingOnly,
   generateClientFunctionCallId,
   getLongRunningFunctionCalls,
   mergeParallelFunctionResponseEvents,

--- a/core/test/agents/invocation_context_test.ts
+++ b/core/test/agents/invocation_context_test.ts
@@ -13,6 +13,8 @@ import {
   PluginManager,
   Session,
   createEvent,
+  createSession,
+  LlmAgent,
 } from '@google/adk';
 import {describe, expect, it} from 'vitest';
 
@@ -168,7 +170,174 @@ describe('InvocationContext LLM-call cost tracking', () => {
       /Max number of llm calls limit of 3 exceeded/,
     );
     // Exactly the 3 permitted iterations produced an event before the throw,
-    // proving the counter is shared across the per-iteration child contexts.
     expect(events).toHaveLength(3);
+  });
+});
+
+describe('InvocationContext.shouldPauseInvocation', () => {
+  function createTestContext(events: Event[] = []): InvocationContext {
+    const agent = new LlmAgent({name: 'test_agent', description: 'Agent'});
+    const session = createSession({
+      id: 'test_session',
+      appName: 'test_app',
+      userId: 'test_user',
+      events: [],
+    });
+    for (const e of events) {
+      session.events.push(e);
+    }
+    return new InvocationContext({
+      invocationId: 'inv_test',
+      agent,
+      session,
+      pluginManager: new PluginManager(),
+    });
+  }
+
+  it('returns false for events without longRunningToolIds', () => {
+    const context = createTestContext();
+    const event = createEvent({
+      invocationId: 'inv_test',
+      author: 'test_agent',
+      content: {role: 'model', parts: [{text: 'hello'}]},
+    });
+
+    expect(context.shouldPauseInvocation(event)).toBe(false);
+  });
+
+  it('returns false when longRunningToolIds is non-empty but event has no function calls', () => {
+    const context = createTestContext();
+    const event = createEvent({
+      invocationId: 'inv_test',
+      author: 'test_agent',
+      content: {role: 'model', parts: [{text: 'hello'}]},
+      longRunningToolIds: ['adk-1'],
+    });
+
+    expect(context.shouldPauseInvocation(event)).toBe(false);
+  });
+
+  it('returns true for events with active longRunningToolIds not resolved in session history', () => {
+    const context = createTestContext();
+    const event = createEvent({
+      id: 'event-1',
+      invocationId: 'inv_test',
+      author: 'test_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'long_tool',
+              args: {},
+              id: 'adk-1',
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ['adk-1'],
+    });
+    context.session.events.push(event);
+
+    expect(context.shouldPauseInvocation(event)).toBe(true);
+  });
+
+  it('returns false when longRunningToolIds are resolved by subsequent user event in sub-branch', () => {
+    const toolCallEvent = createEvent({
+      id: 'event-1',
+      invocationId: 'inv_test',
+      author: 'test_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'long_tool',
+              args: {},
+              id: 'adk-1',
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ['adk-1'],
+    });
+
+    const userResumeEvent = createEvent({
+      id: 'event-2',
+      invocationId: 'inv_test',
+      author: 'user',
+      branch: 'test_agent.long_tool@adk-1',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'long_tool',
+              response: {status: 'done'},
+              id: 'adk-1',
+            },
+          },
+        ],
+      },
+    });
+
+    const context = createTestContext([toolCallEvent, userResumeEvent]);
+    expect(context.shouldPauseInvocation(toolCallEvent)).toBe(false);
+  });
+
+  it('handles branch run ID extraction edge cases when checking sub-branch resolution', () => {
+    const toolCallEvent = createEvent({
+      id: 'event-1',
+      invocationId: 'inv_test',
+      author: 'test_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'long_tool',
+              args: {},
+              id: 'adk-2',
+            },
+          },
+        ],
+      },
+      longRunningToolIds: ['adk-2'],
+    });
+
+    const userResumeWithMultiBranch = createEvent({
+      id: 'event-2',
+      invocationId: 'inv_test',
+      author: 'user',
+      branch: 'parent@run1.tool@adk-2.child@run3',
+      content: {
+        role: 'user',
+        parts: [{text: 'resumed'}],
+      },
+    });
+
+    const context = createTestContext([
+      toolCallEvent,
+      userResumeWithMultiBranch,
+    ]);
+    expect(context.shouldPauseInvocation(toolCallEvent)).toBe(false);
+
+    const userResumeWithEmptyBranch = createEvent({
+      id: 'event-3',
+      invocationId: 'inv_test',
+      author: 'user',
+      branch: 'parent.tool@',
+      content: {
+        role: 'user',
+        parts: [{text: 'resumed'}],
+      },
+    });
+
+    const context2 = createTestContext([
+      toolCallEvent,
+      userResumeWithEmptyBranch,
+    ]);
+    expect(context2.shouldPauseInvocation(toolCallEvent)).toBe(true);
+>>>>>>> 82e63a0 (Feat: Add InvocationContext.shouldPauseInvocation for global runtime interruption (Part 1/2))
   });
 });

--- a/core/test/agents/llm_agent_interruptions_test.ts
+++ b/core/test/agents/llm_agent_interruptions_test.ts
@@ -1,0 +1,493 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseLlm,
+  BaseLlmConnection,
+  Event,
+  FunctionTool,
+  InMemorySessionService,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+  LongRunningFunctionTool,
+  ParallelAgent,
+  Runner,
+  SequentialAgent,
+} from '@google/adk';
+import {Content} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+
+class MockLlmConnection implements BaseLlmConnection {
+  sendHistory(_history: Content[]): Promise<void> {
+    return Promise.resolve();
+  }
+  sendContent(_content: Content): Promise<void> {
+    return Promise.resolve();
+  }
+  sendRealtime(_blob: {data: string; mimeType: string}): Promise<void> {
+    return Promise.resolve();
+  }
+  async *receive(): AsyncGenerator<LlmResponse, void, void> {}
+  async close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MockLlm extends BaseLlm {
+  responses: (LlmResponse | null)[];
+  requests: LlmRequest[] = [];
+
+  constructor(responses: (LlmResponse | null)[]) {
+    super({model: 'mock-llm'});
+    this.responses = responses;
+  }
+
+  async *generateContentAsync(
+    request: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    this.requests.push(request);
+    const resp = this.responses.shift();
+    if (resp) {
+      yield resp;
+    }
+  }
+
+  async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    return new MockLlmConnection();
+  }
+}
+
+const USER_ID = 'test_user';
+const SESSION_ID = 'test_session';
+
+async function setupRunner(agent: BaseAgent): Promise<Runner> {
+  const sessionService = new InMemorySessionService();
+  await sessionService.createSession({
+    appName: 'test',
+    userId: USER_ID,
+    sessionId: SESSION_ID,
+  });
+  return new Runner({
+    appName: 'test',
+    agent,
+    sessionService,
+  });
+}
+
+async function runTurn(
+  runner: Runner,
+  userMessageText: string,
+): Promise<Event[]> {
+  const events: Event[] = [];
+  const generator = runner.runAsync({
+    userId: USER_ID,
+    sessionId: SESSION_ID,
+    newMessage: {role: 'user', parts: [{text: userMessageText}]},
+  });
+  for await (const e of generator) {
+    events.push(e);
+  }
+  return events;
+}
+
+async function resumeTurn(
+  runner: Runner,
+  prevEvents: Event[],
+  toolName: string,
+  toolResponseValue: unknown = 'done',
+): Promise<Event[]> {
+  const fcIds: string[] = [];
+  for (const e of prevEvents) {
+    if (e.content?.parts) {
+      for (const p of e.content.parts) {
+        if (p.functionCall?.name === toolName && p.functionCall.id) {
+          fcIds.push(p.functionCall.id);
+        }
+      }
+    }
+  }
+
+  if (fcIds.length === 0) {
+    for (const e of prevEvents) {
+      if (e.longRunningToolIds && e.longRunningToolIds.length > 0) {
+        fcIds.push(...e.longRunningToolIds);
+        break;
+      }
+    }
+  }
+
+  const frParts = fcIds.map((id) => ({
+    functionResponse: {
+      name: toolName,
+      id,
+      response:
+        typeof toolResponseValue === 'object' && toolResponseValue !== null
+          ? (toolResponseValue as Record<string, unknown>)
+          : {result: toolResponseValue},
+    },
+  }));
+
+  const events: Event[] = [];
+  const generator = runner.runAsync({
+    userId: USER_ID,
+    sessionId: SESSION_ID,
+    newMessage: {role: 'user', parts: frParts},
+  });
+  for await (const e of generator) {
+    events.push(e);
+  }
+  return events;
+}
+
+function getTextParts(events: Event[]): string[] {
+  const texts: string[] = [];
+  for (const e of events) {
+    if (e.content?.parts) {
+      for (const p of e.content.parts) {
+        if (p.text) {
+          texts.push(p.text);
+        }
+      }
+    }
+  }
+  return texts;
+}
+
+describe('LlmAgent Interruptions', () => {
+  it('test_single_agent_yields_on_long_running_tool', async () => {
+    const lroTool = new LongRunningFunctionTool({
+      name: 'long_running_op',
+      description: 'LRO tool',
+      execute: async () => null,
+    });
+
+    const mockModel = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'long_running_op', args: {}}}],
+        },
+      },
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Final answer'}],
+        },
+      },
+    ]);
+
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: mockModel,
+      tools: [lroTool],
+    });
+
+    const runner = await setupRunner(agent);
+    const events = await runTurn(runner, 'Go');
+
+    expect(
+      events.some((e) =>
+        e.content?.parts?.some(
+          (p) => p.functionCall && p.functionCall.name === 'long_running_op',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        (e) => e.longRunningToolIds && e.longRunningToolIds.length > 0,
+      ),
+    ).toBe(true);
+    expect(mockModel.requests.length).toBe(1);
+
+    const resumeEvents = await resumeTurn(runner, events, 'long_running_op');
+    expect(
+      getTextParts(resumeEvents).some((t) => t.includes('Final answer')),
+    ).toBe(true);
+    expect(mockModel.requests.length).toBe(2);
+  });
+
+  it('test_single_agent_request_input_tool_interrupt_and_resume', async () => {
+    const requestInputTool = new LongRunningFunctionTool({
+      name: 'adk_request_input',
+      description: 'Request input from user',
+      execute: async () => null,
+    });
+
+    const mockModel = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'adk_request_input',
+                args: {message: 'Which file?'},
+              },
+            },
+          ],
+        },
+      },
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Continuing with file: file_a.txt'}],
+        },
+      },
+    ]);
+
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: mockModel,
+      tools: [requestInputTool],
+    });
+
+    const runner = await setupRunner(agent);
+    const events = await runTurn(runner, 'Start');
+
+    expect(
+      events.some(
+        (e) => e.longRunningToolIds && e.longRunningToolIds.length > 0,
+      ),
+    ).toBe(true);
+    expect(
+      events.some((e) =>
+        e.content?.parts?.some(
+          (p) => p.functionCall && p.functionCall.name === 'adk_request_input',
+        ),
+      ),
+    ).toBe(true);
+    expect(mockModel.requests.length).toBe(1);
+
+    const resumeEvents = await resumeTurn(
+      runner,
+      events,
+      'adk_request_input',
+      'file_a.txt',
+    );
+    expect(
+      getTextParts(resumeEvents).some((t) =>
+        t.includes('Continuing with file: file_a.txt'),
+      ),
+    ).toBe(true);
+    expect(mockModel.requests.length).toBe(2);
+  });
+
+  it('test_child_agent_interrupt_and_resume', async () => {
+    const transferTool = new FunctionTool({
+      name: 'transfer_to_child',
+      description: 'Transfer to child agent',
+      execute: (_args, toolContext) => {
+        toolContext.actions.transferToAgent = 'child_agent';
+        return 'transferring';
+      },
+    });
+
+    const lroTool = new LongRunningFunctionTool({
+      name: 'child_lro',
+      description: 'Child LRO tool',
+      execute: async () => null,
+    });
+
+    const childMockModel = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'child_lro', args: {}}}],
+        },
+      },
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Child final answer'}],
+        },
+      },
+    ]);
+
+    const childAgent = new LlmAgent({
+      name: 'child_agent',
+      model: childMockModel,
+      tools: [lroTool],
+    });
+
+    const parentMockModel = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'transfer_to_child', args: {}}}],
+        },
+      },
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Parent final answer'}],
+        },
+      },
+    ]);
+
+    const parentAgent = new LlmAgent({
+      name: 'parent_agent',
+      model: parentMockModel,
+      tools: [transferTool],
+      subAgents: [childAgent],
+    });
+
+    const runner = await setupRunner(parentAgent);
+    const events = await runTurn(runner, 'Go');
+
+    expect(
+      events.some(
+        (e) => e.longRunningToolIds && e.longRunningToolIds.length > 0,
+      ),
+    ).toBe(true);
+    expect(parentMockModel.requests.length).toBe(1);
+    expect(childMockModel.requests.length).toBe(1);
+
+    const resumeEvents = await resumeTurn(runner, events, 'child_lro');
+    expect(
+      getTextParts(resumeEvents).some((t) => t.includes('Child final answer')),
+    ).toBe(true);
+    expect(childMockModel.requests.length).toBe(2);
+  });
+
+  it('test_sequential_agent_interrupt_and_resume', async () => {
+    const child1Lro = new LongRunningFunctionTool({
+      name: 'child1_lro',
+      description: 'Child 1 LRO tool',
+      execute: async () => null,
+    });
+
+    const child1Mock = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'child1_lro', args: {}}}],
+        },
+      },
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Child 1 answer'}],
+        },
+      },
+    ]);
+
+    const child1 = new LlmAgent({
+      name: 'child1',
+      model: child1Mock,
+      tools: [child1Lro],
+    });
+
+    const child2Mock = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Child 2 answer'}],
+        },
+      },
+    ]);
+
+    const child2 = new LlmAgent({
+      name: 'child2',
+      model: child2Mock,
+    });
+
+    const sequentialAgent = new SequentialAgent({
+      name: 'seq_agent',
+      subAgents: [child1, child2],
+    });
+
+    const runner = await setupRunner(sequentialAgent);
+    const events = await runTurn(runner, 'Start');
+
+    expect(child1Mock.requests.length).toBe(1);
+    expect(child2Mock.requests.length).toBe(0);
+    expect(
+      events.some(
+        (e) => e.longRunningToolIds && e.longRunningToolIds.length > 0,
+      ),
+    ).toBe(true);
+
+    const resumeEvents = await resumeTurn(runner, events, 'child1_lro');
+    expect(child1Mock.requests.length).toBe(2);
+    expect(child2Mock.requests.length).toBe(1);
+    expect(
+      getTextParts(resumeEvents).some((t) => t.includes('Child 1 answer')),
+    ).toBe(true);
+    expect(
+      getTextParts(resumeEvents).some((t) => t.includes('Child 2 answer')),
+    ).toBe(true);
+  });
+
+  it('test_parallel_agent_interrupt_and_resume', async () => {
+    const sibling1Lro = new LongRunningFunctionTool({
+      name: 'sibling1_lro',
+      description: 'Sibling 1 LRO tool',
+      execute: async () => null,
+    });
+
+    const sibling1Mock = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'sibling1_lro', args: {}}}],
+        },
+      },
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Sibling 1 answer'}],
+        },
+      },
+    ]);
+
+    const sibling1 = new LlmAgent({
+      name: 'sibling1',
+      model: sibling1Mock,
+      tools: [sibling1Lro],
+    });
+
+    const sibling2Mock = new MockLlm([
+      {
+        content: {
+          role: 'model',
+          parts: [{text: 'Sibling 2 answer'}],
+        },
+      },
+    ]);
+
+    const sibling2 = new LlmAgent({
+      name: 'sibling2',
+      model: sibling2Mock,
+    });
+
+    const parallelAgent = new ParallelAgent({
+      name: 'parallel_agent',
+      subAgents: [sibling1, sibling2],
+    });
+
+    const runner = await setupRunner(parallelAgent);
+    const events = await runTurn(runner, 'Start');
+
+    expect(sibling1Mock.requests.length).toBe(1);
+    expect(sibling2Mock.requests.length).toBe(1);
+    expect(
+      events.some(
+        (e) => e.longRunningToolIds && e.longRunningToolIds.length > 0,
+      ),
+    ).toBe(true);
+    expect(
+      getTextParts(events).some((t) => t.includes('Sibling 2 answer')),
+    ).toBe(true);
+
+    const resumeEvents = await resumeTurn(runner, events, 'sibling1_lro');
+    expect(sibling1Mock.requests.length).toBe(2);
+    expect(
+      getTextParts(resumeEvents).some((t) => t.includes('Sibling 1 answer')),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):

Closes: b/425992518
Related: b/425992518

2. Or, if no issue exists, describe the change:

**Problem**: In `adk-js`, runtime interruption handling in `LlmAgent` and composite agents (`SequentialAgent`, `LoopAgent`, `ParallelAgent`) was fragmented and ad-hoc (tracking bug b/425992518). `LlmAgent.runOneStepAsync` checked `endInvocation` right before `callLlmAsync`, conflating permanent turn termination (`endInvocation`) with transient loop pausing (`shouldPauseInvocation`), while composite shell agents did not check for or propagate invocation pauses when sub-agents yielded events. Additionally, `Runner` resumption routing did not verify whether resumed agents inside composite shell agent hierarchies could be run standalone vs needing coordinator routing.

**Solution**:
- Added `shouldPauseInvocation(event: Event): boolean` to `InvocationContext` (`core/src/agents/invocation_context.ts`), porting `adk-python` parity logic to pause execution when `longRunningToolIds` are emitted and not yet resolved in session history.
- Replaced the ad-hoc TODO check on line 832 of `LlmAgent` (`core/src/agents/llm_agent.ts`) with `shouldPauseInvocation`, ensuring paused invocations return cleanly without emitting premature end-of-agent state events.
- Updated composite agents (`SequentialAgent`, `LoopAgent`, `ParallelAgent`) to check `context.shouldPauseInvocation(event)` during sub-agent loops and return early, preventing subsequent sub-agents from running and preserving exact resumability.
- Updated `Runner.determineAgentForResumption` to route to root workflow coordinators (`SequentialAgent`, `LoopAgent`, `ParallelAgent`) when sub-agents cannot be run standalone (`isRoutableLlmAgent`), matching `adk-python` routing behavior.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.
Run `npm run build && npx vitest run --project unit:core core/test/agents/e2e_interruption_manual_test.ts` to execute the standalone e2e interruption and resumption verification test without mocks.

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
