### PR TITLE
fix(config): validate the effective maxLlmCalls value

### DIFF
--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -122,9 +122,9 @@ export function createRunConfig(params: Partial<RunConfig> = {}) {
     supportCfc: false,
     enableAffectiveDialog: false,
     streamingMode: StreamingMode.NONE,
-    maxLlmCalls: validateMaxLlmCalls(params.maxLlmCalls || 500),
     pauseOnToolCalls: false,
     ...params,
+    maxLlmCalls: validateMaxLlmCalls(params.maxLlmCalls ?? 500),
   };
 }
 

--- a/core/test/agents/run_config_test.ts
+++ b/core/test/agents/run_config_test.ts
@@ -60,7 +60,8 @@ describe('createRunConfig', () => {
 
   it('logs a warning when maxLlmCalls is negative', () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    createRunConfig({maxLlmCalls: -1});
+    const config = createRunConfig({maxLlmCalls: -1});
+    expect(config.maxLlmCalls).toBe(-1);
     expect(warnSpy).toHaveBeenCalledOnce();
     warnSpy.mockRestore();
   });

--- a/core/test/agents/run_config_test.ts
+++ b/core/test/agents/run_config_test.ts
@@ -6,6 +6,7 @@
 
 import {describe, expect, it, vi} from 'vitest';
 import {createRunConfig, StreamingMode} from '../../src/agents/run_config.js';
+import {logger} from '../../src/utils/logger.js';
 
 describe('StreamingMode', () => {
   it('has NONE, SSE, and BIDI values', () => {
@@ -50,17 +51,23 @@ describe('createRunConfig', () => {
   });
 
   it('logs a warning when maxLlmCalls is 0', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    createRunConfig({maxLlmCalls: 0});
-    // The warning goes through the logger; restore spy regardless of whether
-    // it is intercepted at the console level.
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const config = createRunConfig({maxLlmCalls: 0});
+    expect(config.maxLlmCalls).toBe(0);
+    expect(warnSpy).toHaveBeenCalledOnce();
     warnSpy.mockRestore();
   });
 
   it('logs a warning when maxLlmCalls is negative', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     createRunConfig({maxLlmCalls: -1});
+    expect(warnSpy).toHaveBeenCalledOnce();
     warnSpy.mockRestore();
+  });
+
+  it('uses the default when maxLlmCalls is explicitly undefined', () => {
+    const config = createRunConfig({maxLlmCalls: undefined});
+    expect(config.maxLlmCalls).toBe(500);
   });
 
   it('throws when maxLlmCalls exceeds Number.MAX_SAFE_INTEGER', () => {


### PR DESCRIPTION
### Description of Change

**Problem:**

`createRunConfig()` validated `params.maxLlmCalls || 500` before spreading `params` over the result. As a result, `0` bypassed its documented warning, while an explicit `undefined` overwrote the validated default.

**Solution:**

Spread caller parameters first, then assign `maxLlmCalls` from the validated nullish-coalesced value. The warning tests now observe the project logger and assert that validation occurred.

### Testing Plan

**Unit Tests:**

- [x] Strengthened zero and negative warning assertions.
- [x] Added coverage for an explicitly undefined `maxLlmCalls`.
- [x] `npx vitest run --project unit:core run_config_test.ts` (9 tests passed)
- [x] `npm run build`
- [x] ESLint and Prettier checks pass for the changed files.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] The relevant unit tests pass locally with my changes.

### Additional context

The behavior is unchanged for ordinary positive values. Omitted or explicitly undefined values resolve to `500`, while zero and negative values remain supported and trigger the documented warning.