### PR TITLE
Feat: Add EnterpriseWebSearchTool for Gemini web grounding (adk-python parity)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -236,6 +236,10 @@ export type {
 export {BaseToolset, isBaseToolset} from './tools/base_toolset.js';
 export type {ToolPredicate} from './tools/base_toolset.js';
 export {ConsolidateContextTool} from './tools/consolidate_context_tool.js';
+export {
+  ENTERPRISE_WEB_SEARCH,
+  EnterpriseWebSearchTool,
+} from './tools/enterprise_web_search_tool.js';
 export {ExampleTool} from './tools/example_tool.js';
 export {EXIT_LOOP, ExitLoopTool} from './tools/exit_loop_tool.js';
 export {FunctionTool, isFunctionTool} from './tools/function_tool.js';

--- a/core/src/tools/enterprise_web_search_tool.ts
+++ b/core/src/tools/enterprise_web_search_tool.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {GenerateContentConfig} from '@google/genai';
+
+import {LlmRequest} from '../models/llm_request.js';
+import {
+  isGemini1Model,
+  isGeminiModel,
+  isGeminiModelIdCheckDisabled,
+} from '../utils/model_name.js';
+
+import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+
+/**
+ * Appends the Enterprise Web Search built-in tool to the LLM request when the
+ * target model supports it.
+ *
+ * NOTE: This is NOT Vertex AI Search (formerly "Enterprise Search"). See
+ * https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/web-grounding-enterprise
+ */
+export function applyEnterpriseWebSearch(llmRequest: LlmRequest): void {
+  if (!llmRequest.model) {
+    return;
+  }
+
+  const modelCheckDisabled = isGeminiModelIdCheckDisabled();
+  llmRequest.config = llmRequest.config || ({} as GenerateContentConfig);
+  llmRequest.config.tools = llmRequest.config.tools || [];
+
+  if (isGeminiModel(llmRequest.model) || modelCheckDisabled) {
+    if (
+      isGemini1Model(llmRequest.model) &&
+      llmRequest.config.tools.length > 0
+    ) {
+      throw new Error(
+        'Enterprise Web Search tool cannot be used with other tools in Gemini 1.x.',
+      );
+    }
+
+    llmRequest.config.tools.push({enterpriseWebSearch: {}});
+
+    return;
+  }
+
+  throw new Error(
+    `Enterprise Web Search tool is not supported for model ${llmRequest.model}`,
+  );
+}
+
+/**
+ * A Gemini 2+ built-in tool that grounds responses on public web data via
+ * Vertex AI Search with Enterprise (Sec4) compliance.
+ *
+ * This tool operates internally within the model and does not require or
+ * perform local code execution.
+ */
+export class EnterpriseWebSearchTool extends BaseTool {
+  constructor() {
+    super({
+      name: 'enterprise_web_search',
+      description: 'Enterprise Web Search Tool',
+    });
+  }
+
+  runAsync(): Promise<unknown> {
+    // This is a built-in tool on server side, it's triggered by setting the
+    // corresponding request parameters.
+    return Promise.resolve();
+  }
+
+  override async processLlmRequest({
+    llmRequest,
+  }: ToolProcessLlmRequest): Promise<void> {
+    applyEnterpriseWebSearch(llmRequest);
+  }
+}
+
+/**
+ * A global instance of {@link EnterpriseWebSearchTool}.
+ */
+export const ENTERPRISE_WEB_SEARCH = new EnterpriseWebSearchTool();

--- a/core/test/tools/enterprise_web_search_tool_test.ts
+++ b/core/test/tools/enterprise_web_search_tool_test.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ENTERPRISE_WEB_SEARCH,
+  EnterpriseWebSearchTool,
+  LlmRequest,
+} from '@google/adk';
+import {Tool} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+
+function makeRequest(model?: string, tools: Tool[] = []): LlmRequest {
+  return {
+    model,
+    config: {tools},
+    contents: [],
+    toolsDict: {},
+    liveConnectConfig: {},
+  } as unknown as LlmRequest;
+}
+
+describe('EnterpriseWebSearchTool', () => {
+  describe('processLlmRequest', () => {
+    it('returns early when model is not set', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req = makeRequest(undefined);
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config?.tools).toEqual([]);
+    });
+
+    it('adds enterpriseWebSearch for Gemini 2+ model', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req = makeRequest('gemini-2.0-flash');
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{enterpriseWebSearch: {}}]);
+    });
+
+    it('adds enterpriseWebSearch for path-form Gemini 2+ model', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req = makeRequest(
+        'projects/test-project/locations/global/publishers/google/models/gemini-2.5-flash',
+      );
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{enterpriseWebSearch: {}}]);
+    });
+
+    it('initializes config.tools when config is absent', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req: LlmRequest = {
+        model: 'gemini-2.0-flash',
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      } as unknown as LlmRequest;
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{enterpriseWebSearch: {}}]);
+    });
+
+    it('adds enterpriseWebSearch for Gemini 1.x model with no other tools', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req = makeRequest('gemini-1.5-pro');
+      await tool.processLlmRequest({
+        llmRequest: req,
+        toolContext: {} as never,
+      });
+
+      expect(req.config!.tools).toEqual([{enterpriseWebSearch: {}}]);
+    });
+
+    it('throws when Gemini 1.x model already has other tools', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req = makeRequest('gemini-1.5-flash', [{googleSearch: {}}]);
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow(
+        'Enterprise Web Search tool cannot be used with other tools in Gemini 1.x.',
+      );
+    });
+
+    it('throws for unsupported (non-Gemini) model', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req = makeRequest('gpt-4o');
+      await expect(
+        tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        }),
+      ).rejects.toThrow(
+        'Enterprise Web Search tool is not supported for model gpt-4o',
+      );
+    });
+
+    it('adds enterpriseWebSearch for non-Gemini model when check is disabled', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      const req = makeRequest('internal-model-v1');
+
+      const originalValue = process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK;
+      process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK = 'true';
+
+      try {
+        await tool.processLlmRequest({
+          llmRequest: req,
+          toolContext: {} as never,
+        });
+        expect(req.config!.tools).toEqual([{enterpriseWebSearch: {}}]);
+      } finally {
+        if (originalValue === undefined) {
+          delete process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK;
+        } else {
+          process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK = originalValue;
+        }
+      }
+    });
+
+    it('runAsync returns resolved promise', async () => {
+      const tool = new EnterpriseWebSearchTool();
+      await expect(tool.runAsync()).resolves.toBeUndefined();
+    });
+  });
+
+  it('has a global instance ENTERPRISE_WEB_SEARCH', () => {
+    expect(ENTERPRISE_WEB_SEARCH).toBeInstanceOf(EnterpriseWebSearchTool);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

**Problem:** `adk-python` ships an `EnterpriseWebSearchTool` — a Gemini 2+ built-in tool that grounds model responses on public web data via Vertex AI Search with Sec4/Enterprise compliance ("Web Grounding for Enterprise"). `adk-js` had `GoogleSearchTool`, `VertexAiSearchTool`, and `UrlContextTool` but no enterprise web search built-in, leaving a cross-language parity gap. (Note: this is distinct from Vertex AI Search / `VertexAiSearchTool`, which is a datastore/engine retrieval tool; this is the model built-in `enterpriseWebSearch` grounding source.)

**Solution:** Add `EnterpriseWebSearchTool` (extending `BaseTool`) to `adk-js` with behavior identical to the Python reference. Like the other built-in grounding tools it performs no client-side execution; it only mutates the outgoing `LlmRequest` inside `processLlmRequest(...)` by appending `{enterpriseWebSearch: {}}` to `llmRequest.config.tools` after validating the target model. The implementation deliberately mirrors the existing sibling `google_maps_grounding_tool.ts` idiom — an extracted standalone `applyEnterpriseWebSearch(llmRequest)` function that the class method delegates to, plus honoring the `ADK_DISABLE_GEMINI_MODEL_ID_CHECK` escape hatch via the shared `isGeminiModel` / `isGemini1Model` / `isGeminiModelIdCheckDisabled` utilities. Model handling matches the reference exactly: Gemini 2+ (including `projects/.../models/...` path form) appends the built-in; Gemini 1.x appends only when no other tools are present and otherwise throws `'Enterprise Web Search tool cannot be used with other tools in Gemini 1.x.'`; non-Gemini models throw `'Enterprise Web Search tool is not supported for model <model>'` unless the model-id check is disabled. The tool and its singleton `ENTERPRISE_WEB_SEARCH` are exported from the public API via `common.ts` (re-exported by `index.ts`). No new runtime dependencies — `@google/genai` already provides `Tool.enterpriseWebSearch`. Purely additive; no existing signatures, exports, or behavior change.

Usage:

```ts
import {LlmAgent, ENTERPRISE_WEB_SEARCH} from '@google/adk';

const agent = new LlmAgent({
  name: 'enterprise_researcher',
  model: 'gemini-2.5-flash',
  tools: [ENTERPRISE_WEB_SEARCH],
});
```

Reference docs: https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/web-grounding-enterprise

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `core/test/tools/enterprise_web_search_tool_test.ts` (mirrors `google_search_tool_test.ts` / `google_maps_grounding_tool_test.ts`; mock-free; imports via the `@google/adk` public entry point). It covers every branch of `applyEnterpriseWebSearch` for 100% line and branch coverage of the new file:

- model unset → early return (no mutation)
- Gemini 2+ plain id (`gemini-2.0-flash`) → `[{enterpriseWebSearch: {}}]`
- Gemini 2+ path form (`projects/.../models/gemini-2.5-flash`) → `[{enterpriseWebSearch: {}}]` (parity with the Python parametrized case; also pins the path-aware `isGeminiModel` delegation)
- `config` absent → `config`/`config.tools` initialized
- Gemini 1.x with no other tools (`gemini-1.5-pro`) → appended (does not throw)
- Gemini 1.x with an existing tool (`gemini-1.5-flash` + `googleSearch`) → throws the "other tools in Gemini 1.x" error
- non-Gemini (`gpt-4o`) → throws "not supported for model"
- non-Gemini with `ADK_DISABLE_GEMINI_MODEL_ID_CHECK=true` (saved/restored in `finally`) → appended
- `runAsync()` resolves to `undefined`
- exported singleton `ENTERPRISE_WEB_SEARCH` is an instance of the tool

Commands run locally (from `adk-js/`):

- `npm run test:unit -- core/test/tools/enterprise_web_search_tool_test.ts` → 10 passed
- coverage for `core/src/tools/enterprise_web_search_tool.ts` → 100% statements / branches / functions / lines
- `npm run lint` → clean
- `npm run build` → clean (TypeScript declaration emit for the new public export succeeds)

**Manual End-to-End (E2E) Tests:**

The unit tests are mock-free and exercise the real public `processLlmRequest` — the exact method the flow invokes at `llm_agent.ts` — on real `LlmRequest` objects, asserting the real request mutation (the tool's only observable behavior). A live grounding call cannot run in CI because Web Grounding for Enterprise requires a Vertex AI project with enterprise entitlement; the sibling built-ins (`GoogleSearchTool`, `GoogleMapsGroundingTool`) likewise have no live E2E for this reason. To manually verify against a real backend:

1. Authenticate to a GCP project entitled for Web Grounding for Enterprise and set the standard ADK/Vertex environment variables (`GOOGLE_GENAI_USE_VERTEXAI=true`, `GOOGLE_CLOUD_PROJECT=<your-project>`, `GOOGLE_CLOUD_LOCATION=<your-region>`).
2. Build an agent with the tool:
   ```ts
   import {
     LlmAgent,
     ENTERPRISE_WEB_SEARCH,
     Runner,
     InMemorySessionService,
   } from '@google/adk';
   const agent = new LlmAgent({
     name: 'enterprise_researcher',
     model: 'gemini-2.5-flash',
     tools: [ENTERPRISE_WEB_SEARCH],
   });
   ```
3. Run a query that needs fresh public web facts (e.g. a recent news event) and confirm the response is grounded (grounding metadata / citations present) and that no local tool execution occurs.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR brings `adk-js` to parity with `adk-python`'s `EnterpriseWebSearchTool`. It is purely additive: a new tool file plus its unit test, and a single public re-export line in `common.ts`. No existing exports, signatures, or behavior change.
