### PR TITLE
fix(security): require confirmation before executing inline skill scripts

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -46,7 +46,10 @@ export {
   loadSkillFromDir,
   validateSkillDir,
 } from './skills/loader.js';
-export {RunSkillInlineScriptTool} from './tools/skill/run_skill_inline_script_tool.js';
+export {
+  RunSkillInlineScriptErrorCode,
+  RunSkillInlineScriptTool,
+} from './tools/skill/run_skill_inline_script_tool.js';
 export {RunSkillScriptTool} from './tools/skill/run_skill_script_tool.js';
 
 export * from './integrations/agent_registry/agent_registry.js';

--- a/core/src/tools/skill/run_skill_inline_script_tool.ts
+++ b/core/src/tools/skill/run_skill_inline_script_tool.ts
@@ -14,6 +14,19 @@ import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
 import {SkillToolset} from './skill_toolset.js';
 
 /**
+ * Error codes returned by {@link RunSkillInlineScriptTool} when a call cannot
+ * be completed. The string values are part of the tool's response contract and
+ * must remain stable.
+ */
+export enum RunSkillInlineScriptErrorCode {
+  MISSING_SCRIPT_CONTENT = 'MISSING_SCRIPT_CONTENT',
+  MISSING_LANGUAGE = 'MISSING_LANGUAGE',
+  NO_CODE_EXECUTOR = 'NO_CODE_EXECUTOR',
+  EXECUTION_ERROR = 'EXECUTION_ERROR',
+  CONFIRMATION_REJECTED = 'CONFIRMATION_REJECTED',
+}
+
+/**
  * Message returned while the tool call is paused waiting for the client to
  * confirm (or reject) execution of the model-provided inline script. Mirrors
  * the intermediate message used by the tool-confirmation flow elsewhere in the
@@ -78,13 +91,13 @@ export class RunSkillInlineScriptTool extends BaseTool {
     if (!inlineScriptContent) {
       return {
         error: 'Script content is required.',
-        errorCode: 'MISSING_SCRIPT_CONTENT',
+        errorCode: RunSkillInlineScriptErrorCode.MISSING_SCRIPT_CONTENT,
       };
     }
     if (!language) {
       return {
         error: 'Language is required.',
-        errorCode: 'MISSING_LANGUAGE',
+        errorCode: RunSkillInlineScriptErrorCode.MISSING_LANGUAGE,
       };
     }
 
@@ -99,7 +112,7 @@ export class RunSkillInlineScriptTool extends BaseTool {
     if (!codeExecutor) {
       return {
         error: 'No code executor configured.',
-        errorCode: 'NO_CODE_EXECUTOR',
+        errorCode: RunSkillInlineScriptErrorCode.NO_CODE_EXECUTOR,
       };
     }
 
@@ -134,7 +147,7 @@ export class RunSkillInlineScriptTool extends BaseTool {
     } catch (e: unknown) {
       return {
         error: `Failed to execute inline script: ${(e as Error).message}`,
-        errorCode: 'EXECUTION_ERROR',
+        errorCode: RunSkillInlineScriptErrorCode.EXECUTION_ERROR,
       };
     }
   }
@@ -155,7 +168,10 @@ export class RunSkillInlineScriptTool extends BaseTool {
     toolContext: Context,
     scriptContent: string,
     language: string,
-  ): {partial: string} | {error: string; errorCode: string} | undefined {
+  ):
+    | {partial: string}
+    | {error: string; errorCode: RunSkillInlineScriptErrorCode}
+    | undefined {
     const confirmation = toolContext.toolConfirmation;
 
     if (!confirmation) {
@@ -173,7 +189,7 @@ export class RunSkillInlineScriptTool extends BaseTool {
     if (!confirmation.confirmed) {
       return {
         error: 'Inline script execution was not confirmed and was rejected.',
-        errorCode: 'CONFIRMATION_REJECTED',
+        errorCode: RunSkillInlineScriptErrorCode.CONFIRMATION_REJECTED,
       };
     }
 

--- a/core/src/tools/skill/run_skill_inline_script_tool.ts
+++ b/core/src/tools/skill/run_skill_inline_script_tool.ts
@@ -5,12 +5,22 @@
  */
 
 import {FunctionDeclaration, Type} from '@google/genai';
