### PR TITLE
Fix: add explicit per-test timeout to real-PowerShell skill-script integration test

### DIFF
--- a/tests/integration/tools/run_skill_script_tool_test.ts
+++ b/tests/integration/tools/run_skill_script_tool_test.ts
@@ -21,6 +21,11 @@ import {describe, expect, it} from 'vitest';
 const IS_WINDOWS = os.platform() === 'win32';
 const IS_UNIX = os.platform() === 'linux' || os.platform() === 'darwin';
 
+// Each test spawns a real child process; cold-start on slow CI runners can
+// exceed vitest's 5000ms default. 40s also clears the executor's own 30s
+// internal timeout so its cleaner error surfaces on a genuine hang.
+const TEST_EXECUTION_TIMEOUT = 40000;
+
 describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
   function createMockContext(agentName = 'test-agent') {
     return new Context({
@@ -76,23 +81,27 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
     },
   };
 
-  it('successfully executes a real JavaScript skill script', async () => {
-    const executor = new UnsafeLocalCodeExecutor();
-    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-    const tool = new RunSkillScriptTool(toolset);
+  it(
+    'successfully executes a real JavaScript skill script',
+    async () => {
+      const executor = new UnsafeLocalCodeExecutor();
+      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+      const tool = new RunSkillScriptTool(toolset);
 
-    const result = (await tool.runAsync({
-      args: {
-        skill_name: 'test-skill',
-        script_path: 'scripts/hello.js',
-      },
-      toolContext: createMockContext(),
-    })) as CodeExecutionResult;
+      const result = (await tool.runAsync({
+        args: {
+          skill_name: 'test-skill',
+          script_path: 'scripts/hello.js',
+        },
+        toolContext: createMockContext(),
+      })) as CodeExecutionResult;
 
-    expect(result).toBeDefined();
-    expect(result.stdout).toContain('hello from skill js');
-    expect(result.stderr).toBe('');
-  });
+      expect(result).toBeDefined();
+      expect(result.stdout).toContain('hello from skill js');
+      expect(result.stderr).toBe('');
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
 
   it.skipIf(!IS_UNIX)(
     'successfully executes a real Shell skill script',
@@ -113,24 +122,29 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result.stdout).toContain('hello from skill sh');
       expect(result.stderr).toBe('');
     },
+    TEST_EXECUTION_TIMEOUT,
   );
 
-  it('captures stderr from a failing JavaScript skill script', async () => {
-    const executor = new UnsafeLocalCodeExecutor();
-    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-    const tool = new RunSkillScriptTool(toolset);
+  it(
+    'captures stderr from a failing JavaScript skill script',
+    async () => {
+      const executor = new UnsafeLocalCodeExecutor();
+      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+      const tool = new RunSkillScriptTool(toolset);
 
-    const result = (await tool.runAsync({
-      args: {
-        skill_name: 'test-skill',
-        script_path: 'scripts/fail.js',
-      },
-      toolContext: createMockContext(),
-    })) as CodeExecutionResult;
+      const result = (await tool.runAsync({
+        args: {
+          skill_name: 'test-skill',
+          script_path: 'scripts/fail.js',
+        },
+        toolContext: createMockContext(),
+      })) as CodeExecutionResult;
 
-    expect(result).toBeDefined();
-    expect(result.stderr).toContain('skill js error');
-  });
+      expect(result).toBeDefined();
+      expect(result.stderr).toContain('skill js error');
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
 
   it.skipIf(!IS_UNIX)(
     'captures stderr and exit code from a failing Shell skill script',
@@ -150,42 +164,51 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result).toBeDefined();
       expect(result.stderr).toContain('skill sh error');
     },
+    TEST_EXECUTION_TIMEOUT,
   );
 
-  it('successfully executes a real Python skill script', async () => {
-    const executor = new UnsafeLocalCodeExecutor();
-    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-    const tool = new RunSkillScriptTool(toolset);
+  it(
+    'successfully executes a real Python skill script',
+    async () => {
+      const executor = new UnsafeLocalCodeExecutor();
+      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+      const tool = new RunSkillScriptTool(toolset);
 
-    const result = (await tool.runAsync({
-      args: {
-        skill_name: 'test-skill',
-        script_path: 'scripts/hello.py',
-      },
-      toolContext: createMockContext(),
-    })) as CodeExecutionResult;
+      const result = (await tool.runAsync({
+        args: {
+          skill_name: 'test-skill',
+          script_path: 'scripts/hello.py',
+        },
+        toolContext: createMockContext(),
+      })) as CodeExecutionResult;
 
-    expect(result).toBeDefined();
-    expect(result.stdout).toContain('hello from skill python');
-    expect(result.stderr).toBe('');
-  });
+      expect(result).toBeDefined();
+      expect(result.stdout).toContain('hello from skill python');
+      expect(result.stderr).toBe('');
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
 
-  it('captures stderr from a failing Python skill script', async () => {
-    const executor = new UnsafeLocalCodeExecutor();
-    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-    const tool = new RunSkillScriptTool(toolset);
+  it(
+    'captures stderr from a failing Python skill script',
+    async () => {
+      const executor = new UnsafeLocalCodeExecutor();
+      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+      const tool = new RunSkillScriptTool(toolset);
 
-    const result = (await tool.runAsync({
-      args: {
-        skill_name: 'test-skill',
-        script_path: 'scripts/fail.py',
-      },
-      toolContext: createMockContext(),
-    })) as CodeExecutionResult;
+      const result = (await tool.runAsync({
+        args: {
+          skill_name: 'test-skill',
+          script_path: 'scripts/fail.py',
+        },
+        toolContext: createMockContext(),
+      })) as CodeExecutionResult;
 
-    expect(result).toBeDefined();
-    expect(result.stderr).toContain('skill python error');
-  });
+      expect(result).toBeDefined();
+      expect(result.stderr).toContain('skill python error');
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
 
   it.skipIf(!IS_WINDOWS)(
     'successfully executes a real PowerShell skill script',
@@ -206,6 +229,7 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result.stdout).toContain('hello from skill powershell');
       expect(result.stderr).toBe('');
     },
+    TEST_EXECUTION_TIMEOUT,
   );
 
   it.skipIf(!IS_WINDOWS)(
@@ -227,6 +251,7 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result.stderr).toContain('skill');
       expect(result.stderr).toContain('powershell error');
     },
+    TEST_EXECUTION_TIMEOUT,
   );
 
   it.skipIf(!IS_WINDOWS)(
@@ -248,6 +273,7 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result.stdout).toContain('hello from skill cmd');
       expect(result.stderr).toBe('');
     },
