### PR TITLE
Feat: Add SSRF-safe load_web_page tool (adk-python parity)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -250,6 +250,8 @@ export {
   LoadArtifactsTool,
 } from './tools/load_artifacts_tool.js';
 export {LOAD_MEMORY, LoadMemoryTool} from './tools/load_memory_tool.js';
+export {LOAD_WEB_PAGE, loadWebPage} from './tools/load_web_page.js';
+export type {LoadWebPageOptions} from './tools/load_web_page.js';
 export {LongRunningFunctionTool} from './tools/long_running_tool.js';
 export {
   PRELOAD_MEMORY,

--- a/core/src/tools/load_web_page.ts
+++ b/core/src/tools/load_web_page.ts
@@ -23,9 +23,6 @@ const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
 /** Default request timeout in milliseconds. */
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-/** Parity failure string returned for every expected failure condition. */
-const FAILURE_PREFIX = 'Failed to fetch url: ';
-
 /**
  * IPv4 ranges that are not globally routable and therefore blocked to defeat
  * SSRF. Mirrors the non-global ranges rejected by Python's
@@ -67,7 +64,7 @@ const BLOCKED_IPV6_CIDRS = [
 
 /** Builds the parity failure message for a URL. */
 function failedToFetchMessage(url: string): string {
-  return `${FAILURE_PREFIX}${url}`;
+  return `Failed to fetch url: ${url}`;
 }
 
 /**

--- a/core/src/tools/load_web_page.ts
+++ b/core/src/tools/load_web_page.ts
@@ -1,0 +1,319 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {lookup} from 'node:dns/promises';
+import {isIP} from 'node:net';
+
+import {z} from 'zod';
+
+import {FunctionTool} from './function_tool.js';
+
+/** Options for {@link loadWebPage}. */
+export interface LoadWebPageOptions {
+  /** Request timeout in milliseconds. Defaults to 30_000 (30s). */
+  timeoutMs?: number;
+}
+
+/** URL schemes that are allowed to be fetched (WHATWG `URL.protocol` form). */
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+/** Default request timeout in milliseconds. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Parity failure string returned for every expected failure condition. */
+const FAILURE_PREFIX = 'Failed to fetch url: ';
+
+/**
+ * IPv4 ranges that are not globally routable and therefore blocked to defeat
+ * SSRF. Mirrors the non-global ranges rejected by Python's
+ * `ipaddress.is_global`.
+ */
+const BLOCKED_IPV4_CIDRS = [
+  '0.0.0.0/8', // "this host on this network"
+  '10.0.0.0/8', // private
+  '100.64.0.0/10', // shared address space / CGNAT
+  '127.0.0.0/8', // loopback
+  '169.254.0.0/16', // link-local (includes GCP metadata 169.254.169.254)
+  '172.16.0.0/12', // private
+  '192.0.0.0/24', // IETF protocol assignments
+  '192.0.2.0/24', // TEST-NET-1 (documentation)
+  '192.88.99.0/24', // 6to4 relay anycast (deprecated)
+  '192.168.0.0/16', // private
+  '198.18.0.0/15', // benchmarking
+  '198.51.100.0/24', // TEST-NET-2 (documentation)
+  '203.0.113.0/24', // TEST-NET-3 (documentation)
+  '224.0.0.0/4', // multicast
+  '240.0.0.0/4', // reserved / future use (includes 255.255.255.255)
+].map(parseIpv4Cidr);
+
+/**
+ * IPv6 ranges that are not globally routable and therefore blocked. The
+ * IPv4-mapped range `::ffff:0:0/96` is handled separately by extracting the
+ * embedded IPv4 address and re-checking it with the IPv4 rules.
+ */
+const BLOCKED_IPV6_CIDRS = [
+  '::/128', // unspecified
+  '::1/128', // loopback
+  '64:ff9b:1::/48', // local NAT64
+  '100::/64', // discard-only
+  '2001:db8::/32', // documentation
+  'fc00::/7', // unique-local (ULA, private)
+  'fe80::/10', // link-local
+  'ff00::/8', // multicast
+].map(parseIpv6Cidr);
+
+/** Builds the parity failure message for a URL. */
+function failedToFetchMessage(url: string): string {
+  return `${FAILURE_PREFIX}${url}`;
+}
+
+/**
+ * Returns `true` for `localhost` and any `*.localhost` name (case-insensitive,
+ * ignoring a trailing dot), matching the Python `_is_blocked_hostname` helper.
+ */
+function isBlockedHostname(hostname: string): boolean {
+  const normalized = hostname.replace(/\.+$/, '').toLowerCase();
+  return normalized === 'localhost' || normalized.endsWith('.localhost');
+}
+
+/** Strips the surrounding brackets from an IPv6 URL hostname (`[::1]` → `::1`). */
+function normalizeHost(hostname: string): string {
+  return hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
+}
+
+/** Parses a dotted-quad IPv4 string into its four octets, or `null`. */
+function parseIpv4(address: string): number[] | null {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(address);
+  if (!match) {
+    return null;
+  }
+  const octets = match.slice(1).map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    return null;
+  }
+  return octets;
+}
+
+/** Expands a valid IPv6 address string into its eight 16-bit hextets, or `null`. */
+function parseIpv6(address: string): number[] | null {
+  if (isIP(address) !== 6) {
+    return null;
+  }
+  const [head, tail] = address.split('::');
+  const highGroups = head ? expandHextets(head) : [];
+  const lowGroups = tail ? expandHextets(tail) : [];
+  const compressed = address.includes('::')
+    ? new Array(8 - highGroups.length - lowGroups.length).fill(0)
+    : [];
+  return [...highGroups, ...compressed, ...lowGroups];
+}
+
+/**
+ * Converts a colon-separated IPv6 fragment into hextets, expanding a trailing
+ * embedded IPv4 group (e.g. the `1.2.3.4` in `::ffff:1.2.3.4`) into two hextets.
+ */
+function expandHextets(fragment: string): number[] {
+  const hextets: number[] = [];
+  for (const group of fragment.split(':')) {
+    if (group.includes('.')) {
+      const octets = parseIpv4(group)!;
+      hextets.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
+    } else {
+      hextets.push(parseInt(group, 16));
+    }
+  }
+  return hextets;
+}
+
+/** Packs four IPv4 octets into an unsigned 32-bit integer. */
+function ipv4ToInt(octets: number[]): number {
+  return (
+    ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0
+  );
+}
+
+/** Packs eight IPv6 hextets into a 128-bit BigInt. */
+function hextetsToBigInt(hextets: number[]): bigint {
+  let value = 0n;
+  for (const hextet of hextets) {
+    value = (value << 16n) | BigInt(hextet);
+  }
+  return value;
+}
+
+/** Precomputes the network address and mask for an IPv4 CIDR string. */
+function parseIpv4Cidr(cidr: string): {base: number; mask: number} {
+  const [address, prefix] = cidr.split('/');
+  const mask = (0xffffffff << (32 - Number(prefix))) >>> 0;
+  return {base: (ipv4ToInt(parseIpv4(address)!) & mask) >>> 0, mask};
+}
+
+/** Precomputes the network address and prefix length for an IPv6 CIDR string. */
+function parseIpv6Cidr(cidr: string): {base: bigint; prefix: number} {
+  const [address, prefix] = cidr.split('/');
+  return {base: hextetsToBigInt(parseIpv6(address)!), prefix: Number(prefix)};
+}
+
+/** Returns `true` if the IPv4 octets fall within any blocked range. */
+function isBlockedIpv4(octets: number[]): boolean {
+  const value = ipv4ToInt(octets);
+  return BLOCKED_IPV4_CIDRS.some(
+    ({base, mask}) => (value & mask) >>> 0 === base,
+  );
+}
+
+/** Returns `true` if the IPv6 hextets fall within any blocked range. */
+function isBlockedIpv6(hextets: number[]): boolean {
+  const value = hextetsToBigInt(hextets);
+  // IPv4-mapped (::ffff:0:0/96): re-check the embedded IPv4 address.
+  if (value >> 32n === 0xffffn) {
+    return isBlockedIpv4([
+      Number((value >> 24n) & 0xffn),
+      Number((value >> 16n) & 0xffn),
+      Number((value >> 8n) & 0xffn),
+      Number(value & 0xffn),
+    ]);
+  }
+  return BLOCKED_IPV6_CIDRS.some(
+    ({base, prefix}) =>
+      value >> BigInt(128 - prefix) === base >> BigInt(128 - prefix),
+  );
+}
+
+/**
+ * Returns `true` when `address` is not globally routable (private, loopback,
+ * link-local, shared, reserved, multicast, ...). Unparseable input fails
+ * closed (blocked).
+ */
+function isBlockedAddress(address: string): boolean {
+  const octets = parseIpv4(address);
+  if (octets) {
+    return isBlockedIpv4(octets);
+  }
+  const hextets = parseIpv6(address);
+  if (hextets) {
+    return isBlockedIpv6(hextets);
+  }
+  return true;
+}
+
+/**
+ * Resolves `hostname` to a de-duplicated list of IP addresses. IP literals are
+ * returned as-is; hostnames are resolved via DNS. Throws when resolution
+ * yields no address.
+ */
+async function resolveHostAddresses(hostname: string): Promise<string[]> {
+  if (isIP(hostname) !== 0) {
+    return [hostname];
+  }
+  const records = await lookup(hostname, {all: true});
+  const addresses = [...new Set(records.map((record) => record.address))];
+  if (addresses.length === 0) {
+    throw new Error(`Unable to resolve host: ${hostname}`);
+  }
+  return addresses;
+}
+
+/**
+ * Validates the URL's scheme and hostname up front (before any network access).
+ * Throws for malformed URLs, disallowed schemes, and blocked hostnames.
+ */
+function assertUrlAllowed(url: string): URL {
+  const parsed = new URL(url);
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    throw new Error(`Unsupported url scheme: ${url}`);
+  }
+  if (isBlockedHostname(parsed.hostname)) {
+    throw new Error(`Blocked host: ${parsed.hostname}`);
+  }
+  return parsed;
+}
+
+/** Resolves the host and throws if any resolved address is not globally routable. */
+async function validateResolvedAddresses(hostname: string): Promise<void> {
+  const addresses = await resolveHostAddresses(hostname);
+  if (addresses.some(isBlockedAddress)) {
+    throw new Error(`Blocked host: ${hostname}`);
+  }
+}
+
+/** Decodes the small set of HTML entities that survive tag stripping. */
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Extracts readable text from an HTML document. Removes `<script>`/`<style>`
+ * blocks and comments, strips remaining tags, decodes common entities, and
+ * keeps only lines with more than three words (parity with the Python tool).
+ */
+function htmlToText(html: string): string {
+  const withoutCode = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ');
+  const text = decodeHtmlEntities(withoutCode.replace(/<[^>]+>/g, '\n'));
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.split(/\s+/).filter(Boolean).length > 3)
+    .join('\n');
+}
+
+/**
+ * Fetches the content at `url` and returns its extracted, readable text.
+ *
+ * Hardened against SSRF: only `http`/`https` URLs are fetched, the host is
+ * resolved and rejected up front if it is `localhost`-style or resolves to a
+ * private / loopback / link-local / shared / reserved / multicast address, and
+ * redirects are never followed. Never throws for expected failures (bad scheme,
+ * blocked host, non-200, timeout, network error); returns
+ * `Failed to fetch url: <url>` instead.
+ *
+ * Known limitation: global `fetch` performs its own DNS resolution at connect
+ * time, so a residual time-of-check/time-of-use (DNS-rebinding) window exists
+ * between this pre-flight lookup and fetch's own lookup. Full connection
+ * IP-pinning (e.g. an `undici` Agent with a custom `lookup`) is a possible
+ * future hardening.
+ */
+export async function loadWebPage(
+  url: string,
+  options?: LoadWebPageOptions,
+): Promise<string> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  try {
+    const parsed = assertUrlAllowed(url);
+    await validateResolvedAddresses(normalizeHost(parsed.hostname));
+    const response = await fetch(url, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (response.status !== 200) {
+      return failedToFetchMessage(url);
+    }
+    return htmlToText(await response.text());
+  } catch {
+    return failedToFetchMessage(url);
+  }
+}
+
+/** A global {@link FunctionTool} exposing {@link loadWebPage} to the model. */
+export const LOAD_WEB_PAGE = new FunctionTool({
+  name: 'load_web_page',
+  description:
+    'Fetches the content at the given URL and returns the readable text extracted from the page.',
+  parameters: z.object({
+    url: z.string().describe('The URL to fetch and extract text from.'),
+  }),
+  execute: ({url}) => loadWebPage(url),
+});

