### PR TITLE
fix(security): require authentication when mounting A2A server

### DIFF
--- a/core/src/a2a/agent_to_a2a.ts
+++ b/core/src/a2a/agent_to_a2a.ts
@@ -20,8 +20,22 @@ import {BaseMemoryService} from '../memory/base_memory_service.js';
 import {Runner} from '../runner/runner.js';
 import {BaseSessionService} from '../sessions/base_session_service.js';
 import {InMemorySessionService} from '../sessions/in_memory_session_service.js';
+import {logger} from '../utils/logger.js';
 import {getA2AAgentCard, resolveAgentCard} from './agent_card.js';
 import {A2AAgentExecutor} from './agent_executor.js';
+
+/**
+ * A request authenticator for the A2A surface.
+ *
+ * This is the `UserBuilder` hook from `@a2a-js/sdk`: an async function that
+ * receives the incoming Express request, validates its credentials (for
+ * example a bearer token or an OIDC ID token) and resolves to the
+ * authenticated `User`. Implementations should reject unauthenticated
+ * requests by throwing (or by resolving to a user whose `isAuthenticated` is
+ * `false`), which prevents the underlying agent and its tools from being
+ * invoked by anonymous callers.
+ */
+export type A2aUserBuilder = UserBuilder;
 
 /**
  * Options for the `toA2a` function.
@@ -47,6 +61,70 @@ export interface ToA2aOptions {
   artifactService?: BaseArtifactService;
   /** Optional existing express application */
   app?: express.Application;
+  /**
+   * Authenticator used to validate incoming A2A requests.
+   *
+   * A2A is the production-intended inter-agent surface: any network-reachable
+   * caller that can reach it can invoke the agent and its tools with arbitrary
+   * input and read the output. Provide a `UserBuilder` (from
+   * `@a2a-js/sdk/server/express`) that validates the request's credentials —
+   * for example a bearer token or an OIDC ID token — and it will be wired into
+   * both the REST and JSON-RPC handlers.
+   *
+   * When omitted, `toA2a` fails closed and throws unless
+   * {@link ToA2aOptions.allowUnauthenticated} is explicitly set to `true`.
+   */
+  authentication?: A2aUserBuilder;
+  /**
+   * Explicit escape hatch to mount the A2A surface WITHOUT authentication.
+   *
+   * This is intentionally insecure and must only be used for local, trusted
+   * development where the surface is not network reachable. When set to
+   * `true` (and no {@link ToA2aOptions.authentication} is provided), a loud
+   * warning is logged and the handlers are mounted with no authentication.
+   *
+   * Defaults to `false`, which makes `toA2a` fail closed. See b/508330032.
+   */
+  allowUnauthenticated?: boolean;
+}
+
+/**
+ * Resolves the `UserBuilder` used to authenticate the A2A surface, failing
+ * closed by default.
+ *
+ * - If an {@link ToA2aOptions.authentication} authenticator is provided, it is
+ *   used for both the REST and JSON-RPC handlers.
+ * - Otherwise, if {@link ToA2aOptions.allowUnauthenticated} is explicitly
+ *   `true`, a loud warning is logged and the surface is mounted with no
+ *   authentication.
+ * - Otherwise, an error is thrown: the A2A surface must not be exposed without
+ *   authentication (b/508330032).
+ */
+function resolveA2aUserBuilder(options: ToA2aOptions): UserBuilder {
+  if (options.authentication) {
+    return options.authentication;
+  }
+
+  if (options.allowUnauthenticated === true) {
+    logger.warn(
+      'SECURITY WARNING: Mounting the A2A server WITHOUT authentication ' +
+        'because `allowUnauthenticated: true` was set. The agent and all of ' +
+        'its tools are exposed to any network-reachable caller, which can ' +
+        'invoke them with arbitrary input and read the output. Do NOT use ' +
+        'this outside of local, trusted development (see b/508330032).',
+    );
+    return UserBuilder.noAuthentication;
+  }
+
+  throw new Error(
+    'toA2a: refusing to mount the A2A server without authentication. The A2A ' +
+      'surface lets any network-reachable caller invoke this agent and its ' +
+      'tools with arbitrary input and read the output, so it must be ' +
+      'authenticated. Provide `authentication` (a UserBuilder that validates ' +
+      'the request, e.g. a bearer token or OIDC credential) or, only for ' +
+      'local/trusted development, explicitly set `allowUnauthenticated: ' +
+      'true`. See b/508330032.',
+  );
 }
 
 /**
@@ -60,6 +138,10 @@ export async function toA2a(
   agent: BaseAgent,
   options: ToA2aOptions = {},
 ): Promise<express.Application> {
+  // Fail closed before doing any work: the A2A surface must be authenticated
+  // unless the caller explicitly opts out (see b/508330032).
+  const userBuilder = resolveA2aUserBuilder(options);
+
   const host = options.host ?? 'localhost';
   const port = options.port ?? 8000;
   const protocol = options.protocol ?? 'http';
@@ -111,14 +193,14 @@ export async function toA2a(
     `${basePath}/rest`,
     restHandler({
       requestHandler,
-      userBuilder: UserBuilder.noAuthentication,
+      userBuilder,
     }),
   );
   app.use(
     `${basePath}/jsonrpc`,
     jsonRpcHandler({
       requestHandler,
-      userBuilder: UserBuilder.noAuthentication,
+      userBuilder,
     }),
   );
 

--- a/core/src/a2a/agent_to_a2a.ts
+++ b/core/src/a2a/agent_to_a2a.ts
@@ -83,7 +83,7 @@ export interface ToA2aOptions {
    * `true` (and no {@link ToA2aOptions.authentication} is provided), a loud
    * warning is logged and the handlers are mounted with no authentication.
    *
-   * Defaults to `false`, which makes `toA2a` fail closed. See b/508330032.
+   * Defaults to `false`, which makes `toA2a` fail closed.
    */
   allowUnauthenticated?: boolean;
 }
