### PR TITLE
feat: add optimization module with SimplePromptOptimizer (Part 2/2)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -209,6 +209,17 @@ export {LLMRegistry} from './models/registry.js';
 export type {BaseLlmType} from './models/registry.js';
 export {RoutedLlm} from './models/routed_llm.js';
 export type {LlmRouter} from './models/routed_llm.js';
+export {AgentOptimizer} from './optimization/agent_optimizer.js';
+export type {
+  AgentWithScores,
+  OptimizerResult,
+  SamplingResult,
+  UnstructuredSamplingResult,
+} from './optimization/data_types.js';
+export {Sampler} from './optimization/sampler.js';
+export type {ExampleSet} from './optimization/sampler.js';
+export {SimplePromptOptimizer} from './optimization/simple_prompt_optimizer.js';
+export type {SimplePromptOptimizerConfig} from './optimization/simple_prompt_optimizer.js';
 export {
   GLOBAL_SCOPE_KEY,
   REFLECT_AND_RETRY_RESPONSE_TYPE,

--- a/core/src/optimization/agent_optimizer.ts
+++ b/core/src/optimization/agent_optimizer.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LlmAgent} from '../agents/llm_agent.js';
+import {
+  AgentWithScores,
+  OptimizerResult,
+  SamplingResult,
+} from './data_types.js';
+import {Sampler} from './sampler.js';
+
+/**
+ * Base class for agent optimizers.
+ *
+ * @experimental
+ */
+export abstract class AgentOptimizer<
+  S extends SamplingResult,
+  A extends AgentWithScores,
+> {
+  /**
+   * Runs the optimizer.
+   *
+   * @param initialAgent The initial agent to optimize.
+   * @param sampler Used to get train/validation example UIDs and to score
+   *     candidate agents.
+   * @returns The optimized agents along with their scores.
+   */
+  abstract optimize(
+    initialAgent: LlmAgent,
+    sampler: Sampler<S>,
+  ): Promise<OptimizerResult<A>>;
+}

--- a/core/src/optimization/data_types.ts
+++ b/core/src/optimization/data_types.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LlmAgent} from '../agents/llm_agent.js';
+
+/**
+ * Base evaluation result: per-example scores (higher is better).
+ *
+ * @experimental
+ */
+export interface SamplingResult {
+  /** Map from example UID to the agent's overall score on that example. */
+  scores: Record<string, number>;
+}
+
+/**
+ * Evaluation result with optional per-example unstructured data.
+ *
+ * @experimental
+ */
+export interface UnstructuredSamplingResult extends SamplingResult {
+  /**
+   * Map from example UID to JSON-serializable data useful for optimization
+   * (e.g. inputs, trajectories, and metrics).
+   */
+  data?: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * An optimized agent together with its scores.
+ *
+ * @experimental
+ */
+export interface AgentWithScores {
+  /** The optimized agent. */
+  optimizedAgent: LlmAgent;
+  /** The overall score of the optimized agent (e.g. mean validation score). */
+  overallScore?: number;
+}
+
+/**
+ * Base optimizer result: a Pareto-front of optimized agents that cannot be
+ * considered strictly better than one another
+ * (https://en.wikipedia.org/wiki/Pareto_front), along with their scores.
+ *
+ * @experimental
+ */
+export interface OptimizerResult<T extends AgentWithScores = AgentWithScores> {
+  /** The optimized agents produced by the run. */
+  optimizedAgents: T[];
+}

--- a/core/src/optimization/sampler.ts
+++ b/core/src/optimization/sampler.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LlmAgent} from '../agents/llm_agent.js';
+import {SamplingResult} from './data_types.js';
+
+/** Which example set to sample and score against. */
+export type ExampleSet = 'train' | 'validation';
+
+/**
+ * Base class for optimizers to sample and score candidate agents.
+ *
+ * Developers implement this to plug their scoring/evaluation service into an
+ * optimizer. The optimizer calls {@link sampleAndScore} to evaluate a candidate
+ * agent on a batch of examples. Keeping scoring behind this interface means the
+ * optimizer never decides what "good" means.
+ *
+ * @experimental
+ */
+export abstract class Sampler<T extends SamplingResult> {
+  /** Returns the UIDs of examples to use for training the agent. */
+  abstract getTrainExampleIds(): string[];
+
+  /** Returns the UIDs of examples to use for validating the optimized agent. */
+  abstract getValidationExampleIds(): string[];
+
+  /**
+   * Evaluates the candidate agent on a batch of examples.
+   *
+   * @param candidate The candidate agent to evaluate.
+   * @param exampleSet The set to evaluate against (defaults to `'validation'`).
+   * @param batch UIDs to evaluate; if omitted, uses all examples in the set.
+   * @param captureFullEvalData If true, also capture data useful for
+   *     optimization (e.g. trajectories, outputs, metrics). Defaults to false.
+   * @returns The evaluation results, containing per-example scores.
+   */
+  abstract sampleAndScore(
+    candidate: LlmAgent,
+    exampleSet?: ExampleSet,
+    batch?: string[],
+    captureFullEvalData?: boolean,
+  ): Promise<T>;
+}