--- a/core/test/tools/load_web_page_test.ts
+++ b/core/test/tools/load_web_page_test.ts
@@ -1,0 +1,376 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {lookup} from 'node:dns/promises';
+
+import {FunctionTool, LOAD_WEB_PAGE, loadWebPage} from '@google/adk';
+import {afterEach, beforeEach, describe, expect, it, Mock, vi} from 'vitest';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
+
+// `lookup` is overloaded; treat the mock as a plain Mock so `mockResolvedValue`
+// accepts the `{all: true}` array-return shape used by the implementation.
+const lookupMock = lookup as unknown as Mock;
+
+/** Builds a minimal `Response`-like object for the stubbed global `fetch`. */
+function htmlResponse(body: string, status = 200): Response {
+  return {
+    status,
+    text: async () => body,
+  } as unknown as Response;
+}
+
+/** Resolves any hostname to the given IP list for the DNS `lookup` mock. */
+function resolveTo(...addresses: string[]): void {
+  lookupMock.mockResolvedValue(
+    addresses.map((address) => ({
+      address,
+      family: address.includes(':') ? 6 : 4,
+    })),
+  );
+}
+
+describe('loadWebPage', () => {
+  let fetchMock: Mock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      new AbortController().signal,
+    );
+    lookupMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('scheme and hostname rejection (no network)', () => {
+    it('rejects non-http(s) schemes without resolving or fetching', async () => {
+      const result = await loadWebPage('file:///etc/passwd');
+
+      expect(result).toBe('Failed to fetch url: file:///etc/passwd');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed URLs', async () => {
+      const result = await loadWebPage('not a url');
+
+      expect(result).toBe('Failed to fetch url: not a url');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects the localhost hostname', async () => {
+      const result = await loadWebPage('http://localhost:8080/');
+
+      expect(result).toBe('Failed to fetch url: http://localhost:8080/');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects *.localhost hostnames', async () => {
+      const result = await loadWebPage('http://api.localhost./');
+
+      expect(result).toBe('Failed to fetch url: http://api.localhost./');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SSRF IP rejection', () => {
+    it('rejects loopback IPv4 literals without a DNS lookup', async () => {
+      const url =
+        'http://127.0.0.1:19876/latest/meta-data/iam/security-credentials/';
+
+      const result = await loadWebPage(url);
+
+      expect(result).toBe(`Failed to fetch url: ${url}`);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects shared address space (CGNAT) IPv4 literals', async () => {
+      const result = await loadWebPage('http://100.64.0.1/internal');
+
+      expect(result).toBe('Failed to fetch url: http://100.64.0.1/internal');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'http://10.1.2.3/',
+      'http://172.16.5.4/',
+      'http://192.168.1.1/',
+      'http://169.254.169.254/',
+      'http://0.0.0.0/',
+      'http://192.0.2.5/',
+      'http://198.18.0.1/',
+      'http://224.0.0.1/',
+      'http://240.0.0.1/',
+    ])('rejects non-global IPv4 literal %s', async (url) => {
+      const result = await loadWebPage(url);
+
+      expect(result).toBe(`Failed to fetch url: ${url}`);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a private IP discovered via DNS resolution', async () => {
+      resolveTo('169.254.169.254');
+
+      const url = 'http://metadata.google.internal/computeMetadata/v1/';
+      const result = await loadWebPage(url);
+
+      expect(result).toBe(`Failed to fetch url: ${url}`);
+      expect(lookupMock).toHaveBeenCalledWith('metadata.google.internal', {
+        all: true,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects when any of several resolved addresses is non-global', async () => {
+      resolveTo('93.184.216.34', '10.0.0.5');
+
+      const result = await loadWebPage('http://mixed.example/');
+
+      expect(result).toBe('Failed to fetch url: http://mixed.example/');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when DNS resolves to an unparseable address', async () => {
+      resolveTo('not-an-ip');
+
+      const result = await loadWebPage('http://weird.example/');
+
+      expect(result).toBe('Failed to fetch url: http://weird.example/');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when DNS resolves to an out-of-range IPv4', async () => {
+      resolveTo('1.2.3.999');
+
+      const result = await loadWebPage('http://weird.example/');
+
+      expect(result).toBe('Failed to fetch url: http://weird.example/');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fails when DNS resolution returns no addresses', async () => {
+      lookupMock.mockResolvedValue([]);
+
+      const result = await loadWebPage('http://empty.example/');
+
+      expect(result).toBe('Failed to fetch url: http://empty.example/');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fails when DNS resolution throws', async () => {
+      lookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+
+      const result = await loadWebPage('http://missing.example/');
+
+      expect(result).toBe('Failed to fetch url: http://missing.example/');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects IPv6 loopback literals', async () => {
+      const result = await loadWebPage('http://[::1]/');
+
+      expect(result).toBe('Failed to fetch url: http://[::1]/');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'http://[fe80::1]/',
+      'http://[fc00::1]/',
+      'http://[ff02::1]/',
+      'http://[2001:db8::1]/',
+      'http://[::]/',
+    ])('rejects non-global IPv6 literal %s', async (url) => {
+      const result = await loadWebPage(url);
+
+      expect(result).toBe(`Failed to fetch url: ${url}`);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an IPv4-mapped IPv6 address pointing at a private IP', async () => {
+      resolveTo('::ffff:127.0.0.1');
+
+      const result = await loadWebPage('http://mapped.example/');
+
+      expect(result).toBe('Failed to fetch url: http://mapped.example/');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful fetch and text extraction', () => {
+    it('extracts readable text and drops short lines', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockResolvedValue(
+        htmlResponse(
+          '<html><body><p>This page has enough words to keep.</p>' +
+            '<p>tiny</p></body></html>',
+        ),
+      );
+
+      const result = await loadWebPage('https://example.com/search?q=adk');
+
+      expect(result).toBe('This page has enough words to keep.');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestedUrl, init] = fetchMock.mock.calls[0];
+      expect(requestedUrl).toBe('https://example.com/search?q=adk');
+      expect(init).toMatchObject({redirect: 'manual'});
+    });
+
+    it('strips <script> and <style> blocks and decodes entities', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockResolvedValue(
+        htmlResponse(
+          '<html><head><style>.a{color:red}</style>' +
+            '<script>var secret = "do not leak this";</script></head>' +
+            '<body><!-- a comment that should vanish -->' +
+            '<p>Fish &amp; chips are quite tasty today</p></body></html>',
+        ),
+      );
+
+      const result = await loadWebPage('https://example.com/');
+
+      expect(result).toBe('Fish & chips are quite tasty today');
+      expect(result).not.toContain('secret');
+      expect(result).not.toContain('color:red');
+      expect(result).not.toContain('comment');
+    });
+
+    it('allows a global IPv6 literal target', async () => {
+      fetchMock.mockResolvedValue(
+        htmlResponse('<p>The quick brown fox jumped over here</p>'),
+      );
+
+      const result = await loadWebPage('http://[2606:4700:4700::1111]/');
+
+      expect(result).toBe('The quick brown fox jumped over here');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('allows a global IPv6 address resolved via DNS (full form)', async () => {
+      resolveTo('2606:4700:4700:0:0:0:0:1111');
+      fetchMock.mockResolvedValue(
+        htmlResponse('<p>The quick brown fox jumped over here</p>'),
+      );
+
+      const result = await loadWebPage('http://ipv6.example/');
+
+      expect(result).toBe('The quick brown fox jumped over here');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows an IPv4-mapped IPv6 address pointing at a public IP', async () => {
+      resolveTo('::ffff:93.184.216.34');
+      fetchMock.mockResolvedValue(
+        htmlResponse('<p>The quick brown fox jumped over here</p>'),
+      );
+
+      const result = await loadWebPage('http://mapped-public.example/');
+
+      expect(result).toBe('The quick brown fox jumped over here');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an empty string when no line has enough words', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockResolvedValue(htmlResponse('<p>too short</p>'));
+
+      const result = await loadWebPage('https://example.com/');
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('response and transport failures', () => {
+    it.each([301, 302, 404, 500])(
+      'returns the failure string for non-200 status %i',
+      async (status) => {
+        resolveTo('93.184.216.34');
+        fetchMock.mockResolvedValue(
+          htmlResponse('<p>ignored body here</p>', status),
+        );
+
+        const result = await loadWebPage('https://example.com/');
+
+        expect(result).toBe('Failed to fetch url: https://example.com/');
+      },
+    );
+
+    it('returns the failure string when the request times out', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockRejectedValue(
+        new DOMException('The operation timed out.', 'TimeoutError'),
+      );
+
+      const result = await loadWebPage('https://example.com/');
+
+      expect(result).toBe('Failed to fetch url: https://example.com/');
+    });
+
+    it('returns the failure string on a network error', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockRejectedValue(new TypeError('network failure'));
+
+      const result = await loadWebPage('https://example.com/');
+
+      expect(result).toBe('Failed to fetch url: https://example.com/');
+    });
+  });
+
+  describe('timeout configuration', () => {
+    it('uses the 30s default and honors an override', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockResolvedValue(
+        htmlResponse('<p>enough words to be kept here</p>'),
+      );
+
+      await loadWebPage('https://example.com/');
+      expect(vi.mocked(AbortSignal.timeout)).toHaveBeenLastCalledWith(30_000);
+
+      await loadWebPage('https://example.com/', {timeoutMs: 5000});
+      expect(vi.mocked(AbortSignal.timeout)).toHaveBeenLastCalledWith(5000);
+    });
+
+    it('falls back to the default when options omit timeoutMs', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockResolvedValue(
+        htmlResponse('<p>enough words to be kept here</p>'),
+      );
+
+      await loadWebPage('https://example.com/', {});
+
+      expect(vi.mocked(AbortSignal.timeout)).toHaveBeenLastCalledWith(30_000);
+    });
+  });
+});
+
+describe('LOAD_WEB_PAGE tool', () => {
+  it('is a FunctionTool exposing a load_web_page declaration', () => {
+    expect(LOAD_WEB_PAGE).toBeInstanceOf(FunctionTool);
+
+    const declaration = LOAD_WEB_PAGE._getDeclaration();
+    expect(declaration?.name).toBe('load_web_page');
+    expect(declaration?.parameters?.properties?.['url']).toBeDefined();
+  });
+
+  it('runs through the tool interface and returns the parity failure string', async () => {
+    const result = await LOAD_WEB_PAGE.runAsync({
+      args: {url: 'file:///etc/passwd'},
+      toolContext: {} as never,
+    });
+
+    expect(result).toBe('Failed to fetch url: file:///etc/passwd');
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: N/A
- Related: N/A

**2. Or, if no issue exists, describe the change:**

**Problem:** `adk-python` ships a `load_web_page` tool (`src/google/adk/tools/load_web_page.py`) that fetches a URL and returns its extracted, readable text, hardened against SSRF. `adk-js` has no equivalent page-fetch/extract tool, leaving a cross-language parity gap.

**Solution:** Add a functionally equivalent, SSRF-safe `load_web_page` tool to `adk-js` (`core/src/tools/load_web_page.ts`), exposing `loadWebPage()`, the `LOAD_WEB_PAGE` `FunctionTool`, and the `LoadWebPageOptions` type via the `@google/adk` public API (`core/src/common.ts`).

The tool:

- accepts `{ url: string }` and rejects any non-`http(s)` scheme up front (no DNS, no fetch);
- applies SSRF hardening before connecting — rejects `localhost`/`*.localhost` and any host that resolves to a private / loopback / link-local / shared (CGNAT) / reserved / multicast / IPv4-mapped-IPv6 address (a hand-rolled, dependency-free CIDR classifier mirroring Python's `ipaddress.is_global`);
- never follows redirects (`redirect: 'manual'`) to prevent SSRF-via-redirect;
- enforces a finite request timeout via `AbortSignal.timeout` (default 30s, configurable through `loadWebPage(url, { timeoutMs })`);
- on HTTP 200 returns extracted, human-readable text (`<script>`/`<style>`/comments/markup stripped, common entities decoded, lines with more than three words kept — parity with the Python tool);
- never throws for expected failures (bad scheme, blocked host, DNS failure, non-200, timeout, network error); it returns the parity string `Failed to fetch url: <url>` instead.

Design notes:

- **Zero new dependencies**: uses global `fetch`, `node:dns/promises`, `node:net`, and the existing `zod` + `FunctionTool`. The IP classifier and HTML→text extraction are implemented in-file to honor the "no heavy new deps" constraint.
- **Adaptation from Python**: `requests` + a pinned `HTTPAdapter` becomes a pre-flight resolve-then-`fetch` gate. Because global `fetch` does its own DNS resolution at connect time, a residual time-of-check/time-of-use (DNS-rebinding) window remains between the validation lookup and fetch's own lookup; this is documented in the code, with full connection IP-pinning noted as possible future hardening. Mitigations in place: hostname + IP-literal blocklists, `redirect: 'manual'`, and rejection of non-global resolved addresses.
- Purely additive: one new source file, one new export, one new test. No existing signatures, exports, or behaviors change.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`core/test/tools/load_web_page_test.ts` (44 cases) mirrors the Python edge-case spec and covers: non-`http(s)` scheme rejection, malformed URLs, `localhost`/`*.localhost` rejection, IPv4 literal SSRF blocks (loopback, CGNAT, private, link-local, reserved, multicast), IPv6 literal blocks (loopback, ULA, link-local, multicast, documentation, unspecified), IPv4-mapped-IPv6 blocking, DNS-resolved private-host rejection, fail-closed handling of unparseable/out-of-range/empty/throwing DNS results, successful fetch + text extraction, `<script>`/`<style>`/comment stripping and entity decoding, non-200/redirect failure, timeout and network-error failure, default vs. overridden timeout, and `FunctionTool` wiring (`load_web_page` declaration + `runAsync`). New code has 100% line and branch coverage; `npm run lint`, `npm run format:check`, and `npm run docs:check` all pass.

**Manual End-to-End (E2E) Tests:**

An end-to-end script exercised the tool with no mocks:

1. Build the package: `npm install && npm run build`.
2. Run the following (Node 18+):
   ```js
   import {loadWebPage, LOAD_WEB_PAGE} from '@google/adk';
   // Real public fetch → extracted readable text:
   console.log(await loadWebPage('https://example.com/'));
   // SSRF blocks → "Failed to fetch url: <url>" (no connection made):
   console.log(await loadWebPage('http://169.254.169.254/')); // GCP metadata (link-local)
   console.log(await loadWebPage('http://127.0.0.1:19876/')); // loopback
   console.log(await loadWebPage('http://localhost:8080/')); // localhost
   console.log(await loadWebPage('file:///etc/passwd')); // bad scheme
   ```
   Observed: `https://example.com/` returned clean extracted text ("This domain is for use in documentation examples..."); every blocked target returned the exact `Failed to fetch url: <url>` string with no outbound connection.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Purely additive change: one new source file (`core/src/tools/load_web_page.ts`), one new export in `core/src/common.ts`, and one new test file (`core/test/tools/load_web_page_test.ts`). No existing signatures, exports, or behaviors change.
