### PR TITLE
fix(tools): use the statically configured credential in OpenAPI tools

### DIFF
--- a/core/src/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.ts
@@ -86,23 +86,37 @@ export class ToolAuthHandler {
       credentialKey: this.credentialKey || 'default_openapi_key',
     };
 
-    const credential = this.context.getAuthResponse(authConfig);
-    if (credential) {
-      const exchanger = new AutoAuthCredentialExchanger();
-      const result = await exchanger.exchange({
-        authScheme: this.authScheme,
-        authCredential: credential,
-      });
+    // A credential returned by an auth response was supplied interactively by
+    // the client. Otherwise fall back to the credential the tool was
+    // configured with: schemes such as `apiKey`, `http` and `serviceAccount`
+    // need no user interaction, so requesting one would strand the tool in
+    // `pending` forever.
+    const authResponseCredential = this.context.getAuthResponse(authConfig);
+    const credential = authResponseCredential ?? this.authCredential;
 
-      const key = store.getCredentialKey(this.authScheme);
-      store.storeCredential(key, result.credential);
+    if (!credential) {
+      // No credential to work with, so ask the client for one.
+      this.context.requestCredential(authConfig);
 
-      return {state: 'done', authCredential: result.credential};
+      return {state: 'pending'};
     }
 
-    // If credential is not available, request it
-    this.context.requestCredential(authConfig);
+    const exchanger = new AutoAuthCredentialExchanger();
+    const result = await exchanger.exchange({
+      authScheme: this.authScheme,
+      authCredential: credential,
+    });
 
-    return {state: 'pending'};
+    // Only cache what cannot cheaply be obtained again: an auth response is
+    // readable once, and an exchange costs a round trip. A statically
+    // configured credential that needed no exchange is already available on
+    // every invocation, so persisting it to session state would only copy a
+    // secret into the session store for nothing.
+    if (authResponseCredential || result.wasExchanged) {
+      const key = store.getCredentialKey(this.authScheme);
+      store.storeCredential(key, result.credential);
+    }
+
+    return {state: 'done', authCredential: result.credential};
   }
 }

--- a/core/test/tools/openapi_tool/tool_auth_handler_test.ts
+++ b/core/test/tools/openapi_tool/tool_auth_handler_test.ts
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AuthCredentialTypes, Context, ToolAuthHandler} from '@google/adk';
+import {
+  AuthCredential,
+  AuthCredentialTypes,
+  Context,
+  ToolAuthHandler,
+} from '@google/adk';
 import {describe, expect, it, vi} from 'vitest';
 import {State} from '../../../src/sessions/state.js';
+import {AutoAuthCredentialExchanger} from '../../../src/tools/openapi_tool/auth/credential_exchangers/auto_auth_credential_exchanger.js';
 
 // Mock AutoAuthCredentialExchanger
 vi.mock(
@@ -146,5 +152,95 @@ describe('ToolAuthHandler', () => {
     );
     // The cached credential was reused; no second exchange was triggered.
     expect(secondContext.getAuthResponse).not.toHaveBeenCalled();
+  });
+
+  it('uses the credential the tool was configured with instead of requesting one', async () => {
+    const mockContext = {
+      state: new State(),
+      getAuthResponse: vi.fn().mockReturnValue(undefined),
+      requestCredential: vi.fn(),
+    } as unknown as Context;
+
+    const result = await new ToolAuthHandler(
+      mockContext,
+      {type: 'apiKey', name: 'X-API-Key', in: 'header'},
+      {authType: AuthCredentialTypes.API_KEY, apiKey: 'static-key'},
+    ).prepareAuthCredentials();
+
+    // Schemes like apiKey need no user interaction, so asking the client for a
+    // credential would leave the tool stuck in `pending` forever.
+    expect(result.state).toBe('done');
+    expect(mockContext.requestCredential).not.toHaveBeenCalled();
+  });
+
+  it('does not copy a static credential that needed no exchange into session state', async () => {
+    const staticCredential: AuthCredential = {
+      authType: AuthCredentialTypes.API_KEY,
+      apiKey: 'static-key',
+    };
+    // The real exchanger has no exchanger registered for apiKey/http, so it
+    // hands the credential straight back.
+    vi.mocked(AutoAuthCredentialExchanger).mockImplementationOnce(
+      () =>
+        ({
+          exchange: vi.fn().mockResolvedValue({
+            credential: staticCredential,
+            wasExchanged: false,
+          }),
+        }) as unknown as AutoAuthCredentialExchanger,
+    );
+
+    const state = new State();
+    const mockContext = {
+      state,
+      getAuthResponse: vi.fn().mockReturnValue(undefined),
+      requestCredential: vi.fn(),
+    } as unknown as Context;
+
+    const result = await new ToolAuthHandler(
+      mockContext,
+      {type: 'apiKey', name: 'X-API-Key', in: 'header'},
+      staticCredential,
+    ).prepareAuthCredentials();
+
+    expect(result.state).toBe('done');
+    expect(result.authCredential?.apiKey).toBe('static-key');
+    // It is readable from the tool on every invocation, so persisting it would
+    // only write the secret into the session store for nothing.
+    expect(state.get('apiKey_existing_exchanged_credential')).toBeUndefined();
+    expect(state.hasDelta()).toBe(false);
+  });
+
+  it('caches a static credential that did require an exchange', async () => {
+    const state = new State();
+    const mockContext = {
+      state,
+      getAuthResponse: vi.fn().mockReturnValue(undefined),
+      requestCredential: vi.fn(),
+    } as unknown as Context;
+
+    const result = await new ToolAuthHandler(
+      mockContext,
+      {
+        type: 'oauth2',
+        flows: {
+          clientCredentials: {
+            tokenUrl: 'https://example.com/token',
+            scopes: {},
+          },
+        },
+      },
+      {
+        authType: AuthCredentialTypes.OAUTH2,
+        oauth2: {clientId: 'client-id', clientSecret: 'client-secret'},
+      },
+    ).prepareAuthCredentials();
+
+    expect(result.state).toBe('done');
+    // An exchange costs a round trip, so its result is worth persisting.
+    const stored = state.get<{http?: {credentials: {token: string}}}>(
+      'oauth2_existing_exchanged_credential',
+    );
+    expect(stored?.http?.credentials.token).toBe('exchanged-token');
   });
 });