+    TEST_EXECUTION_TIMEOUT,
   );
 
   it.skipIf(!IS_WINDOWS)(
@@ -268,83 +294,92 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result).toBeDefined();
       expect(result.stderr).toContain('skill cmd error');
     },
+    TEST_EXECUTION_TIMEOUT,
   );
 
-  it('creates files in process.cwd returned from execution', async () => {
-    const executor = new UnsafeLocalCodeExecutor();
-    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-    const tool = new RunSkillScriptTool(toolset);
+  it(
+    'creates files in process.cwd returned from execution',
+    async () => {
+      const executor = new UnsafeLocalCodeExecutor();
+      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+      const tool = new RunSkillScriptTool(toolset);
 
-    const result = (await tool.runAsync({
-      args: {
-        skill_name: 'test-skill',
-        script_path: 'scripts/create_file.js',
-      },
-      toolContext: createMockContext(),
-    })) as CodeExecutionResult;
+      const result = (await tool.runAsync({
+        args: {
+          skill_name: 'test-skill',
+          script_path: 'scripts/create_file.js',
+        },
+        toolContext: createMockContext(),
+      })) as CodeExecutionResult;
 
-    expect(result).toBeDefined();
-    expect(result.outputFiles).toBeDefined();
-    expect(result.outputFiles?.length).toBeGreaterThan(0);
+      expect(result).toBeDefined();
+      expect(result.outputFiles).toBeDefined();
+      expect(result.outputFiles?.length).toBeGreaterThan(0);
 
-    const outputFile = result.outputFiles?.find(
-      (f) => f.name === 'output_from_script.txt',
-    );
-    expect(outputFile).toBeDefined();
+      const outputFile = result.outputFiles?.find(
+        (f) => f.name === 'output_from_script.txt',
+      );
+      expect(outputFile).toBeDefined();
 
-    // Verify file was created in process.cwd()
-    const fullPath = path.join(process.cwd(), 'output_from_script.txt');
-    const exists = await fs
-      .access(fullPath)
-      .then(() => true)
-      .catch(() => false);
-    expect(exists).toBe(true);
+      // Verify file was created in process.cwd()
+      const fullPath = path.join(process.cwd(), 'output_from_script.txt');
+      const exists = await fs
+        .access(fullPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
 
-    const content = await fs.readFile(fullPath, 'utf-8');
-    expect(content).toBe('hello from script file');
+      const content = await fs.readFile(fullPath, 'utf-8');
+      expect(content).toBe('hello from script file');
 
-    // Clean up
-    await fs.unlink(fullPath);
-  });
+      // Clean up
+      await fs.unlink(fullPath);
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
 
-  it('handles file collisions by appending a numeric suffix', async () => {
-    const executor = new UnsafeLocalCodeExecutor();
-    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-    const tool = new RunSkillScriptTool(toolset);
+  it(
+    'handles file collisions by appending a numeric suffix',
+    async () => {
+      const executor = new UnsafeLocalCodeExecutor();
+      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+      const tool = new RunSkillScriptTool(toolset);
 
-    // Pre-create the target file to force a collision
-    const targetFile = path.join(process.cwd(), 'output_from_script.txt');
-    await fs.writeFile(targetFile, 'existing content');
+      // Pre-create the target file to force a collision
+      const targetFile = path.join(process.cwd(), 'output_from_script.txt');
+      await fs.writeFile(targetFile, 'existing content');
 
-    const result = (await tool.runAsync({
-      args: {
-        skill_name: 'test-skill',
-        script_path: 'scripts/create_file.js',
-      },
-      toolContext: createMockContext(),
-    })) as CodeExecutionResult;
+      const result = (await tool.runAsync({
+        args: {
+          skill_name: 'test-skill',
+          script_path: 'scripts/create_file.js',
+        },
+        toolContext: createMockContext(),
+      })) as CodeExecutionResult;
 
-    expect(result).toBeDefined();
-    expect(result.outputFiles).toBeDefined();
+      expect(result).toBeDefined();
+      expect(result.outputFiles).toBeDefined();
 
-    const outputFile = result.outputFiles?.find(
-      (f) => f.name === 'output_from_script_2.txt',
-    );
-    expect(outputFile).toBeDefined();
+      const outputFile = result.outputFiles?.find(
+        (f) => f.name === 'output_from_script_2.txt',
+      );
+      expect(outputFile).toBeDefined();
 
-    // Verify collision file was created in process.cwd()
-    const fullPath = path.join(process.cwd(), 'output_from_script_2.txt');
-    const exists = await fs
-      .access(fullPath)
-      .then(() => true)
-      .catch(() => false);
-    expect(exists).toBe(true);
+      // Verify collision file was created in process.cwd()
+      const fullPath = path.join(process.cwd(), 'output_from_script_2.txt');
+      const exists = await fs
+        .access(fullPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
 
-    const content = await fs.readFile(fullPath, 'utf-8');
-    expect(content).toBe('hello from script file');
+      const content = await fs.readFile(fullPath, 'utf-8');
+      expect(content).toBe('hello from script file');
 
-    // Clean up both files
-    await fs.unlink(targetFile);
-    await fs.unlink(fullPath);
-  });
+      // Clean up both files
+      await fs.unlink(targetFile);
+      await fs.unlink(fullPath);
+    },
+    TEST_EXECUTION_TIMEOUT,
+  );
 });

--- a/tests/integration/tools/run_skill_script_tool_test.ts
+++ b/tests/integration/tools/run_skill_script_tool_test.ts
@@ -21,9 +21,10 @@ import {describe, expect, it} from 'vitest';
 const IS_WINDOWS = os.platform() === 'win32';
 const IS_UNIX = os.platform() === 'linux' || os.platform() === 'darwin';
 
-// Each test spawns a real child process; cold-start on slow CI runners can
-// exceed vitest's 5000ms default. 40s also clears the executor's own 30s
-// internal timeout so its cleaner error surfaces on a genuine hang.
+// PowerShell/cmd cold-start on the windows-latest CI runner can exceed vitest's
+// 5000ms default. Must also exceed UnsafeLocalCodeExecutor's default
+// timeoutSeconds (30) so the executor's own timeout error surfaces first; see
+// core/src/code_executors/unsafe_local_code_executor.ts
 const TEST_EXECUTION_TIMEOUT = 40000;
 
 describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
@@ -81,27 +82,23 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
     },
   };
 
