### PR TITLE
fix(a2a): preserve errorCode in event metadata

### DIFF
--- a/core/src/a2a/metadata_converter_utils.ts
+++ b/core/src/a2a/metadata_converter_utils.ts
@@ -86,7 +86,7 @@ export function getA2AEventMetadata(
     [A2AMetadataKeys.INVOCATION_ID]: adkEvent.invocationId,
     [A2AMetadataKeys.AUTHOR]: adkEvent.author,
     [A2AMetadataKeys.BRANCH]: adkEvent.branch,
-    [A2AMetadataKeys.ERROR_CODE]: adkEvent.errorMessage,
+    [A2AMetadataKeys.ERROR_CODE]: adkEvent.errorCode,
     [A2AMetadataKeys.ERROR_MESSAGE]: adkEvent.errorMessage,
     [A2AMetadataKeys.CITATION_METADATA]: adkEvent.citationMetadata,
     [A2AMetadataKeys.GROUNDING_METADATA]: adkEvent.groundingMetadata,

--- a/core/test/a2a/metadata_converter_utils_test.ts
+++ b/core/test/a2a/metadata_converter_utils_test.ts
@@ -145,7 +145,7 @@ describe('metadata_converter_utils', () => {
         kind: 'message',
         messageId: 'msg-1',
         role: 'agent',
-        parts: [],
+        parts: [{kind: 'text', text: 'error'}],
         metadata,
       };
 

--- a/core/test/a2a/metadata_converter_utils_test.ts
+++ b/core/test/a2a/metadata_converter_utils_test.ts
@@ -53,7 +53,8 @@ describe('metadata_converter_utils', () => {
         invocationId: 'inv-1',
         author: 'user1',
         branch: 'branch-1',
-        errorMessage: 'Something went wrong',
+        errorCode: 'RESOURCE_EXHAUSTED',
+        errorMessage: 'Quota exceeded',
         citationMetadata: {
           citations: [
             {
@@ -100,8 +101,8 @@ describe('metadata_converter_utils', () => {
         [A2AMetadataKeys.INVOCATION_ID]: 'inv-1',
         [A2AMetadataKeys.AUTHOR]: 'user1',
         [A2AMetadataKeys.BRANCH]: 'branch-1',
-        [A2AMetadataKeys.ERROR_CODE]: 'Something went wrong',
-        [A2AMetadataKeys.ERROR_MESSAGE]: 'Something went wrong',
+        [A2AMetadataKeys.ERROR_CODE]: 'RESOURCE_EXHAUSTED',
+        [A2AMetadataKeys.ERROR_MESSAGE]: 'Quota exceeded',
         [A2AMetadataKeys.CITATION_METADATA]: {
           citations: [
             {

--- a/core/test/a2a/metadata_converter_utils_test.ts
+++ b/core/test/a2a/metadata_converter_utils_test.ts
@@ -7,6 +7,7 @@
 import {Message, Task} from '@a2a-js/sdk';
 import {Event as AdkEvent, createEventActions} from '@google/adk';
 import {describe, expect, it} from 'vitest';
+import {toAdkEvent} from '../../src/a2a/event_converter_utils.js';
 import {
   A2AMetadataKeys,
   AdkMetadataKeys,
@@ -127,6 +128,31 @@ describe('metadata_converter_utils', () => {
         [A2AMetadataKeys.TRANSFER_TO_AGENT]: 'agent-2',
         [A2AMetadataKeys.IS_LONG_RUNNING]: true,
       });
+    });
+
+    it('preserves error details through a round-trip', () => {
+      const adkEvent = {
+        errorCode: 'RESOURCE_EXHAUSTED',
+        errorMessage: 'Quota exceeded',
+        actions: createEventActions(),
+      } as AdkEvent;
+      const metadata = getA2AEventMetadata(adkEvent, {
+        appName: 'my-app',
+        userId: 'user-id',
+        sessionId: 'session-id',
+      });
+      const message: Message = {
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'agent',
+        parts: [],
+        metadata,
+      };
+
+      const roundTrippedEvent = toAdkEvent(message, 'inv-1', 'agent-1');
+
+      expect(roundTrippedEvent?.errorCode).toBe('RESOURCE_EXHAUSTED');
+      expect(roundTrippedEvent?.errorMessage).toBe('Quota exceeded');
     });
 
     it('creates metadata with missing optional fields', () => {


### PR DESCRIPTION
### Description of Change

**Problem:**

A2A metadata conversion populated both `adk_error_code` and `adk_error_message` from `event.errorMessage`, silently discarding the machine-readable error code.

**Solution:**

Populate `adk_error_code` from `event.errorCode` and update the existing unit test to use distinct code and message values.

### Testing Plan

**Unit Tests:**

- [x] Updated the metadata converter unit test.
- [x] `npx vitest run --project unit:core metadata_converter_utils_test.ts` (4 tests passed)
- [x] `npm run build`
- [x] ESLint and Prettier checks pass for the changed files.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove the fix is effective.
- [x] The focused unit tests pass locally with my changes.

### Additional context

This restores the intended round-trip behavior because A2A-to-ADK conversion already reads `adk_error_code` and `adk_error_message` into separate event fields.