### PR TITLE
Feat: add LoadMcpResourceTool (read MCP server resources) for adk-python parity

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -55,6 +55,7 @@ export {RunSkillScriptTool} from './tools/skill/run_skill_script_tool.js';
 export * from './integrations/agent_registry/agent_registry.js';
 export * from './telemetry/google_cloud.js';
 export * from './telemetry/setup.js';
+export * from './tools/mcp/load_mcp_resource_tool.js';
 export * from './tools/mcp/mcp_session_manager.js';
 export * from './tools/mcp/mcp_tool.js';
 export * from './tools/mcp/mcp_toolset.js';

--- a/core/src/tools/mcp/load_mcp_resource_tool.ts
+++ b/core/src/tools/mcp/load_mcp_resource_tool.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Part, Type} from '@google/genai';
+import {
+  BlobResourceContents,
+  TextResourceContents,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import {appendInstructions, LlmRequest} from '../../models/llm_request.js';
+import {logger} from '../../utils/logger.js';
+import {
+  BaseTool,
+  RunAsyncToolRequest,
+  ToolProcessLlmRequest,
+} from '../base_tool.js';
+
+import {MCPToolset} from './mcp_toolset.js';
+
+/**
+ * A tool that loads MCP server resources and adds them to the session.
+ *
+ * This mirrors the in-repo `LoadArtifactsTool` idiom: the model calls
+ * `load_mcp_resource` with the names of the resources it wants, and on the next
+ * turn {@link processLlmRequest} reads those resources over the MCP session and
+ * appends their contents (text and base64-encoded binary) to the request
+ * context.
+ */
+export class LoadMcpResourceTool extends BaseTool {
+  private readonly mcpToolset: MCPToolset;
+
+  constructor(mcpToolset: MCPToolset) {
+    super({
+      name: 'load_mcp_resource',
+      description: `Loads resources from the MCP server.\n\nNOTE: Call when you need access to resources.`,
+    });
+    this.mcpToolset = mcpToolset;
+  }
+
+  override _getDeclaration(): FunctionDeclaration {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          resource_names: {
+            type: Type.ARRAY,
+            items: {
+              type: Type.STRING,
+            },
+            description: 'The names of the MCP resources to load.',
+          },
+        },
+      },
+    };
+  }
+
+  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    const resourceNames = (args['resource_names'] as string[]) || [];
+    return {
+      resource_names: resourceNames,
+      status:
+        'resource contents temporarily inserted and removed. to access these resources, call load_mcp_resource tool again.',
+    };
+  }
+
+  override async processLlmRequest(
+    request: ToolProcessLlmRequest,
+  ): Promise<void> {
+    await super.processLlmRequest(request);
+    await this.appendResourcesToLlmRequest(request.llmRequest);
+  }
+
+  private async appendResourcesToLlmRequest(
+    llmRequest: LlmRequest,
+  ): Promise<void> {
+    try {
+      const availableResourceNames = await this.mcpToolset.listResources();
+      if (availableResourceNames.length > 0) {
+        appendInstructions(llmRequest, [
+          `You have a list of MCP resources:\n${JSON.stringify(
+            availableResourceNames,
+          )}\n\nWhen the user asks questions about any of the resources, you should call the\n\`load_mcp_resource\` function to load the resource. Always call load_mcp_resource\nbefore answering questions related to the resources.`,
+        ]);
+      }
+    } catch (e) {
+      logger.warn(`Failed to list MCP resources: ${e}`);
+    }
+
+    const lastContent = llmRequest.contents.at(-1);
+    const functionResponse = lastContent?.parts?.[0]?.functionResponse;
+    if (!functionResponse || functionResponse.name !== this.name) {
+      return;
+    }
+
+    const response =
+      (functionResponse.response as Record<string, unknown>) || {};
+    const requestedResourceNames =
+      (response['resource_names'] as string[]) || [];
+
+    for (const resourceName of requestedResourceNames) {
+      try {
+        const resourceContents =
+          await this.mcpToolset.readResource(resourceName);
+        for (const content of resourceContents) {
+          llmRequest.contents.push({
+            role: 'user',
+            parts: [
+              {text: `Resource ${resourceName} is:`},
+              this.mcpContentToPart(content, resourceName),
+            ],
+          });
+        }
+      } catch (e) {
+        logger.warn(`Failed to read MCP resource '${resourceName}': ${e}`);
+      }
+    }
+  }
+
+  private mcpContentToPart(
+    content: TextResourceContents | BlobResourceContents,
+    resourceName: string,
+  ): Part {
+    if ('text' in content) {
+      return {text: content.text};
+    }
+    if ('blob' in content) {
+      // The MCP SDK blob and Part.inlineData.data are both base64 strings, so
+      // the blob is assigned directly with no decode/re-encode step.
+      return {
+        inlineData: {
+          data: content.blob,
+          mimeType: content.mimeType ?? 'application/octet-stream',
+        },
+      };
+    }
+    return {text: `[Unknown content type for ${resourceName}]`};
+  }
+}

