### PR TITLE
feat: refactor BaseSessionService and callers to use SessionScope (Part 3)

### DIFF
--- a/core/src/a2a/agent_executor.ts
+++ b/core/src/a2a/agent_executor.ts
@@ -268,19 +268,8 @@ async function getAdkSession(
   sessionService: BaseSessionService,
   appName: string,
 ): Promise<Session> {
-  const session = await sessionService.getSession({
-    appName,
-    userId,
-    sessionId,
-  });
-  if (session) {
-    return session;
-  }
-
-  return sessionService.createSession({
-    appName,
-    userId,
-    sessionId,
+  return sessionService.getOrCreateSession({
+    scope: {appName, userId, sessionId},
   });
 }
 

--- a/core/src/artifacts/base_artifact_service.ts
+++ b/core/src/artifacts/base_artifact_service.ts
@@ -5,12 +5,14 @@
  */
 
 import {Part} from '@google/genai';
-import {CompositeSessionKey} from '../sessions/session.js';
+import {SessionScope} from '../sessions/session_scope.js';
 
 /**
  * The parameters for `saveArtifact`.
  */
-export interface SaveArtifactRequest extends CompositeSessionKey {
+export interface SaveArtifactRequest {
+  /** The session scope. */
+  scope: SessionScope;
   /** The filename of the artifact. */
   filename: string;
   /** The artifact to save. */
@@ -24,7 +26,9 @@ export interface SaveArtifactRequest extends CompositeSessionKey {
 /**
  * The parameters for `loadArtifact`.
  */
-export interface LoadArtifactRequest extends CompositeSessionKey {
+export interface LoadArtifactRequest {
+  /** The session scope. */
+  scope: SessionScope;
   /** The filename of the artifact. */
   filename: string;
   /**
@@ -37,12 +41,17 @@ export interface LoadArtifactRequest extends CompositeSessionKey {
 /**
  * The parameters for `listArtifactKeys`.
  */
-export type ListArtifactKeysRequest = CompositeSessionKey;
+export interface ListArtifactKeysRequest {
+  /** The session scope. */
+  scope: SessionScope;
+}
 
 /**
  * The parameters for `deleteArtifact`.
  */
-export interface DeleteArtifactRequest extends CompositeSessionKey {
+export interface DeleteArtifactRequest {
+  /** The session scope. */
+  scope: SessionScope;
   /** The filename of the artifact. */
   filename: string;
 }
@@ -50,7 +59,9 @@ export interface DeleteArtifactRequest extends CompositeSessionKey {
 /**
  * The parameters for `listVersions`.
  */
-export interface ListVersionsRequest extends CompositeSessionKey {
+export interface ListVersionsRequest {
+  /** The session scope. */
+  scope: SessionScope;
   /** The filename of the artifact. */
   filename: string;
 }

--- a/core/src/artifacts/file_artifact_service.ts
+++ b/core/src/artifacts/file_artifact_service.ts
@@ -71,8 +71,7 @@ export class FileArtifactService implements BaseArtifactService {
   }
 
   async saveArtifact({
-    userId,
-    sessionId,
+    scope: {userId, sessionId},
     filename,
     artifact,
     customMetadata,
@@ -139,8 +138,7 @@ export class FileArtifactService implements BaseArtifactService {
   }
 
   async loadArtifact({
-    userId,
-    sessionId,
+    scope: {userId, sessionId},
     filename,
     version,
   }: LoadArtifactRequest): Promise<Part | undefined> {
@@ -246,8 +244,7 @@ export class FileArtifactService implements BaseArtifactService {
   }
 
   async listArtifactKeys({
-    userId,
-    sessionId,
+    scope: {userId, sessionId},
   }: ListArtifactKeysRequest): Promise<string[]> {
     const filenames: Set<string> = new Set();
     const userRoot = getUserRoot(this.rootDir, userId);
@@ -280,8 +277,7 @@ export class FileArtifactService implements BaseArtifactService {
   }
 
   async deleteArtifact({
-    userId,
-    sessionId,
+    scope: {userId, sessionId},
     filename,
   }: DeleteArtifactRequest): Promise<void> {
     try {
@@ -301,8 +297,7 @@ export class FileArtifactService implements BaseArtifactService {
   }
 
   async listVersions({
-    userId,
-    sessionId,
+    scope: {userId, sessionId},
     filename,
   }: ListVersionsRequest): Promise<number[]> {
     try {
@@ -323,8 +318,7 @@ export class FileArtifactService implements BaseArtifactService {
   }
 
   async listArtifactVersions({
-    userId,
-    sessionId,
+    scope: {userId, sessionId},
     filename,
   }: ListVersionsRequest): Promise<ArtifactVersion[]> {
     try {
@@ -364,8 +358,7 @@ export class FileArtifactService implements BaseArtifactService {
   }
 
   async getArtifactVersion({
-    userId,
-    sessionId,
+    scope: {userId, sessionId},
     filename,
     version,
   }: LoadArtifactRequest): Promise<ArtifactVersion | undefined> {

--- a/core/src/artifacts/gcs_artifact_service.ts
+++ b/core/src/artifacts/gcs_artifact_service.ts
@@ -163,8 +163,8 @@ export class GcsArtifactService implements BaseArtifactService {
   }
 
   async listArtifactKeys(request: ListArtifactKeysRequest): Promise<string[]> {
-    const sessionPrefix = `${request.appName}/${request.userId}/${request.sessionId}/`;
-    const usernamePrefix = `${request.appName}/${request.userId}/user/`;
+    const sessionPrefix = `${request.scope.appName}/${request.scope.userId}/${request.scope.sessionId}/`;
+    const usernamePrefix = `${request.scope.appName}/${request.scope.userId}/user/`;
     const [[sessionFiles], [userSessionFiles]] = await Promise.all([
       this.bucket.getFiles({prefix: sessionPrefix}),
       this.bucket.getFiles({prefix: usernamePrefix}),
@@ -262,7 +262,7 @@ export class GcsArtifactService implements BaseArtifactService {
       };
     } catch (e) {
       logger.warn(
-        `[GcsArtifactService] getArtifactVersion: Failed to get artifact version for userId: ${request.userId} sessionId: ${request.sessionId} filename: ${request.filename} version: ${request.version}`,
+        `[GcsArtifactService] getArtifactVersion: Failed to get artifact version for userId: ${request.scope.userId} sessionId: ${request.scope.sessionId} filename: ${request.filename} version: ${request.version}`,
         e,
       );
       return undefined;
@@ -271,9 +271,7 @@ export class GcsArtifactService implements BaseArtifactService {
 }
 
 function getFileName({
-  appName,
-  userId,
-  sessionId,
+  scope: {appName, userId, sessionId},
   filename,
   version,
 }: LoadArtifactRequest): string {

--- a/core/src/artifacts/in_memory_artifact_service.ts
+++ b/core/src/artifacts/in_memory_artifact_service.ts
@@ -30,9 +30,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
   > = {};
 
   saveArtifact({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     filename,
     artifact,
     customMetadata,
@@ -67,9 +65,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
   }
 
   loadArtifact({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     filename,
     version,
   }: LoadArtifactRequest): Promise<Part | undefined> {
@@ -88,9 +84,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
   }
 
   listArtifactKeys({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
   }: ListArtifactKeysRequest): Promise<string[]> {
     const sessionPrefix = `${appName}/${userId}/${sessionId}/`;
     const usernamespacePrefix = `${appName}/${userId}/user/`;
@@ -110,9 +104,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
   }
 
   deleteArtifact({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     filename,
   }: DeleteArtifactRequest): Promise<void> {
     const path = artifactPath(appName, userId, sessionId, filename);
@@ -125,9 +117,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
   }
 
   listVersions({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     filename,
   }: ListVersionsRequest): Promise<number[]> {
     const path = artifactPath(appName, userId, sessionId, filename);
@@ -146,9 +136,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
   }
 
   listArtifactVersions({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     filename,
   }: ListVersionsRequest): Promise<ArtifactVersion[]> {
     const path = artifactPath(appName, userId, sessionId, filename);
@@ -162,9 +150,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
   }
 
   getArtifactVersion({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     filename,
     version,
   }: LoadArtifactRequest): Promise<ArtifactVersion | undefined> {

--- a/core/src/artifacts/scoped_artifact_service.ts
+++ b/core/src/artifacts/scoped_artifact_service.ts
@@ -5,6 +5,7 @@
  */
 
 import {Part} from '@google/genai';
+import {SessionScope} from '../sessions/session_scope.js';
 import {ArtifactVersion, BaseArtifactService} from './base_artifact_service.js';
 import {
   SessionArtifactService,
@@ -18,16 +19,12 @@ import {
 export class ScopedArtifactService implements SessionArtifactService {
   constructor(
     private readonly delegate: BaseArtifactService,
-    private readonly appName: string,
-    private readonly userId: string,
-    private readonly sessionId: string,
+    private readonly scope: SessionScope,
   ) {}
 
   async saveArtifact(request: SessionSaveArtifactRequest): Promise<number> {
     return this.delegate.saveArtifact({
-      appName: this.appName,
-      userId: this.userId,
-      sessionId: this.sessionId,
+      scope: this.scope,
       ...request,
     });
   }
@@ -36,44 +33,34 @@ export class ScopedArtifactService implements SessionArtifactService {
     request: SessionLoadArtifactRequest,
   ): Promise<Part | undefined> {
     return this.delegate.loadArtifact({
-      appName: this.appName,
-      userId: this.userId,
-      sessionId: this.sessionId,
+      scope: this.scope,
       ...request,
     });
   }
 
   async listArtifactKeys(): Promise<string[]> {
     return this.delegate.listArtifactKeys({
-      appName: this.appName,
-      userId: this.userId,
-      sessionId: this.sessionId,
+      scope: this.scope,
     });
   }
 
   async deleteArtifact(filename: string): Promise<void> {
     return this.delegate.deleteArtifact({
-      appName: this.appName,
-      userId: this.userId,
-      sessionId: this.sessionId,
+      scope: this.scope,
       filename,
     });
   }
 
   async listVersions(filename: string): Promise<number[]> {
     return this.delegate.listVersions({
-      appName: this.appName,
-      userId: this.userId,
-      sessionId: this.sessionId,
+      scope: this.scope,
       filename,
     });
   }
 
   async listArtifactVersions(filename: string): Promise<ArtifactVersion[]> {
     return this.delegate.listArtifactVersions({
-      appName: this.appName,
-      userId: this.userId,
-      sessionId: this.sessionId,
+      scope: this.scope,
       filename,
     });
   }
@@ -82,9 +69,7 @@ export class ScopedArtifactService implements SessionArtifactService {
     request: SessionLoadArtifactRequest,
   ): Promise<ArtifactVersion | undefined> {
     return this.delegate.getArtifactVersion({
-      appName: this.appName,
-      userId: this.userId,
-      sessionId: this.sessionId,
+      scope: this.scope,
       ...request,
     });
   }

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -218,7 +218,7 @@ export type {
 } from './sessions/base_session_service.js';
 export {InMemorySessionService} from './sessions/in_memory_session_service.js';
 export {createSession} from './sessions/session.js';
-export type {CompositeSessionKey, Session} from './sessions/session.js';
+export type {Session} from './sessions/session.js';
 export type {
   CreateSessionScope,
   SessionScope,

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -219,6 +219,11 @@ export type {
 export {InMemorySessionService} from './sessions/in_memory_session_service.js';
 export {createSession} from './sessions/session.js';
 export type {CompositeSessionKey, Session} from './sessions/session.js';
+export type {
+  CreateSessionScope,
+  SessionScope,
+  UserScope,
+} from './sessions/session_scope.js';
 export {State} from './sessions/state.js';
 export {AgentTool, isAgentTool} from './tools/agent_tool.js';
 export type {AgentToolConfig} from './tools/agent_tool.js';
@@ -316,4 +321,5 @@ export * from './artifacts/base_artifact_service.js';
 export * from './features/feature_registry.js';
 export * from './memory/base_memory_service.js';
 export * from './sessions/base_session_service.js';
+export * from './sessions/session_scope.js';
 export * from './tools/base_tool.js';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -39,12 +39,6 @@ export {
 export * from './common.js';
 export {DatabaseSessionService} from './sessions/database_session_service.js';
 export {getSessionServiceFromUri} from './sessions/registry.js';
-export * from './sessions/session_scope.js';
-export type {
-  CreateSessionScope,
-  SessionScope,
-  UserScope,
-} from './sessions/session_scope.js';
 export {VertexAiSessionService} from './sessions/vertex_ai_session_service.js';
 export type {VertexAiSessionServiceOptions} from './sessions/vertex_ai_session_service.js';
 export {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -39,6 +39,12 @@ export {
 export * from './common.js';
 export {DatabaseSessionService} from './sessions/database_session_service.js';
 export {getSessionServiceFromUri} from './sessions/registry.js';
+export * from './sessions/session_scope.js';
+export type {
+  CreateSessionScope,
+  SessionScope,
+  UserScope,
+} from './sessions/session_scope.js';
 export {VertexAiSessionService} from './sessions/vertex_ai_session_service.js';
 export type {VertexAiSessionServiceOptions} from './sessions/vertex_ai_session_service.js';
 export {

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -189,8 +189,10 @@ export class Runner {
     customMetadata?: Record<string, unknown>;
   }): AsyncGenerator<Event, void, undefined> {
     const session = await this.sessionService.createSession({
-      appName: this.appName,
-      userId: params.userId,
+      scope: {
+        appName: this.appName,
+        userId: params.userId,
+      },
     });
     const sessionId = session.id;
 
@@ -205,9 +207,11 @@ export class Runner {
       });
     } finally {
       await this.sessionService.deleteSession({
-        appName: this.appName,
-        userId: params.userId,
-        sessionId,
+        scope: {
+          appName: this.appName,
+          userId: params.userId,
+          sessionId,
+        },
       });
     }
   }
@@ -250,11 +254,12 @@ export class Runner {
         ctx,
         this,
         async function* () {
-          const session = await this.sessionService.getSession({
+          const scope = {
             appName: this.appName,
             userId,
             sessionId,
-          });
+          };
+          const session = await this.sessionService.getSession({scope});
 
           if (params.abortSignal?.aborted) {
             return;
@@ -286,11 +291,7 @@ export class Runner {
 
           const invocationContext = new InvocationContext({
             artifactService: this.artifactService
-              ? new ScopedArtifactService(this.artifactService, {
-                  appName: this.appName,
-                  userId,
-                  sessionId,
-                })
+              ? new ScopedArtifactService(this.artifactService, scope)
               : undefined,
             sessionService: this.sessionService,
             memoryService: this.memoryService,

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -286,12 +286,11 @@ export class Runner {
 
           const invocationContext = new InvocationContext({
             artifactService: this.artifactService
-              ? new ScopedArtifactService(
-                  this.artifactService,
-                  this.appName,
+              ? new ScopedArtifactService(this.artifactService, {
+                  appName: this.appName,
                   userId,
                   sessionId,
-                )
+                })
               : undefined,
             sessionService: this.sessionService,
             memoryService: this.memoryService,
@@ -479,7 +478,11 @@ export class Runner {
       }
       const fileName = `artifact_${invocationId}_${i}`;
       await this.artifactService.saveArtifact({
-        ...sessionKey,
+        scope: {
+          appName: this.appName,
+          userId,
+          sessionId,
+        },
         filename: fileName,
         artifact: part,
       });

--- a/core/src/sessions/base_session_service.ts
+++ b/core/src/sessions/base_session_service.ts
@@ -8,7 +8,8 @@ import {cloneDeep} from 'lodash-es';
 
 import {Event} from '../events/event.js';
 
-import {CompositeSessionKey, Session} from './session.js';
+import {Session} from './session.js';
+import {CreateSessionScope, SessionScope, UserScope} from './session_scope.js';
 import {State} from './state.js';
 
 /**
@@ -25,20 +26,18 @@ export interface GetSessionConfig {
  * The parameters for `createSession`.
  */
 export interface CreateSessionRequest {
-  /** The name of the application. */
-  appName: string;
-  /** The ID of the user. */
-  userId: string;
+  /** The scope for session creation. */
+  scope: CreateSessionScope;
   /** The initial state of the session. */
   state?: Record<string, unknown>;
-  /** The ID of the session. A new ID will be generated if not provided. */
-  sessionId?: string;
 }
 
 /**
  * The parameters for `getSession`.
  */
-export interface GetSessionRequest extends CompositeSessionKey {
+export interface GetSessionRequest {
+  /** The session scope. */
+  scope: SessionScope;
   /** The configurations for getting the session. */
   config?: GetSessionConfig;
 }
@@ -47,10 +46,8 @@ export interface GetSessionRequest extends CompositeSessionKey {
  * The parameters for `listSessions`.
  */
 export interface ListSessionsRequest {
-  /** The name of the application. */
-  appName: string;
-  /** The ID of the user. */
-  userId: string;
+  /** The user scope. */
+  scope: UserScope;
   /** Maximum number of sessions to return. */
   limit?: number;
   /** Zero-based index of the first session to return. Ignored if `page` is set. */
@@ -64,7 +61,10 @@ export interface ListSessionsRequest {
 /**
  * The parameters for `deleteSession`.
  */
-export type DeleteSessionRequest = CompositeSessionKey;
+export interface DeleteSessionRequest {
+  /** The session scope. */
+  scope: SessionScope;
+}
 
 /**
  * The parameters for `appendEvent`.
@@ -127,13 +127,11 @@ export abstract class BaseSessionService {
    * @return A promise that resolves to the session instance.
    */
   async getOrCreateSession(request: CreateSessionRequest): Promise<Session> {
-    if (!request.sessionId) {
+    if (!request.scope.sessionId) {
       return this.createSession(request);
     }
     const session = await this.getSession({
-      appName: request.appName,
-      userId: request.userId,
-      sessionId: request.sessionId,
+      scope: request.scope as SessionScope,
     });
     if (session) {
       return session;

--- a/core/src/sessions/database_session_service.ts
+++ b/core/src/sessions/database_session_service.ts
@@ -101,10 +101,8 @@ export class DatabaseSessionService extends BaseSessionService {
   }
 
   async createSession({
-    appName,
-    userId,
+    scope: {appName, userId, sessionId},
     state,
-    sessionId,
   }: CreateSessionRequest): Promise<Session> {
     await this.init();
     const em = this.orm!.em.fork();
@@ -192,9 +190,7 @@ export class DatabaseSessionService extends BaseSessionService {
   }
 
   async getSession({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     config,
   }: GetSessionRequest): Promise<Session | undefined> {
     await this.init();
@@ -252,8 +248,7 @@ export class DatabaseSessionService extends BaseSessionService {
   }
 
   async listSessions({
-    appName,
-    userId,
+    scope: {appName, userId},
     limit,
     offset,
     page,
@@ -355,9 +350,7 @@ export class DatabaseSessionService extends BaseSessionService {
   }
 
   async deleteSession({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
   }: DeleteSessionRequest): Promise<void> {
     await this.init();
     const em = this.orm!.em.fork();

--- a/core/src/sessions/in_memory_session_service.ts
+++ b/core/src/sessions/in_memory_session_service.ts
@@ -53,10 +53,8 @@ export class InMemorySessionService extends BaseSessionService {
   private appState: Record<string, Record<string, unknown>> = {};
 
   async createSession({
-    appName,
-    userId,
+    scope: {appName, userId, sessionId},
     state,
-    sessionId,
   }: CreateSessionRequest): Promise<Session> {
     const filteredState = state ? trimTempState(state) : undefined;
     const session = createSession({
@@ -88,9 +86,7 @@ export class InMemorySessionService extends BaseSessionService {
   }
 
   async getSession({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     config,
   }: GetSessionRequest): Promise<Session | undefined> {
     if (
@@ -134,8 +130,7 @@ export class InMemorySessionService extends BaseSessionService {
   }
 
   listSessions({
-    appName,
-    userId,
+    scope: {appName, userId},
     limit,
     offset,
     page,
@@ -229,17 +224,9 @@ export class InMemorySessionService extends BaseSessionService {
   }
 
   async deleteSession({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
   }: DeleteSessionRequest): Promise<void> {
-    const session = await this.getSession({appName, userId, sessionId});
-
-    if (!session) {
-      return;
-    }
-
-    delete this.sessions[appName][userId][sessionId];
+    delete this.sessions[appName]?.[userId]?.[sessionId];
   }
 
   override async appendEvent({

--- a/core/src/sessions/session_scope.ts
+++ b/core/src/sessions/session_scope.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A scope identifying a user within an application context.
+ */
+export interface UserScope {
+  /** The application name. */
+  appName: string;
+  /** The user ID. */
+  userId: string;
+}
+
+/**
+ * A composite key/scope identifying a specific session within an application and user context.
+ */
+export interface SessionScope extends UserScope {
+  /** The session ID. */
+  sessionId: string;
+}
+
+/**
+ * A scope for session creation where sessionId is optional (generated if omitted).
+ */
+export interface CreateSessionScope extends UserScope {
+  /** The optional session ID. */
+  sessionId?: string;
+}

--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -129,10 +129,8 @@ export class VertexAiSessionService extends BaseSessionService {
   }
 
   async createSession({
-    appName,
-    userId,
+    scope: {appName, userId, sessionId},
     state,
-    sessionId,
   }: CreateSessionRequest): Promise<Session> {
     const reasoningEngineId = this.getReasoningEngineId(appName);
     const filteredState = state ? trimTempState(state) : undefined;
@@ -181,9 +179,7 @@ export class VertexAiSessionService extends BaseSessionService {
   }
 
   async getSession({
-    appName,
-    userId,
-    sessionId,
+    scope: {appName, userId, sessionId},
     config,
   }: GetSessionRequest): Promise<Session | undefined> {
     const reasoningEngineId = this.getReasoningEngineId(appName);
@@ -257,8 +253,7 @@ export class VertexAiSessionService extends BaseSessionService {
   }
 
   async listSessions({
-    appName,
-    userId,
+    scope: {appName, userId},
     limit,
     offset,
     page,
@@ -344,11 +339,9 @@ export class VertexAiSessionService extends BaseSessionService {
   }
 
   async deleteSession({
-    appName,
-    userId,
-    sessionId,
+    scope,
   }: DeleteSessionRequest): Promise<void> {
-    const reasoningEngineId = this.getReasoningEngineId(appName);
+    const reasoningEngineId = this.getReasoningEngineId(scope.appName);
 
     // A session may only be deleted by the user it belongs to. getSession
     // already enforces this and throws when the stored session's userId does
@@ -356,9 +349,7 @@ export class VertexAiSessionService extends BaseSessionService {
     // owned by this user. This keeps deleteSession consistent with getSession
     // and with InMemorySessionService.deleteSession.
     const session = await this.getSession({
-      appName,
-      userId,
-      sessionId,
+      scope,
       config: {numRecentEvents: 0},
     });
     if (!session) {
@@ -366,7 +357,7 @@ export class VertexAiSessionService extends BaseSessionService {
     }
 
     await this.sessions.delete({
-      name: `reasoningEngines/${reasoningEngineId}/sessions/${sessionId}`,
+      name: `reasoningEngines/${reasoningEngineId}/sessions/${scope.sessionId}`,
     });
   }
 

--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -158,9 +158,11 @@ export class AgentTool extends BaseTool {
     });
 
     const session = await runner.sessionService.getOrCreateSession({
-      appName: this.agent.name,
-      userId: toolContext.invocationContext.userId,
-      sessionId: toolContext.invocationContext.session.id,
+      scope: {
+        appName: this.agent.name,
+        userId: toolContext.invocationContext.userId,
+        sessionId: toolContext.invocationContext.session.id,
+      },
       state: toolContext.state.toRecord(),
     });
 

--- a/core/test/a2a/a2a_agent_test.ts
+++ b/core/test/a2a/a2a_agent_test.ts
@@ -81,7 +81,12 @@ describe('A2A Agent Executor', () => {
     mockSessionService = {
       getSession: vi.fn(),
       createSession: vi.fn(),
-      getOrCreateSession: vi.fn(),
+      getOrCreateSession: vi.fn().mockImplementation(async (req) => {
+        return (
+          (await mockSessionService.getSession(req)) ??
+          (await mockSessionService.createSession(req))
+        );
+      }),
       listSessions: vi.fn(),
       deleteSession: vi.fn(),
       appendEvent: vi.fn(),

--- a/core/test/a2a/agent_executor_test.ts
+++ b/core/test/a2a/agent_executor_test.ts
@@ -42,7 +42,12 @@ describe('A2AAgentExecutor', () => {
     mockSessionService = {
       getSession: vi.fn(),
       createSession: vi.fn(),
-      getOrCreateSession: vi.fn(),
+      getOrCreateSession: vi.fn().mockImplementation(async (req) => {
+        return (
+          (await mockSessionService.getSession(req)) ??
+          (await mockSessionService.createSession(req))
+        );
+      }),
       listSessions: vi.fn(),
       deleteSession: vi.fn(),
       appendEvent: vi.fn(),

--- a/core/test/agents/llm_agent_auth_integration_test.ts
+++ b/core/test/agents/llm_agent_auth_integration_test.ts
@@ -163,8 +163,7 @@ describe('LlmAgent Auth Integration', () => {
     // 3. Run First Turn
     const sessionService = new InMemorySessionService();
     const session = await sessionService.createSession({
-      appName: 'test_app',
-      userId: 'user_1',
+      scope: {appName: 'test_app', userId: 'user_1'},
     });
 
     const runner = new Runner({

--- a/core/test/artifacts/artifact_service_test_utils.ts
+++ b/core/test/artifacts/artifact_service_test_utils.ts
@@ -23,6 +23,7 @@ export function runArtifactServiceTests(
   const appName = 'test-app';
   const userId = 'test-user';
   const sessionId = 'test-session';
+  const scope = {appName, userId, sessionId};
 
   beforeEach(async () => {
     service = await createService();
@@ -37,18 +38,14 @@ export function runArtifactServiceTests(
       const filename = 'test.txt';
       const text = 'hello world';
       const version = await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text},
       });
 
       expect(version).toBe(0);
       const loaded = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version: 0,
       });
@@ -61,18 +58,14 @@ export function runArtifactServiceTests(
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNiAAAABgDNjd8qAAAAAElFTkSuQmCC';
       const mimeType = 'image/png';
       const version = await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {inlineData: {data, mimeType}},
       });
 
       expect(version).toBe(0);
       const loaded = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version: 0,
       });
@@ -84,17 +77,13 @@ export function runArtifactServiceTests(
       const filename = 'user:test.txt';
       const text = 'user scoped';
       const version = await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text},
       });
 
       const loaded = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version,
       });
@@ -104,9 +93,7 @@ export function runArtifactServiceTests(
     it('throws error if artifact has no content', async () => {
       await expect(
         service.saveArtifact({
-          appName,
-          userId,
-          sessionId,
+          scope,
           filename: 'test.txt',
           artifact: {} as unknown as Part,
         }),
@@ -116,18 +103,14 @@ export function runArtifactServiceTests(
     it('increments version number', async () => {
       const filename = 'test.txt';
       const version1 = await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: 'v1'},
       });
       expect(version1).toBe(0);
 
       const version2 = await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: 'v2'},
       });
@@ -138,9 +121,7 @@ export function runArtifactServiceTests(
   describe('loadArtifact', () => {
     it('returns undefined for non-existent artifact', async () => {
       const result = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'nonexistent.txt',
       });
       expect(result).toBeUndefined();
@@ -149,42 +130,32 @@ export function runArtifactServiceTests(
     it('loads specific version', async () => {
       const filename = 'history.txt';
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: 'v0'},
       });
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: 'v1'},
       });
 
       const v0 = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version: 0,
       });
       expect(v0?.text).toBe('v0');
 
       const v1 = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version: 1,
       });
       expect(v1?.text).toBe('v1');
 
       const v = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
       });
       expect(v?.text).toBe('v1');
@@ -194,31 +165,23 @@ export function runArtifactServiceTests(
   describe('listArtifactKeys', () => {
     it('lists artifacts for session and user', async () => {
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'session.txt',
         artifact: {text: '.'},
       });
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'nested/dir/session.txt',
         artifact: {text: '.'},
       });
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'user:user.txt',
         artifact: {text: '.'},
       });
 
       const keys = await service.listArtifactKeys({
-        appName,
-        userId,
-        sessionId,
+        scope,
       });
       expect(keys).toContain('session.txt');
       expect(keys).toContain('nested/dir/session.txt');
@@ -230,18 +193,14 @@ export function runArtifactServiceTests(
     it('deletes an artifact', async () => {
       const filename = 'del.txt';
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '.'},
       });
-      await service.deleteArtifact({appName, userId, sessionId, filename});
+      await service.deleteArtifact({scope, filename});
 
       const loaded = await service.loadArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
       });
       expect(loaded).toBeUndefined();
@@ -249,9 +208,7 @@ export function runArtifactServiceTests(
 
     it('does not fail when deleting non-existent artifact', async () => {
       await service.deleteArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'non-existent',
       });
     });
@@ -261,24 +218,18 @@ export function runArtifactServiceTests(
     it('lists versions', async () => {
       const filename = 'vers.txt';
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '1'},
       });
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '2'},
       });
 
       const versions = await service.listVersions({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
       });
       expect(versions).toEqual([0, 1]);
@@ -286,9 +237,7 @@ export function runArtifactServiceTests(
 
     it('returns empty list for non-existent artifact', async () => {
       const versions = await service.listVersions({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'non-existent',
       });
       expect(versions).toEqual([]);
@@ -300,18 +249,14 @@ export function runArtifactServiceTests(
       const filename = 'meta.txt';
       const customMetadata = {foo: 'bar', baz: 123};
       const version = await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: 'meta'},
         customMetadata,
       });
 
       const versionMetadata = await service.getArtifactVersion({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version,
       });
@@ -325,26 +270,20 @@ export function runArtifactServiceTests(
     it('lists artifact versions with metadata', async () => {
       const filename = 'vers-meta.txt';
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '1'},
         customMetadata: {v: 1},
       });
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '2'},
         customMetadata: {v: 2},
       });
 
       const versions = await service.listArtifactVersions({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
       });
 
@@ -357,9 +296,7 @@ export function runArtifactServiceTests(
 
     it('returns empty list for non-existent artifact', async () => {
       const versions = await service.listArtifactVersions({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'non-existent',
       });
       expect(versions).toHaveLength(0);
@@ -370,44 +307,34 @@ export function runArtifactServiceTests(
     it('gets specific artifact version metadata', async () => {
       const filename = 'get-vers.txt';
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '1'},
         customMetadata: {v: 1},
       });
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '2'},
         customMetadata: {v: 2},
       });
 
       const v0 = await service.getArtifactVersion({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version: 0,
       });
       expect(v0?.customMetadata).toMatchObject({v: 1});
 
       const v1 = await service.getArtifactVersion({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version: 1,
       });
       expect(v1?.customMetadata).toMatchObject({v: 2});
 
       const latest = await service.getArtifactVersion({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
       });
       expect(latest?.customMetadata).toMatchObject({v: 2});
@@ -416,17 +343,13 @@ export function runArtifactServiceTests(
     it('returns undefined for non-existent version', async () => {
       const filename = 'missing-vers.txt';
       await service.saveArtifact({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         artifact: {text: '1'},
       });
 
       const missing = await service.getArtifactVersion({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename,
         version: 99,
       });
@@ -435,9 +358,7 @@ export function runArtifactServiceTests(
 
     it('returns undefined for non-existent artifact', async () => {
       const missing = await service.getArtifactVersion({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'non-existent',
       });
       expect(missing).toBeUndefined();

--- a/core/test/artifacts/file_artifact_service_test.ts
+++ b/core/test/artifacts/file_artifact_service_test.ts
@@ -88,9 +88,7 @@ describe('FileArtifactService', () => {
 
       try {
         await service.saveArtifact({
-          appName,
-          userId,
-          sessionId,
+          scope: {appName, userId, sessionId},
           filename: '../../secret.txt',
           artifact: {text: '.'},
         });

--- a/core/test/artifacts/scoped_artifact_service_test.ts
+++ b/core/test/artifacts/scoped_artifact_service_test.ts
@@ -29,17 +29,13 @@ describe('ScopedArtifactService', () => {
   const appName = 'test-app';
   const userId = 'test-user';
   const sessionId = 'test-session';
+  const scope = {appName, userId, sessionId};
 
   describe('saveArtifact', () => {
     it('delegates with scoped context', async () => {
       const delegate = makeBaseArtifactServiceStub();
       vi.mocked(delegate.saveArtifact).mockResolvedValue(42);
-      const service = new ScopedArtifactService(
-        delegate,
-        appName,
-        userId,
-        sessionId,
-      );
+      const service = new ScopedArtifactService(delegate, scope);
 
       const request: SessionSaveArtifactRequest = {
         filename: 'file.txt',
@@ -50,9 +46,7 @@ describe('ScopedArtifactService', () => {
       const result = await service.saveArtifact(request);
 
       expect(delegate.saveArtifact).toHaveBeenCalledWith({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'file.txt',
         artifact: {text: 'hello'},
         customMetadata: {foo: 'bar'},
@@ -66,12 +60,7 @@ describe('ScopedArtifactService', () => {
       const delegate = makeBaseArtifactServiceStub();
       const part: Part = {text: 'content'};
       vi.mocked(delegate.loadArtifact).mockResolvedValue(part);
-      const service = new ScopedArtifactService(
-        delegate,
-        appName,
-        userId,
-        sessionId,
-      );
+      const service = new ScopedArtifactService(delegate, scope);
 
       const request: SessionLoadArtifactRequest = {
         filename: 'file.txt',
@@ -81,9 +70,7 @@ describe('ScopedArtifactService', () => {
       const result = await service.loadArtifact(request);
 
       expect(delegate.loadArtifact).toHaveBeenCalledWith({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'file.txt',
         version: 2,
       });
@@ -95,19 +82,12 @@ describe('ScopedArtifactService', () => {
     it('delegates with scoped context', async () => {
       const delegate = makeBaseArtifactServiceStub();
       vi.mocked(delegate.listArtifactKeys).mockResolvedValue(['a', 'b']);
-      const service = new ScopedArtifactService(
-        delegate,
-        appName,
-        userId,
-        sessionId,
-      );
+      const service = new ScopedArtifactService(delegate, scope);
 
       const result = await service.listArtifactKeys();
 
       expect(delegate.listArtifactKeys).toHaveBeenCalledWith({
-        appName,
-        userId,
-        sessionId,
+        scope,
       });
       expect(result).toEqual(['a', 'b']);
     });
@@ -116,19 +96,12 @@ describe('ScopedArtifactService', () => {
   describe('deleteArtifact', () => {
     it('delegates with scoped context', async () => {
       const delegate = makeBaseArtifactServiceStub();
-      const service = new ScopedArtifactService(
-        delegate,
-        appName,
-        userId,
-        sessionId,
-      );
+      const service = new ScopedArtifactService(delegate, scope);
 
       await service.deleteArtifact('file.txt');
 
       expect(delegate.deleteArtifact).toHaveBeenCalledWith({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'file.txt',
       });
     });
@@ -138,19 +111,12 @@ describe('ScopedArtifactService', () => {
     it('delegates with scoped context', async () => {
       const delegate = makeBaseArtifactServiceStub();
       vi.mocked(delegate.listVersions).mockResolvedValue([1, 2]);
-      const service = new ScopedArtifactService(
-        delegate,
-        appName,
-        userId,
-        sessionId,
-      );
+      const service = new ScopedArtifactService(delegate, scope);
 
       const result = await service.listVersions('file.txt');
 
       expect(delegate.listVersions).toHaveBeenCalledWith({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'file.txt',
       });
       expect(result).toEqual([1, 2]);
@@ -162,19 +128,12 @@ describe('ScopedArtifactService', () => {
       const delegate = makeBaseArtifactServiceStub();
       const versions = [{version: 1}];
       vi.mocked(delegate.listArtifactVersions).mockResolvedValue(versions);
-      const service = new ScopedArtifactService(
-        delegate,
-        appName,
-        userId,
-        sessionId,
-      );
+      const service = new ScopedArtifactService(delegate, scope);
 
       const result = await service.listArtifactVersions('file.txt');
 
       expect(delegate.listArtifactVersions).toHaveBeenCalledWith({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'file.txt',
       });
       expect(result).toEqual(versions);
@@ -186,12 +145,7 @@ describe('ScopedArtifactService', () => {
       const delegate = makeBaseArtifactServiceStub();
       const version = {version: 1};
       vi.mocked(delegate.getArtifactVersion).mockResolvedValue(version);
-      const service = new ScopedArtifactService(
-        delegate,
-        appName,
-        userId,
-        sessionId,
-      );
+      const service = new ScopedArtifactService(delegate, scope);
 
       const request: SessionLoadArtifactRequest = {
         filename: 'file.txt',
@@ -201,9 +155,7 @@ describe('ScopedArtifactService', () => {
       const result = await service.getArtifactVersion(request);
 
       expect(delegate.getArtifactVersion).toHaveBeenCalledWith({
-        appName,
-        userId,
-        sessionId,
+        scope,
         filename: 'file.txt',
         version: 1,
       });

--- a/core/test/memory/in_memory_memory_service_test.ts
+++ b/core/test/memory/in_memory_memory_service_test.ts
@@ -27,8 +27,7 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'user', parts: [{text: 'hello world'}]},
       });
       const session = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event});
 
@@ -47,8 +46,7 @@ describe('InMemoryMemoryService', () => {
     it('filters out events with no content parts', async () => {
       const emptyEvent = createEvent({author: 'user'});
       const session = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event: emptyEvent});
 
@@ -69,14 +67,12 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'user', parts: [{text: 'hello world'}]},
       });
       const sessionAlice = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session: sessionAlice, event});
 
       const sessionBob = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'bob',
+        scope: {appName: 'myApp', userId: 'bob'},
       });
 
       await service.addSessionToMemory(sessionAlice);
@@ -115,8 +111,7 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'model', parts: [{text: 'the weather is sunny today'}]},
       });
       const session = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event});
 
@@ -138,8 +133,7 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'user', parts: [{text: 'hello world'}]},
       });
       const session = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event});
 
@@ -160,8 +154,7 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'user', parts: [{text: 'Hello World'}]},
       });
       const session = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event});
 
@@ -182,8 +175,7 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'user', parts: [{text: 'secret info'}]},
       });
       const sessionAlice = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session: sessionAlice, event});
 
@@ -204,8 +196,7 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'user', parts: [{text: 'hello world'}]},
       });
       const session = await sessionService.createSession({
-        appName: 'appA',
-        userId: 'alice',
+        scope: {appName: 'appA', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event});
 
@@ -228,8 +219,7 @@ describe('InMemoryMemoryService', () => {
         timestamp,
       });
       const session = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event});
 
@@ -251,8 +241,7 @@ describe('InMemoryMemoryService', () => {
         content: {role: 'user', parts: [{text: 'python programming language'}]},
       });
       const session = await sessionService.createSession({
-        appName: 'myApp',
-        userId: 'alice',
+        scope: {appName: 'myApp', userId: 'alice'},
       });
       await sessionService.appendEvent({session, event});
 

--- a/core/test/runner/in_memory_runner_test.ts
+++ b/core/test/runner/in_memory_runner_test.ts
@@ -89,8 +89,7 @@ describe('InMemoryRunner', () => {
     const runner = new InMemoryRunner({agent});
 
     const session = await runner.sessionService.createSession({
-      appName: runner.appName,
-      userId: TEST_USER_ID,
+      scope: {appName: runner.appName, userId: TEST_USER_ID},
     });
 
     const events: Event[] = [];
@@ -113,12 +112,10 @@ describe('InMemoryRunner', () => {
     const runner = new InMemoryRunner({agent});
 
     const session1 = await runner.sessionService.createSession({
-      appName: runner.appName,
-      userId: 'user_1',
+      scope: {appName: runner.appName, userId: 'user_1'},
     });
     const session2 = await runner.sessionService.createSession({
-      appName: runner.appName,
-      userId: 'user_2',
+      scope: {appName: runner.appName, userId: 'user_2'},
     });
 
     expect(session1.id).not.toBe(session2.id);
@@ -169,8 +166,7 @@ describe('InMemoryRunner', () => {
     const runner = new InMemoryRunner({agent});
 
     const session = await runner.sessionService.createSession({
-      appName: runner.appName,
-      userId: TEST_USER_ID,
+      scope: {appName: runner.appName, userId: TEST_USER_ID},
     });
 
     try {

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -170,9 +170,11 @@ describe('Runner.determineAgentForResumption', () => {
     }
 
     const session = await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     for (const event of inputEvents) {
@@ -318,9 +320,11 @@ describe('Runner.determineAgentForResumption', () => {
 
     // Bypass the runTest method for finer control over events.
     const session = await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     await sessionService.appendEvent({session: session, event: callEvent});
@@ -526,9 +530,11 @@ describe('Runner with plugins', () => {
 
   async function runTest(originalUserInput = 'Hello'): Promise<Event[]> {
     await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
     const events: Event[] = [];
     for await (const event of runner.runAsync({
@@ -552,9 +558,11 @@ describe('Runner with plugins', () => {
 
     await runTest(originalUserInput);
     const session = await sessionService.getSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
     const generatedEvent = session!.events[0];
     const modifiedUserMessage = generatedEvent.content!.parts![0].text;
@@ -601,9 +609,11 @@ describe('Runner with plugins', () => {
     };
 
     await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     const events: Event[] = [];
@@ -619,9 +629,11 @@ describe('Runner with plugins', () => {
     expect(events.length).toBe(0);
 
     const session = await sessionService.getSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
     expect(session!.events.length).toBe(0);
   });
@@ -638,9 +650,11 @@ describe('Runner with plugins', () => {
     };
 
     await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     const events: Event[] = [];
@@ -656,9 +670,11 @@ describe('Runner with plugins', () => {
     expect(events.length).toBe(0);
 
     const session = await sessionService.getSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
     expect(session!.events.length).toBe(1);
     expect(session!.events[0].author).toBe('user');
@@ -676,9 +692,11 @@ describe('Runner with plugins', () => {
     };
 
     await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     const events: Event[] = [];
@@ -694,9 +712,11 @@ describe('Runner with plugins', () => {
     expect(events.length).toBe(0);
 
     const session = await sessionService.getSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
     expect(session!.events.length).toBe(2);
     expect(session!.events[1].author).toBe('test_agent');
@@ -741,9 +761,11 @@ describe('Runner error handling', () => {
     });
 
     const session = await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     const error = await runTestExpectingError(
@@ -803,9 +825,11 @@ describe('Runner customMetadata support', () => {
 
   it('should propagate customMetadata in runAsync and attach to user event', async () => {
     const session = await sessionService.createSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     const customMetadata = {testKey: 'testValue', anotherKey: 123};
@@ -821,9 +845,11 @@ describe('Runner customMetadata support', () => {
     }
 
     const updatedSession = await sessionService.getSession({
-      appName: TEST_APP_ID,
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
+      scope: {
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: TEST_SESSION_ID,
+      },
     });
 
     expect(updatedSession).not.toBeNull();

--- a/core/test/runner/streaming_runner_test.ts
+++ b/core/test/runner/streaming_runner_test.ts
@@ -218,7 +218,9 @@ describe('Runner Streaming and Ephemeral', () => {
       }
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          userId: TEST_USER_ID,
+          scope: expect.objectContaining({
+            userId: TEST_USER_ID,
+          }),
         }),
       );
     });
@@ -237,9 +239,11 @@ describe('Runner Streaming and Ephemeral', () => {
       });
 
       const session = await sessionService.createSession({
-        appName: TEST_APP_ID,
-        userId: TEST_USER_ID,
-        sessionId: 'test_abort_session',
+        scope: {
+          appName: TEST_APP_ID,
+          userId: TEST_USER_ID,
+          sessionId: 'test_abort_session',
+        },
       });
 
       const abortController = new AbortController();
@@ -278,9 +282,11 @@ describe('Runner Streaming and Ephemeral', () => {
       });
 
       const session = await sessionService.createSession({
-        appName: TEST_APP_ID,
-        userId: TEST_USER_ID,
-        sessionId: 'test_abort_tool_session',
+        scope: {
+          appName: TEST_APP_ID,
+          userId: TEST_USER_ID,
+          sessionId: 'test_abort_tool_session',
+        },
       });
 
       const abortController = new AbortController();

--- a/core/test/sessions/database_session_service_test.ts
+++ b/core/test/sessions/database_session_service_test.ts
@@ -39,10 +39,12 @@ describe('DatabaseSessionService', () => {
 
   it('should create a session', async () => {
     const session = await service.createSession({
-      appName: 'test-app',
-      userId: 'test-user',
+      scope: {
+        appName: 'test-app',
+        userId: 'test-user',
+        sessionId: 'test-session-id',
+      },
       state: {'foo': 'bar'},
-      sessionId: 'test-session-id',
     });
 
     expect(session.id).toBe('test-session-id');
@@ -53,13 +55,15 @@ describe('DatabaseSessionService', () => {
 
   it('should filter out temporary state keys prefixed with temp: on creation', async () => {
     const session = await service.createSession({
-      appName: 'test-app',
-      userId: 'test-user',
+      scope: {
+        appName: 'test-app',
+        userId: 'test-user',
+        sessionId: 'test-session-id-2',
+      },
       state: {
         'foo': 'bar',
         [`${State.TEMP_PREFIX}temp`]: 'value',
       },
-      sessionId: 'test-session-id-2',
     });
 
     expect(session.id).toBe('test-session-id-2');
@@ -69,16 +73,20 @@ describe('DatabaseSessionService', () => {
 
   it('should get a session', async () => {
     await service.createSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 'test-session-id',
+      scope: {
+        appName: 'test-app',
+        userId: 'test-user',
+        sessionId: 'test-session-id',
+      },
       state: {'key': 'value'},
     });
 
     const session = await service.getSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 'test-session-id',
+      scope: {
+        appName: 'test-app',
+        userId: 'test-user',
+        sessionId: 'test-session-id',
+      },
     });
 
     expect(session).toBeDefined();
@@ -88,19 +96,14 @@ describe('DatabaseSessionService', () => {
 
   it('should list sessions', async () => {
     await service.createSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'test-user', sessionId: 's1'},
     });
     await service.createSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 's2',
+      scope: {appName: 'test-app', userId: 'test-user', sessionId: 's2'},
     });
 
     const response = await service.listSessions({
-      appName: 'test-app',
-      userId: 'test-user',
+      scope: {appName: 'test-app', userId: 'test-user'},
     });
 
     expect(response.sessions.length).toBe(2);
@@ -110,21 +113,15 @@ describe('DatabaseSessionService', () => {
 
   it('should delete a session', async () => {
     await service.createSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'test-user', sessionId: 's1'},
     });
 
     await service.deleteSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'test-user', sessionId: 's1'},
     });
 
     const session = await service.getSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'test-user', sessionId: 's1'},
     });
 
     expect(session).toBeUndefined();
@@ -132,9 +129,7 @@ describe('DatabaseSessionService', () => {
 
   it('should append event and update state', async () => {
     const session = await service.createSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'test-user', sessionId: 's1'},
       state: {'count': 0},
     });
 
@@ -155,9 +150,7 @@ describe('DatabaseSessionService', () => {
 
     // Verify persistence
     const loadedSession = await service.getSession({
-      appName: 'test-app',
-      userId: 'test-user',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'test-user', sessionId: 's1'},
     });
 
     expect(loadedSession?.state['count']).toBe(1);
@@ -168,17 +161,13 @@ describe('DatabaseSessionService', () => {
   it('should persist app state across sessions', async () => {
     // Create first session and update app state
     await service.createSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
       state: {[State.APP_PREFIX + 'config']: 'dark-mode'},
     });
 
     // Create second session for same app but different user
     const s2 = await service.createSession({
-      appName: 'test-app',
-      userId: 'user2',
-      sessionId: 's2',
+      scope: {appName: 'test-app', userId: 'user2', sessionId: 's2'},
     });
 
     expect(s2.state[State.APP_PREFIX + 'config']).toBe('dark-mode');
@@ -194,9 +183,7 @@ describe('DatabaseSessionService', () => {
 
     // Verify s1 sees the update when re-fetched
     const s1Reloaded = await service.getSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
     });
     expect(s1Reloaded?.state[State.APP_PREFIX + 'config']).toBe('light-mode');
   });
@@ -204,17 +191,13 @@ describe('DatabaseSessionService', () => {
   it('should persist user state across sessions', async () => {
     // Session 1 for user1
     await service.createSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
       state: {[State.USER_PREFIX + 'pref']: 'A'},
     });
 
     // Session 2 for same user
     const s2 = await service.createSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's2',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's2'},
     });
 
     expect(s2.state[State.USER_PREFIX + 'pref']).toBe('A');
@@ -230,26 +213,20 @@ describe('DatabaseSessionService', () => {
 
     // Verify s1 sees update
     const s1Reloaded = await service.getSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
     });
     expect(s1Reloaded?.state[State.USER_PREFIX + 'pref']).toBe('B');
 
     // Verify another user doesn't see it
     const s3 = await service.createSession({
-      appName: 'test-app',
-      userId: 'user2',
-      sessionId: 's3',
+      scope: {appName: 'test-app', userId: 'user2', sessionId: 's3'},
     });
     expect(s3.state[State.USER_PREFIX + 'pref']).toBeUndefined();
   });
 
   it('should filter events in getSession', async () => {
     const session = await service.createSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
     });
 
     const now = Date.now();
@@ -263,9 +240,7 @@ describe('DatabaseSessionService', () => {
 
     // Test numRecentEvents
     const recent = await service.getSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
       config: {numRecentEvents: 2},
     });
     expect(recent?.events.length).toBe(2);
@@ -274,9 +249,7 @@ describe('DatabaseSessionService', () => {
 
     // Test afterTimestamp
     const after = await service.getSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
       config: {afterTimestamp: now - 100},
     });
     expect(after?.events.length).toBe(2);
@@ -285,9 +258,7 @@ describe('DatabaseSessionService', () => {
 
     // Test afterTimestamp
     const after2 = await service.getSession({
-      appName: 'test-app',
-      userId: 'user1',
-      sessionId: 's1',
+      scope: {appName: 'test-app', userId: 'user1', sessionId: 's1'},
       config: {afterTimestamp: now},
     });
     expect(after2?.events.length).toBe(1);
@@ -296,64 +267,48 @@ describe('DatabaseSessionService', () => {
 
   it('should filter sessions by userId in listSessions', async () => {
     await service.createSession({
-      appName: 'app1',
-      userId: 'u1',
-      sessionId: 's1',
+      scope: {appName: 'app1', userId: 'u1', sessionId: 's1'},
     });
     await service.createSession({
-      appName: 'app1',
-      userId: 'u2',
-      sessionId: 's2',
+      scope: {appName: 'app1', userId: 'u2', sessionId: 's2'},
     });
     await service.createSession({
-      appName: 'app2', // Diff app
-      userId: 'u1',
-      sessionId: 's3',
+      scope: {appName: 'app2', userId: 'u1', sessionId: 's3'},
     });
 
     const listU1 = await service.listSessions({
-      appName: 'app1',
-      userId: 'u1',
+      scope: {appName: 'app1', userId: 'u1'},
     });
     expect(listU1.sessions.length).toBe(1);
     expect(listU1.sessions[0].id).toBe('s1');
 
     const listAll = await service.listSessions({
-      appName: 'app1',
-      userId: 'u1',
+      scope: {appName: 'app1', userId: 'u1'},
     });
     expect(listAll.sessions.length).toBe(1);
   });
 
   it('should handle errors', async () => {
     await service.createSession({
-      appName: 'app1',
-      userId: 'u1',
-      sessionId: 's1',
+      scope: {appName: 'app1', userId: 'u1', sessionId: 's1'},
     });
 
     // Test duplicate creation
     await expect(
       service.createSession({
-        appName: 'app1',
-        userId: 'u1',
-        sessionId: 's1',
+        scope: {appName: 'app1', userId: 'u1', sessionId: 's1'},
       }),
     ).rejects.toThrow('Session with id s1 already exists');
 
     // Test requesting non-existent session
     const noSession = await service.getSession({
-      appName: 'app1',
-      userId: 'u1',
-      sessionId: 'ghost',
+      scope: {appName: 'app1', userId: 'u1', sessionId: 'ghost'},
     });
     expect(noSession).toBeUndefined();
 
     // Test append to non-existent session
     const ghostSession = await service.createSession({
-      appName: 'app1',
-      userId: 'u1',
-      sessionId: 'temp',
+      scope: {appName: 'app1', userId: 'u1', sessionId: 'temp'},
     });
     // Manually change ID to simulate object mismatch or stale ref
     ghostSession.id = 'missing';
@@ -397,10 +352,10 @@ describe('DatabaseSessionService', () => {
     const userId = 'test-user';
 
     it('no pagination params → returns all sessions with page=1', async () => {
-      await service.createSession({appName, userId, sessionId: 's1'});
-      await service.createSession({appName, userId, sessionId: 's2'});
+      await service.createSession({scope: {appName, userId, sessionId: 's1'}});
+      await service.createSession({scope: {appName, userId, sessionId: 's2'}});
 
-      const response = await service.listSessions({appName, userId});
+      const response = await service.listSessions({scope: {appName, userId}});
 
       expect(response.sessions).toHaveLength(2);
       expect(response.page).toBe(1);
@@ -411,19 +366,13 @@ describe('DatabaseSessionService', () => {
 
     it('order desc returns newest-first', async () => {
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       const s3 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's3',
+        scope: {appName, userId, sessionId: 's3'},
       });
       await service.appendEvent({
         session: s1,
@@ -439,8 +388,7 @@ describe('DatabaseSessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         order: 'desc',
       });
 
@@ -449,19 +397,13 @@ describe('DatabaseSessionService', () => {
 
     it('order asc returns oldest-first', async () => {
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       const s3 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's3',
+        scope: {appName, userId, sessionId: 's3'},
       });
       await service.appendEvent({
         session: s1,
@@ -477,8 +419,7 @@ describe('DatabaseSessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         order: 'asc',
       });
 
@@ -488,9 +429,7 @@ describe('DatabaseSessionService', () => {
     it('limit returns only N sessions with correct metadata', async () => {
       for (let i = 1; i <= 5; i++) {
         const s = await service.createSession({
-          appName,
-          userId,
-          sessionId: `s${i}`,
+          scope: {appName, userId, sessionId: `s${i}`},
         });
         await service.appendEvent({
           session: s,
@@ -499,8 +438,7 @@ describe('DatabaseSessionService', () => {
       }
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         limit: 3,
         order: 'asc',
       });
@@ -514,9 +452,7 @@ describe('DatabaseSessionService', () => {
     it('page + limit returns correct slice', async () => {
       for (let i = 1; i <= 5; i++) {
         const s = await service.createSession({
-          appName,
-          userId,
-          sessionId: `s${i}`,
+          scope: {appName, userId, sessionId: `s${i}`},
         });
         await service.appendEvent({
           session: s,
@@ -525,8 +461,7 @@ describe('DatabaseSessionService', () => {
       }
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         page: 2,
         limit: 2,
         order: 'asc',
@@ -542,9 +477,7 @@ describe('DatabaseSessionService', () => {
     it('offset skips N sessions', async () => {
       for (let i = 1; i <= 4; i++) {
         const s = await service.createSession({
-          appName,
-          userId,
-          sessionId: `s${i}`,
+          scope: {appName, userId, sessionId: `s${i}`},
         });
         await service.appendEvent({
           session: s,
@@ -553,8 +486,7 @@ describe('DatabaseSessionService', () => {
       }
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         limit: 2,
         offset: 2,
         order: 'asc',
@@ -564,11 +496,10 @@ describe('DatabaseSessionService', () => {
     });
 
     it('offset beyond total → empty sessions with correct metadata', async () => {
-      await service.createSession({appName, userId, sessionId: 's1'});
+      await service.createSession({scope: {appName, userId, sessionId: 's1'}});
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         limit: 2,
         offset: 10,
       });
@@ -579,9 +510,12 @@ describe('DatabaseSessionService', () => {
     });
 
     it('limit=0 returns empty sessions and totalPages=0', async () => {
-      await service.createSession({appName, userId, sessionId: 's1'});
+      await service.createSession({scope: {appName, userId, sessionId: 's1'}});
 
-      const response = await service.listSessions({appName, userId, limit: 0});
+      const response = await service.listSessions({
+        scope: {appName, userId},
+        limit: 0,
+      });
 
       expect(response.sessions).toEqual([]);
       expect(response.totalItems).toBe(1);
@@ -590,14 +524,10 @@ describe('DatabaseSessionService', () => {
 
     it('order without limit returns all sessions sorted with page=1', async () => {
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       await service.appendEvent({
         session: s1,
@@ -609,8 +539,7 @@ describe('DatabaseSessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         order: 'desc',
       });
 
@@ -624,9 +553,7 @@ describe('DatabaseSessionService', () => {
     it('page takes precedence over offset when both are provided', async () => {
       for (let i = 1; i <= 5; i++) {
         const s = await service.createSession({
-          appName,
-          userId,
-          sessionId: `s${i}`,
+          scope: {appName, userId, sessionId: `s${i}`},
         });
         await service.appendEvent({
           session: s,
@@ -635,8 +562,7 @@ describe('DatabaseSessionService', () => {
       }
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         page: 2,
         limit: 2,
         offset: 0,
@@ -651,9 +577,7 @@ describe('DatabaseSessionService', () => {
   describe('Alignment Verification', () => {
     it('should trim temp state from event before persistence', async () => {
       const session = await service.createSession({
-        appName: 'test-app',
-        userId: 'test-user',
-        sessionId: 's-temp',
+        scope: {appName: 'test-app', userId: 'test-user', sessionId: 's-temp'},
       });
 
       const event = createEvent({
@@ -682,9 +606,7 @@ describe('DatabaseSessionService', () => {
 
     it('should align session updateTime with event timestamp', async () => {
       const session = await service.createSession({
-        appName: 'test-app',
-        userId: 'test-user',
-        sessionId: 's-time',
+        scope: {appName: 'test-app', userId: 'test-user', sessionId: 's-time'},
       });
 
       const timestamp = 1234567890000;

--- a/core/test/sessions/in_memory_session_service_test.ts
+++ b/core/test/sessions/in_memory_session_service_test.ts
@@ -40,7 +40,10 @@ describe('InMemorySessionService', () => {
       const userId = 'test-user';
       const state = {key: 'value'};
 
-      const session = await service.createSession({appName, userId, state});
+      const session = await service.createSession({
+        scope: {appName, userId},
+        state,
+      });
 
       expect(session).toBeDefined();
       expect(session.id).toBeDefined();
@@ -54,9 +57,7 @@ describe('InMemorySessionService', () => {
     it('creates a session with a provided sessionId', async () => {
       const sessionId = 'custom-session-id';
       const session = await service.createSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId,
+        scope: {appName: 'app', userId: 'user', sessionId},
       });
 
       expect(session.id).toBe(sessionId);
@@ -66,7 +67,7 @@ describe('InMemorySessionService', () => {
       // First, create a session and add some state
       const appName = 'shared-app';
       const userId = 'shared-user';
-      const session1 = await service.createSession({appName, userId});
+      const session1 = await service.createSession({scope: {appName, userId}});
       const event = createEvent({
         timestamp: Date.now(),
         actions: createEventActions({
@@ -79,7 +80,7 @@ describe('InMemorySessionService', () => {
       await service.appendEvent({session: session1, event});
 
       // Now create a new session for the same user and app
-      const session2 = await service.createSession({appName, userId});
+      const session2 = await service.createSession({scope: {appName, userId}});
 
       expect(session2.state).toEqual({
         [`${State.APP_PREFIX}appKey`]: 'appValue',
@@ -95,7 +96,10 @@ describe('InMemorySessionService', () => {
         [`${State.TEMP_PREFIX}tempKey`]: 'tempValue',
       };
 
-      const session = await service.createSession({appName, userId, state});
+      const session = await service.createSession({
+        scope: {appName, userId},
+        state,
+      });
 
       expect(session.state).toHaveProperty('normalKey', 'value');
       expect(session.state).not.toHaveProperty(`${State.TEMP_PREFIX}tempKey`);
@@ -105,22 +109,17 @@ describe('InMemorySessionService', () => {
   describe('getSession', () => {
     it('returns undefined if session does not exist', async () => {
       const session = await service.getSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'non-existent',
+        scope: {appName: 'app', userId: 'user', sessionId: 'non-existent'},
       });
       expect(session).toBeUndefined();
     });
 
     it('returns the session if it exists', async () => {
       const createdSession = await service.createSession({
-        appName: 'app',
-        userId: 'user',
+        scope: {appName: 'app', userId: 'user'},
       });
       const session = await service.getSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId: createdSession.id,
+        scope: {appName: 'app', userId: 'user', sessionId: createdSession.id},
       });
 
       expect(session).toBeDefined();
@@ -129,8 +128,7 @@ describe('InMemorySessionService', () => {
 
     it('respects numRecentEvents config', async () => {
       const session = await service.createSession({
-        appName: 'app',
-        userId: 'user',
+        scope: {appName: 'app', userId: 'user'},
       });
       for (let i = 0; i < 5; i++) {
         await service.appendEvent({
@@ -140,9 +138,7 @@ describe('InMemorySessionService', () => {
       }
 
       const retrievedSession = await service.getSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId: session.id,
+        scope: {appName: 'app', userId: 'user', sessionId: session.id},
         config: {numRecentEvents: 2},
       });
 
@@ -153,8 +149,7 @@ describe('InMemorySessionService', () => {
 
     it('respects afterTimestamp config', async () => {
       const session = await service.createSession({
-        appName: 'app',
-        userId: 'user',
+        scope: {appName: 'app', userId: 'user'},
       });
       for (let i = 0; i < 5; i++) {
         await service.appendEvent({
@@ -164,9 +159,7 @@ describe('InMemorySessionService', () => {
       }
 
       const retrievedSession = await service.getSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId: session.id,
+        scope: {appName: 'app', userId: 'user', sessionId: session.id},
         config: {afterTimestamp: 2500},
       });
 
@@ -178,7 +171,7 @@ describe('InMemorySessionService', () => {
     it('merges current state into retrieved session', async () => {
       const appName = 'app';
       const userId = 'user';
-      const session = await service.createSession({appName, userId});
+      const session = await service.createSession({scope: {appName, userId}});
 
       // Update state in another session (simulated by directly modifying internal state or another session)
       const event = createEvent({
@@ -192,9 +185,7 @@ describe('InMemorySessionService', () => {
       await service.appendEvent({session, event});
 
       const retrievedSession = await service.getSession({
-        appName,
-        userId,
-        sessionId: session.id,
+        scope: {appName, userId, sessionId: session.id},
       });
 
       expect(retrievedSession?.state).toEqual({
@@ -206,8 +197,7 @@ describe('InMemorySessionService', () => {
   describe('listSessions', () => {
     it('returns empty list if no sessions exist', async () => {
       const response = await service.listSessions({
-        appName: 'app',
-        userId: 'user',
+        scope: {appName: 'app', userId: 'user'},
       });
       expect(response.sessions).toEqual([]);
       expect(response.page).toBe(1);
@@ -219,10 +209,10 @@ describe('InMemorySessionService', () => {
     it('returns list of sessions without events', async () => {
       const appName = 'app';
       const userId = 'user';
-      await service.createSession({appName, userId});
-      await service.createSession({appName, userId});
+      await service.createSession({scope: {appName, userId}});
+      await service.createSession({scope: {appName, userId}});
 
-      const response = await service.listSessions({appName, userId});
+      const response = await service.listSessions({scope: {appName, userId}});
 
       expect(response.sessions).toHaveLength(2);
       expect(response.sessions[0].events).toEqual([]);
@@ -231,8 +221,7 @@ describe('InMemorySessionService', () => {
 
     it('limit on empty result → returns pagination metadata with zeros', async () => {
       const response = await service.listSessions({
-        appName: 'app',
-        userId: 'user',
+        scope: {appName: 'app', userId: 'user'},
         limit: 10,
       });
       expect(response.sessions).toEqual([]);
@@ -245,10 +234,10 @@ describe('InMemorySessionService', () => {
     it('no pagination params → returns all sessions with page=1', async () => {
       const appName = 'app';
       const userId = 'user';
-      await service.createSession({appName, userId});
-      await service.createSession({appName, userId});
+      await service.createSession({scope: {appName, userId}});
+      await service.createSession({scope: {appName, userId}});
 
-      const response = await service.listSessions({appName, userId});
+      const response = await service.listSessions({scope: {appName, userId}});
 
       expect(response.page).toBe(1);
       expect(response.limit).toBe(2);
@@ -260,19 +249,13 @@ describe('InMemorySessionService', () => {
       const appName = 'app';
       const userId = 'user';
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       const s3 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's3',
+        scope: {appName, userId, sessionId: 's3'},
       });
       await service.appendEvent({
         session: s1,
@@ -288,8 +271,7 @@ describe('InMemorySessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         order: 'asc',
       });
 
@@ -300,19 +282,13 @@ describe('InMemorySessionService', () => {
       const appName = 'app';
       const userId = 'user';
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       const s3 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's3',
+        scope: {appName, userId, sessionId: 's3'},
       });
       await service.appendEvent({
         session: s1,
@@ -328,8 +304,7 @@ describe('InMemorySessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         order: 'desc',
       });
 
@@ -340,14 +315,10 @@ describe('InMemorySessionService', () => {
       const appName = 'app';
       const userId = 'user';
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       await service.appendEvent({
         session: s1,
@@ -358,10 +329,16 @@ describe('InMemorySessionService', () => {
         event: createEvent({timestamp: 1000}),
       });
 
-      const asc = await service.listSessions({appName, userId, order: 'asc'});
+      const asc = await service.listSessions({
+        scope: {appName, userId},
+        order: 'asc',
+      });
       expect(asc.sessions.map((s) => s.id)).toEqual(['s1', 's2']);
 
-      const desc = await service.listSessions({appName, userId, order: 'desc'});
+      const desc = await service.listSessions({
+        scope: {appName, userId},
+        order: 'desc',
+      });
       expect(desc.sessions.map((s) => s.id)).toEqual(['s1', 's2']);
     });
 
@@ -369,12 +346,13 @@ describe('InMemorySessionService', () => {
       const appName = 'app';
       const userId = 'user';
       for (let i = 1; i <= 5; i++) {
-        await service.createSession({appName, userId, sessionId: `s${i}`});
+        await service.createSession({
+          scope: {appName, userId, sessionId: `s${i}`},
+        });
       }
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         limit: 3,
         order: 'asc',
       });
@@ -388,19 +366,13 @@ describe('InMemorySessionService', () => {
       const appName = 'app';
       const userId = 'user';
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       const s3 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's3',
+        scope: {appName, userId, sessionId: 's3'},
       });
       await service.appendEvent({
         session: s1,
@@ -416,8 +388,7 @@ describe('InMemorySessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         limit: 2,
         offset: 1,
         order: 'asc',
@@ -431,9 +402,7 @@ describe('InMemorySessionService', () => {
       const userId = 'user';
       for (let i = 1; i <= 5; i++) {
         const s = await service.createSession({
-          appName,
-          userId,
-          sessionId: `s${i}`,
+          scope: {appName, userId, sessionId: `s${i}`},
         });
         await service.appendEvent({
           session: s,
@@ -442,8 +411,7 @@ describe('InMemorySessionService', () => {
       }
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         page: 2,
         limit: 2,
         order: 'asc',
@@ -459,11 +427,10 @@ describe('InMemorySessionService', () => {
     it('offset beyond total → empty sessions with correct metadata', async () => {
       const appName = 'app';
       const userId = 'user';
-      await service.createSession({appName, userId, sessionId: 's1'});
+      await service.createSession({scope: {appName, userId, sessionId: 's1'}});
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         limit: 2,
         offset: 10,
       });
@@ -476,9 +443,12 @@ describe('InMemorySessionService', () => {
     it('limit=0 returns empty sessions and totalPages=0', async () => {
       const appName = 'app';
       const userId = 'user';
-      await service.createSession({appName, userId, sessionId: 's1'});
+      await service.createSession({scope: {appName, userId, sessionId: 's1'}});
 
-      const response = await service.listSessions({appName, userId, limit: 0});
+      const response = await service.listSessions({
+        scope: {appName, userId},
+        limit: 0,
+      });
 
       expect(response.sessions).toEqual([]);
       expect(response.totalItems).toBe(1);
@@ -489,14 +459,10 @@ describe('InMemorySessionService', () => {
       const appName = 'app';
       const userId = 'user';
       const s1 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's1',
+        scope: {appName, userId, sessionId: 's1'},
       });
       const s2 = await service.createSession({
-        appName,
-        userId,
-        sessionId: 's2',
+        scope: {appName, userId, sessionId: 's2'},
       });
       await service.appendEvent({
         session: s1,
@@ -508,8 +474,7 @@ describe('InMemorySessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         order: 'desc',
       });
 
@@ -525,9 +490,7 @@ describe('InMemorySessionService', () => {
       const userId = 'user';
       for (let i = 1; i <= 5; i++) {
         const s = await service.createSession({
-          appName,
-          userId,
-          sessionId: `s${i}`,
+          scope: {appName, userId, sessionId: `s${i}`},
         });
         await service.appendEvent({
           session: s,
@@ -537,8 +500,7 @@ describe('InMemorySessionService', () => {
 
       // page=2, limit=2 → sessions 3,4; offset=0 should be ignored
       const response = await service.listSessions({
-        appName,
-        userId,
+        scope: {appName, userId},
         page: 2,
         limit: 2,
         offset: 0,
@@ -553,19 +515,14 @@ describe('InMemorySessionService', () => {
   describe('deleteSession', () => {
     it('deletes an existing session', async () => {
       const session = await service.createSession({
-        appName: 'app',
-        userId: 'user',
+        scope: {appName: 'app', userId: 'user'},
       });
       await service.deleteSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId: session.id,
+        scope: {appName: 'app', userId: 'user', sessionId: session.id},
       });
 
       const retrievedSession = await service.getSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId: session.id,
+        scope: {appName: 'app', userId: 'user', sessionId: session.id},
       });
       expect(retrievedSession).toBeUndefined();
     });
@@ -573,9 +530,7 @@ describe('InMemorySessionService', () => {
     it('does nothing if session does not exist', async () => {
       await expect(
         service.deleteSession({
-          appName: 'app',
-          userId: 'user',
-          sessionId: 'non-existent',
+          scope: {appName: 'app', userId: 'user', sessionId: 'non-existent'},
         }),
       ).resolves.not.toThrow();
     });
@@ -584,8 +539,7 @@ describe('InMemorySessionService', () => {
   describe('appendEvent', () => {
     it('appends event to session and updates lastUpdateTime', async () => {
       const session = await service.createSession({
-        appName: 'app',
-        userId: 'user',
+        scope: {appName: 'app', userId: 'user'},
       });
       const timestamp = Date.now() + 1000;
       const event = createEvent({timestamp});
@@ -593,9 +547,7 @@ describe('InMemorySessionService', () => {
       await service.appendEvent({session, event});
 
       const retrievedSession = await service.getSession({
-        appName: 'app',
-        userId: 'user',
-        sessionId: session.id,
+        scope: {appName: 'app', userId: 'user', sessionId: session.id},
       });
       expect(retrievedSession?.events).toHaveLength(1);
       expect(retrievedSession?.events[0]).toEqual(event);
@@ -605,7 +557,7 @@ describe('InMemorySessionService', () => {
     it('updates app state', async () => {
       const appName = 'app';
       const userId = 'user';
-      const session = await service.createSession({appName, userId});
+      const session = await service.createSession({scope: {appName, userId}});
       const event = createEvent({
         timestamp: Date.now(),
         actions: createEventActions({
@@ -618,14 +570,14 @@ describe('InMemorySessionService', () => {
       await service.appendEvent({session, event});
 
       // Check via side channel (create another session to see if state persists)
-      const session2 = await service.createSession({appName, userId});
+      const session2 = await service.createSession({scope: {appName, userId}});
       expect(session2.state).toHaveProperty(`${State.APP_PREFIX}key`, 'value');
     });
 
     it('updates user state', async () => {
       const appName = 'app';
       const userId = 'user';
-      const session = await service.createSession({appName, userId});
+      const session = await service.createSession({scope: {appName, userId}});
       const event = createEvent({
         timestamp: Date.now(),
         actions: createEventActions({
@@ -637,7 +589,7 @@ describe('InMemorySessionService', () => {
 
       await service.appendEvent({session, event});
 
-      const session2 = await service.createSession({appName, userId});
+      const session2 = await service.createSession({scope: {appName, userId}});
       expect(session2.state).toHaveProperty(`${State.USER_PREFIX}key`, 'value');
     });
 

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -138,8 +138,7 @@ describe('VertexAiSessionService', () => {
     });
 
     await serviceWithEngineId.createSession({
-      appName: '12345',
-      userId: 'testUser',
+      scope: {appName: '12345', userId: 'testUser'},
     });
 
     expect(mockClient.createInternal).toHaveBeenCalledWith(
@@ -152,8 +151,7 @@ describe('VertexAiSessionService', () => {
   it('throws error if appName is invalid', async () => {
     await expect(
       service.createSession({
-        appName: 'invalid-app-name',
-        userId: 'testUser',
+        scope: {appName: 'invalid-app-name', userId: 'testUser'},
       }),
     ).rejects.toThrow('App name invalid-app-name is not valid');
   });
@@ -169,8 +167,11 @@ describe('VertexAiSessionService', () => {
     });
 
     await service.createSession({
-      appName: 'projects/my-project/locations/us-central1/reasoningEngines/999',
-      userId: 'testUser',
+      scope: {
+        appName:
+          'projects/my-project/locations/us-central1/reasoningEngines/999',
+        userId: 'testUser',
+      },
     });
 
     expect(mockClient.createInternal).toHaveBeenCalledWith(
@@ -183,8 +184,7 @@ describe('VertexAiSessionService', () => {
   describe('createSession', () => {
     it('creates a new session generating a random id', async () => {
       const session = await service.createSession({
-        appName: '12345', // Must be digits or resource name
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
         state: {foo: 'bar'},
       });
 
@@ -199,8 +199,7 @@ describe('VertexAiSessionService', () => {
 
     it('filters out temporary state keys prefixed with temp:', async () => {
       const session = await service.createSession({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
         state: {
           foo: 'bar',
           [`${State.TEMP_PREFIX}tempKey`]: 'tempValue',
@@ -218,9 +217,11 @@ describe('VertexAiSessionService', () => {
 
     it('passes sessionId in config if provided', async () => {
       await service.createSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'user-provided-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'user-provided-id',
+        },
       });
 
       expect(mockClient.createInternal).toHaveBeenCalledWith(
@@ -245,8 +246,7 @@ describe('VertexAiSessionService', () => {
       vi.useFakeTimers();
 
       const createPromise = service.createSession({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
       });
 
       await Promise.all([
@@ -270,8 +270,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const session = await service.createSession({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
       });
 
       expect(session.lastUpdateTime).toBeGreaterThan(0);
@@ -281,9 +280,11 @@ describe('VertexAiSessionService', () => {
   describe('getSession', () => {
     it('returns the session if it exists', async () => {
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
       });
 
       expect(session).toBeDefined();
@@ -300,9 +301,11 @@ describe('VertexAiSessionService', () => {
 
     it('calls get without listing events when numRecentEvents is 0', async () => {
       await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
         config: {numRecentEvents: 0},
       });
 
@@ -313,9 +316,11 @@ describe('VertexAiSessionService', () => {
     it('applies afterTimestamp filter when listing events', async () => {
       const afterTimestamp = 1600000000000;
       await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
         config: {afterTimestamp},
       });
 
@@ -338,9 +343,11 @@ describe('VertexAiSessionService', () => {
 
       await expect(
         service.getSession({
-          appName: '12345',
-          userId: 'testUser',
-          sessionId: 'my-session-id',
+          scope: {
+            appName: '12345',
+            userId: 'testUser',
+            sessionId: 'my-session-id',
+          },
         }),
       ).rejects.toThrow(
         'Session my-session-id does not belong to user testUser',
@@ -373,9 +380,11 @@ describe('VertexAiSessionService', () => {
       });
 
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
       });
 
       expect(session?.events).toHaveLength(1);
@@ -393,9 +402,11 @@ describe('VertexAiSessionService', () => {
       });
 
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
         config: {numRecentEvents: 1},
       });
 
@@ -407,9 +418,11 @@ describe('VertexAiSessionService', () => {
       mockClient.get.mockRejectedValueOnce({code: 5, message: 'Not found'});
 
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
       });
 
       expect(session).toBeUndefined();
@@ -419,9 +432,11 @@ describe('VertexAiSessionService', () => {
       mockClient.get.mockRejectedValueOnce({code: 404, message: 'Not found'});
 
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
       });
 
       expect(session).toBeUndefined();
@@ -435,9 +450,11 @@ describe('VertexAiSessionService', () => {
       mockClient.events.listInternal.mockResolvedValue({}); // No sessionEvents!
 
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
       });
 
       expect(session?.events).toEqual([]);
@@ -451,9 +468,11 @@ describe('VertexAiSessionService', () => {
       });
 
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
       });
 
       expect(session?.state).toEqual({});
@@ -477,9 +496,11 @@ describe('VertexAiSessionService', () => {
       });
 
       const session = await service.getSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'my-session-id',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        },
       });
 
       expect(session?.events[0].actions).toEqual({
@@ -506,9 +527,11 @@ describe('VertexAiSessionService', () => {
 
       await expect(
         service.getSession({
-          appName: '12345',
-          userId: 'testUser',
-          sessionId: 'my-session-id',
+          scope: {
+            appName: '12345',
+            userId: 'testUser',
+            sessionId: 'my-session-id',
+          },
         }),
       ).rejects.toThrow('Permission Denied');
       expect(loggerSpy).toHaveBeenCalled();
@@ -528,8 +551,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const response = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
       });
 
       expect(mockClient.listInternal).toHaveBeenCalledWith({
@@ -560,7 +582,7 @@ describe('VertexAiSessionService', () => {
 
     it('lists sessions without filter if userId is missing', async () => {
       await service.listSessions({
-        appName: '12345',
+        scope: {appName: '12345'},
       });
 
       expect(mockClient.listInternal).toHaveBeenCalledWith(
@@ -576,7 +598,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
+        scope: {appName: '12345'},
       });
 
       expect(result.sessions[0].state).toEqual({});
@@ -587,7 +609,7 @@ describe('VertexAiSessionService', () => {
       mockClient.listInternal.mockResolvedValue({}); // No sessions!
 
       const result = await service.listSessions({
-        appName: '12345',
+        scope: {appName: '12345'},
       });
 
       expect(result.sessions).toEqual([]);
@@ -606,7 +628,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
+        scope: {appName: '12345'},
       });
 
       expect(result.sessions[0].state).toEqual({foo: 'bar'});
@@ -624,8 +646,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
       });
 
       expect(result.page).toBe(1);
@@ -638,8 +659,7 @@ describe('VertexAiSessionService', () => {
       mockClient.listInternal.mockResolvedValue({});
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
       });
 
       expect(result.sessions).toEqual([]);
@@ -665,8 +685,7 @@ describe('VertexAiSessionService', () => {
         });
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
       });
 
       expect(result.sessions).toHaveLength(3);
@@ -698,8 +717,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
         order: 'asc',
       });
 
@@ -728,8 +746,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
         order: 'desc',
       });
 
@@ -758,8 +775,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
         limit: 2,
         order: 'asc',
       });
@@ -803,8 +819,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
         page: 2,
         limit: 2,
         order: 'asc',
@@ -839,8 +854,7 @@ describe('VertexAiSessionService', () => {
       });
 
       const result = await service.listSessions({
-        appName: '12345',
-        userId: 'testUser',
+        scope: {appName: '12345', userId: 'testUser'},
         limit: 2,
         offset: 1,
         order: 'asc',
@@ -853,9 +867,11 @@ describe('VertexAiSessionService', () => {
   describe('deleteSession', () => {
     it('deletes an existing session', async () => {
       await service.deleteSession({
-        appName: '12345',
-        userId: 'testUser',
-        sessionId: 'delete-session',
+        scope: {
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'delete-session',
+        },
       });
 
       expect(mockClient.delete).toHaveBeenCalledWith({

--- a/core/test/tools/agent_tool_test.ts
+++ b/core/test/tools/agent_tool_test.ts
@@ -92,9 +92,11 @@ describe('AgentTool', () => {
     // Verify getOrCreateSession called with parent context
     expect(mockSessionService.getOrCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        appName: 'sub-agent',
-        userId: 'parent-user',
-        sessionId: 'parent-session',
+        scope: expect.objectContaining({
+          appName: 'sub-agent',
+          userId: 'parent-user',
+          sessionId: 'parent-session',
+        }),
       }),
     );
 
@@ -159,7 +161,9 @@ describe('AgentTool', () => {
     // session on the second call rather than throwing a duplicate-session error
     expect(mockSessionService.getOrCreateSession).toHaveBeenCalledTimes(2);
     expect(mockSessionService.getOrCreateSession).toHaveBeenCalledWith(
-      expect.objectContaining({sessionId: 'parent-session'}),
+      expect.objectContaining({
+        scope: expect.objectContaining({sessionId: 'parent-session'}),
+      }),
     );
   });
 
@@ -502,9 +506,11 @@ describe('AgentTool', () => {
 
     // Retrieve the created session from the service
     const subAgentSession = await mockSessionService.getSession({
-      appName: 'sub-agent',
-      userId: 'parent-user',
-      sessionId: 'parent-session',
+      scope: {
+        appName: 'sub-agent',
+        userId: 'parent-user',
+        sessionId: 'parent-session',
+      },
     });
 
     expect(subAgentSession).toBeDefined();

--- a/core/test/tools/forwarding_artifact_service_test.ts
+++ b/core/test/tools/forwarding_artifact_service_test.ts
@@ -49,9 +49,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: SaveArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
         artifact: {text: 'hello'},
       };
@@ -72,9 +70,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
         version: 2,
       };
@@ -90,9 +86,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
       };
 
@@ -111,9 +105,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: ListArtifactKeysRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
       };
 
       const result = await service.listArtifactKeys(request);
@@ -130,9 +122,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: DeleteArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
       };
 
@@ -145,9 +135,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: DeleteArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
       };
 
@@ -165,9 +153,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
       };
 
@@ -181,9 +167,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
       };
 
@@ -202,9 +186,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
       };
 
@@ -220,9 +202,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: ListVersionsRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
       };
 
@@ -241,9 +221,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
         version: 1,
       };
@@ -261,9 +239,7 @@ describe('ForwardingArtifactService', () => {
       const service = new ForwardingArtifactService(toolContext);
 
       const request: LoadArtifactRequest = {
-        appName: 'app',
-        userId: 'user',
-        sessionId: 'session',
+        scope: {appName: 'app', userId: 'user', sessionId: 'session'},
         filename: 'file.txt',
         version: 0,
       };

--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -67,8 +67,7 @@ async function runFromInputFile(
   fileContent.state['_time'] = new Date().toISOString();
 
   const session = await options.sessionService.createSession({
-    appName: options.appName,
-    userId: options.userId,
+    scope: {appName: options.appName, userId: options.userId},
     state: fileContent.state,
   });
 
@@ -193,8 +192,7 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
     const app = isApp(loaded) ? loaded : undefined;
 
     let session = await sessionService.createSession({
-      appName: app?.name ?? rootAgent.name,
-      userId,
+      scope: {appName: app?.name ?? rootAgent.name, userId},
     });
 
     const reloadSubscribers: Array<(agent: BaseAgent) => void> = [];
@@ -293,9 +291,11 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
         `${sessionId}.session.json`,
       );
       const sessionToStore = await sessionService.getSession({
-        appName: session.appName,
-        userId: session.userId,
-        sessionId: session.id,
+        scope: {
+          appName: session.appName,
+          userId: session.userId,
+          sessionId: session.id,
+        },
       });
       await saveToFile(path.join(dirname, sessionPath), sessionToStore);
 

--- a/dev/src/integration/test_runner.ts
+++ b/dev/src/integration/test_runner.ts
@@ -83,9 +83,7 @@ export class TestRunner {
 
     // Create the session explicitly
     await sessionService.createSession({
-      appName: 'test-runner',
-      userId,
-      sessionId,
+      scope: {appName: 'test-runner', userId, sessionId},
     });
 
     const userMessages = testInfo.spec.userMessages!;
@@ -108,9 +106,7 @@ export class TestRunner {
     }
 
     const session = await sessionService.getSession({
-      appName: 'test-runner',
-      userId,
-      sessionId,
+      scope: {appName: 'test-runner', userId, sessionId},
     });
 
     if (!session) {

--- a/dev/src/server/adk_api_client.ts
+++ b/dev/src/server/adk_api_client.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Event} from '@google/adk';
+import type {
+  CreateSessionScope,
+  Event,
+  SessionScope,
+  UserScope,
+} from '@google/adk';
 import {Session} from '@google/adk';
 import {Content, createUserContent} from '@google/genai';
 
@@ -41,13 +46,13 @@ export class AdkApiClient {
     return this.fetch<string[]>(`${this.backendUrl}/list-apps`);
   }
 
-  async getSession(params: {
-    appName: string;
-    userId: string;
-    sessionId: string;
+  async getSession({
+    scope: {appName, userId, sessionId},
+  }: {
+    scope: SessionScope;
   }): Promise<Session> {
     return this.fetch<Session>(
-      `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions/${params.sessionId}`,
+      `${this.backendUrl}/apps/${appName}/users/${userId}/sessions/${sessionId}`,
       {
         method: 'GET',
         headers: {
@@ -57,15 +62,16 @@ export class AdkApiClient {
     );
   }
 
-  async createSession(params: {
-    appName: string;
-    userId: string;
-    sessionId?: string;
+  async createSession({
+    scope: {appName, userId, sessionId},
+    state,
+  }: {
+    scope: CreateSessionScope;
     state?: Record<string, unknown>;
   }): Promise<Session> {
-    let url = `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions`;
-    if (params.sessionId) {
-      url += `/${params.sessionId}`;
+    let url = `${this.backendUrl}/apps/${appName}/users/${userId}/sessions`;
+    if (sessionId) {
+      url += `/${sessionId}`;
     }
     return this.fetch<Session>(url, {
       method: 'POST',
@@ -73,18 +79,18 @@ export class AdkApiClient {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        state: params.state,
+        state,
       }),
     });
   }
 
-  async deleteSession(params: {
-    appName: string;
-    userId: string;
-    sessionId: string;
+  async deleteSession({
+    scope: {appName, userId, sessionId},
+  }: {
+    scope: SessionScope;
   }): Promise<void> {
     return this.fetch<void>(
-      `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions/${params.sessionId}`,
+      `${this.backendUrl}/apps/${appName}/users/${userId}/sessions/${sessionId}`,
       {
         method: 'DELETE',
         headers: {
@@ -99,17 +105,18 @@ export class AdkApiClient {
 
     return Promise.all(
       apps.map((appName) =>
-        this.listSessions({appName, userId: params.userId}),
+        this.listSessions({scope: {appName, userId: params.userId}}),
       ),
     ).then((sessions) => sessions.flat());
   }
 
-  async listSessions(params: {
-    appName: string;
-    userId: string;
+  async listSessions({
+    scope: {appName, userId},
+  }: {
+    scope: UserScope;
   }): Promise<Session[]> {
     const sessions = await this.fetch<Session[] | {sessions: Session[]}>(
-      `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions`,
+      `${this.backendUrl}/apps/${appName}/users/${userId}/sessions`,
       {
         method: 'GET',
         headers: {
@@ -185,13 +192,13 @@ export class AdkApiClient {
     }
   }
 
-  async listArtifacts(params: {
-    appName: string;
-    userId: string;
-    sessionId: string;
+  async listArtifacts({
+    scope: {appName, userId, sessionId},
+  }: {
+    scope: SessionScope;
   }): Promise<Array<{filename: string}>> {
     return this.fetch<Array<{filename: string}>>(
-      `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions/${params.sessionId}/artifacts`,
+      `${this.backendUrl}/apps/${appName}/users/${userId}/sessions/${sessionId}/artifacts`,
       {
         method: 'GET',
         headers: {
@@ -201,16 +208,18 @@ export class AdkApiClient {
     );
   }
 
-  async loadArtifact(params: {
-    appName: string;
-    userId: string;
-    sessionId: string;
+  async loadArtifact({
+    scope: {appName, userId, sessionId},
+    artifactName,
+    version,
+  }: {
+    scope: SessionScope;
     artifactName: string;
     version?: number;
   }): Promise<unknown> {
-    let url = `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions/${params.sessionId}/artifacts/${params.artifactName}`;
-    if (params.version !== undefined) {
-      url += `/versions/${params.version}`;
+    let url = `${this.backendUrl}/apps/${appName}/users/${userId}/sessions/${sessionId}/artifacts/${artifactName}`;
+    if (version !== undefined) {
+      url += `/versions/${version}`;
     }
     return this.fetch<unknown>(url, {
       method: 'GET',
@@ -220,13 +229,14 @@ export class AdkApiClient {
     });
   }
 
-  async listArtifactVersions(params: {
-    appName: string;
-    userId: string;
-    sessionId: string;
+  async listArtifactVersions({
+    scope: {appName, userId, sessionId},
+    artifactName,
+  }: {
+    scope: SessionScope;
     artifactName: string;
   }): Promise<number[]> {
-    const url = `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions/${params.sessionId}/artifacts/${params.artifactName}/versions`;
+    const url = `${this.backendUrl}/apps/${appName}/users/${userId}/sessions/${sessionId}/artifacts/${artifactName}/versions`;
     return this.fetch<number[]>(url, {
       method: 'GET',
       headers: {
@@ -235,13 +245,14 @@ export class AdkApiClient {
     });
   }
 
-  async deleteArtifact(params: {
-    appName: string;
-    userId: string;
-    sessionId: string;
+  async deleteArtifact({
+    scope: {appName, userId, sessionId},
+    artifactName,
+  }: {
+    scope: SessionScope;
     artifactName: string;
   }): Promise<void> {
-    const url = `${this.backendUrl}/apps/${params.appName}/users/${params.userId}/sessions/${params.sessionId}/artifacts/${params.artifactName}`;
+    const url = `${this.backendUrl}/apps/${appName}/users/${userId}/sessions/${sessionId}/artifacts/${artifactName}`;
     return this.fetch<void>(url, {
       method: 'DELETE',
       headers: {

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -288,9 +288,7 @@ export class AdkApiServer {
           const eventId = req.params['eventId'];
 
           const session = await this.sessionService.getSession({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
           });
 
           if (!session) {
@@ -367,9 +365,7 @@ export class AdkApiServer {
           const sessionId = req.params['sessionId'];
 
           const session = await this.sessionService.getSession({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
           });
 
           if (!session) {
@@ -395,8 +391,7 @@ export class AdkApiServer {
           const userId = req.params['userId'];
 
           const sessions = await this.sessionService.listSessions({
-            appName,
-            userId,
+            scope: {appName, userId},
           });
 
           res.json(sessions);
@@ -419,9 +414,7 @@ export class AdkApiServer {
           const state = req.body['state'] || {};
 
           const existingSession = await this.sessionService.getSession({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
           });
 
           if (existingSession) {
@@ -432,10 +425,8 @@ export class AdkApiServer {
           }
 
           const createdSession = await this.sessionService.createSession({
-            appName,
-            userId,
+            scope: {appName, userId, sessionId},
             state,
-            sessionId,
           });
 
           res.json(createdSession);
@@ -457,8 +448,7 @@ export class AdkApiServer {
           const state = req.body['state'] || {};
 
           const createdSession = await this.sessionService.createSession({
-            appName,
-            userId,
+            scope: {appName, userId},
             state,
           });
 
@@ -481,9 +471,7 @@ export class AdkApiServer {
           const sessionId = req.params['sessionId'];
 
           const session = await this.sessionService.getSession({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
           });
 
           if (!session) {
@@ -492,9 +480,7 @@ export class AdkApiServer {
           }
 
           await this.sessionService.deleteSession({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
           });
 
           res.status(204).json({});
@@ -718,9 +704,7 @@ export class AdkApiServer {
     app.post('/run', async (req: Request, res: Response) => {
       const {appName, userId, sessionId, newMessage, stateDelta} = req.body;
       const session = await this.sessionService.getSession({
-        appName,
-        userId,
-        sessionId,
+        scope: {appName, userId, sessionId},
       });
 
       if (!session) {
@@ -783,9 +767,7 @@ export class AdkApiServer {
         }
         try {
           await this.sessionService.getOrCreateSession({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
             state: {},
           });
           const events: Event[] = [];
@@ -844,9 +826,7 @@ export class AdkApiServer {
         req.body;
 
       const session = await this.sessionService.getSession({
-        appName,
-        userId,
-        sessionId,
+        scope: {appName, userId, sessionId},
       });
 
       if (!session) {

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -518,9 +518,7 @@ export class AdkApiServer {
           const artifactName = req.params['artifactName'];
 
           const artifact = await this.artifactService.loadArtifact({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
             filename: artifactName,
           });
 
@@ -552,9 +550,7 @@ export class AdkApiServer {
           const versionId = req.params['versionId'];
 
           const artifact = await this.artifactService.loadArtifact({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
             filename: artifactName,
             version: parseInt(versionId, 10),
           });
@@ -585,9 +581,7 @@ export class AdkApiServer {
           const sessionId = req.params['sessionId'];
 
           const artifactKeys = await this.artifactService.listArtifactKeys({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
           });
 
           res.json(artifactKeys);
@@ -610,9 +604,7 @@ export class AdkApiServer {
           const artifactName = req.params['artifactName'];
 
           const artifactVersions = await this.artifactService.listVersions({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
             filename: artifactName,
           });
 
@@ -636,9 +628,7 @@ export class AdkApiServer {
           const artifactName = req.params['artifactName'];
 
           await this.artifactService.deleteArtifact({
-            appName,
-            userId,
-            sessionId,
+            scope: {appName, userId, sessionId},
             filename: artifactName,
           });
 

--- a/dev/test/server/adk_api_client_test.ts
+++ b/dev/test/server/adk_api_client_test.ts
@@ -64,9 +64,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.getSession({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
@@ -94,8 +92,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.createSession({
-        appName: 'app1',
-        userId: 'user1',
+        scope: {appName: 'app1', userId: 'user1'},
         state: {key: 'value'},
       });
 
@@ -123,9 +120,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.createSession({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
@@ -148,9 +143,7 @@ describe('AdkApiClient', () => {
       });
 
       await client.deleteSession({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
@@ -174,8 +167,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.listSessions({
-        appName: 'app1',
-        userId: 'user1',
+        scope: {appName: 'app1', userId: 'user1'},
       });
 
       expect(result).toEqual(mockSessions);
@@ -191,8 +183,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.listSessions({
-        appName: 'app1',
-        userId: 'user1',
+        scope: {appName: 'app1', userId: 'user1'},
       });
 
       expect(result).toEqual(mockSessions);
@@ -344,9 +335,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.listArtifacts({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
@@ -369,9 +358,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.loadArtifact({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
         artifactName: 'file1.txt',
       });
 
@@ -393,9 +380,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.loadArtifact({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
         artifactName: 'file1.txt',
         version: 1,
       });
@@ -420,9 +405,7 @@ describe('AdkApiClient', () => {
       });
 
       const result = await client.listArtifactVersions({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
         artifactName: 'file1.txt',
       });
 
@@ -445,9 +428,7 @@ describe('AdkApiClient', () => {
       });
 
       await client.deleteArtifact({
-        appName: 'app1',
-        userId: 'user1',
-        sessionId: 'session1',
+        scope: {appName: 'app1', userId: 'user1', sessionId: 'session1'},
         artifactName: 'file1.txt',
       });
 

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -270,9 +270,7 @@ describe('AdkWebServer', () => {
 
     it('should return 400 if session with given id already exists', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       try {
@@ -287,9 +285,7 @@ describe('AdkWebServer', () => {
 
     it('should return a session by id', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const response = await client.get<Session>(
@@ -310,9 +306,7 @@ describe('AdkWebServer', () => {
 
     it('should delete a session', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const response = await client.delete(
@@ -322,9 +316,11 @@ describe('AdkWebServer', () => {
       expect(response.status).toBe(204);
       expect(
         await sessionService.getSession({
-          appName: 'testApp',
-          userId: 'testUser',
-          sessionId: 'sessionId',
+          scope: {
+            appName: 'testApp',
+            userId: 'testUser',
+            sessionId: 'sessionId',
+          },
         }),
       ).toBeUndefined();
     });
@@ -333,9 +329,7 @@ describe('AdkWebServer', () => {
   describe('Artifacts', () => {
     it('should return an empty list of artifacts', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const response = await client.get(
@@ -348,9 +342,7 @@ describe('AdkWebServer', () => {
 
     it('should return an artifact by name', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
       await artifactService.saveArtifact({
         scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
@@ -372,9 +364,7 @@ describe('AdkWebServer', () => {
 
     it('should return 404 if artifact not found', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       try {
@@ -388,9 +378,7 @@ describe('AdkWebServer', () => {
 
     it('should return an artifact by version', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
       await artifactService.saveArtifact({
         scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
@@ -410,9 +398,7 @@ describe('AdkWebServer', () => {
 
     it('should return a list of artifact versions', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
       await artifactService.saveArtifact({
         scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
@@ -439,9 +425,7 @@ describe('AdkWebServer', () => {
 
     it('should delete an artifact', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
       await artifactService.saveArtifact({
         scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
@@ -472,9 +456,7 @@ describe('AdkWebServer', () => {
   describe('run', () => {
     it('should return a list of events', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const response = await client.post<Event[]>('/run', {
@@ -501,9 +483,7 @@ describe('AdkWebServer', () => {
 
     it('should update session state if stateDelta is provided', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
         state: {foo: 'bar'},
       });
 
@@ -524,9 +504,7 @@ describe('AdkWebServer', () => {
 
       expect(response.status).toBe(200);
       const session = await sessionService.getSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
       // The state should be merged or updated. Assuming deep merge or at least key addition.
       // If Runner does shallow merge of stateDelta:
@@ -554,9 +532,7 @@ describe('AdkWebServer', () => {
       agentLoader.getAgentFile = () => Promise.reject(new Error('Load failed'));
 
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       try {
@@ -575,9 +551,7 @@ describe('AdkWebServer', () => {
 
     it('should pass abortSignal to Runner.runAsync in /run', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const spy = vi.spyOn(Runner.prototype, 'runAsync');
@@ -605,9 +579,7 @@ describe('AdkWebServer', () => {
   describe('run_sse', () => {
     it('should return a stream of events', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const response = await client.post('/run_sse', {
@@ -643,9 +615,7 @@ describe('AdkWebServer', () => {
 
     it('should update session state if stateDelta is provided', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
         state: {foo: 'bar'},
       });
 
@@ -666,9 +636,7 @@ describe('AdkWebServer', () => {
 
       expect(response.status).toBe(200);
       const session = await sessionService.getSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
       expect(session?.state).toEqual({foo: 'bar', baz: 'qux'});
     });
@@ -694,9 +662,7 @@ describe('AdkWebServer', () => {
       agentLoader.getAgentFile = () => Promise.reject(new Error('Load failed'));
 
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       try {
@@ -715,9 +681,7 @@ describe('AdkWebServer', () => {
 
     it('should pass abortSignal to Runner.runAsync in /run_sse', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const spy = vi.spyOn(Runner.prototype, 'runAsync');
@@ -836,9 +800,9 @@ describe('AdkWebServer', () => {
       const originalGetSession = sessionService.getSession;
       sessionService.getSession = async () =>
         createSession({
-          id: 'fullSession',
           appName: 'testApp',
           userId: 'testUser',
+          id: 'fullSession',
           events: [
             createEvent({
               id: 'event1',
@@ -877,9 +841,11 @@ describe('AdkWebServer', () => {
 
     it('should return 404 if event not found', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionNoEvents',
+        scope: {
+          appName: 'testApp',
+          userId: 'testUser',
+          sessionId: 'sessionNoEvents',
+        },
       });
       try {
         await client.get(
@@ -934,9 +900,7 @@ describe('AdkWebServer', () => {
 
     it('should query the agent using reasoning_engine route with valid JSON', async () => {
       await sessionService.createSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
       });
 
       const response = await client.post<{output: Event[]}>(
@@ -982,9 +946,11 @@ describe('AdkWebServer', () => {
       expect(response.data?.output).toBeDefined();
 
       const session = await sessionService.getSession({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'newSessionId',
+        scope: {
+          appName: 'testApp',
+          userId: 'testUser',
+          sessionId: 'newSessionId',
+        },
       });
       expect(session).toBeDefined();
     });

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -353,9 +353,7 @@ describe('AdkWebServer', () => {
         sessionId: 'sessionId',
       });
       await artifactService.saveArtifact({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
         filename: 'artifact.txt',
         artifact: {
           text: 'content',
@@ -395,9 +393,7 @@ describe('AdkWebServer', () => {
         sessionId: 'sessionId',
       });
       await artifactService.saveArtifact({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
         filename: 'artifact.txt',
         artifact: {
           text: 'content',
@@ -419,18 +415,14 @@ describe('AdkWebServer', () => {
         sessionId: 'sessionId',
       });
       await artifactService.saveArtifact({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
         filename: 'artifact.txt',
         artifact: {
           text: 'content',
         },
       });
       await artifactService.saveArtifact({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
         filename: 'artifact.txt',
         artifact: {
           text: 'content2',
@@ -452,9 +444,7 @@ describe('AdkWebServer', () => {
         sessionId: 'sessionId',
       });
       await artifactService.saveArtifact({
-        appName: 'testApp',
-        userId: 'testUser',
-        sessionId: 'sessionId',
+        scope: {appName: 'testApp', userId: 'testUser', sessionId: 'sessionId'},
         filename: 'artifact.txt',
         artifact: {
           text: 'content',
@@ -468,9 +458,11 @@ describe('AdkWebServer', () => {
       expect(response.status).toBe(204);
       expect(
         await artifactService.loadArtifact({
-          appName: 'testApp',
-          userId: 'testUser',
-          sessionId: 'sessionId',
+          scope: {
+            appName: 'testApp',
+            userId: 'testUser',
+            sessionId: 'sessionId',
+          },
           filename: 'artifact.txt',
         }),
       ).toBeUndefined();

--- a/tests/e2e/context_compaction/e2e_compaction_test.ts
+++ b/tests/e2e/context_compaction/e2e_compaction_test.ts
@@ -68,8 +68,7 @@ describe('E2e Context Compaction', () => {
         plugins: [plugin],
       });
       const session = await runner.sessionService.createSession({
-        appName: 'e2e_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_test', userId: 'test_user'},
       });
 
       const turns = [
@@ -92,9 +91,11 @@ describe('E2e Context Compaction', () => {
 
       // Now retrieve the session and check its events
       const updatedSession = await runner.sessionService.getSession({
-        appName: 'e2e_test',
-        userId: 'test_user',
-        sessionId: session.id,
+        scope: {
+          appName: 'e2e_test',
+          userId: 'test_user',
+          sessionId: session.id,
+        },
       });
 
       // Find if there is a CompactedEvent

--- a/tests/e2e/context_compaction/e2e_compaction_vertexai_test.ts
+++ b/tests/e2e/context_compaction/e2e_compaction_vertexai_test.ts
@@ -75,8 +75,10 @@ describe('E2e Context Compaction (Vertex AI)', () => {
       });
 
       const session = await runner.sessionService.createSession({
-        appName: `projects/${projectId}/locations/${location}/reasoningEngines/${agentEngineId}`,
-        userId: 'test_user',
+        scope: {
+          appName: `projects/${projectId}/locations/${location}/reasoningEngines/${agentEngineId}`,
+          userId: 'test_user',
+        },
       });
 
       const turns = [
@@ -98,9 +100,11 @@ describe('E2e Context Compaction (Vertex AI)', () => {
       }
 
       const updatedSession = await runner.sessionService.getSession({
-        appName: 'e2e_test',
-        userId: 'test_user',
-        sessionId: session.id,
+        scope: {
+          appName: 'e2e_test',
+          userId: 'test_user',
+          sessionId: session.id,
+        },
       });
 
       const compactedEvents = updatedSession!.events.filter(isCompactedEvent);

--- a/tests/e2e/custom_metadata/custom_metadata_test.ts
+++ b/tests/e2e/custom_metadata/custom_metadata_test.ts
@@ -57,8 +57,7 @@ describe.skipIf(!hasAKey)('E2e customMetadata Support', () => {
     };
 
     const session = await runner.sessionService.createSession({
-      appName: 'e2e_custom_metadata_test',
-      userId: 'e2e_user',
+      scope: {appName: 'e2e_custom_metadata_test', userId: 'e2e_user'},
     });
 
     const responseGen = runner.runAsync({
@@ -76,9 +75,11 @@ describe.skipIf(!hasAKey)('E2e customMetadata Support', () => {
 
     // Retrieve the session and check events
     const updatedSession = await runner.sessionService.getSession({
-      appName: 'e2e_custom_metadata_test',
-      userId: 'e2e_user',
-      sessionId: session.id,
+      scope: {
+        appName: 'e2e_custom_metadata_test',
+        userId: 'e2e_user',
+        sessionId: session.id,
+      },
     });
 
     expect(updatedSession).not.toBeNull();

--- a/tests/e2e/routing/ab_testing_agent_test.ts
+++ b/tests/e2e/routing/ab_testing_agent_test.ts
@@ -64,8 +64,7 @@ describe.skipIf(!hasAKey)('E2e A/B Testing with RoutedAgent', () => {
       appName: 'ab_testing_agent_test',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'ab_testing_agent_test',
-      userId: 'test_user',
+      scope: {appName: 'ab_testing_agent_test', userId: 'test_user'},
     });
 
     const responseGen = runner.runAsync({
@@ -90,8 +89,7 @@ describe.skipIf(!hasAKey)('E2e A/B Testing with RoutedAgent', () => {
       appName: 'ab_testing_agent_test',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'ab_testing_agent_test',
-      userId: 'test_user',
+      scope: {appName: 'ab_testing_agent_test', userId: 'test_user'},
     });
 
     const responseGen = runner.runAsync({

--- a/tests/e2e/routing/auto_routing_agent_test.ts
+++ b/tests/e2e/routing/auto_routing_agent_test.ts
@@ -94,8 +94,7 @@ Request: "${text}"`;
       appName: 'auto_routing_agent_test',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'auto_routing_agent_test',
-      userId: 'test_user',
+      scope: {appName: 'auto_routing_agent_test', userId: 'test_user'},
     });
 
     const responseGen = runner.runAsync({
@@ -177,8 +176,7 @@ Request: "${text}"`;
       appName: 'auto_routing_agent_test',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'auto_routing_agent_test',
-      userId: 'test_user',
+      scope: {appName: 'auto_routing_agent_test', userId: 'test_user'},
     });
 
     const responseGen = runner.runAsync({

--- a/tests/e2e/routing/planning_mode_test.ts
+++ b/tests/e2e/routing/planning_mode_test.ts
@@ -99,8 +99,7 @@ describe.skipIf(!hasAKey)('E2e Planning Mode with RoutedAgent', () => {
       appName: 'planning_mode_test',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'planning_mode_test',
-      userId: 'test_user',
+      scope: {appName: 'planning_mode_test', userId: 'test_user'},
     });
 
     const responseGen = runner.runAsync({
@@ -125,8 +124,7 @@ describe.skipIf(!hasAKey)('E2e Planning Mode with RoutedAgent', () => {
       appName: 'planning_mode_test',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'planning_mode_test',
-      userId: 'test_user',
+      scope: {appName: 'planning_mode_test', userId: 'test_user'},
     });
 
     const responseGen = runner.runAsync({

--- a/tests/e2e/streaming/streaming_e2e_test.ts
+++ b/tests/e2e/streaming/streaming_e2e_test.ts
@@ -65,8 +65,7 @@ describe('E2E Live Model Streaming & Tool Call History', () => {
         });
 
         const session = await runner.sessionService.createSession({
-          appName: 'e2e_streaming_test',
-          userId: 'e2e_user',
+          scope: {appName: 'e2e_streaming_test', userId: 'e2e_user'},
         });
 
         const results: Event[] = [];
@@ -104,9 +103,11 @@ describe('E2E Live Model Streaming & Tool Call History', () => {
 
           // Verify that the DB session history contains the tool call properly saved
           const dbSession = await runner.sessionService.getSession({
-            appName: 'e2e_streaming_test',
-            userId: 'e2e_user',
-            sessionId: session.id,
+            scope: {
+              appName: 'e2e_streaming_test',
+              userId: 'e2e_user',
+              sessionId: session.id,
+            },
           });
 
           expect(dbSession).toBeDefined();

--- a/tests/e2e/tools/agent_registry_e2e_test.ts
+++ b/tests/e2e/tools/agent_registry_e2e_test.ts
@@ -50,8 +50,7 @@ describe('E2E Live Agent Registry', () => {
         appName: 'e2e_registry_test',
       });
       const session = await runner.sessionService.createSession({
-        appName: 'e2e_registry_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_registry_test', userId: 'test_user'},
       });
 
       let finalResponse = '';

--- a/tests/e2e/tools/agent_tool_e2e_test.ts
+++ b/tests/e2e/tools/agent_tool_e2e_test.ts
@@ -52,8 +52,7 @@ describe('E2E AgentTool State Filtering', () => {
       });
 
       const session = await runner.sessionService.createSession({
-        appName: 'e2e_agent_tool_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_agent_tool_test', userId: 'test_user'},
         state: {
           normalKey: 'parent_value',
           [`${State.TEMP_PREFIX}tempKey`]: 'should_be_filtered',
@@ -71,9 +70,11 @@ describe('E2E AgentTool State Filtering', () => {
 
       // Retrieve the sub-agent's session
       const subAgentSession = await runner.sessionService.getSession({
-        appName: 'sub_agent',
-        userId: 'test_user',
-        sessionId: session.id,
+        scope: {
+          appName: 'sub_agent',
+          userId: 'test_user',
+          sessionId: session.id,
+        },
       });
 
       expect(subAgentSession).toBeDefined();

--- a/tests/e2e/tools/before_tool_selection_test.ts
+++ b/tests/e2e/tools/before_tool_selection_test.ts
@@ -79,9 +79,11 @@ describe('E2E beforeToolSelection', () => {
         'utf8',
       ).toString('base64');
       await runner.artifactService!.saveArtifact({
-        appName: 'e2e_tool_test',
-        userId: 'test_user',
-        sessionId: session.id,
+        scope: {
+          appName: 'e2e_tool_test',
+          userId: 'test_user',
+          sessionId: session.id,
+        },
         filename: 'people.csv',
         artifact: {
           inlineData: {
@@ -151,9 +153,11 @@ describe('E2E beforeToolSelection', () => {
         'utf8',
       ).toString('base64');
       await runner.artifactService!.saveArtifact({
-        appName: 'e2e_tool_test',
-        userId: 'test_user',
-        sessionId: session.id,
+        scope: {
+          appName: 'e2e_tool_test',
+          userId: 'test_user',
+          sessionId: session.id,
+        },
         filename: 'people.csv',
         artifact: {
           inlineData: {

--- a/tests/e2e/tools/before_tool_selection_test.ts
+++ b/tests/e2e/tools/before_tool_selection_test.ts
@@ -69,8 +69,7 @@ describe('E2E beforeToolSelection', () => {
         plugins: [filterPlugin],
       });
       const session = await runner.sessionService.createSession({
-        appName: 'e2e_tool_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_tool_test', userId: 'test_user'},
       });
 
       // Provide an artifact
@@ -143,8 +142,7 @@ describe('E2E beforeToolSelection', () => {
         plugins: [new NoOpPlugin()],
       });
       const session = await runner.sessionService.createSession({
-        appName: 'e2e_tool_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_tool_test', userId: 'test_user'},
       });
 
       // Provide an artifact

--- a/tests/e2e/tools/load_artifacts_tool_test.ts
+++ b/tests/e2e/tools/load_artifacts_tool_test.ts
@@ -38,8 +38,7 @@ describe('E2E LoadArtifactsTool', () => {
 
       const runner = new InMemoryRunner({agent, appName: 'e2e_tool_test'});
       const session = await runner.sessionService.createSession({
-        appName: 'e2e_tool_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_tool_test', userId: 'test_user'},
       });
 
       // Provide an artifact

--- a/tests/e2e/tools/load_artifacts_tool_test.ts
+++ b/tests/e2e/tools/load_artifacts_tool_test.ts
@@ -48,9 +48,11 @@ describe('E2E LoadArtifactsTool', () => {
         'utf8',
       ).toString('base64');
       await runner.artifactService!.saveArtifact({
-        appName: 'e2e_tool_test',
-        userId: 'test_user',
-        sessionId: session.id,
+        scope: {
+          appName: 'e2e_tool_test',
+          userId: 'test_user',
+          sessionId: session.id,
+        },
         filename: 'people.csv',
         artifact: {
           inlineData: {

--- a/tests/e2e/tools/load_memory_tool_test.ts
+++ b/tests/e2e/tools/load_memory_tool_test.ts
@@ -42,8 +42,7 @@ describe('E2E LoadMemoryTool', () => {
       });
 
       const session1 = await runner.sessionService.createSession({
-        appName: 'e2e_memory_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_memory_test', userId: 'test_user'},
       });
 
       // Save a piece of memory by talking to a simple prompt, then saving the session
@@ -68,8 +67,7 @@ describe('E2E LoadMemoryTool', () => {
       await runner.memoryService!.addSessionToMemory(session1);
 
       const session2 = await runner.sessionService.createSession({
-        appName: 'e2e_memory_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_memory_test', userId: 'test_user'},
       });
 
       let finalResponse = '';

--- a/tests/e2e/tools/preload_memory_tool_test.ts
+++ b/tests/e2e/tools/preload_memory_tool_test.ts
@@ -46,8 +46,7 @@ describe('E2E PreloadMemoryTool', () => {
       });
 
       const session1 = await runner.sessionService.createSession({
-        appName: 'e2e_preload_memory_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_preload_memory_test', userId: 'test_user'},
       });
 
       // Save a piece of memory
@@ -62,8 +61,7 @@ describe('E2E PreloadMemoryTool', () => {
       await runner.memoryService!.addSessionToMemory(session1);
 
       const session2 = await runner.sessionService.createSession({
-        appName: 'e2e_preload_memory_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_preload_memory_test', userId: 'test_user'},
       });
 
       let finalResponse = '';

--- a/tests/e2e/tools/rest_api_tool_auth_e2e_test.ts
+++ b/tests/e2e/tools/rest_api_tool_auth_e2e_test.ts
@@ -103,8 +103,7 @@ describe('RestApiTool Auth E2E', () => {
       });
 
       const session = await runner.sessionService.createSession({
-        appName: 'auth_e2e_test',
-        userId: 'test_user',
+        scope: {appName: 'auth_e2e_test', userId: 'test_user'},
       });
 
       // Start turn 1: ask agent to get data

--- a/tests/e2e/tools/skills_registry_e2e_test.ts
+++ b/tests/e2e/tools/skills_registry_e2e_test.ts
@@ -75,8 +75,7 @@ describe('E2E Live GCP Skills Registry', () => {
       });
 
       const session = await runner.sessionService.createSession({
-        appName: 'e2e_skills_test',
-        userId: 'test_user',
+        scope: {appName: 'e2e_skills_test', userId: 'test_user'},
       });
 
       // Execute a prompt asking the agent to load the remote skill.

--- a/tests/integration/a2a/input_required/input_required_test.ts
+++ b/tests/integration/a2a/input_required/input_required_test.ts
@@ -42,8 +42,7 @@ describe('A2A: RemoteAgent InputRequired', () => {
       appName: 'caller',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'caller',
-      userId: 'caller-user',
+      scope: {appName: 'caller', userId: 'caller-user'},
     });
 
     const events: AdkEvent[] = [];
@@ -108,8 +107,7 @@ describe('A2A: RemoteAgent InputRequired', () => {
       appName: 'caller',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'caller',
-      userId: 'caller-user',
+      scope: {appName: 'caller', userId: 'caller-user'},
     });
 
     const events: AdkEvent[] = [];
@@ -167,8 +165,7 @@ describe('A2A: RemoteAgent InputRequired', () => {
       appName: 'caller',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'caller',
-      userId: 'caller-user',
+      scope: {appName: 'caller', userId: 'caller-user'},
     });
 
     const events: AdkEvent[] = [];

--- a/tests/integration/a2a/stream/stream_test.ts
+++ b/tests/integration/a2a/stream/stream_test.ts
@@ -39,8 +39,7 @@ describe('A2A: RemoteAgent Streaming', () => {
 
     const runner = new InMemoryRunner({agent: remoteAgent, appName: 'caller'});
     const session = await runner.sessionService.createSession({
-      appName: 'caller',
-      userId: 'caller-user',
+      scope: {appName: 'caller', userId: 'caller-user'},
     });
 
     const events: AdkEvent[] = [];
@@ -70,8 +69,7 @@ describe('A2A: RemoteAgent Streaming', () => {
 
     const runner = new InMemoryRunner({agent: remoteAgent, appName: 'caller'});
     const session = await runner.sessionService.createSession({
-      appName: 'caller',
-      userId: 'caller-user',
+      scope: {appName: 'caller', userId: 'caller-user'},
     });
 
     const events: AdkEvent[] = [];

--- a/tests/integration/context_compaction/tokens/agent_test.ts
+++ b/tests/integration/context_compaction/tokens/agent_test.ts
@@ -65,8 +65,7 @@ describe('Context Compaction with Tokens', () => {
       appName: 'compaction_agent',
     });
     const session = await runner.sessionService.createSession({
-      appName: 'compaction_agent',
-      userId: 'test_user',
+      scope: {appName: 'compaction_agent', userId: 'test_user'},
     });
 
     // Turn 1
@@ -100,9 +99,11 @@ describe('Context Compaction with Tokens', () => {
 
     // Assert that compaction occurred
     const updatedSession = await runner.sessionService.getSession({
-      sessionId: session.id,
-      userId: 'test_user',
-      appName: 'compaction_agent',
+      scope: {
+        sessionId: session.id,
+        userId: 'test_user',
+        appName: 'compaction_agent',
+      },
     });
     const hasCompactedEvent = updatedSession!.events.some(isCompactedEvent);
     // Depending on ADK's core implementation completeness for ContextCompactorRequestProcessor,

--- a/tests/integration/context_compaction/trajectory_thought_pruning_test.ts
+++ b/tests/integration/context_compaction/trajectory_thought_pruning_test.ts
@@ -79,8 +79,7 @@ describe('TrajectoryThoughtPruning Integration', () => {
     const userId = 'test_user';
     const runner = new InMemoryRunner({agent, appName});
     const session = await runner.sessionService.createSession({
-      appName,
-      userId,
+      scope: {appName, userId},
     });
 
     // --- Turn 1 ---
@@ -96,9 +95,7 @@ describe('TrajectoryThoughtPruning Integration', () => {
     }
 
     const sessionAfterTurn1 = await runner.sessionService.getSession({
-      appName,
-      userId,
-      sessionId: session.id,
+      scope: {appName, userId, sessionId: session.id},
     });
     expect(sessionAfterTurn1).toBeDefined();
     const events1 = sessionAfterTurn1!.events;
@@ -132,9 +129,7 @@ describe('TrajectoryThoughtPruning Integration', () => {
     }
 
     const sessionAfterTurn2 = await runner.sessionService.getSession({
-      appName,
-      userId,
-      sessionId: session.id,
+      scope: {appName, userId, sessionId: session.id},
     });
     const events2 = sessionAfterTurn2!.events;
     expect(events2.length).toBe(6);

--- a/tests/integration/memory/vertex_ai_memory_bank_service_test.ts
+++ b/tests/integration/memory/vertex_ai_memory_bank_service_test.ts
@@ -104,8 +104,7 @@ describe('VertexAiMemoryBankService Integration', () => {
 
     // Define a mock memory session
     const memorySession = await runner.sessionService.createSession({
-      appName: 'test_memory_app',
-      userId: 'test_user',
+      scope: {appName: 'test_memory_app', userId: 'test_user'},
     });
     await runner.sessionService.appendEvent({
       session: memorySession,
@@ -122,8 +121,7 @@ describe('VertexAiMemoryBankService Integration', () => {
     expect(mockMemories.generateInternal).toHaveBeenCalled();
 
     const session = await runner.sessionService.createSession({
-      appName: 'test_memory_app',
-      userId: 'test_user',
+      scope: {appName: 'test_memory_app', userId: 'test_user'},
     });
 
     let finalResponse = '';

--- a/tests/integration/state_dump_utils.ts
+++ b/tests/integration/state_dump_utils.ts
@@ -30,8 +30,7 @@ export async function createRunner(
   const appName = agent.name;
   const runner = new InMemoryRunner({agent: agent, appName, plugins});
   const session = await runner.sessionService.createSession({
-    appName,
-    userId,
+    scope: {appName, userId},
   });
 
   return {

--- a/tests/integration/streaming_sse/sse_agent_test.ts
+++ b/tests/integration/streaming_sse/sse_agent_test.ts
@@ -81,8 +81,7 @@ describe('SSE Streaming Model Response Integration', () => {
     const appName = sseAgent.name;
     const runner = new InMemoryRunner({agent: sseAgent, appName});
     const session = await runner.sessionService.createSession({
-      appName,
-      userId,
+      scope: {appName, userId},
     });
 
     const results: Event[] = [];
@@ -155,9 +154,7 @@ describe('SSE Streaming Model Response Integration', () => {
 
     // Fetch session history from DB and verify that the tool call is correctly saved
     const dbSession = await runner.sessionService.getSession({
-      appName,
-      userId,
-      sessionId: session.id,
+      scope: {appName, userId, sessionId: session.id},
     });
     expect(dbSession).toBeDefined();
 

--- a/tests/integration/test_case_utils.ts
+++ b/tests/integration/test_case_utils.ts
@@ -139,8 +139,7 @@ export async function createRunner(
   const appName = agent.name;
   const runner = new InMemoryRunner({agent: agent, appName, plugins});
   const session = await runner.sessionService.createSession({
-    appName,
-    userId,
+    scope: {appName, userId},
   });
 
   return {

--- a/tests/integration/tools/agent_tool_test.ts
+++ b/tests/integration/tools/agent_tool_test.ts
@@ -91,9 +91,7 @@ describe('AgentTool', () => {
     const memoryService = new InMemoryMemoryService();
 
     await sessionService.createSession({
-      appName: 'ADKTest',
-      userId: 'TestUser',
-      sessionId: '1',
+      scope: {appName: 'ADKTest', userId: 'TestUser', sessionId: '1'},
       state: {initialStateKey: 'contexto inicial'},
     });
 
@@ -118,9 +116,7 @@ describe('AgentTool', () => {
     }
 
     const session = await sessionService.getSession({
-      appName: 'ADKTest',
-      userId: 'TestUser',
-      sessionId: '1',
+      scope: {appName: 'ADKTest', userId: 'TestUser', sessionId: '1'},
     });
 
     expect(session).toBeDefined();

--- a/tests/integration/tools/agent_tool_vertexai_test.ts
+++ b/tests/integration/tools/agent_tool_vertexai_test.ts
@@ -165,9 +165,11 @@ describe('AgentTool (Vertex AI)', () => {
     });
 
     const createdSession = await sessionService.createSession({
-      appName:
-        'projects/1055446556895/locations/us-west1/reasoningEngines/9208858483368132608',
-      userId: 'TestUser',
+      scope: {
+        appName:
+          'projects/1055446556895/locations/us-west1/reasoningEngines/9208858483368132608',
+        userId: 'TestUser',
+      },
       state: {initialStateKey: 'contexto inicial'},
     });
 
@@ -193,10 +195,12 @@ describe('AgentTool (Vertex AI)', () => {
     }
 
     const session = await sessionService.getSession({
-      appName:
-        'projects/1055446556895/locations/us-west1/reasoningEngines/9208858483368132608',
-      userId: 'TestUser',
-      sessionId: createdSession.id,
+      scope: {
+        appName:
+          'projects/1055446556895/locations/us-west1/reasoningEngines/9208858483368132608',
+        userId: 'TestUser',
+        sessionId: createdSession.id,
+      },
     });
 
     expect(session).toBeDefined();

--- a/tests/integration/tools/load_artifacts_tool_test.ts
+++ b/tests/integration/tools/load_artifacts_tool_test.ts
@@ -65,9 +65,11 @@ describe('LoadArtifactsTool Integration', () => {
       'base64',
     );
     await runner.artifactService!.saveArtifact({
-      appName: 'test_artifact_app',
-      userId: 'test_user',
-      sessionId: session.id,
+      scope: {
+        appName: 'test_artifact_app',
+        userId: 'test_user',
+        sessionId: session.id,
+      },
       filename: 'test.csv',
       artifact: {
         inlineData: {

--- a/tests/integration/tools/load_artifacts_tool_test.ts
+++ b/tests/integration/tools/load_artifacts_tool_test.ts
@@ -56,8 +56,7 @@ describe('LoadArtifactsTool Integration', () => {
     });
 
     const session = await runner.sessionService.createSession({
-      appName: 'test_artifact_app',
-      userId: 'test_user',
+      scope: {appName: 'test_artifact_app', userId: 'test_user'},
     });
 
     // We manually add an artifact to the session using the artifactService

--- a/tests/integration/tools/load_memory_tool_test.ts
+++ b/tests/integration/tools/load_memory_tool_test.ts
@@ -57,8 +57,7 @@ describe('LoadMemoryTool Integration', () => {
 
     // We define a mock memory session
     const memorySession = await runner.sessionService.createSession({
-      appName: 'test_memory_app',
-      userId: 'test_user',
+      scope: {appName: 'test_memory_app', userId: 'test_user'},
     });
     await runner.sessionService.appendEvent({
       session: memorySession,
@@ -71,8 +70,7 @@ describe('LoadMemoryTool Integration', () => {
     await runner.memoryService!.addSessionToMemory(memorySession);
 
     const session = await runner.sessionService.createSession({
-      appName: 'test_memory_app',
-      userId: 'test_user',
+      scope: {appName: 'test_memory_app', userId: 'test_user'},
     });
     let finalResponse = '';
     let memoryLoaded = false;

--- a/tests/integration/tools/preload_memory_tool_test.ts
+++ b/tests/integration/tools/preload_memory_tool_test.ts
@@ -53,8 +53,7 @@ describe('PreloadMemoryTool Integration', () => {
 
     // We define a mock memory session
     const memorySession = await runner.sessionService.createSession({
-      appName: 'test_memory_app',
-      userId: 'test_user',
+      scope: {appName: 'test_memory_app', userId: 'test_user'},
     });
 
     // Create some events for memory
@@ -69,8 +68,7 @@ describe('PreloadMemoryTool Integration', () => {
     await runner.memoryService!.addSessionToMemory(memorySession);
 
     const session = await runner.sessionService.createSession({
-      appName: 'test_memory_app',
-      userId: 'test_user',
+      scope: {appName: 'test_memory_app', userId: 'test_user'},
     });
 
     let finalResponse = '';

--- a/tests/integration/tools/skills_registry_integration_test.ts
+++ b/tests/integration/tools/skills_registry_integration_test.ts
@@ -190,8 +190,7 @@ describe('Skills Registry Integration', () => {
     });
 
     const session = await runner.sessionService.createSession({
-      appName: 'test_skills_app',
-      userId: 'test_user',
+      scope: {appName: 'test_skills_app', userId: 'test_user'},
     });
 
     const events: Event[] = [];


### PR DESCRIPTION
### Summary
Refactors `BaseSessionService`, concrete implementations (`InMemorySessionService`, `DatabaseSessionService`, `VertexAiSessionService`), `runner.ts`, `agent_executor.ts`, `adk_api_client.ts`, `adk_api_server.ts`, and all 164 unit/integration/e2e test suites to take `scope: SessionScope | CreateSessionScope | UserScope` parameter signatures. (Part 3 of Composite Session/User Scope Key refactor)

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