### PR DESCRIPTION
## Summary

`ToolAuthHandler` accepts an `authCredential` in its constructor, stores it on
`this.authCredential`, and then never reads it. `prepareAuthCredentials()` only
ever consults the interactive route:

```ts
const credential = this.context.getAuthResponse(authConfig);
if (credential) {
  // ...exchange, store, return {state: 'done'}
}

// If credential is not available, request it
this.context.requestCredential(authConfig);

return {state: 'pending'};
```

So a credential supplied when the tool is constructed is ignored, and the tool
asks the client to authorize instead.

For the `apiKey`, `http` and `serviceAccount` schemes there is nothing to
authorize — no user interaction is involved — so nothing will ever resolve that
request. The tool returns `pending` on the first call and on every call after
it, while the credential it was handed sits unused on the handler.

Minimal repro:

```ts
const tools = new OpenAPIToolset({
  specStr: spec,
  authScheme: {type: 'apiKey', name: 'appid', in: 'query'},
  authCredential: {
    authType: AuthCredentialTypes.API_KEY,
    apiKey: process.env.API_KEY,
  },
});

// Every invocation, forever:
// => {pending: true, message: 'Needs your authorization to access your data.'}
```

There is no authorization UI for an API key, so the agent reports that it needs
authorization and the user has nothing to act on.

adk-python does not have this problem because the configured credential is the
fallback when no auth response is present
(`fetched_credential = self._get_auth_response() or self.auth_credential`).

## Fix

Prefer the auth response — it is the more specific credential, supplied for this
particular user — and fall back to the credential the tool was configured with.
Only ask the client to authorize when neither source has anything:

```ts
const authResponseCredential = this.context.getAuthResponse(authConfig);
const credential = authResponseCredential ?? this.authCredential;

if (!credential) {
  this.context.requestCredential(authConfig);

  return {state: 'pending'};
}
```

## One call-out for the reviewer: what gets written to session state

The previous code persisted every credential it resolved. With the fallback in
place, that would newly copy a statically configured secret — the developer's
API key, say — into session state on every run, and from there into the session
store (a table, for `DatabaseSessionService`).

The credential store exists to avoid repeating work that either *cannot* be
repeated (an auth response is readable exactly once) or costs a round trip (an
exchange). A static credential that needed no exchange is neither — the handler
receives it again on every invocation — so it is no longer persisted.
Interactive credentials and exchange results are cached exactly as before, and
the pre-existing tests covering that pass unchanged.

Happy to drop this half and keep the storage unconditional if you would rather
hold the change surface to the fallback alone.

## Test plan

- [x] 3 new tests in `core/test/tools/openapi_tool/tool_auth_handler_test.ts`:
      the configured credential is used instead of prompting; a credential that
      needed no exchange is not written to session state; one that *did* require
      an exchange still is.
- [x] Verified all 3 fail against `main` and pass with the fix. The 6
      pre-existing tests in that file pass unchanged.
- [x] Full unit suite green (`unit:core` + `unit:dev`): **2374 passing**.
- [x] ESLint, Prettier and secretlint clean; `npm run build` green.