--- a/core/src/tools/mcp/mcp_toolset.ts
+++ b/core/src/tools/mcp/mcp_toolset.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ListToolsResult} from '@modelcontextprotocol/sdk/types.js';
+import {
+  BlobResourceContents,
+  ListResourcesResult,
+  ListToolsResult,
+  ReadResourceResult,
+  Resource,
+  TextResourceContents,
+} from '@modelcontextprotocol/sdk/types.js';
 
 import {ReadonlyContext} from '../../agents/readonly_context.js';
 import {logger} from '../../utils/logger.js';
@@ -102,6 +109,76 @@ export class MCPToolset extends BaseToolset {
         'was called without a ReadonlyContext. The filter will not be applied.',
     );
     return tools;
+  }
+
+  /**
+   * Lists the names of the resources advertised by the MCP server.
+   *
+   * @return The resource names available on the server.
+   */
+  async listResources(): Promise<string[]> {
+    const session = await this.mcpSessionManager.createSession();
+    try {
+      const result = (await session.listResources()) as ListResourcesResult;
+      return result.resources.map((resource) => resource.name);
+    } finally {
+      await this.mcpSessionManager.closeSession(session);
+    }
+  }
+
+  /**
+   * Returns metadata for the resource whose name matches `name`.
+   *
+   * @param name The advertised name of the resource.
+   * @return The matching MCP `Resource`.
+   * @throws If no resource with the given name is advertised by the server.
+   */
+  async getResourceInfo(name: string): Promise<Resource> {
+    const session = await this.mcpSessionManager.createSession();
+    let result: ListResourcesResult;
+    try {
+      result = (await session.listResources()) as ListResourcesResult;
+    } finally {
+      await this.mcpSessionManager.closeSession(session);
+    }
+
+    const resource = result.resources.find(
+      (candidate) => candidate.name === name,
+    );
+    if (!resource) {
+      throw new Error(`Resource with name '${name}' not found.`);
+    }
+    return resource;
+  }
+
+  /**
+   * Reads the contents of the named resource from the MCP server.
+   *
+   * The resource name is resolved to a URI via {@link getResourceInfo} before
+   * reading. Binary contents are returned base64-encoded, exactly as provided
+   * by the server (never decoded and re-encoded).
+   *
+   * @param name The advertised name of the resource to read.
+   * @return The resource contents (text and/or base64-encoded binary).
+   * @throws If the resource is unknown or has no URI.
+   */
+  async readResource(
+    name: string,
+  ): Promise<Array<TextResourceContents | BlobResourceContents>> {
+    const resourceInfo = await this.getResourceInfo(name);
+    if (!resourceInfo.uri) {
+      throw new Error(`Resource '${name}' has no URI.`);
+    }
+
+    const session = await this.mcpSessionManager.createSession();
+    try {
+      const result = (await session.readResource({
+        uri: resourceInfo.uri,
+      })) as ReadResourceResult;
+      return result.contents;
+    } finally {
+      await this.mcpSessionManager.closeSession(session);
+    }
   }
 
   async close(): Promise<void> {

--- a/core/test/tools/mcp/load_mcp_resource_tool_test.ts
+++ b/core/test/tools/mcp/load_mcp_resource_tool_test.ts
@@ -1,0 +1,273 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  LlmRequest,
+  LoadMcpResourceTool,
+  MCPToolset,
+  RunAsyncToolRequest,
+} from '@google/adk';
+import {Content, Type} from '@google/genai';
+import {beforeEach, describe, expect, it, Mock, vi} from 'vitest';
+
+/**
+ * Builds a {@link LoadMcpResourceTool} backed by a minimal mock toolset. Only
+ * `listResources`/`readResource` are exercised by the tool, so those are the
+ * only methods stubbed.
+ */
+function setup() {
+  const listResources = vi.fn().mockResolvedValue([] as string[]);
+  const readResource = vi.fn().mockResolvedValue([]);
+  const toolset = {listResources, readResource} as unknown as MCPToolset;
+  const tool = new LoadMcpResourceTool(toolset);
+  return {tool, listResources, readResource};
+}
+
+/** A throwaway tool context; the tool never reads from it. */
+const toolContext = {} as unknown as Context;
+
+/** Builds a bare LlmRequest suitable for `processLlmRequest`. */
+function makeLlmRequest(contents: Content[] = []): LlmRequest {
+  return {contents, toolsDict: {}} as unknown as LlmRequest;
+}
+
+/** Builds a content whose first part is a `load_mcp_resource` function response. */
+function functionResponseContent(response: Record<string, unknown>): Content {
+  return {
+    role: 'user',
+    parts: [{functionResponse: {name: 'load_mcp_resource', response}}],
+  };
+}
+
+describe('LoadMcpResourceTool', () => {
+  let listResources: Mock;
+  let readResource: Mock;
+  let tool: LoadMcpResourceTool;
+
+  beforeEach(() => {
+    ({tool, listResources, readResource} = setup());
+  });
+
+  it('initializes with the load_mcp_resource name', () => {
+    expect(tool.name).toBe('load_mcp_resource');
+  });
+
+  describe('_getDeclaration', () => {
+    it('declares a resource_names array-of-strings parameter', () => {
+      const declaration = tool._getDeclaration();
+
+      expect(declaration.name).toBe('load_mcp_resource');
+      const resourceNames =
+        declaration.parameters?.properties?.['resource_names'];
+      expect(resourceNames?.type).toBe(Type.ARRAY);
+      expect(resourceNames?.items?.type).toBe(Type.STRING);
+    });
+  });
+
+  describe('runAsync', () => {
+    it('echoes the requested resource names with a status', async () => {
+      const result = (await tool.runAsync({
+        args: {resource_names: ['res1', 'res2']},
+        toolContext,
+      })) as {resource_names: string[]; status: string};
+
+      expect(result.resource_names).toEqual(['res1', 'res2']);
+      expect(result.status).toContain('temporarily inserted');
+    });
+
+    it('defaults resource_names to an empty array when absent', async () => {
+      const result = (await tool.runAsync({
+        args: {},
+        toolContext,
+      } as RunAsyncToolRequest)) as {resource_names: string[]};
+
+      expect(result.resource_names).toEqual([]);
+    });
+  });
+
+  describe('processLlmRequest', () => {
+    it('injects the resource list into the system instruction', async () => {
+      listResources.mockResolvedValue(['res1', 'res2']);
+      const llmRequest = makeLlmRequest([]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.config?.systemInstruction).toContain('res1');
+      expect(llmRequest.config?.systemInstruction).toContain('res2');
+    });
+
+    it('does not inject instructions when there are no resources', async () => {
+      listResources.mockResolvedValue([]);
+      const llmRequest = makeLlmRequest([]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.config?.systemInstruction).toBeUndefined();
+    });
+
+    it('swallows list errors and still processes function responses', async () => {
+      listResources.mockRejectedValue(new Error('list failed'));
+      readResource.mockResolvedValue([
+        {uri: 'file:///res1', mimeType: 'text/plain', text: 'hello content'},
+      ]);
+      const llmRequest = makeLlmRequest([
+        functionResponseContent({resource_names: ['res1']}),
+      ]);
+
+      await expect(
+        tool.processLlmRequest({toolContext, llmRequest}),
+      ).resolves.toBeUndefined();
+
+      expect(llmRequest.contents).toHaveLength(2);
+    });
+
+    it('appends text resource content', async () => {
+      readResource.mockResolvedValue([
+        {uri: 'file:///res1', mimeType: 'text/plain', text: 'hello content'},
+      ]);
+      const llmRequest = makeLlmRequest([
+        functionResponseContent({resource_names: ['res1']}),
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(readResource).toHaveBeenCalledWith('res1');
+      expect(llmRequest.contents).toHaveLength(2);
+      const appended = llmRequest.contents[1];
+      expect(appended.role).toBe('user');
+      expect(appended.parts?.[0].text).toBe('Resource res1 is:');
+      expect(appended.parts?.[1].text).toBe('hello content');
+    });
+
+    it('appends binary resource content without decoding the base64 blob', async () => {
+      const blob = Buffer.from('binary data').toString('base64');
+      readResource.mockResolvedValue([
+        {uri: 'file:///res1', mimeType: 'image/png', blob},
+      ]);
+      const llmRequest = makeLlmRequest([
+        functionResponseContent({resource_names: ['res1']}),
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      const part = llmRequest.contents[1].parts?.[1];
+      expect(part?.inlineData?.data).toBe(blob);
+      expect(part?.inlineData?.mimeType).toBe('image/png');
+    });
+
+    it('defaults the mime type for binary content that lacks one', async () => {
+      const blob = Buffer.from('binary data').toString('base64');
+      readResource.mockResolvedValue([{uri: 'file:///res1', blob}]);
+      const llmRequest = makeLlmRequest([
+        functionResponseContent({resource_names: ['res1']}),
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      const part = llmRequest.contents[1].parts?.[1];
+      expect(part?.inlineData?.mimeType).toBe('application/octet-stream');
+    });
+
+    it('renders a placeholder for unknown content types', async () => {
+      readResource.mockResolvedValue([{uri: 'file:///res1'}]);
+      const llmRequest = makeLlmRequest([
+        functionResponseContent({resource_names: ['res1']}),
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.contents[1].parts?.[1].text).toContain(
+        'Unknown content type',
+      );
+    });
+
+    it('swallows read errors and appends nothing for that resource', async () => {
+      readResource.mockRejectedValue(new Error('read failed'));
+      const llmRequest = makeLlmRequest([
+        functionResponseContent({resource_names: ['res1']}),
+      ]);
+
+      await expect(
+        tool.processLlmRequest({toolContext, llmRequest}),
+      ).resolves.toBeUndefined();
+
+      expect(llmRequest.contents).toHaveLength(1);
+    });
+
+    it('does nothing when the last content is not a matching function response', async () => {
+      const llmRequest = makeLlmRequest([
+        {
+          role: 'user',
+          parts: [{functionResponse: {name: 'other_tool', response: {}}}],
+        },
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.contents).toHaveLength(1);
+      expect(readResource).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the last content has no parts', async () => {
+      const llmRequest = makeLlmRequest([{role: 'user'}]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.contents).toHaveLength(1);
+      expect(readResource).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the last content has an empty parts array', async () => {
+      const llmRequest = makeLlmRequest([{role: 'user', parts: []}]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.contents).toHaveLength(1);
+      expect(readResource).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the first part is not a function response', async () => {
+      const llmRequest = makeLlmRequest([
+        {role: 'user', parts: [{text: 'just text'}]},
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.contents).toHaveLength(1);
+      expect(readResource).not.toHaveBeenCalled();
+    });
+
+    it('reads nothing when the function response omits resource_names', async () => {
+      const llmRequest = makeLlmRequest([
+        {
+          role: 'user',
+          parts: [{functionResponse: {name: 'load_mcp_resource'}}],
+        },
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.contents).toHaveLength(1);
+      expect(readResource).not.toHaveBeenCalled();
+    });
+
+    it('appends content after a preceding conversation turn', async () => {
+      readResource.mockResolvedValue([
+        {uri: 'file:///res1', mimeType: 'text/plain', text: 'hello content'},
+      ]);
+      const llmRequest = makeLlmRequest([
+        {role: 'user', parts: [{text: 'earlier message'}]},
+        functionResponseContent({resource_names: ['res1']}),
+      ]);
+
+      await tool.processLlmRequest({toolContext, llmRequest});
+
+      expect(llmRequest.contents).toHaveLength(3);
+      expect(llmRequest.contents[2].parts?.[1].text).toBe('hello content');
+    });
+  });
+});

--- a/core/test/tools/mcp/mcp_toolset_test.ts
+++ b/core/test/tools/mcp/mcp_toolset_test.ts
@@ -25,9 +25,23 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
           {name: 'other-tool', description: 'Another tool', inputSchema: {}},
         ],
       }),
+      listResources: vi.fn().mockResolvedValue({
+        resources: [
+          {uri: 'file:///res1', name: 'res1'},
+          {uri: 'file:///res2', name: 'res2'},
+        ],
+      }),
+      readResource: vi.fn().mockResolvedValue({
+        contents: [
+          {uri: 'file:///res1', mimeType: 'text/plain', text: 'hello'},
+        ],
+      }),
     })),
   };
 });
+
+/** A client method stub that resolves to nothing (connect/close). */
+const noop = () => vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => {
   return {
@@ -147,6 +161,176 @@ describe('MCPToolset', () => {
       await expect(toolset.getTools()).rejects.toThrow('List tools failed');
       expect(spy).toHaveBeenCalledOnce();
       expect(toolset['mcpSessionManager'].getActiveSessions()).toHaveLength(0);
+    });
+  });
+
+  describe('resources', () => {
+    it('listResources returns the mapped resource names', async () => {
+      const toolset = new MCPToolset(stdioParams);
+
+      const names = await toolset.listResources();
+
+      expect(names).toEqual(['res1', 'res2']);
+    });
+
+    it('getResourceInfo returns the matching resource', async () => {
+      const toolset = new MCPToolset(stdioParams);
+
+      const info = await toolset.getResourceInfo('res1');
+
+      expect(info.name).toBe('res1');
+      expect(info.uri).toBe('file:///res1');
+    });
+
+    it('getResourceInfo rejects when the name is unknown', async () => {
+      const toolset = new MCPToolset(stdioParams);
+
+      await expect(toolset.getResourceInfo('nope')).rejects.toThrow(
+        "Resource with name 'nope' not found.",
+      );
+    });
+
+    it('readResource resolves the URI and returns the contents', async () => {
+      const {Client} =
+        await import('@modelcontextprotocol/sdk/client/index.js');
+      const readResource = vi.fn().mockResolvedValue({
+        contents: [{uri: 'file:///res1', text: 'hello'}],
+      });
+      vi.mocked(Client)
+        .mockImplementationOnce(
+          () =>
+            ({
+              connect: noop(),
+              close: noop(),
+              listResources: vi.fn().mockResolvedValue({
+                resources: [{uri: 'file:///res1', name: 'res1'}],
+              }),
+            }) as unknown as Client,
+        )
+        .mockImplementationOnce(
+          () =>
+            ({
+              connect: noop(),
+              close: noop(),
+              readResource,
+            }) as unknown as Client,
+        );
+
+      const toolset = new MCPToolset(stdioParams);
+      const contents = await toolset.readResource('res1');
+
+      expect(readResource).toHaveBeenCalledWith({uri: 'file:///res1'});
+      expect(contents).toEqual([{uri: 'file:///res1', text: 'hello'}]);
+    });
+
+    it('readResource rejects when the name is unknown', async () => {
+      const toolset = new MCPToolset(stdioParams);
+
+      await expect(toolset.readResource('nope')).rejects.toThrow(
+        "Resource with name 'nope' not found.",
+      );
+    });
+
+    it('readResource rejects when the resolved resource has no URI', async () => {
+      const {Client} =
+        await import('@modelcontextprotocol/sdk/client/index.js');
+      vi.mocked(Client).mockImplementationOnce(
+        () =>
+          ({
+            connect: noop(),
+            close: noop(),
+            listResources: vi.fn().mockResolvedValue({
+              resources: [{uri: '', name: 'res1'}],
+            }),
+          }) as unknown as Client,
+      );
+
+      const toolset = new MCPToolset(stdioParams);
+
+      await expect(toolset.readResource('res1')).rejects.toThrow(
+        "Resource 'res1' has no URI.",
+      );
+    });
+
+    describe('cleanup', () => {
+      it('closes the session after listResources succeeds', async () => {
+        const toolset = new MCPToolset(stdioParams);
+        const spy = vi.spyOn(toolset['mcpSessionManager'], 'closeSession');
+
+        await toolset.listResources();
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(toolset['mcpSessionManager'].getActiveSessions()).toHaveLength(
+          0,
+        );
+      });
+
+      it('closes the session even if the client listResources rejects', async () => {
+        const {Client} =
+          await import('@modelcontextprotocol/sdk/client/index.js');
+        vi.mocked(Client).mockImplementationOnce(
+          () =>
+            ({
+              connect: noop(),
+              close: noop(),
+              listResources: vi.fn().mockRejectedValue(new Error('list boom')),
+            }) as unknown as Client,
+        );
+
+        const toolset = new MCPToolset(stdioParams);
+        const spy = vi.spyOn(toolset['mcpSessionManager'], 'closeSession');
+
+        await expect(toolset.listResources()).rejects.toThrow('list boom');
+        expect(spy).toHaveBeenCalledOnce();
+        expect(toolset['mcpSessionManager'].getActiveSessions()).toHaveLength(
+          0,
+        );
+      });
+
+      it('closes both sessions after readResource succeeds', async () => {
+        const toolset = new MCPToolset(stdioParams);
+        const spy = vi.spyOn(toolset['mcpSessionManager'], 'closeSession');
+
+        await toolset.readResource('res1');
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(toolset['mcpSessionManager'].getActiveSessions()).toHaveLength(
+          0,
+        );
+      });
+
+      it('closes both sessions even if the client readResource rejects', async () => {
+        const {Client} =
+          await import('@modelcontextprotocol/sdk/client/index.js');
+        vi.mocked(Client)
+          .mockImplementationOnce(
+            () =>
+              ({
+                connect: noop(),
+                close: noop(),
+                listResources: vi.fn().mockResolvedValue({
+                  resources: [{uri: 'file:///res1', name: 'res1'}],
+                }),
+              }) as unknown as Client,
+          )
+          .mockImplementationOnce(
+            () =>
+              ({
+                connect: noop(),
+                close: noop(),
+                readResource: vi.fn().mockRejectedValue(new Error('read boom')),
+              }) as unknown as Client,
+          );
+
+        const toolset = new MCPToolset(stdioParams);
+        const spy = vi.spyOn(toolset['mcpSessionManager'], 'closeSession');
+
+        await expect(toolset.readResource('res1')).rejects.toThrow('read boom');
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(toolset['mcpSessionManager'].getActiveSessions()).toHaveLength(
+          0,
+        );
+      });
     });
   });
 });