@@ -98,7 +98,7 @@ export interface ToA2aOptions {
  *   `true`, a loud warning is logged and the surface is mounted with no
  *   authentication.
  * - Otherwise, an error is thrown: the A2A surface must not be exposed without
- *   authentication (b/508330032).
+ *   authentication.
  */
 function resolveA2aUserBuilder(options: ToA2aOptions): UserBuilder {
   if (options.authentication) {
@@ -111,7 +111,7 @@ function resolveA2aUserBuilder(options: ToA2aOptions): UserBuilder {
         'because `allowUnauthenticated: true` was set. The agent and all of ' +
         'its tools are exposed to any network-reachable caller, which can ' +
         'invoke them with arbitrary input and read the output. Do NOT use ' +
-        'this outside of local, trusted development (see b/508330032).',
+        'this outside of local, trusted development.',
     );
     return UserBuilder.noAuthentication;
   }
@@ -123,7 +123,7 @@ function resolveA2aUserBuilder(options: ToA2aOptions): UserBuilder {
       'authenticated. Provide `authentication` (a UserBuilder that validates ' +
       'the request, e.g. a bearer token or OIDC credential) or, only for ' +
       'local/trusted development, explicitly set `allowUnauthenticated: ' +
-      'true`. See b/508330032.',
+      'true`.',
   );
 }
 
@@ -139,7 +139,7 @@ export async function toA2a(
   options: ToA2aOptions = {},
 ): Promise<express.Application> {
   // Fail closed before doing any work: the A2A surface must be authenticated
-  // unless the caller explicitly opts out (see b/508330032).
+  // unless the caller explicitly opts out.
   const userBuilder = resolveA2aUserBuilder(options);
 
   const host = options.host ?? 'localhost';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -21,7 +21,7 @@ export type {
   RunnerOrRunnerConfig,
 } from './a2a/agent_executor.js';
 export {toA2a} from './a2a/agent_to_a2a.js';
-export type {ToA2aOptions} from './a2a/agent_to_a2a.js';
+export type {A2aUserBuilder, ToA2aOptions} from './a2a/agent_to_a2a.js';
 export type {ExecutorContext} from './a2a/executor_context.js';
 export {InvocationContext} from './agents/invocation_context.js';
 export {FileArtifactService} from './artifacts/file_artifact_service.js';

--- a/core/test/a2a/agent_to_a2a_test.ts
+++ b/core/test/a2a/agent_to_a2a_test.ts
@@ -204,7 +204,9 @@ describe('toA2a', () => {
         toA2a(agent, {
           allowUnauthenticated: false,
         }),
-      ).rejects.toThrow(/b\/508330032/);
+      ).rejects.toThrow(
+        /refusing to mount the A2A server without authentication/i,
+      );
     });
 
     it('warns and mounts with noAuthentication when allowUnauthenticated is true', async () => {

--- a/core/test/a2a/agent_to_a2a_test.ts
+++ b/core/test/a2a/agent_to_a2a_test.ts
@@ -15,12 +15,13 @@ import express from 'express';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {getA2AAgentCard, resolveAgentCard} from '../../src/a2a/agent_card.js';
 import {A2AAgentExecutor} from '../../src/a2a/agent_executor.js';
-import {toA2a} from '../../src/a2a/agent_to_a2a.js';
+import {A2aUserBuilder, toA2a} from '../../src/a2a/agent_to_a2a.js';
 import {BaseAgent} from '../../src/agents/base_agent.js';
 import {InvocationContext} from '../../src/agents/invocation_context.js';
 import {Event} from '../../src/events/event.js';
 import {Runner} from '../../src/runner/runner.js';
 import {BaseSessionService} from '../../src/sessions/base_session_service.js';
+import {logger} from '../../src/utils/logger.js';
 
 class TestAgent extends BaseAgent {
   constructor() {
@@ -84,8 +85,8 @@ describe('toA2a', () => {
     agent = new TestAgent();
   });
 
-  it('should create an express app with default handlers', async () => {
-    const app = await toA2a(agent);
+  it('should create an express app with handlers when unauthenticated access is explicitly allowed', async () => {
+    const app = await toA2a(agent, {allowUnauthenticated: true});
 
     expect(express).toHaveBeenCalled();
     const expressMock = express as unknown as MockExpress;
@@ -142,6 +143,7 @@ describe('toA2a', () => {
       app: customApp as unknown as express.Application,
       runner: customRunner,
       sessionService: customSessionService,
+      allowUnauthenticated: true,
     });
 
     expect(express).not.toHaveBeenCalled();
@@ -170,6 +172,7 @@ describe('toA2a', () => {
   it('should resolve agentCard when provided as string', async () => {
     await toA2a(agent, {
       agentCard: 'path/to/card.json',
+      allowUnauthenticated: true,
     });
 
     expect(resolveAgentCard).toHaveBeenCalledWith('path/to/card.json');
@@ -180,9 +183,71 @@ describe('toA2a', () => {
     const card = {name: 'provided_card'} as unknown as AgentCard;
     await toA2a(agent, {
       agentCard: card,
+      allowUnauthenticated: true,
     });
 
     expect(resolveAgentCard).toHaveBeenCalledWith(card);
     expect(getA2AAgentCard).not.toHaveBeenCalled();
+  });
+
+  describe('authentication (b/508330032)', () => {
+    it('fails closed when no authentication is provided and access is not explicitly opened', async () => {
+      await expect(toA2a(agent)).rejects.toThrow(/authenticat/i);
+
+      // Nothing should be mounted when refusing to start.
+      expect(restHandler).not.toHaveBeenCalled();
+      expect(jsonRpcHandler).not.toHaveBeenCalled();
+    });
+
+    it('rejects allowUnauthenticated set to any non-true value', async () => {
+      await expect(
+        toA2a(agent, {
+          allowUnauthenticated: false,
+        }),
+      ).rejects.toThrow(/b\/508330032/);
+    });
+
+    it('warns and mounts with noAuthentication when allowUnauthenticated is true', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      await toA2a(agent, {allowUnauthenticated: true});
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/SECURITY WARNING/);
+      expect(restHandler).toHaveBeenCalledWith({
+        requestHandler: expect.any(Object),
+        userBuilder: 'noAuthentication',
+      });
+      expect(jsonRpcHandler).toHaveBeenCalledWith({
+        requestHandler: expect.any(Object),
+        userBuilder: 'noAuthentication',
+      });
+
+      warnSpy.mockRestore();
+    });
+
+    it('wires the provided authenticator into both REST and JSON-RPC handlers', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const authenticator: A2aUserBuilder = vi.fn(async () => ({
+        isAuthenticated: true,
+        userName: 'alice',
+      }));
+
+      await toA2a(agent, {authentication: authenticator});
+
+      // A provided authenticator is used verbatim and must not fall back to
+      // noAuthentication, nor emit the insecure-mode warning.
+      expect(restHandler).toHaveBeenCalledWith({
+        requestHandler: expect.any(Object),
+        userBuilder: authenticator,
+      });
+      expect(jsonRpcHandler).toHaveBeenCalledWith({
+        requestHandler: expect.any(Object),
+        userBuilder: authenticator,
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/core/test/a2a/agent_to_a2a_test.ts
+++ b/core/test/a2a/agent_to_a2a_test.ts
@@ -190,7 +190,7 @@ describe('toA2a', () => {
     expect(getA2AAgentCard).not.toHaveBeenCalled();
   });
 
-  describe('authentication (b/508330032)', () => {
+  describe('authentication', () => {
     it('fails closed when no authentication is provided and access is not explicitly opened', async () => {
       await expect(toA2a(agent)).rejects.toThrow(/authenticat/i);
 

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -164,7 +164,7 @@ export class AdkApiServer {
         runner,
         app: this.app,
         // This is the local development API server. `toA2a` fails closed by
-        // default (see b/508330032), so explicitly opt out of authentication
+        // default, so explicitly opt out of authentication
         // here; a loud warning is logged at startup. Production A2A deployments
         // should instead pass an `authentication` UserBuilder.
         allowUnauthenticated: true,

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -163,6 +163,11 @@ export class AdkApiServer {
         artifactService: this.artifactService,
         runner,
         app: this.app,
+        // This is the local development API server. `toA2a` fails closed by
+        // default (see b/508330032), so explicitly opt out of authentication
+        // here; a loud warning is logged at startup. Production A2A deployments
+        // should instead pass an `authentication` UserBuilder.
+        allowUnauthenticated: true,
       });
     }
   }


### PR DESCRIPTION
## Summary

`toA2a()` mounted the A2A REST and JSON-RPC handlers with
`UserBuilder.noAuthentication` and offered no way to require authentication.
A2A is the production-intended inter-agent surface, so any network-reachable
caller could invoke the agent and its tools with arbitrary input and read the
output. This change makes the A2A surface authenticated by default and fails
closed.

## Changes

- Extend `ToA2aOptions` with:
  - `authentication?: A2aUserBuilder` — a `UserBuilder` (from
    `@a2a-js/sdk/server/express`) that validates each request's credentials
    (e.g. a bearer token or OIDC ID token). When provided, it is wired into
    **both** the REST and JSON-RPC handlers, replacing `noAuthentication`.
  - `allowUnauthenticated?: boolean` — an explicit, intentionally-insecure
    escape hatch for local/trusted development only.
- `toA2a()` now **fails closed**: if no `authentication` is provided and
  `allowUnauthenticated` is not explicitly `true`, it throws a clear `Error`
  explaining that the A2A surface must be authenticated. When
  `allowUnauthenticated: true` is set, it logs a loud security warning and
  proceeds with no authentication.
- Export the new `A2aUserBuilder` type from the package entry point.
- Unit tests cover: fail-closed when no auth and no opt-out; warn + proceed
  when `allowUnauthenticated: true`; and use of the provided authenticator in
  both handlers.

The API is additive and backward-tolerant but secure by default: existing
callers that intend to run without auth simply set `allowUnauthenticated: true`.
