### PR TITLE
fix(artifacts): return undefined for missing in-memory versions

### DIFF
--- a/core/src/artifacts/in_memory_artifact_service.ts
+++ b/core/src/artifacts/in_memory_artifact_service.ts
@@ -84,7 +84,7 @@ export class InMemoryArtifactService implements BaseArtifactService {
       version = versions.length - 1;
     }
 
-    return Promise.resolve(versions[version].part);
+    return Promise.resolve(versions[version]?.part);
   }
 
   listArtifactKeys({

--- a/core/src/artifacts/in_memory_artifact_service.ts
+++ b/core/src/artifacts/in_memory_artifact_service.ts
@@ -6,6 +6,8 @@
 
 import {Part} from '@google/genai';
 
+import {logger} from '../utils/logger.js';
+
 import {
   ArtifactVersion,
   BaseArtifactService,
@@ -84,7 +86,14 @@ export class InMemoryArtifactService implements BaseArtifactService {
       version = versions.length - 1;
     }
 
-    return Promise.resolve(versions[version]?.part);
+    if (!versions[version]) {
+      logger.warn(
+        `[InMemoryArtifactService] loadArtifact: Artifact ${filename} version ${version} not found`,
+      );
+      return Promise.resolve(undefined);
+    }
+
+    return Promise.resolve(versions[version].part);
   }
 
   listArtifactKeys({

--- a/core/test/artifacts/artifact_service_test_utils.ts
+++ b/core/test/artifacts/artifact_service_test_utils.ts
@@ -146,6 +146,26 @@ export function runArtifactServiceTests(
       expect(result).toBeUndefined();
     });
 
+    it('returns undefined for non-existent version', async () => {
+      const filename = 'missing-version.txt';
+      await service.saveArtifact({
+        appName,
+        userId,
+        sessionId,
+        filename,
+        artifact: {text: 'v0'},
+      });
+
+      const result = await service.loadArtifact({
+        appName,
+        userId,
+        sessionId,
+        filename,
+        version: 999,
+      });
+      expect(result).toBeUndefined();
+    });
+
     it('loads specific version', async () => {
       const filename = 'history.txt';
       await service.saveArtifact({


### PR DESCRIPTION
### Description of Change

**Problem:**

`InMemoryArtifactService.loadArtifact()` dereferenced the requested version without checking whether it existed. Loading a stale or unavailable version therefore threw a `TypeError`, despite the artifact service contract specifying `undefined` for missing artifacts.

**Solution:**

Use safe access for the requested in-memory version. The shared artifact-service test suite now verifies that every backend returns `undefined` for an unavailable version.

### Testing Plan

**Unit Tests:**

- [x] Added shared contract coverage for unavailable artifact versions.
- [x] `npx vitest run --project unit:core in_memory_artifact_service_test.ts file_artifact_service_test.ts gcs_artifact_service_test.ts` (99 tests passed)
- [x] `npm run build`
- [x] ESLint and Prettier checks pass for the changed files.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] The relevant unit tests pass locally with my changes.

### Additional context

`getArtifactVersion()` already returns `undefined` for the same missing-version case, so this aligns the two in-memory lookup methods.