--- a/tests/e2e/tools/mcp/load_mcp_resource_e2e_test.ts
+++ b/tests/e2e/tools/mcp/load_mcp_resource_e2e_test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  LlmRequest,
+  LoadMcpResourceTool,
+  MCPToolset,
+} from '@google/adk';
+import {fileURLToPath} from 'node:url';
+import {afterEach, describe, expect, it} from 'vitest';
+
+/**
+ * End-to-end test with NO mocks: a real `MCPToolset` talks to a real MCP server
+ * (spawned as a stdio child process, see `mcp_resource_server.mjs`) that exposes
+ * a text and a binary resource. This proves the resource path works against an
+ * actual MCP server, not just against test doubles.
+ */
+
+const SERVER_PATH = fileURLToPath(
+  new URL('./mcp_resource_server.mjs', import.meta.url),
+);
+
+/** A throwaway tool context; the tool never reads from it. */
+const toolContext = {} as unknown as Context;
+
+function createToolset(): MCPToolset {
+  return new MCPToolset({
+    type: 'StdioConnectionParams',
+    serverParams: {command: process.execPath, args: [SERVER_PATH]},
+  });
+}
+
+function functionResponseRequest(resourceNames: string[]): LlmRequest {
+  return {
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'load_mcp_resource',
+              response: {resource_names: resourceNames},
+            },
+          },
+        ],
+      },
+    ],
+    toolsDict: {},
+  } as unknown as LlmRequest;
+}
+
+describe('LoadMcpResourceTool (e2e, real MCP server over stdio)', () => {
+  let toolset: MCPToolset;
+
+  afterEach(async () => {
+    await toolset?.close();
+  });
+
+  it('lists, resolves, and reads real MCP resources', async () => {
+    toolset = createToolset();
+
+    const names = await toolset.listResources();
+    expect(names).toEqual(expect.arrayContaining(['readme', 'logo']));
+
+    const info = await toolset.getResourceInfo('readme');
+    expect(info.uri).toBe('file:///readme.txt');
+
+    const textContents = await toolset.readResource('readme');
+    expect(textContents[0]).toMatchObject({text: 'hello from mcp resource'});
+
+    const binaryContents = await toolset.readResource('logo');
+    expect(binaryContents[0]).toMatchObject({
+      blob: Buffer.from('binary-logo-bytes').toString('base64'),
+      mimeType: 'image/png',
+    });
+  });
+
+  it('rejects when reading an unknown resource', async () => {
+    toolset = createToolset();
+
+    await expect(toolset.readResource('does-not-exist')).rejects.toThrow(
+      'not found',
+    );
+  });
+
+  it('injects real resource contents into the LlmRequest via the tool', async () => {
+    toolset = createToolset();
+    const tool = new LoadMcpResourceTool(toolset);
+    const llmRequest = functionResponseRequest(['readme', 'logo']);
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    // The server advertises the resources, so the guidance is injected.
+    expect(llmRequest.config?.systemInstruction).toContain('readme');
+
+    // The original function-response turn plus one appended turn per resource.
+    expect(llmRequest.contents).toHaveLength(3);
+
+    const textTurn = llmRequest.contents[1];
+    expect(textTurn.role).toBe('user');
+    expect(textTurn.parts?.[0].text).toBe('Resource readme is:');
+    expect(textTurn.parts?.[1].text).toBe('hello from mcp resource');
+
+    const binaryTurn = llmRequest.contents[2];
+    expect(binaryTurn.parts?.[0].text).toBe('Resource logo is:');
+    expect(binaryTurn.parts?.[1].inlineData?.mimeType).toBe('image/png');
+    expect(binaryTurn.parts?.[1].inlineData?.data).toBe(
+      Buffer.from('binary-logo-bytes').toString('base64'),
+    );
+  });
+});