-  it(
-    'successfully executes a real JavaScript skill script',
-    async () => {
-      const executor = new UnsafeLocalCodeExecutor();
-      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-      const tool = new RunSkillScriptTool(toolset);
+  it('successfully executes a real JavaScript skill script', async () => {
+    const executor = new UnsafeLocalCodeExecutor();
+    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+    const tool = new RunSkillScriptTool(toolset);
 
-      const result = (await tool.runAsync({
-        args: {
-          skill_name: 'test-skill',
-          script_path: 'scripts/hello.js',
-        },
-        toolContext: createMockContext(),
-      })) as CodeExecutionResult;
+    const result = (await tool.runAsync({
+      args: {
+        skill_name: 'test-skill',
+        script_path: 'scripts/hello.js',
+      },
+      toolContext: createMockContext(),
+    })) as CodeExecutionResult;
 
-      expect(result).toBeDefined();
-      expect(result.stdout).toContain('hello from skill js');
-      expect(result.stderr).toBe('');
-    },
-    TEST_EXECUTION_TIMEOUT,
-  );
+    expect(result).toBeDefined();
+    expect(result.stdout).toContain('hello from skill js');
+    expect(result.stderr).toBe('');
+  });
 
   it.skipIf(!IS_UNIX)(
     'successfully executes a real Shell skill script',
@@ -122,29 +119,24 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result.stdout).toContain('hello from skill sh');
       expect(result.stderr).toBe('');
     },
