### PR TITLE
Docs: document minimum supported Node.js version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ web runtimes.
 
 ## 🚀 Installation
 
-> **Prerequisite:** ADK for TypeScript requires Node.js 18 or newer.
+> **Prerequisite:** ADK for TypeScript requires a current Node.js LTS release.
 
 ```bash
 npm install @google/adk

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ web runtimes.
 
 ## 🚀 Installation
 
+> **Prerequisite:** ADK for TypeScript requires Node.js 18 or newer.
+
 ```bash
 npm install @google/adk
 npm install -D @google/adk-devtools


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

**Problem:**
The `README.md` Installation section does not state which Node.js runtime is
required. New users can run `npm install @google/adk` on an unsupported Node.js
version and hit cryptic runtime failures.

**Solution:**
Add a single short prerequisite note directly under the `## 🚀 Installation`
heading stating that ADK for TypeScript requires Node.js 18 or newer. This is
the most discoverable spot for a runtime requirement. The repository declares no
`engines.node` field in any `package.json` (root or workspace manifests), so the
note uses the mandated fallback version of "Node.js 18 or newer" rather than
inferring one from dev/type dependencies. The change is a 2-line docs edit (one
blockquote line plus a surrounding blank line) and touches no other content.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**

This is a documentation-only change, so no automated tests apply. Verified
manually:

1. Opened `README.md` and confirmed exactly one sentence about the minimum
   Node.js version now appears under `## 🚀 Installation`.
2. Confirmed the stated version is "Node.js 18 or newer".
3. Confirmed `git diff main` shows only the added line(s) and no other content
   changed.
4. Confirmed the Markdown renders correctly (heading, blockquote note, and code
   block all display properly) and the change is consistent with the repo's
   Prettier config (`printWidth: 80`, default `proseWrap`).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Documentation-only change; no additional context to add.