--- a/tests/e2e/tools/mcp/mcp_resource_server.mjs
+++ b/tests/e2e/tools/mcp/mcp_resource_server.mjs
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A minimal, real MCP server exposing two resources (one text, one binary) over
+ * stdio. It is spawned as a child process by the LoadMcpResourceTool e2e test to
+ * exercise the resource path end-to-end with no mocks.
+ */
+
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = new McpServer({name: 'e2e-resource-server', version: '1.0.0'});
+
+server.registerResource(
+  'readme',
+  'file:///readme.txt',
+  {mimeType: 'text/plain'},
+  async (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: 'text/plain',
+        text: 'hello from mcp resource',
+      },
+    ],
+  }),
+);
+
+server.registerResource(
+  'logo',
+  'file:///logo.png',
+  {mimeType: 'image/png'},
+  async (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: 'image/png',
+        blob: Buffer.from('binary-logo-bytes').toString('base64'),
+      },
+    ],
+  }),
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

**Problem:** adk-js can already expose MCP *tools* (`core/src/tools/mcp/`), but it has no way to load MCP *resources* into the model's context. adk-python has `LoadMcpResourceTool` (`src/google/adk/tools/load_mcp_resource_tool.py`) for exactly this, so adk-js is missing cross-language parity: an agent cannot discover or pull MCP server resources on demand.