-    TEST_EXECUTION_TIMEOUT,
   );
 
-  it(
-    'captures stderr from a failing JavaScript skill script',
-    async () => {
-      const executor = new UnsafeLocalCodeExecutor();
-      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-      const tool = new RunSkillScriptTool(toolset);
+  it('captures stderr from a failing JavaScript skill script', async () => {
+    const executor = new UnsafeLocalCodeExecutor();
+    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+    const tool = new RunSkillScriptTool(toolset);
 
-      const result = (await tool.runAsync({
-        args: {
-          skill_name: 'test-skill',
-          script_path: 'scripts/fail.js',
-        },
-        toolContext: createMockContext(),
-      })) as CodeExecutionResult;
+    const result = (await tool.runAsync({
+      args: {
+        skill_name: 'test-skill',
+        script_path: 'scripts/fail.js',
+      },
+      toolContext: createMockContext(),
+    })) as CodeExecutionResult;
 
-      expect(result).toBeDefined();
-      expect(result.stderr).toContain('skill js error');
-    },
-    TEST_EXECUTION_TIMEOUT,
-  );
+    expect(result).toBeDefined();
+    expect(result.stderr).toContain('skill js error');
+  });
 
   it.skipIf(!IS_UNIX)(
     'captures stderr and exit code from a failing Shell skill script',
@@ -164,51 +156,42 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
       expect(result).toBeDefined();
       expect(result.stderr).toContain('skill sh error');
     },