--- a/core/src/optimization/simple_prompt_optimizer.ts
+++ b/core/src/optimization/simple_prompt_optimizer.ts
@@ -1,0 +1,280 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {GenerateContentConfig} from '@google/genai';
+
+import {LlmAgent} from '../agents/llm_agent.js';
+import {BaseLlm, isBaseLlm} from '../models/base_llm.js';
+import {LlmRequest} from '../models/llm_request.js';
+import {LLMRegistry} from '../models/registry.js';
+import {experimental} from '../utils/experimental.js';
+import {logger} from '../utils/logger.js';
+
+import {AgentOptimizer} from './agent_optimizer.js';
+import {
+  AgentWithScores,
+  OptimizerResult,
+  UnstructuredSamplingResult,
+} from './data_types.js';
+import {Sampler} from './sampler.js';
+
+/** Default model used to rewrite prompts. */
+const DEFAULT_OPTIMIZER_MODEL = 'gemini-2.5-flash';
+/** Default number of optimization rounds. */
+const DEFAULT_NUM_ITERATIONS = 10;
+/** Default number of training examples used to score each candidate. */
+const DEFAULT_BATCH_SIZE = 5;
+/** Default thinking budget (tokens) for the optimizer model. */
+const DEFAULT_THINKING_BUDGET = 10240;
+
+/**
+ * Prompt template sent to the optimizer model. `{currentScore}` and
+ * `{currentPromptText}` are interpolated before use.
+ */
+const OPTIMIZER_PROMPT_TEMPLATE = `
+You are an expert prompt engineer. Your task is to improve the system prompt for an AI agent.
+The agent's current prompt achieved an average score of {currentScore} on a set of evaluation tasks. A higher score is better.
+
+Here is the current prompt:
+<current_prompt>
+{currentPromptText}
+</current_prompt>
+
+Based on the current prompt, rewrite it to create a new, improved version that is likely to achieve a higher score.
+The agent needs to solve customer support tasks by using tools correctly and following policies.
+Focus on clarity, structure, and providing actionable guidance for the agent.
+
+**Output only the new, full, improved agent prompt. Do not add any other text, explanations, or markdown formatting.**
+`;
+
+/**
+ * Configuration for {@link SimplePromptOptimizer}.
+ *
+ * @experimental
+ */
+export interface SimplePromptOptimizerConfig {
+  /**
+   * Model used to rewrite prompts. A string is resolved via {@link LLMRegistry};
+   * a {@link BaseLlm} instance is used directly (which enables no-network
+   * tests). Defaults to `'gemini-2.5-flash'`.
+   */
+  optimizerModel?: string | BaseLlm;
+
+  /**
+   * Config for the optimizer model. Defaults to a thinking config with
+   * `includeThoughts: true` and a thinking budget of 10240 tokens.
+   */
+  modelConfiguration?: GenerateContentConfig;
+
+  /** Number of optimization rounds. Defaults to 10. */
+  numIterations?: number;
+
+  /** Training examples used to score each candidate. Defaults to 5. */
+  batchSize?: number;
+}
+
+/**
+ * A naive optimizer that iteratively tries to improve an agent's prompt.
+ *
+ * Each round it asks an LLM to rewrite the agent's `instruction` (telling it the
+ * current score), builds a candidate via `clone({instruction})`, scores it on a
+ * random batch of training examples, and keeps it only if it beats the current
+ * best. After `numIterations` rounds it scores the winner on the validation set
+ * and returns it.
+ *
+ * Scoring is pluggable: the developer supplies a {@link Sampler}; this optimizer
+ * never decides what "good" means.
+ *
+ * Note: running this is not free. With the defaults (10 iterations, batch size
+ * 5) a single run performs 50+ candidate scoring runs plus ~10 rewriter model
+ * calls, so expect real cost and latency.
+ *
+ * @experimental
+ */
+@experimental
+export class SimplePromptOptimizer extends AgentOptimizer<
+  UnstructuredSamplingResult,
+  AgentWithScores
+> {
+  private readonly llm: BaseLlm;
+  private readonly optimizerModelName: string;
+  private readonly modelConfiguration: GenerateContentConfig;
+  private readonly numIterations: number;
+  private batchSize: number;
+
+  constructor(config: SimplePromptOptimizerConfig = {}) {
+    super();
+    const model = config.optimizerModel ?? DEFAULT_OPTIMIZER_MODEL;
+    this.llm = isBaseLlm(model) ? model : LLMRegistry.newLlm(model);
+    this.optimizerModelName = this.llm.model;
+    this.modelConfiguration = config.modelConfiguration ?? {
+      thinkingConfig: {
+        includeThoughts: true,
+        thinkingBudget: DEFAULT_THINKING_BUDGET,
+      },
+    };
+    this.numIterations = config.numIterations ?? DEFAULT_NUM_ITERATIONS;
+    this.batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
+  }
+
+  override async optimize(
+    initialAgent: LlmAgent,
+    sampler: Sampler<UnstructuredSamplingResult>,
+  ): Promise<OptimizerResult<AgentWithScores>> {
+    // Fail fast before any LLM or sampler calls.
+    requireStringInstruction(initialAgent);
+
+    const trainExampleIds = sampler.getTrainExampleIds();
+    if (this.batchSize > trainExampleIds.length) {
+      logger.warn(
+        `Batch size (${this.batchSize}) is larger than the number of training ` +
+          `examples (${trainExampleIds.length}). Using all training examples ` +
+          `for each evaluation.`,
+      );
+      this.batchSize = trainExampleIds.length;
+    }
+
+    const {bestAgent} = await this.runOptimizationIterations(
+      initialAgent,
+      sampler,
+      trainExampleIds,
+    );
+
+    const finalScore = await this.runFinalValidation(bestAgent, sampler);
+
+    return {
+      optimizedAgents: [{optimizedAgent: bestAgent, overallScore: finalScore}],
+    };
+  }
+
+  /** Generates a new prompt candidate using the optimizer LLM. */
+  private async generateCandidatePrompt(
+    bestAgent: LlmAgent,
+    bestScore: number,
+  ): Promise<string> {
+    const currentPrompt = requireStringInstruction(bestAgent);
+    const promptForOptimizer = OPTIMIZER_PROMPT_TEMPLATE.replace(
+      '{currentScore}',
+      bestScore.toFixed(2),
+    ).replace('{currentPromptText}', currentPrompt);
+
+    const llmRequest: LlmRequest = {
+      model: this.optimizerModelName,
+      config: this.modelConfiguration,
+      contents: [{role: 'user', parts: [{text: promptForOptimizer}]}],
+      liveConnectConfig: {},
+      toolsDict: {},
+    };
+
+    let responseText = '';
+    for await (const llmResponse of this.llm.generateContentAsync(llmRequest)) {
+      const parts = llmResponse.content?.parts;
+      if (!parts) {
+        continue;
+      }
+      for (const part of parts) {
+        // Skip thought parts so reasoning never leaks into the new prompt.
+        if (part.text && !part.thought) {
+          responseText += part.text;
+        }
+      }
+    }
+    return responseText;
+  }
+
+  /** Scores the agent on a random batch of training examples. */
+  private async scoreAgentOnBatch(
+    agent: LlmAgent,
+    sampler: Sampler<UnstructuredSamplingResult>,
+    exampleIds: string[],
+  ): Promise<number> {
+    const evalBatch = randomSample(exampleIds, this.batchSize);
+    const results = await sampler.sampleAndScore(
+      agent,
+      'train',
+      evalBatch,
+      false,
+    );
+    return meanScore(results.scores);
+  }
+
+  /** Runs the optimization loop and returns the best agent and its score. */
+  private async runOptimizationIterations(
+    initialAgent: LlmAgent,
+    sampler: Sampler<UnstructuredSamplingResult>,
+    trainExampleIds: string[],
+  ): Promise<{bestAgent: LlmAgent; bestScore: number}> {
+    let bestAgent = initialAgent;
+    let bestScore = await this.scoreAgentOnBatch(
+      bestAgent,
+      sampler,
+      trainExampleIds,
+    );
+
+    for (let i = 0; i < this.numIterations; i++) {
+      const newPrompt = await this.generateCandidatePrompt(
+        bestAgent,
+        bestScore,
+      );
+      const candidate = bestAgent.clone({instruction: newPrompt});
+      const candidateScore = await this.scoreAgentOnBatch(
+        candidate,
+        sampler,
+        trainExampleIds,
+      );
+      if (candidateScore > bestScore) {
+        bestAgent = candidate;
+        bestScore = candidateScore;
+      }
+    }
+    return {bestAgent, bestScore};
+  }
+
+  /** Runs final validation on the best agent found. */
+  private async runFinalValidation(
+    bestAgent: LlmAgent,
+    sampler: Sampler<UnstructuredSamplingResult>,
+  ): Promise<number> {
+    const results = await sampler.sampleAndScore(bestAgent, 'validation');
+    return meanScore(results.scores);
+  }
+}
+
+/**
+ * Returns the agent's instruction as a string, throwing if it is an
+ * `InstructionProvider` (a provider function cannot be embedded as prompt text).
+ */
+function requireStringInstruction(agent: LlmAgent): string {
+  if (typeof agent.instruction !== 'string') {
+    throw new Error(
+      'SimplePromptOptimizer supports only string instructions; got an ' +
+        'InstructionProvider.',
+    );
+  }
+  return agent.instruction;
+}
+
+/**
+ * Returns `k` unique elements sampled without replacement, like Python's
+ * `random.sample`. Callers must pass `k <= items.length`.
+ */
+function randomSample<T>(items: T[], k: number): T[] {
+  const pool = [...items];
+  for (let i = 0; i < k; i++) {
+    const j = i + Math.floor(Math.random() * (pool.length - i));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  return pool.slice(0, k);
+}
+
+/** Returns the mean of the score values, or 0 when there are none. */
+function meanScore(scores: Record<string, number>): number {
+  const values = Object.values(scores);
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}

--- a/core/test/optimization/simple_prompt_optimizer_test.ts
+++ b/core/test/optimization/simple_prompt_optimizer_test.ts
@@ -1,0 +1,375 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  AgentOptimizer,
+  AgentWithScores,
+  BaseLlm,
+  BaseLlmConnection,
+  ExampleSet,
+  getLogger,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+  Logger,
+  OptimizerResult,
+  ReadonlyContext,
+  Sampler,
+  setLogger,
+  SimplePromptOptimizer,
+  UnstructuredSamplingResult,
+} from '@google/adk';
+import {describe, expect, it, vi} from 'vitest';
+
+/** An LLM stub that yields a fixed list of responses and counts calls. */
+class MockLlm extends BaseLlm {
+  callCount = 0;
+  lastRequest?: LlmRequest;
+
+  constructor(private readonly responses: LlmResponse[]) {
+    super({model: 'mock-optimizer'});
+  }
+
+  override async *generateContentAsync(
+    request: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    this.callCount++;
+    this.lastRequest = request;
+    for (const response of this.responses) {
+      yield response;
+    }
+  }
+
+  override async connect(): Promise<BaseLlmConnection> {
+    throw new Error('connect is not supported in MockLlm');
+  }
+}
+
+type ScoreFn = (
+  candidate: LlmAgent,
+  exampleSet: ExampleSet,
+  ids: string[],
+) => Record<string, number>;
+
+interface StubSamplerOptions {
+  trainIds: string[];
+  validationIds: string[];
+  score: ScoreFn;
+}
+
+/** A Sampler stub that records how it was called. */
+class StubSampler extends Sampler<UnstructuredSamplingResult> {
+  getTrainExampleIdsCallCount = 0;
+  calls: Array<{exampleSet: ExampleSet; batch?: string[]}> = [];
+
+  constructor(private readonly options: StubSamplerOptions) {
+    super();
+  }
+
+  override getTrainExampleIds(): string[] {
+    this.getTrainExampleIdsCallCount++;
+    return this.options.trainIds;
+  }
+
+  override getValidationExampleIds(): string[] {
+    return this.options.validationIds;
+  }
+
+  override async sampleAndScore(
+    candidate: LlmAgent,
+    exampleSet: ExampleSet = 'validation',
+    batch?: string[],
+    _captureFullEvalData = false,
+  ): Promise<UnstructuredSamplingResult> {
+    this.calls.push({exampleSet, batch});
+    const ids =
+      batch ??
+      (exampleSet === 'train'
+        ? this.options.trainIds
+        : this.options.validationIds);
+    return {scores: this.options.score(candidate, exampleSet, ids)};
+  }
+}
+
+/** Scores `hi` when the instruction contains `keyword`, else `lo`. */
+function keywordScorer(keyword: string, hi: number, lo: number): ScoreFn {
+  return (candidate, _exampleSet, ids) => {
+    const instruction = candidate.instruction as string;
+    const value = instruction.includes(keyword) ? hi : lo;
+    return Object.fromEntries(ids.map((id) => [id, value]));
+  };
+}
+
+function textResponse(...texts: string[]): LlmResponse {
+  return {content: {parts: texts.map((text) => ({text}))}};
+}
+
+describe('SimplePromptOptimizer', () => {
+  it('adopts a better rewritten prompt and reports the validation score', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1', '2', '3', '4', '5'],
+      validationIds: ['v1', 'v2'],
+      score: keywordScorer('IMPROVED', 0.9, 0.5),
+    });
+    const llm = new MockLlm([textResponse('IMPROVED PROMPT')]);
+    const optimizer = new SimplePromptOptimizer({
+      optimizerModel: llm,
+      numIterations: 2,
+      batchSize: 2,
+    });
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: 'Initial Prompt',
+    });
+
+    const result = await optimizer.optimize(initialAgent, sampler);
+
+    expect(result.optimizedAgents).toHaveLength(1);
+    expect(result.optimizedAgents[0].optimizedAgent.instruction).toBe(
+      'IMPROVED PROMPT',
+    );
+    expect(result.optimizedAgents[0].overallScore).toBe(0.9);
+    // The original agent is untouched.
+    expect(initialAgent.instruction).toBe('Initial Prompt');
+    // 1 baseline + 2 iterations + 1 validation.
+    expect(sampler.calls).toHaveLength(4);
+    expect(sampler.getTrainExampleIdsCallCount).toBe(1);
+    // One rewriter call per iteration.
+    expect(llm.callCount).toBe(2);
+    // Batches drawn from train are the requested size, unique, and in-set.
+    const baselineBatch = sampler.calls[0].batch ?? [];
+    expect(baselineBatch).toHaveLength(2);
+    expect(new Set(baselineBatch).size).toBe(2);
+    for (const id of baselineBatch) {
+      expect(['1', '2', '3', '4', '5']).toContain(id);
+    }
+  });
+
+  it('discards a candidate that does not beat the baseline', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1', '2', '3'],
+      validationIds: ['v1'],
+      score: keywordScorer('IMPROVED', 0.9, 0.5),
+    });
+    const llm = new MockLlm([textResponse('WORSE PROMPT')]);
+    const optimizer = new SimplePromptOptimizer({
+      optimizerModel: llm,
+      numIterations: 1,
+      batchSize: 2,
+    });
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: 'Initial Prompt',
+    });
+
+    const result = await optimizer.optimize(initialAgent, sampler);
+
+    expect(result.optimizedAgents[0].optimizedAgent.instruction).toBe(
+      'Initial Prompt',
+    );
+  });
+
+  it('skips thought parts and parts without text when building the prompt', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1', '2', '3'],
+      validationIds: ['v1'],
+      score: keywordScorer('REAL', 0.9, 0.5),
+    });
+    // First response has no parts (exercises the skip); second mixes a thought
+    // part, a text-less part, and the real prompt text.
+    const llm = new MockLlm([
+      {content: {}},
+      {
+        content: {
+          parts: [
+            {text: 'internal reasoning', thought: true},
+            {functionCall: {name: 'noop'}},
+            {text: 'REAL PROMPT'},
+          ],
+        },
+      },
+    ]);
+    const optimizer = new SimplePromptOptimizer({
+      optimizerModel: llm,
+      numIterations: 1,
+      batchSize: 2,
+    });
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: 'start',
+    });
+
+    const result = await optimizer.optimize(initialAgent, sampler);
+
+    expect(result.optimizedAgents[0].optimizedAgent.instruction).toBe(
+      'REAL PROMPT',
+    );
+  });
+
+  it('warns and uses all training examples when batchSize is too large', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1', '2', '3'],
+      validationIds: ['v1'],
+      score: keywordScorer('IMPROVED', 0.9, 0.5),
+    });
+    const llm = new MockLlm([textResponse('IMPROVED PROMPT')]);
+    const optimizer = new SimplePromptOptimizer({
+      optimizerModel: llm,
+      numIterations: 1,
+      batchSize: 10,
+    });
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: 'Initial Prompt',
+    });
+    const warnSpy = vi.fn();
+    const stubLogger: Logger = {
+      log: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+      setLogLevel: vi.fn(),
+    };
+    const previousLogger = getLogger();
+    setLogger(stubLogger);
+
+    try {
+      await optimizer.optimize(initialAgent, sampler);
+    } finally {
+      setLogger(previousLogger);
+    }
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    // The batch is clamped to all training examples (a full permutation).
+    const baselineBatch = sampler.calls[0].batch ?? [];
+    expect([...baselineBatch].sort()).toEqual(['1', '2', '3']);
+  });
+
+  it('returns an overall score of 0 when validation yields no scores', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1', '2'],
+      validationIds: ['v1'],
+      score: (_candidate, exampleSet): Record<string, number> =>
+        exampleSet === 'validation' ? {} : {'1': 0.5, '2': 0.5},
+    });
+    const llm = new MockLlm([textResponse('anything')]);
+    const optimizer = new SimplePromptOptimizer({
+      optimizerModel: llm,
+      numIterations: 1,
+      batchSize: 2,
+    });
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: 'Initial Prompt',
+    });
+
+    const result = await optimizer.optimize(initialAgent, sampler);
+
+    expect(result.optimizedAgents[0].overallScore).toBe(0);
+  });
+
+  it('averages validation scores for the overall score', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1', '2'],
+      validationIds: ['a', 'b'],
+      score: (_candidate, exampleSet): Record<string, number> =>
+        exampleSet === 'validation' ? {a: 1, b: 0} : {'1': 0.5, '2': 0.5},
+    });
+    const optimizer = new SimplePromptOptimizer({
+      optimizerModel: new MockLlm([textResponse('unused')]),
+      numIterations: 0,
+      batchSize: 2,
+    });
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: 'Initial Prompt',
+    });
+
+    const result = await optimizer.optimize(initialAgent, sampler);
+
+    expect(result.optimizedAgents[0].overallScore).toBe(0.5);
+  });
+
+  it('throws when the initial instruction is not a string', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1'],
+      validationIds: ['v1'],
+      score: keywordScorer('IMPROVED', 0.9, 0.5),
+    });
+    const llm = new MockLlm([textResponse('IMPROVED PROMPT')]);
+    const optimizer = new SimplePromptOptimizer({optimizerModel: llm});
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: (_context: ReadonlyContext) => 'dynamic instruction',
+    });
+
+    await expect(optimizer.optimize(initialAgent, sampler)).rejects.toThrow(
+      'SimplePromptOptimizer supports only string instructions',
+    );
+    // Fails fast: no rewriter or sampler calls were made.
+    expect(llm.callCount).toBe(0);
+    expect(sampler.calls).toHaveLength(0);
+  });
+
+  it('sends the configured model configuration on the request', async () => {
+    const sampler = new StubSampler({
+      trainIds: ['1', '2'],
+      validationIds: ['v1'],
+      score: keywordScorer('IMPROVED', 0.9, 0.5),
+    });
+    const llm = new MockLlm([textResponse('IMPROVED PROMPT')]);
+    const modelConfiguration = {temperature: 0.2};
+    const optimizer = new SimplePromptOptimizer({
+      optimizerModel: llm,
+      modelConfiguration,
+      numIterations: 1,
+      batchSize: 2,
+    });
+    const initialAgent = new LlmAgent({
+      name: 'test_agent',
+      instruction: 'Initial Prompt',
+    });
+
+    await optimizer.optimize(initialAgent, sampler);
+
+    expect(llm.lastRequest?.config).toBe(modelConfiguration);
+    expect(llm.lastRequest?.model).toBe('mock-optimizer');
+  });
+
+  it('resolves the default string model via the LLM registry', () => {
+    // With no optimizerModel, the default string is resolved via LLMRegistry
+    // (Gemini construction only reads the key; it makes no network call here).
+    const previousKey = process.env.GOOGLE_GENAI_API_KEY;
+    process.env.GOOGLE_GENAI_API_KEY = 'test-api-key';
+    try {
+      const optimizer = new SimplePromptOptimizer();
+      expect(optimizer).toBeInstanceOf(SimplePromptOptimizer);
+      expect(optimizer).toBeInstanceOf(AgentOptimizer);
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env.GOOGLE_GENAI_API_KEY;
+      } else {
+        process.env.GOOGLE_GENAI_API_KEY = previousKey;
+      }
+    }
+  });
+
+  it('supports custom AgentOptimizer subclasses', () => {
+    // A custom optimizer subclass satisfies the AgentOptimizer contract.
+    class NoopOptimizer extends AgentOptimizer<
+      UnstructuredSamplingResult,
+      AgentWithScores
+    > {
+      override async optimize(
+        initialAgent: LlmAgent,
+      ): Promise<OptimizerResult<AgentWithScores>> {
+        return {optimizedAgents: [{optimizedAgent: initialAgent}]};
+      }
+    }
+    expect(new NoopOptimizer()).toBeInstanceOf(AgentOptimizer);
+  });
+});