**Solution:** Port `LoadMcpResourceTool` to adk-js and add the resource-access methods it needs on `MCPToolset`.

- `MCPToolset` gains `listResources()`, `getResourceInfo(name)`, and `readResource(name)`. Each opens a session via the existing `MCPSessionManager` and closes it in a `finally` — the same `create -> try -> closeSession` pattern already used by `getTools()`, so no session leaks even on error. Resolution keys off the resource **name** and reads off its **URI**, mirroring adk-python's `mcp_toolset.py`.
- New `LoadMcpResourceTool` (`core/src/tools/mcp/load_mcp_resource_tool.ts`) mirrors the in-repo `LoadArtifactsTool` idiom: it declares `load_mcp_resource({ resource_names: string[] })`, and its `processLlmRequest` injects a resource-list guidance instruction and, on the following turn, appends each requested resource's contents to `llmRequest.contents`.
- Binary contents are passed through as base64 end-to-end: the MCP SDK's `blob` and `Part.inlineData.data` are both base64 strings, so the port assigns the blob directly with **no** decode/re-encode step (matching the "base64-encoded binary contents" requirement).
- The tool is exported from the `@google/adk` public entry point (`core/src/index.ts`).

This is purely additive and non-breaking: no existing signatures change, and no new dependency is introduced (`@modelcontextprotocol/sdk` and `@google/genai` are already present). The adk-python `use_mcp_resources` constructor flag that auto-appends the tool inside `getTools()` is intentionally out of scope (it introduces an import cycle) and is deferred as a follow-up.