-    TEST_EXECUTION_TIMEOUT,
   );
 
-  it(
-    'successfully executes a real Python skill script',
-    async () => {
-      const executor = new UnsafeLocalCodeExecutor();
-      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-      const tool = new RunSkillScriptTool(toolset);
+  it('successfully executes a real Python skill script', async () => {
+    const executor = new UnsafeLocalCodeExecutor();
+    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+    const tool = new RunSkillScriptTool(toolset);
 
-      const result = (await tool.runAsync({
-        args: {
-          skill_name: 'test-skill',
-          script_path: 'scripts/hello.py',
-        },
-        toolContext: createMockContext(),
-      })) as CodeExecutionResult;
+    const result = (await tool.runAsync({
+      args: {
+        skill_name: 'test-skill',
+        script_path: 'scripts/hello.py',
+      },
+      toolContext: createMockContext(),
+    })) as CodeExecutionResult;
 
-      expect(result).toBeDefined();
-      expect(result.stdout).toContain('hello from skill python');
-      expect(result.stderr).toBe('');
-    },
-    TEST_EXECUTION_TIMEOUT,
-  );
+    expect(result).toBeDefined();
+    expect(result.stdout).toContain('hello from skill python');
+    expect(result.stderr).toBe('');
+  });
 
-  it(
-    'captures stderr from a failing Python skill script',
-    async () => {
-      const executor = new UnsafeLocalCodeExecutor();
-      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-      const tool = new RunSkillScriptTool(toolset);
+  it('captures stderr from a failing Python skill script', async () => {
+    const executor = new UnsafeLocalCodeExecutor();
+    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+    const tool = new RunSkillScriptTool(toolset);
 
-      const result = (await tool.runAsync({
-        args: {
-          skill_name: 'test-skill',
-          script_path: 'scripts/fail.py',
-        },
-        toolContext: createMockContext(),
-      })) as CodeExecutionResult;
+    const result = (await tool.runAsync({
+      args: {
+        skill_name: 'test-skill',
+        script_path: 'scripts/fail.py',
+      },
+      toolContext: createMockContext(),
+    })) as CodeExecutionResult;
 
-      expect(result).toBeDefined();
-      expect(result.stderr).toContain('skill python error');
-    },
-    TEST_EXECUTION_TIMEOUT,
-  );
+    expect(result).toBeDefined();
+    expect(result.stderr).toContain('skill python error');
+  });
 
   it.skipIf(!IS_WINDOWS)(
     'successfully executes a real PowerShell skill script',
@@ -297,89 +280,81 @@ describe('RunSkillScriptTool Integration with UnsafeLocalCodeExecutor', () => {
     TEST_EXECUTION_TIMEOUT,
   );
 
-  it(
-    'creates files in process.cwd returned from execution',
-    async () => {
-      const executor = new UnsafeLocalCodeExecutor();
-      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-      const tool = new RunSkillScriptTool(toolset);
+  it('creates files in process.cwd returned from execution', async () => {
+    const executor = new UnsafeLocalCodeExecutor();
+    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+    const tool = new RunSkillScriptTool(toolset);
 
-      const result = (await tool.runAsync({
-        args: {
-          skill_name: 'test-skill',
-          script_path: 'scripts/create_file.js',
-        },
-        toolContext: createMockContext(),
-      })) as CodeExecutionResult;
+    const result = (await tool.runAsync({
+      args: {
+        skill_name: 'test-skill',
+        script_path: 'scripts/create_file.js',
+      },
+      toolContext: createMockContext(),
+    })) as CodeExecutionResult;
 
-      expect(result).toBeDefined();
-      expect(result.outputFiles).toBeDefined();
-      expect(result.outputFiles?.length).toBeGreaterThan(0);
+    expect(result).toBeDefined();
+    expect(result.outputFiles).toBeDefined();
+    expect(result.outputFiles?.length).toBeGreaterThan(0);
 
-      const outputFile = result.outputFiles?.find(
-        (f) => f.name === 'output_from_script.txt',
-      );
-      expect(outputFile).toBeDefined();
+    const outputFile = result.outputFiles?.find(
+      (f) => f.name === 'output_from_script.txt',
+    );
+    expect(outputFile).toBeDefined();
 
-      // Verify file was created in process.cwd()
-      const fullPath = path.join(process.cwd(), 'output_from_script.txt');
-      const exists = await fs
-        .access(fullPath)
-        .then(() => true)
-        .catch(() => false);
-      expect(exists).toBe(true);
+    // Verify file was created in process.cwd()
+    const fullPath = path.join(process.cwd(), 'output_from_script.txt');
+    const exists = await fs
+      .access(fullPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(true);
 
-      const content = await fs.readFile(fullPath, 'utf-8');
-      expect(content).toBe('hello from script file');
+    const content = await fs.readFile(fullPath, 'utf-8');
+    expect(content).toBe('hello from script file');
 
-      // Clean up
-      await fs.unlink(fullPath);
-    },
-    TEST_EXECUTION_TIMEOUT,
-  );
+    // Clean up
+    await fs.unlink(fullPath);
+  });
 
-  it(
-    'handles file collisions by appending a numeric suffix',
-    async () => {
-      const executor = new UnsafeLocalCodeExecutor();
-      const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
-      const tool = new RunSkillScriptTool(toolset);
+  it('handles file collisions by appending a numeric suffix', async () => {
+    const executor = new UnsafeLocalCodeExecutor();
+    const toolset = new SkillToolset([testSkill], {codeExecutor: executor});
+    const tool = new RunSkillScriptTool(toolset);
 
-      // Pre-create the target file to force a collision
-      const targetFile = path.join(process.cwd(), 'output_from_script.txt');
-      await fs.writeFile(targetFile, 'existing content');
+    // Pre-create the target file to force a collision
+    const targetFile = path.join(process.cwd(), 'output_from_script.txt');
+    await fs.writeFile(targetFile, 'existing content');
 
-      const result = (await tool.runAsync({
-        args: {
-          skill_name: 'test-skill',
-          script_path: 'scripts/create_file.js',
-        },
-        toolContext: createMockContext(),
-      })) as CodeExecutionResult;
+    const result = (await tool.runAsync({
+      args: {
+        skill_name: 'test-skill',
+        script_path: 'scripts/create_file.js',
+      },
+      toolContext: createMockContext(),
+    })) as CodeExecutionResult;
 
-      expect(result).toBeDefined();
-      expect(result.outputFiles).toBeDefined();
+    expect(result).toBeDefined();
+    expect(result.outputFiles).toBeDefined();
 
-      const outputFile = result.outputFiles?.find(
-        (f) => f.name === 'output_from_script_2.txt',
-      );
-      expect(outputFile).toBeDefined();
+    const outputFile = result.outputFiles?.find(
+      (f) => f.name === 'output_from_script_2.txt',
+    );
+    expect(outputFile).toBeDefined();
 
-      // Verify collision file was created in process.cwd()
-      const fullPath = path.join(process.cwd(), 'output_from_script_2.txt');
-      const exists = await fs
-        .access(fullPath)
-        .then(() => true)
-        .catch(() => false);
-      expect(exists).toBe(true);
+    // Verify collision file was created in process.cwd()
+    const fullPath = path.join(process.cwd(), 'output_from_script_2.txt');
+    const exists = await fs
+      .access(fullPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(true);
 
-      const content = await fs.readFile(fullPath, 'utf-8');
-      expect(content).toBe('hello from script file');
+    const content = await fs.readFile(fullPath, 'utf-8');
+    expect(content).toBe('hello from script file');
 
-      // Clean up both files
-      await fs.unlink(targetFile);
-      await fs.unlink(fullPath);
-    },
-    TEST_EXECUTION_TIMEOUT,
-  );
+    // Clean up both files
+    await fs.unlink(targetFile);
+    await fs.unlink(fullPath);
+  });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- No existing issue is linked; the change is described below.

**2. Or, if no issue exists, describe the change:**

**Problem:**

The `validation` workflow's `run-tests (windows-latest)` job intermittently fails
with `Error: Test timed out in 5000ms.` on the integration test
`'successfully executes a real PowerShell skill script'` in
`tests/integration/tools/run_skill_script_tool_test.ts`. The test spawns a
**real** PowerShell child process through `UnsafeLocalCodeExecutor`; PowerShell
cold-start plus script execution on the shared, slow `windows-latest` runner
routinely exceeds vitest's built-in default `testTimeout` of 5000ms.
`vitest.config.ts` sets no `testTimeout` for the `integration` project, so the
5000ms default applies to every `it(...)` that does not pass its own budget.
Notably, the executor's _own_ internal timeout defaults to 30s (see
`timeoutSeconds` in `core/src/code_executors/unsafe_local_code_executor.ts`), so
the code under test is willing to wait far longer than vitest allows — vitest
kills the test at 5s.

**Solution:**

This is a pure test-infrastructure (flakiness) fix; no production/runtime
behavior changes. Mirroring the established in-repo pattern in
`tests/integration/build_setup/build_setup_test.ts`, a file-level constant
`const TEST_EXECUTION_TIMEOUT = 40000;` is introduced and passed as the optional
3rd argument to every `it(...)` / `it.skipIf(...)` in the file.

Every test in this file spawns a real child process (`node`, `python`,
PowerShell, `cmd`, or `sh`), so they all share the same 5000ms-default flakiness
class; applying the constant uniformly is the root-cause fix and keeps the file
consistent.

`40000` (40s) was chosen because it deliberately **exceeds the executor's own 30s
internal timeout**, so that on a genuine hang the executor's cleaner
`Code execution timed out after N seconds.` error surfaces instead of vitest's
generic abort. It also matches the sibling constants in
`tests/integration/app_loader/app_loader_test.ts` and
`tests/integration/agent_loader/agent_dirname_test.ts`, which both use `40000`.
A per-test timeout is an upper bound, not a delay, so fast-completing tests are
unaffected.

No changes were made to `vitest.config.ts`, `build_setup_test.ts`, or any
production source under `core/`, `dev/`, or `integrations/`. The large line count
in the diff is purely Prettier re-wrapping the previously single-line
`it('name', async () => {...})` calls onto multiple lines once a 3rd argument is
added — the canonical formatting also used by `build_setup_test.ts`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

This is a test-only change; the modified integration test **is** the end-to-end
exercise (it runs real skill scripts through `UnsafeLocalCodeExecutor` with no
mocks).

Targeted run of the affected file:

```
npx vitest run --project integration tests/integration/tools/run_skill_script_tool_test.ts
```

On a Linux dev host this reported **8 passed | 4 skipped (12)** — the four
Windows-gated PowerShell/CMD tests are correctly `skipped` (not failed),
confirming the `.skipIf(...)(name, fn, timeout)` call shape compiles and
type-checks and that the JS/Python/Shell tests still pass.

Lint and format gates (both enforced by the `validation` workflow) are clean:
`npm run lint` and `npm run format:check`.

**Manual End-to-End (E2E) Tests:**

- Build the workspaces (required so the `integration` project's `globalSetup` can
  resolve `@google/adk`): `npm ci && npm run build`
- Run the affected file directly:
  `npx vitest run --project integration tests/integration/tools/run_skill_script_tool_test.ts`
- The authoritative verification is a green `run-tests (windows-latest)` job,
  where the PowerShell/CMD tests actually execute under the new 40s budget. On
  Windows, confirm the PowerShell test passes and completes well under 40s.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The added constant is documented inline in the test file so future readers
understand why the budget is 40s rather than an arbitrary larger number: it must
clear the executor's own 30s internal timeout for the executor's error message to
win the race on a genuine hang.
