### PR TITLE
fix(mcp): close agent registry tool-discovery sessions

### DIFF
--- a/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
+++ b/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
@@ -6,6 +6,7 @@
 
 import {ListToolsResult} from '@modelcontextprotocol/sdk/types.js';
 import {ReadonlyContext} from '../../agents/readonly_context.js';
+import {logger} from '../../utils/logger.js';
 import {AuthCredential} from '../../auth/auth_credential.js';
 import {AuthScheme} from '../../auth/auth_schemes.js';
 import {BaseTool} from '../../tools/base_tool.js';
@@ -111,7 +112,9 @@ export class AgentRegistrySingleMCPToolset extends BaseToolset {
     try {
       listResult = (await session.listTools()) as ListToolsResult;
     } finally {
-      await sessionManager.closeSession(session);
+      await sessionManager.closeSession(session).catch((e) => {
+        logger.warn('Failed to close MCP discovery session', e);
+      });
     }
 
     // Map tool definitions to MCPTools

--- a/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
+++ b/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
@@ -106,8 +106,15 @@ export class AgentRegistrySingleMCPToolset extends BaseToolset {
     const sessionManager = new MCPSessionManager(connectionParamsCopy);
     const session = await sessionManager.createSession();
 
-    // Retrieve tools from the remote server and map them to MCPTools
-    const listResult = (await session.listTools()) as ListToolsResult;
+    // Retrieve tools from the remote server and close the discovery session
+    let listResult: ListToolsResult;
+    try {
+      listResult = (await session.listTools()) as ListToolsResult;
+    } finally {
+      await sessionManager.closeSession(session);
+    }
+
+    // Map tool definitions to MCPTools
     const tools = listResult.tools.map((tool) => {
       const prefixedName = this.prefix
         ? `${this.prefix}_${tool.name}`

--- a/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
+++ b/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
@@ -6,7 +6,6 @@
 
 import {ListToolsResult} from '@modelcontextprotocol/sdk/types.js';
 import {ReadonlyContext} from '../../agents/readonly_context.js';
-import {logger} from '../../utils/logger.js';
 import {AuthCredential} from '../../auth/auth_credential.js';
 import {AuthScheme} from '../../auth/auth_schemes.js';
 import {BaseTool} from '../../tools/base_tool.js';
@@ -16,6 +15,7 @@ import {
   StreamableHTTPConnectionParams,
 } from '../../tools/mcp/mcp_session_manager.js';
 import {MCPTool} from '../../tools/mcp/mcp_tool.js';
+import {logger} from '../../utils/logger.js';
 import {GCP_MCP_SERVER_DESTINATION_ID} from './types.js';
 
 /**

--- a/core/test/integrations/agent_registry_mcp_toolset_test.ts
+++ b/core/test/integrations/agent_registry_mcp_toolset_test.ts
@@ -10,6 +10,7 @@ import {
   GCP_MCP_SERVER_DESTINATION_ID,
 } from '../../src/index.js';
 import {StreamableHTTPConnectionParams} from '../../src/tools/mcp/mcp_session_manager.js';
+import {logger} from '../../src/utils/logger.js';
 
 const mockListTools = vi.fn().mockResolvedValue({
   tools: [
@@ -213,6 +214,23 @@ describe('AgentRegistrySingleMCPToolset', () => {
 
       await expect(toolset.getTools()).rejects.toThrow('discovery failed');
       expect(mockClose).toHaveBeenCalledOnce();
+    });
+
+    it('preserves the discovery error when closing also fails', async () => {
+      mockListTools.mockRejectedValueOnce(new Error('discovery failed'));
+      mockClose.mockRejectedValueOnce(new Error('close failed'));
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const toolset = new AgentRegistrySingleMCPToolset({
+        connectionParams: BASE_PARAMS,
+      });
+
+      await expect(toolset.getTools()).rejects.toThrow('discovery failed');
+      expect(mockClose).toHaveBeenCalledOnce();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to close MCP discovery session',
+        expect.objectContaining({message: 'close failed'}),
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/core/test/integrations/agent_registry_mcp_toolset_test.ts
+++ b/core/test/integrations/agent_registry_mcp_toolset_test.ts
@@ -19,10 +19,12 @@ const mockListTools = vi.fn().mockResolvedValue({
 });
 
 const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockClose = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: vi.fn().mockImplementation(() => ({
     connect: mockConnect,
+    close: mockClose,
     listTools: mockListTools,
   })),
 }));
@@ -189,6 +191,28 @@ describe('AgentRegistrySingleMCPToolset', () => {
       });
       await toolset.getTools(context);
       expect(headerProvider).toHaveBeenCalledWith(context);
+    });
+  });
+
+  describe('getTools — session cleanup', () => {
+    it('closes the discovery session after listing tools', async () => {
+      const toolset = new AgentRegistrySingleMCPToolset({
+        connectionParams: BASE_PARAMS,
+      });
+
+      await toolset.getTools();
+
+      expect(mockClose).toHaveBeenCalledOnce();
+    });
+
+    it('closes the discovery session when listing tools fails', async () => {
+      mockListTools.mockRejectedValueOnce(new Error('discovery failed'));
+      const toolset = new AgentRegistrySingleMCPToolset({
+        connectionParams: BASE_PARAMS,
+      });
+
+      await expect(toolset.getTools()).rejects.toThrow('discovery failed');
+      expect(mockClose).toHaveBeenCalledOnce();
     });
   });
 

--- a/core/test/integrations/agent_registry_test.ts
+++ b/core/test/integrations/agent_registry_test.ts
@@ -49,6 +49,7 @@ vi.mock('google-auth-library', () => {
 
 const mockMcpClient = {
   connect: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
   listTools: vi.fn().mockResolvedValue({
     tools: [
       {name: 'tool1', description: 'desc1', inputSchema: {}},


### PR DESCRIPTION
### Description of Change

**Problem:**

`AgentRegistrySingleMCPToolset.getTools()` created an MCP session for tool discovery but never closed it. The session remained active after both successful `listTools()` calls and discovery failures.

**Solution:**

Close the discovery session in a `finally` block, matching the lifecycle pattern already used by `MCPToolset`. Returned `MCPTool` instances continue to create and close their own sessions for tool execution.

### Testing Plan

**Unit Tests:**

- [x] Added coverage that successful discovery closes its session.
- [x] Added coverage that failed discovery still closes its session.
- [x] `npx vitest run --project unit:core agent_registry_mcp_toolset_test.ts agent_registry_test.ts` (66 tests passed)
- [x] `npm run build`
- [x] ESLint and Prettier checks pass for the changed files.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] The relevant unit tests pass locally with my changes.

### Additional context

This does not overlap with #527, which changes session creation error formatting in `mcp_session_manager.ts` and leaves `listTools()` paths unchanged.