Design notes for reviewers:

- adk-js's `FeatureName` has no JSON-schema flag (unlike adk-python), so the port emits a single plain `FunctionDeclaration` like `LoadArtifactsTool` — no invented feature flag.
- Errors are contained: `listResources` failures in `processLlmRequest` are logged and skipped; per-resource `readResource` failures are logged and that resource is skipped. `processLlmRequest` never throws.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

- `core/test/tools/mcp/load_mcp_resource_tool_test.ts` (new): init, declaration shape, `runAsync` (incl. default empty `resource_names`), list injection (incl. empty-list and swallowed list errors), text / binary / unknown content, base64 blob pass-through, default mime type, swallowed read errors, and every no-op guard path (non-matching / absent function response, missing / empty parts). 100% line + branch coverage of the new tool.
- `core/test/tools/mcp/mcp_toolset_test.ts` (extended): `listResources` / `getResourceInfo` / `readResource` happy paths and error paths (unknown name, missing URI), plus session-cleanup assertions on both success and failure (`closeSession` in `finally`, no leaked sessions). 100% branch coverage of the new methods.
- Ran only the targeted suites: `npx vitest run --project unit:core --project e2e tools/mcp` (51 tests passing). Also verified `npm run build`, `npm run lint`, `npm run format:check`, and `npm run docs:check` pass locally.

**Manual End-to-End (E2E) Tests:**

An automated, no-mock E2E test is included at `tests/e2e/tools/mcp/load_mcp_resource_e2e_test.ts`. It spawns a real MCP server over stdio (`tests/e2e/tools/mcp/mcp_resource_server.mjs`, exposing a text resource and a binary resource) and drives the real `MCPToolset` + `LoadMcpResourceTool` end-to-end: listing, resolving, and reading resources, and injecting their contents (text + base64 binary) into an `LlmRequest`.

To run it manually:

```
npm install
npx vitest run --project e2e tests/e2e/tools/mcp/load_mcp_resource_e2e_test.ts
```

To try it against your own MCP server, point `MCPToolset` at it and construct `new LoadMcpResourceTool(toolset)`:

```ts
import { MCPToolset, LoadMcpResourceTool } from '@google/adk';

const toolset = new MCPToolset({
  type: 'StreamableHTTPConnectionParams',
  url: 'http://localhost:8788/mcp',
});
const loadResourceTool = new LoadMcpResourceTool(toolset);
// The model can now call load_mcp_resource({ resource_names: ['README', 'config'] }).
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