--- a/dev/samples/simple_prompt_optimizer.ts
+++ b/dev/samples/simple_prompt_optimizer.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Runnable sample / manual integration test for {@link SimplePromptOptimizer}.
+ *
+ * It builds an `LlmAgent`, implements a small deterministic `Sampler` (a
+ * heuristic scorer that needs no credentials), and runs the optimizer with a
+ * self-contained rewriter model so the whole sample runs offline. To try it
+ * against a real model instead, replace `optimizerModel` with
+ * `'gemini-2.5-flash'` and set `GOOGLE_GENAI_API_KEY` (or `GEMINI_API_KEY`).
+ *
+ * Run it directly, e.g. `npx tsx dev/samples/simple_prompt_optimizer.ts`.
+ *
+ * COST WARNING: with a real model this is not free to run. The defaults (10
+ * iterations, batch size 5) perform 50+ candidate scoring runs plus ~10
+ * rewriter model calls per optimize() call, so expect real cost and latency.
+ */
+
+import {fileURLToPath} from 'node:url';
+
+import {
+  BaseLlm,
+  BaseLlmConnection,
+  ExampleSet,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+  Sampler,
+  SimplePromptOptimizer,
+  UnstructuredSamplingResult,
+} from '@google/adk';
+
+/** Keywords the heuristic scorer rewards a prompt for containing. */
+const DESIRED_KEYWORDS = ['step by step', 'policy', 'tools', 'concise'];
+
+/** A stronger instruction the offline rewriter converges toward. */
+const IMPROVED_INSTRUCTION = [
+  'You are a diligent customer support agent.',
+  'Work through each request step by step.',
+  'Always follow company policy and use the available tools correctly.',
+  'Keep your final answer concise.',
+].join(' ');
+
+/** Scores an instruction in [0, 1] by keyword coverage. */
+function scoreInstruction(instruction: string): number {
+  const lower = instruction.toLowerCase();
+  const found = DESIRED_KEYWORDS.filter((kw) => lower.includes(kw)).length;
+  return found / DESIRED_KEYWORDS.length;
+}
+
+/**
+ * A self-contained rewriter model that returns a stronger instruction, so the
+ * sample runs without credentials or network access.
+ */
+class HeuristicRewriterLlm extends BaseLlm {
+  constructor() {
+    super({model: 'heuristic-rewriter'});
+  }
+
+  override async *generateContentAsync(
+    _request: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    yield {content: {role: 'model', parts: [{text: IMPROVED_INSTRUCTION}]}};
+  }
+
+  override connect(): Promise<BaseLlmConnection> {
+    throw new Error('connect is not supported by HeuristicRewriterLlm');
+  }
+}
+
+/** A deterministic sampler that scores candidates by keyword coverage. */
+class HeuristicSampler extends Sampler<UnstructuredSamplingResult> {
+  override getTrainExampleIds(): string[] {
+    return ['t1', 't2', 't3', 't4', 't5'];
+  }
+
+  override getValidationExampleIds(): string[] {
+    return ['v1', 'v2', 'v3'];
+  }
+
+  override async sampleAndScore(
+    candidate: LlmAgent,
+    exampleSet: ExampleSet = 'validation',
+    batch?: string[],
+    _captureFullEvalData = false,
+  ): Promise<UnstructuredSamplingResult> {
+    const ids =
+      batch ??
+      (exampleSet === 'train'
+        ? this.getTrainExampleIds()
+        : this.getValidationExampleIds());
+    const score = scoreInstruction(candidate.instruction as string);
+    return {scores: Object.fromEntries(ids.map((id) => [id, score]))};
+  }
+}
+
+async function main(): Promise<void> {
+  const agent = new LlmAgent({
+    name: 'support_agent',
+    model: 'gemini-2.5-flash',
+    instruction: 'You are a customer support agent.',
+  });
+
+  const optimizer = new SimplePromptOptimizer({
+    optimizerModel: new HeuristicRewriterLlm(),
+    numIterations: 3,
+    batchSize: 3,
+  });
+
+  const result = await optimizer.optimize(agent, new HeuristicSampler());
+  const best = result.optimizedAgents[0];
+
+  console.log('Original instruction:\n ', agent.instruction);
+  console.log('\nOptimized instruction:\n ', best.optimizedAgent.instruction);
+  console.log('\nValidation score:', best.overallScore);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.
### Link to Issue or Description of Change
1. Link to an existing issue (if applicable):
Closes: #534
2. Or, if no issue exists, describe the change:
**Problem**: `adk-python` can automatically rewrite an agent's system prompt to make it score better (`src/google/adk/optimization/`), but `adk-js` has no equivalent. Tuning an agent's `instruction` in `adk-js` is guesswork rather than a measured search.

**Solution**: Port the core of that module plus a concrete `SimplePromptOptimizer` to `@google/adk` (new `core/src/optimization/`), with no new npm dependency and no eval-framework coupling.

- `data_types`: `SamplingResult`, `UnstructuredSamplingResult`, `AgentWithScores`, `OptimizerResult`.
- `Sampler` (abstract): the interface developers implement to plug in their own scoring/evaluation service. Keeping scoring behind this interface means the framework never decides what "good" means, and a local eval-backed sampler can slot in later without touching any optimizer.
- `AgentOptimizer` (abstract): base class for optimizers.
- `SimplePromptOptimizer` (`@experimental`): a hill-climbing prompt optimizer. Each round it (1) asks an LLM to rewrite the agent's `instruction`, telling it the current score; (2) builds a candidate via `clone({instruction})`; (3) scores the candidate on a random batch of training examples via the developer's `Sampler`; (4) keeps the candidate only if it beats the current best. After `numIterations` rounds it scores the winner on the validation set and returns it.

Notes:
- `optimizerModel` accepts either a model-name string (resolved via `LLMRegistry`) or a `BaseLlm` instance. The instance overload keeps the string default for parity with the issue's API and lets unit tests inject a stub model with no network and no registry mocking.
- Thought parts are never included in the generated prompt (`part.text && !part.thought`).
- This optimizer is marked `@experimental`. It is not free to run: with the defaults (10 iterations, batch size 5) a single `optimize()` performs 50+ candidate scoring runs plus ~10 rewriter model calls, so expect real cost and latency.
- This is Part 2 of a two-part stack; it builds on `BaseAgent.clone()` from **Part 1: #545**. Out of scope (tracked separately): the GEPA optimizers, a local-eval-backed `Sampler`, and the eval framework itself.

> **Stacked PR — please review #545 first.** This PR targets the `agent-clone-part1` branch (not `main`), so the diff shown here contains **only** the optimization module, without Part 1's `clone()` changes. Once #545 lands in `main`, this PR will be retargeted to `main` and the base branch deleted.

### Testing Plan
Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.
Unit Tests:
 [x] I have added or updated unit tests for my change.
 [x] All unit tests pass locally.

Added `core/test/optimization/simple_prompt_optimizer_test.ts` using a hand-written `MockLlm extends BaseLlm` (no network) and a `StubSampler extends Sampler`. It covers: the happy path (adopts an improved prompt; exact `sampleAndScore`/`generateContentAsync`/`getTrainExampleIds` call counts; original agent left unmodified; batches are the requested size, unique, and in-set), adopt-if-better discard, thought-part and text-less-part skipping, the `batchSize` clamp + warning, empty-scores-return-0, validation-score averaging, the non-string-instruction fail-fast error (no LLM/sampler calls made), passing through the configured model configuration, and default model resolution via `LLMRegistry`. All new executable code has 100% line and branch coverage (`data_types.ts` is interfaces-only, so it has no executable code to cover).

Ran locally (from repo root):
- `npx vitest run --project unit:core simple_prompt_optimizer_test` — 10/10 pass.
- `npm run build` (core) — passes.
- `npm run lint`, `prettier --check`, and `npm run docs:check` (TypeDoc, warnings-as-errors) — all clean.

Manual End-to-End (E2E) Tests:
Added `dev/samples/simple_prompt_optimizer.ts`, a runnable sample that doubles as a manual integration test. It builds an `LlmAgent`, implements a small deterministic `Sampler` (heuristic keyword scorer, no credentials), and runs the optimizer with a self-contained rewriter model, so it exercises the real `optimize()` → `clone()` → scoring loop end-to-end with no mocks and no network. Run it with:

```
npx tsx dev/samples/simple_prompt_optimizer.ts
```

Observed output: the instruction is rewritten from `"You are a customer support agent."` to the stronger prompt and the validation score rises to `1`. To try it against a real model, set `optimizerModel: 'gemini-2.5-flash'` and provide `GOOGLE_GENAI_API_KEY` (or `GEMINI_API_KEY`); the `@experimental` warning is logged once per process.

### Checklist
 [x] I have read the CONTRIBUTING.md document.
 [x] I have performed a self-review of my own code.
 [x] I have commented my code, particularly in hard-to-understand areas.
 [x] I have added tests that prove my fix is effective or that my feature works.
 [x] New and existing unit tests pass locally with my changes.