+import {Context} from '../../agents/context.js';
 import {isLlmAgent} from '../../agents/llm_agent.js';
 import {CodeExecutionLanguage} from '../../code_executors/code_execution_utils.js';
 import {experimental} from '../../utils/experimental.js';
 import {materializeFiles} from '../../utils/file_utils.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
 import {SkillToolset} from './skill_toolset.js';
+
+/**
+ * Message returned while the tool call is paused waiting for the client to
+ * confirm (or reject) execution of the model-provided inline script. Mirrors
+ * the intermediate message used by the tool-confirmation flow elsewhere in the
+ * codebase (see `SecurityPlugin`).
+ */
+const REQUIRE_CONFIRMATION_MESSAGE =
+  'This tool call needs external confirmation before completion.';
 
 @experimental
 export class RunSkillInlineScriptTool extends BaseTool {
@@ -93,6 +103,19 @@ export class RunSkillInlineScriptTool extends BaseTool {
       };
     }
 
+    // Security gate: executing model-provided script content is equivalent to
+    // arbitrary code execution in the code executor's context. Require an
+    // explicit, server-enforced confirmation before dispatching so that a
+    // prompt-injection cannot silently run code. See b/508330164.
+    const confirmationResult = this.enforceConfirmation(
+      toolContext,
+      inlineScriptContent,
+      language,
+    );
+    if (confirmationResult) {
+      return confirmationResult;
+    }
+
     try {
       const result = await codeExecutor.executeCode({
         invocationContext: toolContext.invocationContext,
@@ -114,5 +137,46 @@ export class RunSkillInlineScriptTool extends BaseTool {
         errorCode: 'EXECUTION_ERROR',
       };
     }
+  }
+
+  /**
+   * Enforces a human-in-the-loop confirmation gate before executing an inline
+   * script, using the repo's standard tool-confirmation mechanism.
+   *
+   * - When no confirmation has been provided yet, a confirmation is requested
+   *   (surfacing the language and script that would run) and an intermediate
+   *   result is returned so the tool call pauses until the client responds.
+   * - When a confirmation exists but was not confirmed, a rejection error is
+   *   returned and execution is refused.
+   * - When the confirmation is confirmed, `undefined` is returned to allow the
+   *   caller to proceed with execution.
+   */
+  private enforceConfirmation(
+    toolContext: Context,
+    scriptContent: string,
+    language: string,
+  ): {partial: string} | {error: string; errorCode: string} | undefined {
+    const confirmation = toolContext.toolConfirmation;
+
+    if (!confirmation) {
+      toolContext.requestConfirmation({
+        hint:
+          'Confirmation is required before executing an inline skill script. ' +
+          `The agent requested to run the following ${language} script in the ` +
+          'code executor. Only approve if you trust its contents:\n\n' +
+          scriptContent,
+        payload: {language, scriptContent},
+      });
+      return {partial: REQUIRE_CONFIRMATION_MESSAGE};
+    }
+
+    if (!confirmation.confirmed) {
+      return {
+        error: 'Inline script execution was not confirmed and was rejected.',
+        errorCode: 'CONFIRMATION_REJECTED',
+      };
+    }
+
+    return undefined;
   }
 }

