### PR TITLE
Feat: add clone() to BaseAgent (Part 1/2)

### DIFF
--- a/core/src/a2a/a2a_remote_agent.ts
+++ b/core/src/a2a/a2a_remote_agent.ts
@@ -109,8 +109,12 @@ export interface RemoteA2AAgentConfig extends BaseAgentConfig {
 
 /**
  * RemoteA2AAgent delegates execution to a remote agent using the A2A protocol.
+ *
+ * @remarks
+ * A cloned `RemoteA2AAgent` (via {@link BaseAgent.clone}) is a fresh,
+ * uninitialized instance that re-resolves its client and card on first use.
  */
-export class RemoteA2AAgent extends BaseAgent {
+export class RemoteA2AAgent extends BaseAgent<RemoteA2AAgentConfig> {
   private client?: Client;
   private card?: AgentCard;
   private isInitialized = false;

--- a/core/src/agents/base_agent.ts
+++ b/core/src/agents/base_agent.ts
@@ -70,12 +70,28 @@ export function isBaseAgent(obj: unknown): obj is BaseAgent {
 
 /**
  * Base class for all agents in Agent Development Kit.
+ *
+ * The class is generic over its config type so that {@link clone} can be typed
+ * per subclass (e.g. `LlmAgent.clone({instruction})`). The default keeps bare
+ * `BaseAgent` references valid as `BaseAgent<BaseAgentConfig>`.
  */
-export abstract class BaseAgent {
+export abstract class BaseAgent<
+  TConfig extends BaseAgentConfig = BaseAgentConfig,
+> {
   /**
    * A unique symbol to identify ADK agent classes.
    */
   readonly [BASE_AGENT_SIGNATURE_SYMBOL] = true;
+
+  /**
+   * The config this agent was constructed from.
+   *
+   * Stored so {@link clone} can rebuild the agent by re-running the concrete
+   * constructor with overrides applied, which re-derives all state correctly
+   * instead of copying an already-mutated instance. Shallow-copied so later
+   * external mutation of the caller's object does not leak into clones.
+   */
+  protected readonly config: TConfig;
 
   /**
    * The agent's name.
@@ -147,6 +163,9 @@ export abstract class BaseAgent {
   readonly afterAgentCallback: SingleAgentCallback[];
 
   constructor(config: BaseAgentConfig) {
+    // Captures every field the concrete subclass passed to super(...), even
+    // though the parameter is typed BaseAgentConfig, so clone() can rebuild it.
+    this.config = {...config} as TConfig;
     this.name = validateAgentName(config.name);
     this.description = config.description;
     this.parentAgent = config.parentAgent;
@@ -157,6 +176,59 @@ export abstract class BaseAgent {
     this.afterAgentCallback = getCannonicalCallback(config.afterAgentCallback);
 
     this.setParentAgentForSubAgents();
+  }
+
+  /**
+   * Creates a copy of this agent with the given config fields overridden.
+   *
+   * Mirrors adk-python's `BaseAgent.clone(update=...)`. The clone is a detached
+   * root: its `parentAgent` is always `undefined`. Sub-agents are recursively
+   * cloned (and re-parented to the clone) unless `subAgents` is overridden.
+   * Rebuilding via the concrete constructor re-derives all state, so a cloned
+   * `LlmAgent` gets a fresh `requestProcessors` array rather than sharing the
+   * original's. See google/adk-js#534.
+   *
+   * @param overrides Config fields to override on the clone. Overriding
+   *     `parentAgent` is rejected, matching adk-python.
+   * @returns A new detached agent instance of the same concrete class.
+   */
+  clone(overrides?: Partial<TConfig>): this {
+    if (overrides && 'parentAgent' in overrides) {
+      throw new Error(
+        'Cannot update `parentAgent` field in clone. Parent agent is set ' +
+          'only when the parent agent is instantiated with the sub-agents.',
+      );
+    }
+
+    const merged: TConfig = {...this.config, ...overrides};
+
+    // A clone is always a detached root (matches adk-python setting parent to
+    // None); the rebuilt parent constructor re-parents any cloned children.
+    merged.parentAgent = undefined;
+
+    // Shallow-copy any list-typed field not provided in overrides so the clone
+    // never shares a mutable array (e.g. `tools`) with the original, mirroring
+    // adk-python's per-field list copy.
+    const mergedRecord = merged as Record<string, unknown>;
+    for (const key of Object.keys(mergedRecord)) {
+      if (key === 'subAgents' || (overrides && key in overrides)) {
+        continue;
+      }
+      const value = mergedRecord[key];
+      if (Array.isArray(value)) {
+        mergedRecord[key] = value.slice();
+      }
+    }
+
+    // Recursively clone sub-agents unless explicitly overridden, so the rebuilt
+    // constructor re-parents fresh, unparented children instead of throwing
+    // "already has a parent agent".
+    if (!overrides || !('subAgents' in overrides)) {
+      merged.subAgents = this.subAgents.map((subAgent) => subAgent.clone());
+    }
+
+    const ctor = this.constructor as new (config: TConfig) => this;
+    return new ctor(merged);
   }
 
   /**

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -348,7 +348,7 @@ export function isLlmAgent(obj: unknown): obj is LlmAgent {
 /**
  * An agent that uses a large language model to generate responses.
  */
-export class LlmAgent extends BaseAgent {
+export class LlmAgent extends BaseAgent<LlmAgentConfig> {
   /** A unique symbol to identify ADK LLM agent class. */
   readonly [LLM_AGENT_SIGNATURE_SYMBOL] = true;
 

--- a/core/src/agents/loop_agent.ts
+++ b/core/src/agents/loop_agent.ts
@@ -47,7 +47,7 @@ export function isLoopAgent(obj: unknown): obj is LoopAgent {
  * When sub-agent generates an event with escalate or max_iterations are
  * reached, the loop agent will stop.
  */
-export class LoopAgent extends BaseAgent {
+export class LoopAgent extends BaseAgent<LoopAgentConfig> {
   /**
    * A unique symbol to identify ADK loop agent class.
    */

--- a/core/src/agents/routed_agent.ts
+++ b/core/src/agents/routed_agent.ts
@@ -59,9 +59,16 @@ export interface RoutedAgentConfig extends BaseAgentConfig {
 /**
  * A BaseAgent implementation that delegates to one of multiple agents based on a router function.
  * Routing is strictly limited to the agents passed in the config.
+ *
+ * @remarks
+ * The inherited {@link BaseAgent.clone} does not support `RoutedAgent`: the
+ * constructor derives its routing targets from `config.agents` (not
+ * `subAgents`), so a rebuilt clone re-reads the already-parented originals and
+ * throws. Cloning a `RoutedAgent` is tracked as a follow-up to
+ * google/adk-js#534.
  */
 @experimental
-export class RoutedAgent extends BaseAgent {
+export class RoutedAgent extends BaseAgent<RoutedAgentConfig> {
   readonly [ROUTED_AGENT_SIGNATURE_SYMBOL] = true;
 
   private readonly agents: Readonly<Record<string, BaseAgent>>;

--- a/core/test/agents/base_agent_test.ts
+++ b/core/test/agents/base_agent_test.ts
@@ -5,12 +5,15 @@
  */
 
 import {
+  AgentTransferLlmRequestProcessor,
   BaseAgent,
   BaseAgentConfig,
   Event,
+  FunctionTool,
   InvocationContext,
   LlmAgent,
   PluginManager,
+  RoutedAgent,
   Session,
   createEvent,
 } from '@google/adk';
@@ -159,6 +162,156 @@ describe('BaseAgent', () => {
       }
 
       expect(callback2Called).toBe(false);
+    });
+  });
+
+  describe('clone', () => {
+    const makeTool = (name: string) =>
+      new FunctionTool({
+        name,
+        description: `tool ${name}`,
+        execute: async () => 'ok',
+      });
+
+    it('returns a new, equivalent instance when given no overrides', () => {
+      const tool = makeTool('search');
+      const agent = new LlmAgent({
+        name: 'original',
+        description: 'the original agent',
+        instruction: 'be helpful',
+        model: 'gemini-2.5-flash',
+        tools: [tool],
+      });
+
+      const clone = agent.clone();
+
+      expect(clone).not.toBe(agent);
+      expect(clone).toBeInstanceOf(LlmAgent);
+      expect(clone.name).toBe('original');
+      expect(clone.description).toBe('the original agent');
+      expect(clone.instruction).toBe('be helpful');
+      expect(clone.model).toBe('gemini-2.5-flash');
+      expect(clone.tools).toEqual([tool]);
+    });
+
+    it('shallow-copies list fields so clones never share arrays', () => {
+      const tool = makeTool('search');
+      const agent = new LlmAgent({name: 'original', tools: [tool]});
+
+      const clone = agent.clone();
+
+      // Different array object, same tool instances (shallow copy).
+      expect(clone.tools).not.toBe(agent.tools);
+      expect(clone.tools[0]).toBe(tool);
+    });
+
+    it('rebuilds a single agent-transfer processor (no duplication)', () => {
+      const agent = new LlmAgent({name: 'original', instruction: 'hi'});
+
+      const clone = agent.clone();
+
+      const countTransfer = (a: LlmAgent) =>
+        a.requestProcessors.filter(
+          (p) => p instanceof AgentTransferLlmRequestProcessor,
+        ).length;
+      expect(countTransfer(agent)).toBe(1);
+      expect(countTransfer(clone)).toBe(1);
+    });
+
+    it('applies an instruction override without mutating the original', () => {
+      const agent = new LlmAgent({name: 'original', instruction: 'old'});
+
+      const clone = agent.clone({instruction: 'new'});
+
+      expect(clone.instruction).toBe('new');
+      expect(agent.instruction).toBe('old');
+    });
+
+    it('applies a name override only to the clone', () => {
+      const agent = new LlmAgent({name: 'original'});
+
+      const clone = agent.clone({name: 'renamed'});
+
+      expect(clone.name).toBe('renamed');
+      expect(agent.name).toBe('original');
+    });
+
+    it('uses the provided tools when tools is overridden', () => {
+      const original = makeTool('search');
+      const replacement = makeTool('lookup');
+      const agent = new LlmAgent({name: 'original', tools: [original]});
+
+      const clone = agent.clone({tools: [replacement]});
+
+      expect(clone.tools).toEqual([replacement]);
+      expect(agent.tools).toEqual([original]);
+    });
+
+    it('throws when overriding parentAgent', () => {
+      const agent = new LlmAgent({name: 'original'});
+      const wouldBeParent = new LlmAgent({name: 'parent'});
+
+      expect(() => agent.clone({parentAgent: wouldBeParent})).toThrow(
+        'Cannot update `parentAgent` field in clone.',
+      );
+    });
+
+    it('detaches the clone of a sub-agent from its parent', () => {
+      const subAgent = new LlmAgent({name: 'sub'});
+      const root = new LlmAgent({name: 'root', subAgents: [subAgent]});
+      expect(subAgent.parentAgent).toBe(root);
+
+      const clone = subAgent.clone();
+
+      expect(clone.parentAgent).toBeUndefined();
+    });
+
+    it('recursively clones sub-agents and re-parents them', () => {
+      const subAgent = new LlmAgent({name: 'sub'});
+      const root = new LlmAgent({name: 'root', subAgents: [subAgent]});
+
+      const clonedRoot = root.clone();
+
+      expect(clonedRoot.subAgents).not.toBe(root.subAgents);
+      expect(clonedRoot.subAgents[0]).not.toBe(subAgent);
+      expect(clonedRoot.subAgents[0].parentAgent).toBe(clonedRoot);
+      // The original tree is untouched.
+      expect(subAgent.parentAgent).toBe(root);
+    });
+
+    it('uses the provided sub-agents when subAgents is overridden', () => {
+      const subAgent = new LlmAgent({name: 'sub'});
+      const root = new LlmAgent({name: 'root', subAgents: [subAgent]});
+      const replacement = new LlmAgent({name: 'replacement'});
+
+      const clonedRoot = root.clone({subAgents: [replacement]});
+
+      expect(clonedRoot.subAgents[0]).toBe(replacement);
+      expect(clonedRoot.subAgents[0].parentAgent).toBe(clonedRoot);
+    });
+
+    it('clones a plain BaseAgent subclass', () => {
+      const agent = new MockAgent({name: 'mock', description: 'a mock'});
+
+      const clone = agent.clone();
+
+      expect(clone).not.toBe(agent);
+      expect(clone).toBeInstanceOf(MockAgent);
+      expect(clone.name).toBe('mock');
+      expect(clone.description).toBe('a mock');
+    });
+
+    it('does not support cloning a RoutedAgent (documented limitation)', () => {
+      const target = new LlmAgent({name: 'target'});
+      const routed = new RoutedAgent({
+        name: 'router',
+        agents: [target],
+        router: () => 'target',
+      });
+
+      // The constructor re-derives routing targets from the already-parented
+      // originals, so the rebuilt clone throws. Tracked as a follow-up.
+      expect(() => routed.clone()).toThrow('already has a parent agent');
     });
   });
 });


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.
### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):
Related: #534
2. Or, if no issue exists, describe the change:
**Problem**: `adk-js` has no equivalent of `adk-python`'s `BaseAgent.clone(update=...)`. This is a cross-language parity gap and a prerequisite for the agent optimization module (a `SimplePromptOptimizer` needs to produce an agent variant with a rewritten `instruction`). There is currently no way to copy an agent with selected config fields overridden.

**Solution**: Add `BaseAgent.clone(overrides?)`, mirroring `adk-python`'s `BaseAgent.clone(update=...)`.

- `BaseAgent` is made generic over its config type (`BaseAgent<TConfig extends BaseAgentConfig = BaseAgentConfig>`) so `clone()` overrides are typed per subclass — e.g. `LlmAgent.clone({instruction})` type-checks. The default type parameter keeps every existing bare `BaseAgent` reference valid, so the change is purely additive with no runtime behavior change for existing callers.
- The originating config is stored (shallow-copied) on construction, and `clone()` rebuilds the agent by re-running the concrete constructor with overrides applied. This re-derives all state correctly instead of copying an already-mutated instance — a cloned `LlmAgent` gets a fresh `requestProcessors` array containing exactly one agent-transfer processor rather than sharing or duplicating the original's.
- Clones are detached roots (`parentAgent === undefined`). Sub-agents are recursively cloned and re-parented to the clone unless `subAgents` is overridden. List-typed config fields not present in the overrides are shallow-copied so clones never share mutable arrays (e.g. `tools`) with the original, matching `adk-python`'s per-field list copy.
- Overriding `parentAgent` throws, matching `adk-python`.
- The subclasses `LlmAgent`, `LoopAgent`, `RoutedAgent`, and `RemoteA2AAgent` are parameterized with their config types (type-only change). Cloning a `RoutedAgent` is intentionally out of scope and documented (its constructor derives routing targets from `config.agents` rather than `subAgents`); it is tracked as a follow-up.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.
Unit Tests:
 [x] I have added or updated unit tests for my change.
 [x] All unit tests pass locally.

Added a `describe('clone', ...)` suite to `core/test/agents/base_agent_test.ts` covering: no-override copy equivalence, instruction/name/tools/subAgents overrides, original-left-unmodified, detached parent, recursive sub-agent clone + re-parenting, exactly-one agent-transfer processor (no duplication), no shared arrays, plain `BaseAgent` subclass clone, the `parentAgent`-override error, and the documented `RoutedAgent` limitation. New `clone()` code has 100% line and branch coverage. Ran locally (from repo root):

- `npx vitest run --project unit:core base_agent_test` — 16/16 pass.
- `npx vitest run --project unit:core core/test/agents core/test/a2a` — 444/444 pass (no regressions from the generic change).
- `npm run build` (core `tsc --emitDeclarationOnly` + bundle) — passes, confirming no type regressions.
- `npm run lint`, `prettier --check`, and `npm run docs:check` (TypeDoc, warnings-as-errors) — all clean.

Manual End-to-End (E2E) Tests:
Not applicable — this change adds a synchronous, in-memory `clone()` method with no I/O, network, or credentials. Behavior is fully exercised by the unit tests above.

### Checklist
 [x] I have read the CONTRIBUTING.md document.
 [x] I have performed a self-review of my own code.
 [x] I have commented my code, particularly in hard-to-understand areas.
 [x] I have added tests that prove my fix is effective or that my feature works.
 [x] New and existing unit tests pass locally with my changes.

