### PR TITLE
fix(a2a): handle contentless events

### DIFF
--- a/core/src/a2a/event_converter_utils.ts
+++ b/core/src/a2a/event_converter_utils.ts
@@ -108,7 +108,6 @@ function messageToAdkEvent(
   msg: Message,
   invocationId: string,
   agentName: string,
-  parentEvent?: TaskStatusUpdateEvent,
 ): AdkEvent | undefined {
   const parts = toGenAIParts(msg.parts);
   if (parts.length === 0) {
@@ -116,7 +115,7 @@ function messageToAdkEvent(
   }
 
   return {
-    ...createAdkEventFromMetadata(parentEvent || msg),
+    ...createAdkEventFromMetadata(msg),
     invocationId,
     author: msg.role === MessageRole.USER ? MessageRole.USER : agentName,
     content:
@@ -191,6 +190,9 @@ function taskStatusUpdateToAdkEvent(
   }
 
   const parts = toGenAIParts(msg.parts);
+  if (parts.length === 0) {
+    return undefined;
+  }
 
   return {
     ...createAdkEventFromMetadata(a2aEvent),
@@ -233,7 +235,7 @@ function taskToAdkEvent(
     isInputRequiredTaskStatusUpdateEvent(a2aTask);
   const isFailed = isFailedTaskStatusUpdateEvent(a2aTask);
 
-  if (parts.length === 0 && !isTerminal) {
+  if (parts.length === 0 && !isFailed) {
     return undefined;
   }
 

--- a/core/src/a2a/event_converter_utils.ts
+++ b/core/src/a2a/event_converter_utils.ts
@@ -109,8 +109,11 @@ function messageToAdkEvent(
   invocationId: string,
   agentName: string,
   parentEvent?: TaskStatusUpdateEvent,
-): AdkEvent {
+): AdkEvent | undefined {
   const parts = toGenAIParts(msg.parts);
+  if (parts.length === 0) {
+    return undefined;
+  }
 
   return {
     ...createAdkEventFromMetadata(parentEvent || msg),

--- a/core/src/a2a/event_converter_utils.ts
+++ b/core/src/a2a/event_converter_utils.ts
@@ -108,20 +108,20 @@ function messageToAdkEvent(
   msg: Message,
   invocationId: string,
   agentName: string,
-): AdkEvent | undefined {
+): AdkEvent {
   const parts = toGenAIParts(msg.parts);
-  if (parts.length === 0) {
-    return undefined;
-  }
+  const content =
+    parts.length === 0
+      ? undefined
+      : msg.role === MessageRole.USER
+        ? createUserContent(parts)
+        : createModelContent(parts);
 
   return {
     ...createAdkEventFromMetadata(msg),
     invocationId,
     author: msg.role === MessageRole.USER ? MessageRole.USER : agentName,
-    content:
-      msg.role === MessageRole.USER
-        ? createUserContent(parts)
-        : createModelContent(parts),
+    content,
     turnComplete: true,
     partial: false,
   };

--- a/core/test/a2a/event_converter_utils_test.ts
+++ b/core/test/a2a/event_converter_utils_test.ts
@@ -126,7 +126,7 @@ describe('event_converter_utils', () => {
     });
 
     describe('Message', () => {
-      it('returns undefined for messages without parts', () => {
+      it('preserves messages without parts as contentless events', () => {
         const userMessage: Message = {
           kind: 'message',
           messageId: 'msg-empty-user',
@@ -138,10 +138,23 @@ describe('event_converter_utils', () => {
           messageId: 'msg-empty-agent',
           role: 'agent',
           parts: [],
+          metadata: {'adk_error_code': 'EMPTY_RESPONSE'},
         };
 
-        expect(toAdkEvent(userMessage, 'inv1', 'agent1')).toBeUndefined();
-        expect(toAdkEvent(agentMessage, 'inv1', 'agent1')).toBeUndefined();
+        const userEvent = toAdkEvent(userMessage, 'inv1', 'agent1');
+        const agentEvent = toAdkEvent(agentMessage, 'inv1', 'agent1');
+
+        expect(userEvent).toMatchObject({
+          author: 'user',
+          content: undefined,
+          turnComplete: true,
+        });
+        expect(agentEvent).toMatchObject({
+          author: 'agent1',
+          content: undefined,
+          errorCode: 'EMPTY_RESPONSE',
+          turnComplete: true,
+        });
       });
 
       it('converts user message to AdkEvent', () => {

--- a/core/test/a2a/event_converter_utils_test.ts
+++ b/core/test/a2a/event_converter_utils_test.ts
@@ -286,6 +286,26 @@ describe('event_converter_utils', () => {
         ]);
       });
 
+      it('returns undefined for non-final status update with no parts', () => {
+        const nonFinalUpdate: TaskStatusUpdateEvent = {
+          kind: 'status-update',
+          taskId: 'task1',
+          contextId: 'context1',
+          status: {
+            state: 'working',
+            message: {
+              kind: 'message',
+              messageId: 'msg-empty',
+              role: 'agent',
+              parts: [],
+            },
+          },
+          final: false,
+        };
+
+        expect(toAdkEvent(nonFinalUpdate, 'inv1', 'agent1')).toBeUndefined();
+      });
+
       it('returns undefined if non-final status update has no message', () => {
         const nonFinalUpdate: TaskStatusUpdateEvent = {
           kind: 'status-update',
@@ -418,6 +438,28 @@ describe('event_converter_utils', () => {
           contextId: 'context1',
           status: {state: 'working'},
         };
+        expect(toAdkEvent(task, 'inv1', 'agent1')).toBeUndefined();
+      });
+
+      it('returns undefined for completed task with no parts', () => {
+        const task: Task = {
+          kind: 'task',
+          id: 'task1',
+          contextId: 'context1',
+          status: {state: 'completed'},
+        };
+
+        expect(toAdkEvent(task, 'inv1', 'agent1')).toBeUndefined();
+      });
+
+      it('returns undefined for input-required task with no parts', () => {
+        const task: Task = {
+          kind: 'task',
+          id: 'task1',
+          contextId: 'context1',
+          status: {state: 'input-required'},
+        };
+
         expect(toAdkEvent(task, 'inv1', 'agent1')).toBeUndefined();
       });
 

--- a/core/test/a2a/event_converter_utils_test.ts
+++ b/core/test/a2a/event_converter_utils_test.ts
@@ -126,6 +126,24 @@ describe('event_converter_utils', () => {
     });
 
     describe('Message', () => {
+      it('returns undefined for messages without parts', () => {
+        const userMessage: Message = {
+          kind: 'message',
+          messageId: 'msg-empty-user',
+          role: 'user',
+          parts: [],
+        };
+        const agentMessage: Message = {
+          kind: 'message',
+          messageId: 'msg-empty-agent',
+          role: 'agent',
+          parts: [],
+        };
+
+        expect(toAdkEvent(userMessage, 'inv1', 'agent1')).toBeUndefined();
+        expect(toAdkEvent(agentMessage, 'inv1', 'agent1')).toBeUndefined();
+      });
+
       it('converts user message to AdkEvent', () => {
         const message: Message = {
           kind: 'message',


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

Three A2A conversion paths could pass an empty parts array to `createUserContent` or `createModelContent`, which rejects empty arrays:

- user or agent messages without parts
- non-final status updates whose message has no parts
- terminal, non-failed tasks with no artifacts or message parts

A contentless event could therefore abort remote-agent processing.

**Solution:**

Preserve partless messages as events with `content: undefined`, including any metadata they carry. Ignore contentless non-final status updates and terminal non-failed tasks by returning `undefined`, matching the established behavior for empty artifact/final-status conversions. Failed tasks remain preserved because they can carry error information without content.

The change also removes the unused private `parentEvent` parameter from `messageToAdkEvent`.

### Testing Plan

**Unit Tests:**

- [x] Added contentless-event coverage for user and agent messages, including metadata preservation.
- [x] Added coverage for non-final status updates and completed/input-required tasks without parts.
- [x] `npx vitest run --project unit:core event_converter_utils_test.ts a2a_agent_test.ts` (50 tests passed)
- [x] `npx eslint core/src/a2a/event_converter_utils.ts core/test/a2a/event_converter_utils_test.ts`
- [x] `npx prettier --check core/src/a2a/event_converter_utils.ts core/test/a2a/event_converter_utils_test.ts`
- [x] `npm run build`

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing focused unit tests pass locally with my changes.

### Additional context

This edge case surfaced while adding the error-metadata round-trip regression in #537. It remains separate because it changes production conversion behavior rather than metadata mapping.