--- a/core/src/tools/skill/run_skill_inline_script_tool.ts
+++ b/core/src/tools/skill/run_skill_inline_script_tool.ts
@@ -106,7 +106,7 @@ export class RunSkillInlineScriptTool extends BaseTool {
     // Security gate: executing model-provided script content is equivalent to
     // arbitrary code execution in the code executor's context. Require an
     // explicit, server-enforced confirmation before dispatching so that a
-    // prompt-injection cannot silently run code. See b/508330164.
+    // prompt-injection cannot silently run code.
     const confirmationResult = this.enforceConfirmation(
       toolContext,
       inlineScriptContent,

--- a/core/src/tools/skill/skill_toolset.ts
+++ b/core/src/tools/skill/skill_toolset.ts
@@ -54,6 +54,15 @@ export class SkillToolset extends BaseToolset {
       codeExecutor?: BaseCodeExecutor;
       additionalTools?: Array<BaseTool | BaseToolset>;
       registry?: SkillRegistry;
+      /**
+       * Whether to expose the `run_skill_inline_script` tool, which executes
+       * model-provided script content in the configured code executor. This is
+       * disabled by default because arbitrary inline-script execution is a
+       * sensitive capability; opt in explicitly by setting this to `true`.
+       * Execution additionally remains gated behind a human-in-the-loop
+       * confirmation.
+       */
+      allowInlineScripts?: boolean;
     } = {},
   ) {
     super([], 'adk_skill_toolset');
@@ -69,8 +78,13 @@ export class SkillToolset extends BaseToolset {
       new LoadSkillTool(this),
       new LoadSkillResourceTool(this),
       new RunSkillScriptTool(this),
-      new RunSkillInlineScriptTool(this),
     ];
+
+    // Inline-script execution is opt-in: only expose the tool when explicitly
+    // enabled, so agents are secure-by-default.
+    if (options.allowInlineScripts) {
+      this.tools.push(new RunSkillInlineScriptTool(this));
+    }
 
     if (this.registry) {
       this.tools.push(new SearchSkillsTool(this));

--- a/core/test/tools/skills/run_skill_inline_script_tool_test.ts
+++ b/core/test/tools/skills/run_skill_inline_script_tool_test.ts
@@ -18,6 +18,7 @@ import {
   SkillToolset,
 } from '@google/adk';
 import {describe, expect, it, vi} from 'vitest';
+import {ToolConfirmation} from '../../../src/tools/tool_confirmation.js';
 import {materializeFiles} from '../../../src/utils/file_utils.js';
 
 vi.mock('../../../src/utils/file_utils.js', () => ({
@@ -53,6 +54,10 @@ describe('RunSkillInlineScriptTool', () => {
   function createMockContext(
     agentName = 'test-agent',
     agentExecutor?: BaseCodeExecutor,
+    options: {
+      functionCallId?: string;
+      toolConfirmation?: ToolConfirmation;
+    } = {},
   ): Context {
     const agentObj: Record<string | symbol, unknown> = {name: agentName};
     if (agentExecutor) {
@@ -65,7 +70,16 @@ describe('RunSkillInlineScriptTool', () => {
         session: {state: {}},
         agent: agentObj as unknown as LlmAgent,
       } as unknown as InvocationContext,
+      functionCallId: options.functionCallId,
+      toolConfirmation: options.toolConfirmation,
     });
+  }
+
+  /**
+   * A confirmed confirmation lets execution proceed past the security gate.
+   */
+  function confirmed(): ToolConfirmation {
+    return new ToolConfirmation({confirmed: true});
   }
 
   it('returns error if script content is missing', async () => {
@@ -129,7 +143,9 @@ describe('RunSkillInlineScriptTool', () => {
         script_content: 'console.log("agent");',
         language: CodeExecutionLanguage.JAVASCRIPT,
       },
-      toolContext: createMockContext('agent-with-exec', agentExecutor),
+      toolContext: createMockContext('agent-with-exec', agentExecutor, {
+        toolConfirmation: confirmed(),
+      }),
     })) as CodeExecutionResult;
 
     expect(result.stdout).toBe('agent fallback stdout');
@@ -150,7 +166,9 @@ describe('RunSkillInlineScriptTool', () => {
         script_content: 'console.log("error");',
         language: CodeExecutionLanguage.PYTHON,
       },
-      toolContext: createMockContext(),
+      toolContext: createMockContext('test-agent', undefined, {
+        toolConfirmation: confirmed(),
+      }),
     })) as ToolErrorResponse;
 
     expect(result).toEqual({
@@ -170,7 +188,9 @@ describe('RunSkillInlineScriptTool', () => {
     const toolset = new SkillToolset([], {codeExecutor: mockExecutor});
     const tool = new RunSkillInlineScriptTool(toolset);
 
-    const mockToolContext = createMockContext();
+    const mockToolContext = createMockContext('test-agent', undefined, {
+      toolConfirmation: confirmed(),
+    });
 
     const result = (await tool.runAsync({
       args: {
@@ -221,7 +241,9 @@ describe('RunSkillInlineScriptTool', () => {
         script_content: 'console.log("test");',
         language: CodeExecutionLanguage.JAVASCRIPT,
       },
-      toolContext: createMockContext(),
+      toolContext: createMockContext('test-agent', undefined, {
+        toolConfirmation: confirmed(),
+      }),
     });
 
     expect(materializeFiles).toHaveBeenCalledWith([testFile]);
@@ -238,7 +260,9 @@ describe('RunSkillInlineScriptTool', () => {
     const toolset = new SkillToolset([], {codeExecutor: mockExecutor});
     const tool = new RunSkillInlineScriptTool(toolset);
 
-    const mockToolContext = createMockContext();
+    const mockToolContext = createMockContext('test-agent', undefined, {
+      toolConfirmation: confirmed(),
+    });
 
     await tool.runAsync({
       args: {
@@ -253,5 +277,107 @@ describe('RunSkillInlineScriptTool', () => {
       'arg1',
       'arg2',
     ]);
+  });
+
+  describe('confirmation gate', () => {
+    it('blocks execution and requests confirmation on the first call', async () => {
+      const mockExecutor = new MockCodeExecutor();
+      const toolset = new SkillToolset([], {codeExecutor: mockExecutor});
+      const tool = new RunSkillInlineScriptTool(toolset);
+
+      // No toolConfirmation provided -> the tool must pause and request one.
+      const mockToolContext = createMockContext('test-agent', undefined, {
+        functionCallId: 'fc-1',
+      });
+
+      const result = (await tool.runAsync({
+        args: {
+          script_content: 'rm -rf /',
+          language: CodeExecutionLanguage.SHELL,
+        },
+        toolContext: mockToolContext,
+      })) as {partial: string};
+
+      // Execution must NOT have happened.
+      expect(mockExecutor.executeCodeParams).toBeUndefined();
+
+      // An intermediate "needs confirmation" result is returned.
+      expect(result).toEqual({
+        partial:
+          'This tool call needs external confirmation before completion.',
+      });
+
+      // A confirmation request was recorded against the function call id and
+      // it surfaces the script + language to the client.
+      const requested =
+        mockToolContext.actions.requestedToolConfirmations['fc-1'];
+      expect(requested).toBeDefined();
+      expect(requested.confirmed).toBe(false);
+      expect(requested.hint).toContain('rm -rf /');
+      expect(requested.hint).toContain(CodeExecutionLanguage.SHELL);
+      expect(requested.payload).toEqual({
+        language: CodeExecutionLanguage.SHELL,
+        scriptContent: 'rm -rf /',
+      });
+    });
+
+    it('rejects execution when confirmation is not confirmed', async () => {
+      const mockExecutor = new MockCodeExecutor();
+      const toolset = new SkillToolset([], {codeExecutor: mockExecutor});
+      const tool = new RunSkillInlineScriptTool(toolset);
+
+      const mockToolContext = createMockContext('test-agent', undefined, {
+        functionCallId: 'fc-2',
+        toolConfirmation: new ToolConfirmation({confirmed: false}),
+      });
+
+      const result = (await tool.runAsync({
+        args: {
+          script_content: 'console.log("nope");',
+          language: CodeExecutionLanguage.JAVASCRIPT,
+        },
+        toolContext: mockToolContext,
+      })) as ToolErrorResponse;
+
+      // Execution must NOT have happened.
+      expect(mockExecutor.executeCodeParams).toBeUndefined();
+      expect(result).toEqual({
+        error: 'Inline script execution was not confirmed and was rejected.',
+        errorCode: 'CONFIRMATION_REJECTED',
+      });
+    });
+
+    it('proceeds with execution once confirmed', async () => {
+      const mockExecutor = new MockCodeExecutor();
+      mockExecutor.mockResult = {
+        stdout: 'confirmed output',
+        stderr: '',
+        outputFiles: [],
+      };
+      const toolset = new SkillToolset([], {codeExecutor: mockExecutor});
+      const tool = new RunSkillInlineScriptTool(toolset);
+
+      const mockToolContext = createMockContext('test-agent', undefined, {
+        functionCallId: 'fc-3',
+        toolConfirmation: new ToolConfirmation({confirmed: true}),
+      });
+
+      const result = (await tool.runAsync({
+        args: {
+          script_content: 'console.log("go");',
+          language: CodeExecutionLanguage.JAVASCRIPT,
+        },
+        toolContext: mockToolContext,
+      })) as CodeExecutionResult;
+
+      expect(result.stdout).toBe('confirmed output');
+      expect(mockExecutor.executeCodeParams?.codeExecutionInput.code).toBe(
+        'console.log("go");',
+      );
+      // No new confirmation was requested when already confirmed.
+      expect(
+        mockToolContext.actions.requestedToolConfirmations['fc-3'],
+      ).toBeUndefined();
+    });
   });
 });

--- a/core/test/tools/skills/run_skill_inline_script_tool_test.ts
+++ b/core/test/tools/skills/run_skill_inline_script_tool_test.ts
@@ -14,6 +14,7 @@ import {
   FileContentEncoding,
   InvocationContext,
   LlmAgent,
+  RunSkillInlineScriptErrorCode,
   RunSkillInlineScriptTool,
   SkillToolset,
 } from '@google/adk';
@@ -47,7 +48,7 @@ class MockCodeExecutor extends BaseCodeExecutor {
 
 interface ToolErrorResponse {
   error: string;
-  errorCode: string;
+  errorCode: RunSkillInlineScriptErrorCode;
 }
 
 describe('RunSkillInlineScriptTool', () => {
@@ -92,7 +93,7 @@ describe('RunSkillInlineScriptTool', () => {
 
     expect(result).toEqual({
       error: 'Script content is required.',
-      errorCode: 'MISSING_SCRIPT_CONTENT',
+      errorCode: RunSkillInlineScriptErrorCode.MISSING_SCRIPT_CONTENT,
     });
   });
 
@@ -106,7 +107,7 @@ describe('RunSkillInlineScriptTool', () => {
 
     expect(result).toEqual({
       error: 'Language is required.',
-      errorCode: 'MISSING_LANGUAGE',
+      errorCode: RunSkillInlineScriptErrorCode.MISSING_LANGUAGE,
     });
   });
 
@@ -123,7 +124,7 @@ describe('RunSkillInlineScriptTool', () => {
 
     expect(result).toEqual({
       error: 'No code executor configured.',
-      errorCode: 'NO_CODE_EXECUTOR',
+      errorCode: RunSkillInlineScriptErrorCode.NO_CODE_EXECUTOR,
     });
   });
 
@@ -173,7 +174,7 @@ describe('RunSkillInlineScriptTool', () => {
 
     expect(result).toEqual({
       error: 'Failed to execute inline script: Mock execution failure',
-      errorCode: 'EXECUTION_ERROR',
+      errorCode: RunSkillInlineScriptErrorCode.EXECUTION_ERROR,
     });
   });
 
@@ -343,7 +344,7 @@ describe('RunSkillInlineScriptTool', () => {
       expect(mockExecutor.executeCodeParams).toBeUndefined();
       expect(result).toEqual({
         error: 'Inline script execution was not confirmed and was rejected.',
-        errorCode: 'CONFIRMATION_REJECTED',
+        errorCode: RunSkillInlineScriptErrorCode.CONFIRMATION_REJECTED,
       });
     });
 
@@ -378,6 +379,28 @@ describe('RunSkillInlineScriptTool', () => {
       expect(
         mockToolContext.actions.requestedToolConfirmations['fc-3'],
       ).toBeUndefined();
+    });
+  });
+
+  describe('error codes', () => {
+    it('exposes stable string values for the error-code enum', () => {
+      // The error-code string values are part of the tool's response contract
+      // and must remain stable across releases.
+      expect(RunSkillInlineScriptErrorCode.MISSING_SCRIPT_CONTENT).toBe(
+        'MISSING_SCRIPT_CONTENT',
+      );
+      expect(RunSkillInlineScriptErrorCode.MISSING_LANGUAGE).toBe(
+        'MISSING_LANGUAGE',
+      );
+      expect(RunSkillInlineScriptErrorCode.NO_CODE_EXECUTOR).toBe(
+        'NO_CODE_EXECUTOR',
+      );
+      expect(RunSkillInlineScriptErrorCode.EXECUTION_ERROR).toBe(
+        'EXECUTION_ERROR',
+      );
+      expect(RunSkillInlineScriptErrorCode.CONFIRMATION_REJECTED).toBe(
+        'CONFIRMATION_REJECTED',
+      );
     });
   });
 });

--- a/core/test/tools/skills/skill_toolset_test.ts
+++ b/core/test/tools/skills/skill_toolset_test.ts
@@ -57,13 +57,12 @@ describe('skill_toolset', () => {
     it('returns default tools only when no context provided', async () => {
       const toolset = new SkillToolset([mockSkill]);
       const tools = await toolset.getTools();
-      expect(tools.length).toBe(5);
+      expect(tools.length).toBe(4);
       expect(tools.map((t) => t.name)).toEqual([
         'list_skills',
         'load_skill',
         'load_skill_resource',
         'run_skill_script',
-        'run_skill_inline_script',
       ]);
     });
 
@@ -71,6 +70,29 @@ describe('skill_toolset', () => {
       const toolset = new SkillToolset([mockSkill]);
       const context = createMockContext();
       const tools = await toolset.getTools(context);
+      expect(tools.length).toBe(4);
+    });
+
+    it('does not expose the inline-script tool by default', async () => {
+      const toolset = new SkillToolset([mockSkill]);
+      const tools = await toolset.getTools();
+      expect(tools.map((t) => t.name)).not.toContain('run_skill_inline_script');
+    });
+
+    it('does not expose the inline-script tool when the flag is false', async () => {
+      const toolset = new SkillToolset([mockSkill], {
+        allowInlineScripts: false,
+      });
+      const tools = await toolset.getTools();
+      expect(tools.map((t) => t.name)).not.toContain('run_skill_inline_script');
+    });
+
+    it('exposes the inline-script tool when allowInlineScripts is true', async () => {
+      const toolset = new SkillToolset([mockSkill], {
+        allowInlineScripts: true,
+      });
+      const tools = await toolset.getTools();
+      expect(tools.map((t) => t.name)).toContain('run_skill_inline_script');
       expect(tools.length).toBe(5);
     });
 

--- a/tests/integration/skills/script_js/agent.ts
+++ b/tests/integration/skills/script_js/agent.ts
@@ -35,6 +35,8 @@ export const rootAgent = new LlmAgent({
   tools: [
     new SkillToolset([skill], {
       codeExecutor: new UnsafeLocalCodeExecutor(),
+      // Inline-script execution is opt-in; enable it for this end-to-end test.
+      allowInlineScripts: true,
     }),
   ],
   // Executing model-provided inline scripts is gated behind a confirmation

--- a/tests/integration/skills/script_js/agent.ts
+++ b/tests/integration/skills/script_js/agent.ts
@@ -8,6 +8,7 @@ import {
   LlmAgent,
   loadSkillFromDir,
   SkillToolset,
+  ToolConfirmation,
   UnsafeLocalCodeExecutor,
 } from '@google/adk';
 import * as path from 'node:path';
@@ -36,4 +37,13 @@ export const rootAgent = new LlmAgent({
       codeExecutor: new UnsafeLocalCodeExecutor(),
     }),
   ],
+  // Executing model-provided inline scripts is gated behind a confirmation
+  // (see run_skill_inline_script_tool.ts). This trusted, non-interactive
+  // integration agent auto-approves that gate so the end-to-end flow can run.
+  beforeToolCallback: ({tool, context}) => {
+    if (tool.name === 'run_skill_inline_script') {
+      context.toolConfirmation = new ToolConfirmation({confirmed: true});
+    }
+    return undefined;
+  },
 });

--- a/tests/integration/skills/script_sh/agent.ts
+++ b/tests/integration/skills/script_sh/agent.ts
@@ -11,6 +11,7 @@ import {
   LlmAgent,
   loadSkillFromDir,
   SkillToolset,
+  ToolConfirmation,
   UnsafeLocalCodeExecutor,
 } from '@google/adk';
 import * as fs from 'node:fs';
@@ -80,4 +81,13 @@ export const rootAgent = new LlmAgent({
       codeExecutor: new MockedCurlCodeExecutor(),
     }),
   ],
+  // Executing model-provided inline scripts is gated behind a confirmation
+  // (see run_skill_inline_script_tool.ts). This trusted, non-interactive
+  // integration agent auto-approves that gate so the end-to-end flow can run.
+  beforeToolCallback: ({tool, context}) => {
+    if (tool.name === 'run_skill_inline_script') {
+      context.toolConfirmation = new ToolConfirmation({confirmed: true});
+    }
+    return undefined;
+  },
 });

--- a/tests/integration/skills/script_sh/agent.ts
+++ b/tests/integration/skills/script_sh/agent.ts
@@ -79,6 +79,8 @@ export const rootAgent = new LlmAgent({
   tools: [
     new SkillToolset([skill], {
       codeExecutor: new MockedCurlCodeExecutor(),
+      // Inline-script execution is opt-in; enable it for this end-to-end test.
+      allowInlineScripts: true,
     }),
   ],
   // Executing model-provided inline scripts is gated behind a confirmation

--- a/tests/integration/tools/run_skill_inline_script_tool_test.ts
+++ b/tests/integration/tools/run_skill_inline_script_tool_test.ts
@@ -11,6 +11,7 @@ import {
   InvocationContext,
   RunSkillInlineScriptTool,
   SkillToolset,
+  ToolConfirmation,
   UnsafeLocalCodeExecutor,
 } from '@google/adk';
 import * as fs from 'node:fs/promises';
@@ -18,12 +19,16 @@ import * as path from 'node:path';
 import {describe, expect, it} from 'vitest';
 
 describe('RunSkillInlineScriptTool Integration with UnsafeLocalCodeExecutor', () => {
+  // These integration tests exercise real code execution, which is gated behind
+  // a human-in-the-loop confirmation. Supply an already-confirmed confirmation
+  // so the tool proceeds to execute (see run_skill_inline_script_tool.ts).
   function createMockContext(agentName = 'test-agent') {
     return new Context({
       invocationContext: {
         session: {state: {}},
         agent: {name: agentName},
       } as unknown as InvocationContext,
+      toolConfirmation: new ToolConfirmation({confirmed: true}),
     });
   }
 


### PR DESCRIPTION
## Summary

`run_skill_inline_script` (`core/src/tools/skill/run_skill_inline_script_tool.ts`) passed the model-emitted `script_content` string **verbatim** to `codeExecutor.executeCode()` with no confirmation gate, no allow-list, and no static analysis. Once a `SkillToolset` registers the tool, any prompt injection that persuades the model to call it results in arbitrary code execution in the code executor's context.

This PR adds a **server-enforced, human-in-the-loop confirmation gate** before dispatch, reusing the repo's existing tool-confirmation mechanism (`toolContext.requestConfirmation` / `toolContext.toolConfirmation`), mirroring how `SecurityPlugin` handles `CONFIRM` outcomes.

## What changed

In `RunSkillInlineScriptTool.runAsync`, immediately before calling `codeExecutor.executeCode`:

- **No confirmation yet** → request one via `toolContext.requestConfirmation({ hint, payload })`. The hint surfaces the language and the exact script that would run, and an intermediate result (`{ partial: 'This tool call needs external confirmation before completion.' }`) is returned so the tool call pauses until the client responds.
- **Confirmation present but not confirmed** → return a rejection error (`errorCode: 'CONFIRMATION_REJECTED'`) and refuse execution.
- **Confirmation confirmed** → execution proceeds as before.

The gate lives inside `runAsync`, so it is enforced on every path that registers the tool (the tool is registered unconditionally by `SkillToolset`).

## Tests

Added unit tests to `core/test/tools/skills/run_skill_inline_script_tool_test.ts` covering:
- execution blocked + confirmation requested on first call (and no code executed),
- execution rejected when the confirmation is not confirmed,
- execution proceeds once confirmed.

Existing happy-path tests were updated to pass a confirmed confirmation.

Local gates run green: `npm run build`, targeted `vitest`, `eslint`, `prettier --check`, `secretlint`, and `docs:check`.
