### PR TITLE
feat: Port ReflectAndRetryToolPlugin from adk-python to adk-js

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -187,6 +187,12 @@ export {GlobalInstructionPlugin} from './plugins/global_instruction_plugin.js';
 export {LoggingPlugin} from './plugins/logging_plugin.js';
 export {PluginManager} from './plugins/plugin_manager.js';
 export {
+  REFLECT_AND_RETRY_RESPONSE_TYPE,
+  ReflectAndRetryToolPlugin,
+  TrackingScope,
+} from './plugins/reflect_retry_tool_plugin.js';
+export type {ToolFailureResponse} from './plugins/reflect_retry_tool_plugin.js';
+export {
   InMemoryPolicyEngine,
   PolicyOutcome,
   REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -187,6 +187,7 @@ export {GlobalInstructionPlugin} from './plugins/global_instruction_plugin.js';
 export {LoggingPlugin} from './plugins/logging_plugin.js';
 export {PluginManager} from './plugins/plugin_manager.js';
 export {
+  GLOBAL_SCOPE_KEY,
   REFLECT_AND_RETRY_RESPONSE_TYPE,
   ReflectAndRetryToolPlugin,
   TrackingScope,

--- a/core/src/plugins/reflect_retry_tool_plugin.ts
+++ b/core/src/plugins/reflect_retry_tool_plugin.ts
@@ -5,10 +5,19 @@
  */
 
 import {Context} from '../agents/context.js';
+import {InvocationContext} from '../agents/invocation_context.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {experimental} from '../utils/experimental.js';
 
 import {BasePlugin} from './base_plugin.js';
+
+// Constants
+
+/** Default value for `params.name`. */
+const DEFAULT_PLUGIN_NAME = 'reflect_retry_tool_plugin';
+
+/** Default value for `params.maxRetries`. */
+const DEFAULT_MAX_RETRIES = 3;
 
 /**
  * Marker written to every response this plugin produces. It lets the plugin
@@ -51,7 +60,11 @@ export type ToolFailureResponse = {
   error_type: string;
   /** The raw error message. */
   error_details: string;
-  /** The consecutive failure count that produced this response. */
+  /**
+   * The consecutive failure count that produced this response. For a terminal
+   * retry-limit-exceeded response this is `maxRetries`, not the actual attempt
+   * number that triggered it.
+   */
   retry_count: number;
   /** Human-readable guidance instructing the model how to recover. */
   reflection_guidance: string;
@@ -98,6 +111,11 @@ class ScopedFailureTracker {
       this.counters.delete(scopeKey);
     }
   }
+
+  /** Drops an entire scope, including every item counter it holds. */
+  resetScope(scopeKey: string): void {
+    this.counters.delete(scopeKey);
+  }
 }
 
 /** Resolves the tracking scope key for the given scope and invocation. */
@@ -114,13 +132,31 @@ function resolveScopeKey(
   return GLOBAL_SCOPE_KEY;
 }
 
+/** Narrows an arbitrary value to something safe to index by string key. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 /**
  * Renders an arbitrary value as a string. Objects use `JSON.stringify` so their
  * content is preserved (`String({})` would yield the useless `'[object
  * Object]'`); everything else falls back to `String`.
+ *
+ * This runs inside the error handler, so it must be total: `JSON.stringify`
+ * throws on circular structures (a real risk, since a tool *result* object
+ * reaches here via {@link ReflectAndRetryToolPlugin.extractErrorFromResult})
+ * and returns `undefined` for values it cannot represent. Either would replace
+ * the tool's actual failure with a `TypeError` and lose the reflection payload.
  */
 function stringifyError(error: unknown): string {
-  return typeof error === 'object' ? JSON.stringify(error) : String(error);
+  if (!isRecord(error)) {
+    return String(error);
+  }
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
 }
 
 /**
@@ -292,8 +328,8 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
     throwExceptionIfRetryExceeded?: boolean;
     trackingScope?: TrackingScope;
   }) {
-    super(params?.name ?? 'reflect_retry_tool_plugin');
-    const maxRetries = params?.maxRetries ?? 3;
+    super(params?.name ?? DEFAULT_PLUGIN_NAME);
+    const maxRetries = params?.maxRetries ?? DEFAULT_MAX_RETRIES;
     if (maxRetries < 0) {
       throw new Error('maxRetries must be a non-negative integer.');
     }
@@ -307,6 +343,15 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
    * Handles successful tool calls or extracts and processes errors hidden in
    * otherwise successful results.
    *
+   * `result` is declared `unknown` rather than inheriting
+   * `Record<string, unknown>` from {@link BasePlugin}, because that narrower
+   * type does not describe what the framework actually passes:
+   * `BaseTool.runAsync` returns `Promise<unknown>`, so a tool may return a
+   * primitive or an array, and `handleFunctionCallList` leaves the response
+   * `null` when a tool throws a non-`Error` value. Widening a parameter in an
+   * override is safe, and it lets the guard below be a real type narrowing
+   * instead of an untyped defensive check.
+   *
    * @returns Reflection guidance if an error is detected, or `undefined` if the
    *   call succeeded or the result is already a reflection message.
    */
@@ -319,12 +364,11 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
     tool: BaseTool;
     toolArgs: Record<string, unknown>;
     toolContext: Context;
-    result: Record<string, unknown>;
+    result: unknown;
   }): Promise<Record<string, unknown> | undefined> {
     // Never re-process our own guidance objects as new errors.
     if (
-      result &&
-      typeof result === 'object' &&
+      isRecord(result) &&
       result['response_type'] === REFLECT_AND_RETRY_RESPONSE_TYPE
     ) {
       return undefined;
@@ -356,15 +400,42 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
    * trigger retry logic for results that indicate failure without throwing
    * (e.g. `{status: 'error'}`).
    *
+   * The return type is `unknown` so an override can return an `Error`.
+   * `Error` is an interface and therefore has no implicit index signature, so
+   * it is not assignable to `Record<string, unknown>`; returning one is what
+   * makes `error_type`/`error_details` report the real error class rather than
+   * the generic `'ToolError'`. An override may still narrow either the
+   * parameter or the return type.
+   *
    * @returns The extracted error, or `undefined` if no error was detected.
    */
   async extractErrorFromResult(_params: {
     tool: BaseTool;
     toolArgs: Record<string, unknown>;
     toolContext: Context;
-    result: Record<string, unknown>;
-  }): Promise<Record<string, unknown> | undefined> {
+    result: unknown;
+  }): Promise<unknown> {
     return undefined;
+  }
+
+  /**
+   * Drops this invocation's failure counters once the run has completed.
+   *
+   * Under {@link TrackingScope.INVOCATION} a scope entry is otherwise only
+   * removed when a tool later succeeds, so a run that ends while a tool is
+   * still failing — the model gives up, or the cap is reached with
+   * `throwExceptionIfRetryExceeded: false` — leaves its counters behind for the
+   * life of the process. {@link TrackingScope.GLOBAL} is deliberately untouched
+   * here, since its whole purpose is to outlive the invocation.
+   */
+  override async afterRunCallback({
+    invocationContext,
+  }: {
+    invocationContext: InvocationContext;
+  }): Promise<void> {
+    if (this.scope === TrackingScope.INVOCATION) {
+      this.tracker.resetScope(invocationContext.invocationId);
+    }
   }
 
   /**

--- a/core/src/plugins/reflect_retry_tool_plugin.ts
+++ b/core/src/plugins/reflect_retry_tool_plugin.ts
@@ -131,16 +131,6 @@ function ensureError(error: unknown): Error {
   return error instanceof Error ? error : new Error(stringifyError(error));
 }
 
-/** The error's class name, or `'ToolError'` for non-`Error` values. */
-function errorTypeOf(error: unknown): string {
-  return error instanceof Error ? error.constructor.name : 'ToolError';
-}
-
-/** The raw error message, or a stringified form for non-`Error` values. */
-function errorDetailsOf(error: unknown): string {
-  return error instanceof Error ? error.message : stringifyError(error);
-}
-
 /** Formats the error for the human-readable body of a reflection message. */
 function formatErrorDetails(error: unknown): string {
   return error instanceof Error
@@ -156,8 +146,9 @@ function buildFailureResponse(
 ): ToolFailureResponse {
   return {
     response_type: REFLECT_AND_RETRY_RESPONSE_TYPE,
-    error_type: errorTypeOf(error),
-    error_details: errorDetailsOf(error),
+    error_type: error instanceof Error ? error.constructor.name : 'ToolError',
+    error_details:
+      error instanceof Error ? error.message : stringifyError(error),
     retry_count: retryCount,
     reflection_guidance: reflectionGuidance,
   };

--- a/core/src/plugins/reflect_retry_tool_plugin.ts
+++ b/core/src/plugins/reflect_retry_tool_plugin.ts
@@ -43,32 +43,29 @@ export enum TrackingScope {
 
 /**
  * Structured payload returned to the model when a tool fails, containing the
- * failure details and reflection guidance.
+ * failure details and reflection guidance. This object becomes the
+ * `functionResponse.response` observed by the model.
  *
- * Property names are intentionally `snake_case` to match the exact wire format
- * emitted by the Python ADK, since this object becomes a
- * `functionResponse.response` payload observed by the model.
- *
- * Declared as a type alias (not an interface) so it carries an implicit index
- * signature and is therefore assignable to the `Record<string, unknown>`
- * return type of the plugin callbacks.
+ * Property names are `camelCase`, following this repository's convention. The
+ * Python ADK emits the same fields in `snake_case`; only
+ * {@link REFLECT_AND_RETRY_RESPONSE_TYPE} is a wire value shared with it.
  */
-export type ToolFailureResponse = {
+export interface ToolFailureResponse {
   /** Always {@link REFLECT_AND_RETRY_RESPONSE_TYPE}. */
-  response_type: string;
+  responseType: string;
   /** The error's class name, or `'ToolError'` for non-`Error` values. */
-  error_type: string;
+  errorType: string;
   /** The raw error message. */
-  error_details: string;
+  errorDetails: string;
   /**
    * The consecutive failure count that produced this response. For a terminal
    * retry-limit-exceeded response this is `maxRetries`, not the actual attempt
    * number that triggered it.
    */
-  retry_count: number;
+  retryCount: number;
   /** Human-readable guidance instructing the model how to recover. */
-  reflection_guidance: string;
-};
+  reflectionGuidance: string;
+}
 
 /**
  * Per-scope, per-item consecutive-failure counter.
@@ -181,13 +178,25 @@ function buildFailureResponse(
   reflectionGuidance: string,
 ): ToolFailureResponse {
   return {
-    response_type: REFLECT_AND_RETRY_RESPONSE_TYPE,
-    error_type: error instanceof Error ? error.constructor.name : 'ToolError',
-    error_details:
+    responseType: REFLECT_AND_RETRY_RESPONSE_TYPE,
+    errorType: error instanceof Error ? error.constructor.name : 'ToolError',
+    errorDetails:
       error instanceof Error ? error.message : stringifyError(error),
-    retry_count: retryCount,
-    reflection_guidance: reflectionGuidance,
+    retryCount,
+    reflectionGuidance,
   };
+}
+
+/**
+ * Widens a {@link ToolFailureResponse} into the plain record the plugin
+ * callbacks are contractually required to return. An interface has no implicit
+ * index signature and so is not assignable to `Record<string, unknown>`;
+ * spreading it into a fresh object literal is, with no cast involved.
+ */
+function toResponseRecord(
+  response: ToolFailureResponse,
+): Record<string, unknown> {
+  return {...response};
 }
 
 /** Generates structured reflection guidance for a recoverable tool failure. */
@@ -369,7 +378,7 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
     // Never re-process our own guidance objects as new errors.
     if (
       isRecord(result) &&
-      result['response_type'] === REFLECT_AND_RETRY_RESPONSE_TYPE
+      result['responseType'] === REFLECT_AND_RETRY_RESPONSE_TYPE
     ) {
       return undefined;
     }
@@ -382,7 +391,9 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
     });
 
     if (error) {
-      return this.handleToolError(tool, toolArgs, toolContext, error);
+      return toResponseRecord(
+        this.handleToolError(tool, toolArgs, toolContext, error),
+      );
     }
 
     // On success, reset the failure count for this specific tool within scope.
@@ -403,7 +414,7 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
    * The return type is `unknown` so an override can return an `Error`.
    * `Error` is an interface and therefore has no implicit index signature, so
    * it is not assignable to `Record<string, unknown>`; returning one is what
-   * makes `error_type`/`error_details` report the real error class rather than
+   * makes `errorType`/`errorDetails` report the real error class rather than
    * the generic `'ToolError'`. An override may still narrow either the
    * parameter or the return type.
    *
@@ -455,16 +466,21 @@ export class ReflectAndRetryToolPlugin extends BasePlugin {
     toolContext: Context;
     error: Error;
   }): Promise<Record<string, unknown> | undefined> {
-    return this.handleToolError(tool, toolArgs, toolContext, error);
+    return toResponseRecord(
+      this.handleToolError(tool, toolArgs, toolContext, error),
+    );
   }
 
-  /** Central decision tree for processing a tool error. */
+  /**
+   * Central decision tree for processing a tool error. Every path either
+   * returns guidance or throws, so there is no `undefined` case.
+   */
   private handleToolError(
     tool: BaseTool,
     toolArgs: Record<string, unknown>,
     toolContext: Context,
     error: unknown,
-  ): Record<string, unknown> | undefined {
+  ): ToolFailureResponse {
     if (this.maxRetries === 0) {
       if (this.throwExceptionIfRetryExceeded) {
         throw ensureError(error);

--- a/core/src/plugins/reflect_retry_tool_plugin.ts
+++ b/core/src/plugins/reflect_retry_tool_plugin.ts
@@ -1,0 +1,441 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context} from '../agents/context.js';
+import {BaseTool} from '../tools/base_tool.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BasePlugin} from './base_plugin.js';
+
+/**
+ * Marker written to every response this plugin produces. It lets the plugin
+ * recognize its own guidance objects and avoid re-processing them as new
+ * errors. The value is wire-compatible with the Python ADK implementation.
+ */
+export const REFLECT_AND_RETRY_RESPONSE_TYPE =
+  'ERROR_HANDLED_BY_REFLECT_AND_RETRY_PLUGIN';
+
+/**
+ * Scope key used when tracking failures globally (across all invocations). The
+ * value is wire-compatible with the Python ADK implementation.
+ */
+export const GLOBAL_SCOPE_KEY = '__global_reflect_and_retry_scope__';
+
+/** Defines the lifecycle scope for tracking tool failure counts. */
+export enum TrackingScope {
+  /** Failures are counted independently for each agent invocation. */
+  INVOCATION = 'invocation',
+  /** Failures are counted globally across all invocations and turns. */
+  GLOBAL = 'global',
+}
+
+/**
+ * Structured payload returned to the model when a tool fails, containing the
+ * failure details and reflection guidance.
+ *
+ * Property names are intentionally `snake_case` to match the exact wire format
+ * emitted by the Python ADK, since this object becomes a
+ * `functionResponse.response` payload observed by the model.
+ *
+ * Declared as a type alias (not an interface) so it carries an implicit index
+ * signature and is therefore assignable to the `Record<string, unknown>`
+ * return type of the plugin callbacks.
+ */
+export type ToolFailureResponse = {
+  /** Always {@link REFLECT_AND_RETRY_RESPONSE_TYPE}. */
+  response_type: string;
+  /** The error's class name, or `'ToolError'` for non-`Error` values. */
+  error_type: string;
+  /** The raw error message. */
+  error_details: string;
+  /** The consecutive failure count that produced this response. */
+  retry_count: number;
+  /** Human-readable guidance instructing the model how to recover. */
+  reflection_guidance: string;
+};
+
+/**
+ * Per-scope, per-item consecutive-failure counter.
+ *
+ * The outer map is keyed by scope key (e.g. an invocation id or the global
+ * scope key); the inner map is keyed by tool name.
+ *
+ * Unlike the Python implementation, `increment`/`reset` are synchronous and use
+ * no lock. In JS the event loop is single-threaded and a synchronous
+ * read-modify-write has no `await` suspension point, so it is already atomic
+ * with respect to concurrent tool calls; a mutex would add complexity without
+ * changing behavior.
+ */
+class ScopedFailureTracker {
+  private readonly counters = new Map<string, Map<string, number>>();
+
+  /** Increments and returns the consecutive-failure count for an item. */
+  increment(scopeKey: string, itemName: string): number {
+    let scopeCounters = this.counters.get(scopeKey);
+    if (!scopeCounters) {
+      scopeCounters = new Map<string, number>();
+      this.counters.set(scopeKey, scopeCounters);
+    }
+    const next = (scopeCounters.get(itemName) ?? 0) + 1;
+    scopeCounters.set(itemName, next);
+    return next;
+  }
+
+  /**
+   * Clears the failure count for a single item, leaving other items in the
+   * same scope untouched. Empty scopes are removed to avoid unbounded growth.
+   */
+  reset(scopeKey: string, itemName: string): void {
+    const scopeCounters = this.counters.get(scopeKey);
+    if (!scopeCounters) {
+      return;
+    }
+    scopeCounters.delete(itemName);
+    if (scopeCounters.size === 0) {
+      this.counters.delete(scopeKey);
+    }
+  }
+}
+
+/** Resolves the tracking scope key for the given scope and invocation. */
+function resolveScopeKey(
+  scope: TrackingScope,
+  invocationId: string | undefined,
+): string {
+  if (scope === TrackingScope.INVOCATION) {
+    if (!invocationId) {
+      throw new Error('invocationId must be provided for INVOCATION scope');
+    }
+    return invocationId;
+  }
+  return GLOBAL_SCOPE_KEY;
+}
+
+/**
+ * Renders an arbitrary value as a string. Objects use `JSON.stringify` so their
+ * content is preserved (`String({})` would yield the useless `'[object
+ * Object]'`); everything else falls back to `String`.
+ */
+function stringifyError(error: unknown): string {
+  return typeof error === 'object' ? JSON.stringify(error) : String(error);
+}
+
+/**
+ * Ensures the given value is an `Error`. `Error` instances are returned as-is so
+ * their identity is preserved when re-thrown; other values are wrapped.
+ */
+function ensureError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(stringifyError(error));
+}
+
+/** The error's class name, or `'ToolError'` for non-`Error` values. */
+function errorTypeOf(error: unknown): string {
+  return error instanceof Error ? error.constructor.name : 'ToolError';
+}
+
+/** The raw error message, or a stringified form for non-`Error` values. */
+function errorDetailsOf(error: unknown): string {
+  return error instanceof Error ? error.message : stringifyError(error);
+}
+
+/** Formats the error for the human-readable body of a reflection message. */
+function formatErrorDetails(error: unknown): string {
+  return error instanceof Error
+    ? `${error.constructor.name}: ${error.message}`
+    : stringifyError(error);
+}
+
+/** Builds a {@link ToolFailureResponse} object literal. */
+function buildFailureResponse(
+  error: unknown,
+  retryCount: number,
+  reflectionGuidance: string,
+): ToolFailureResponse {
+  return {
+    response_type: REFLECT_AND_RETRY_RESPONSE_TYPE,
+    error_type: errorTypeOf(error),
+    error_details: errorDetailsOf(error),
+    retry_count: retryCount,
+    reflection_guidance: reflectionGuidance,
+  };
+}
+
+/** Generates structured reflection guidance for a recoverable tool failure. */
+function createReflectionResponse(params: {
+  tool: BaseTool;
+  toolArgs: Record<string, unknown>;
+  error: unknown;
+  retryCount: number;
+  maxRetries: number;
+}): ToolFailureResponse {
+  const {tool, toolArgs, error, retryCount, maxRetries} = params;
+  const argsSummary = JSON.stringify(toolArgs, null, 2);
+  const errorDetails = formatErrorDetails(error);
+
+  const reflectionGuidance = `
+The call to tool \`${tool.name}\` failed.
+
+**Error Details:**
+\`\`\`
+${errorDetails}
+\`\`\`
+
+**Tool Arguments Used:**
+\`\`\`json
+${argsSummary}
+\`\`\`
+
+**Reflection Guidance:**
+This is retry attempt **${retryCount} of ${maxRetries}**. Analyze the error and the arguments you provided. Do not repeat the exact same call. Consider the following before your next attempt:
+
+1.  **Invalid Parameters**: Does the error suggest that one or more arguments are incorrect, badly formatted, or missing? Review the tool's schema and your arguments.
+2.  **State or Preconditions**: Did a previous step fail or not produce the necessary state/resource for this tool to succeed?
+3.  **Alternative Approach**: Is this the right tool for the job? Could another tool or a different sequence of steps achieve the goal?
+4.  **Simplify the Task**: Can you break the problem down into smaller, simpler steps?
+5.  **Wrong Function Name**: Does the error indicates the tool is not found? Please check again and only use available tools.
+
+Formulate a new plan based on your analysis and try a corrected or different approach.
+`.trim();
+
+  return buildFailureResponse(error, retryCount, reflectionGuidance);
+}
+
+/** Generates terminal guidance once the retry limit has been exceeded. */
+function createRetryExceededResponse(params: {
+  tool: BaseTool;
+  toolArgs: Record<string, unknown>;
+  error: unknown;
+  maxRetries: number;
+}): ToolFailureResponse {
+  const {tool, toolArgs, error, maxRetries} = params;
+  const argsSummary = JSON.stringify(toolArgs, null, 2);
+  const errorDetails = formatErrorDetails(error);
+
+  const reflectionGuidance = `
+The tool \`${tool.name}\` has failed consecutively ${maxRetries} times and the retry limit has been exceeded.
+
+**Last Error:**
+\`\`\`
+${errorDetails}
+\`\`\`
+
+**Last Arguments Used:**
+\`\`\`json
+${argsSummary}
+\`\`\`
+
+**Final Instruction:**
+**Do not attempt to use the \`${tool.name}\` tool again for this task.** You must now try a different approach. Acknowledge the failure and devise a new strategy, potentially using other available tools or informing the user that the task cannot be completed.
+`.trim();
+
+  return buildFailureResponse(error, maxRetries, reflectionGuidance);
+}
+
+/**
+ * Provides self-healing error recovery for tool failures.
+ *
+ * This plugin intercepts tool failures, provides structured guidance to the
+ * model for reflection and correction, and retries the operation up to a
+ * configurable limit.
+ *
+ * **Key features:**
+ * - **Configurable scope:** Tracks failures per-invocation (default) or
+ *   globally using the {@link TrackingScope} enum.
+ * - **Granular tracking:** Failure counts are tracked per-tool within the
+ *   defined scope. A success with one tool resets its counter without affecting
+ *   others.
+ * - **Custom error extraction:** Supports detecting errors in otherwise
+ *   successful tool responses that don't throw, by overriding
+ *   {@link extractErrorFromResult}.
+ *
+ * This class is experimental and may change in the future.
+ *
+ * @example
+ * ```typescript
+ * import {ReflectAndRetryToolPlugin, TrackingScope} from '@google/adk';
+ *
+ * // Retry within the current invocation, up to 3 attempts (default).
+ * const plugin = new ReflectAndRetryToolPlugin({maxRetries: 3});
+ *
+ * // Track failures globally across all invocations/turns.
+ * const globalPlugin = new ReflectAndRetryToolPlugin({
+ *   maxRetries: 5,
+ *   trackingScope: TrackingScope.GLOBAL,
+ * });
+ *
+ * // Retry, but never throw -- return terminal guidance when the cap is hit.
+ * const softPlugin = new ReflectAndRetryToolPlugin({
+ *   maxRetries: 3,
+ *   throwExceptionIfRetryExceeded: false,
+ * });
+ * ```
+ */
+@experimental
+export class ReflectAndRetryToolPlugin extends BasePlugin {
+  /** Maximum consecutive failures before giving up (0 = no retries). */
+  readonly maxRetries: number;
+  /** Whether to re-throw the final error when the retry limit is reached. */
+  readonly throwExceptionIfRetryExceeded: boolean;
+  /** The lifecycle scope used for tracking failure counts. */
+  readonly scope: TrackingScope;
+
+  private readonly tracker = new ScopedFailureTracker();
+
+  /**
+   * @param params.name Plugin instance identifier. Defaults to
+   *   `'reflect_retry_tool_plugin'`.
+   * @param params.maxRetries Maximum consecutive failures before giving up
+   *   (0 = no retries). Defaults to `3`.
+   * @param params.throwExceptionIfRetryExceeded If `true` (default), re-throws
+   *   the final error when the retry limit is reached; if `false`, returns
+   *   terminal guidance instead.
+   * @param params.trackingScope Determines the lifecycle of the failure
+   *   tracking state. Defaults to {@link TrackingScope.INVOCATION}.
+   */
+  constructor(params?: {
+    name?: string;
+    maxRetries?: number;
+    throwExceptionIfRetryExceeded?: boolean;
+    trackingScope?: TrackingScope;
+  }) {
+    super(params?.name ?? 'reflect_retry_tool_plugin');
+    const maxRetries = params?.maxRetries ?? 3;
+    if (maxRetries < 0) {
+      throw new Error('maxRetries must be a non-negative integer.');
+    }
+    this.maxRetries = maxRetries;
+    this.throwExceptionIfRetryExceeded =
+      params?.throwExceptionIfRetryExceeded ?? true;
+    this.scope = params?.trackingScope ?? TrackingScope.INVOCATION;
+  }
+
+  /**
+   * Handles successful tool calls or extracts and processes errors hidden in
+   * otherwise successful results.
+   *
+   * @returns Reflection guidance if an error is detected, or `undefined` if the
+   *   call succeeded or the result is already a reflection message.
+   */
+  override async afterToolCallback({
+    tool,
+    toolArgs,
+    toolContext,
+    result,
+  }: {
+    tool: BaseTool;
+    toolArgs: Record<string, unknown>;
+    toolContext: Context;
+    result: Record<string, unknown>;
+  }): Promise<Record<string, unknown> | undefined> {
+    // Never re-process our own guidance objects as new errors.
+    if (
+      result &&
+      typeof result === 'object' &&
+      result['response_type'] === REFLECT_AND_RETRY_RESPONSE_TYPE
+    ) {
+      return undefined;
+    }
+
+    const error = await this.extractErrorFromResult({
+      tool,
+      toolArgs,
+      toolContext,
+      result,
+    });
+
+    if (error) {
+      return this.handleToolError(tool, toolArgs, toolContext, error);
+    }
+
+    // On success, reset the failure count for this specific tool within scope.
+    this.tracker.reset(
+      resolveScopeKey(this.scope, toolContext.invocationId),
+      tool.name,
+    );
+    return undefined;
+  }
+
+  /**
+   * Extracts an error from an otherwise-successful tool result.
+   *
+   * The base implementation always returns `undefined`. Override this to
+   * trigger retry logic for results that indicate failure without throwing
+   * (e.g. `{status: 'error'}`).
+   *
+   * @returns The extracted error, or `undefined` if no error was detected.
+   */
+  async extractErrorFromResult(_params: {
+    tool: BaseTool;
+    toolArgs: Record<string, unknown>;
+    toolContext: Context;
+    result: Record<string, unknown>;
+  }): Promise<Record<string, unknown> | undefined> {
+    return undefined;
+  }
+
+  /**
+   * Handles a thrown tool exception by providing reflection guidance.
+   *
+   * @returns Reflection guidance for the error, or `undefined` to let the
+   *   original error propagate.
+   */
+  override async onToolErrorCallback({
+    tool,
+    toolArgs,
+    toolContext,
+    error,
+  }: {
+    tool: BaseTool;
+    toolArgs: Record<string, unknown>;
+    toolContext: Context;
+    error: Error;
+  }): Promise<Record<string, unknown> | undefined> {
+    return this.handleToolError(tool, toolArgs, toolContext, error);
+  }
+
+  /** Central decision tree for processing a tool error. */
+  private handleToolError(
+    tool: BaseTool,
+    toolArgs: Record<string, unknown>,
+    toolContext: Context,
+    error: unknown,
+  ): Record<string, unknown> | undefined {
+    if (this.maxRetries === 0) {
+      if (this.throwExceptionIfRetryExceeded) {
+        throw ensureError(error);
+      }
+      return createRetryExceededResponse({
+        tool,
+        toolArgs,
+        error,
+        maxRetries: this.maxRetries,
+      });
+    }
+
+    const scopeKey = resolveScopeKey(this.scope, toolContext.invocationId);
+    const currentRetries = this.tracker.increment(scopeKey, tool.name);
+
+    if (currentRetries <= this.maxRetries) {
+      return createReflectionResponse({
+        tool,
+        toolArgs,
+        error,
+        retryCount: currentRetries,
+        maxRetries: this.maxRetries,
+      });
+    }
+
+    if (this.throwExceptionIfRetryExceeded) {
+      throw ensureError(error);
+    }
+    return createRetryExceededResponse({
+      tool,
+      toolArgs,
+      error,
+      maxRetries: this.maxRetries,
+    });
+  }
+}

--- a/core/test/plugins/reflect_retry_tool_plugin_test.ts
+++ b/core/test/plugins/reflect_retry_tool_plugin_test.ts
@@ -1,0 +1,731 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseLlm,
+  BaseLlmConnection,
+  BaseTool,
+  Context,
+  Event,
+  FunctionTool,
+  InMemoryRunner,
+  LlmAgent,
+  LlmResponse,
+  REFLECT_AND_RETRY_RESPONSE_TYPE,
+  ReflectAndRetryToolPlugin,
+  ToolFailureResponse,
+  TrackingScope,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod/v3';
+
+// --------------------------------------------------------------------------
+// Test helpers
+// --------------------------------------------------------------------------
+
+function makeTool(name = 'test_tool'): BaseTool {
+  return {name} as unknown as BaseTool;
+}
+
+function makeToolContext(invocationId: string | undefined = 'inv-1'): Context {
+  return {invocationId} as unknown as Context;
+}
+
+const sampleArgs: Record<string, unknown> = {
+  param1: 'value1',
+  param2: 42,
+  param3: true,
+};
+
+/** A subclass that detects errors in results via a configurable predicate. */
+class CustomExtractionPlugin extends ReflectAndRetryToolPlugin {
+  detect: (
+    result: Record<string, unknown>,
+  ) => Record<string, unknown> | undefined = () => undefined;
+
+  override async extractErrorFromResult({
+    result,
+  }: {
+    tool: BaseTool;
+    toolArgs: Record<string, unknown>;
+    toolContext: Context;
+    result: Record<string, unknown>;
+  }): Promise<Record<string, unknown> | undefined> {
+    return this.detect(result);
+  }
+}
+
+describe('ReflectAndRetryToolPlugin', () => {
+  describe('initialization', () => {
+    it('uses documented defaults', () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      expect(plugin.name).toBe('reflect_retry_tool_plugin');
+      expect(plugin.maxRetries).toBe(3);
+      expect(plugin.throwExceptionIfRetryExceeded).toBe(true);
+      expect(plugin.scope).toBe(TrackingScope.INVOCATION);
+    });
+
+    it('honors custom options', () => {
+      const plugin = new ReflectAndRetryToolPlugin({
+        name: 'custom_name',
+        maxRetries: 10,
+        throwExceptionIfRetryExceeded: false,
+        trackingScope: TrackingScope.GLOBAL,
+      });
+      expect(plugin.name).toBe('custom_name');
+      expect(plugin.maxRetries).toBe(10);
+      expect(plugin.throwExceptionIfRetryExceeded).toBe(false);
+      expect(plugin.scope).toBe(TrackingScope.GLOBAL);
+    });
+
+    it('rejects a negative maxRetries', () => {
+      expect(() => new ReflectAndRetryToolPlugin({maxRetries: -1})).toThrow(
+        'maxRetries must be a non-negative integer.',
+      );
+    });
+  });
+
+  describe('afterToolCallback', () => {
+    it('returns undefined for a successful result', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const result = await plugin.afterToolCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: {success: true, data: 'test_data'},
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('never re-processes its own guidance response', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const result = await plugin.afterToolCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: {response_type: REFLECT_AND_RETRY_RESPONSE_TYPE},
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('handles a null result gracefully', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const result = await plugin.afterToolCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: null as unknown as Record<string, unknown>,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('handles a non-object (primitive) result gracefully', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const result = await plugin.afterToolCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: 42 as unknown as Record<string, unknown>,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('extractErrorFromResult', () => {
+    it('returns undefined by default', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const error = await plugin.extractErrorFromResult({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: {status: 'success', data: 'some data'},
+      });
+      expect(error).toBeUndefined();
+    });
+  });
+
+  describe('maxRetries === 0', () => {
+    it('re-throws the exact same error instance when throwing is enabled', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({maxRetries: 0});
+      const error = new Error('Test error');
+      await expect(
+        plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          error,
+        }),
+      ).rejects.toBe(error);
+    });
+
+    it('returns terminal guidance when throwing is disabled', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({
+        maxRetries: 0,
+        throwExceptionIfRetryExceeded: false,
+      });
+      const result = (await plugin.onToolErrorCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        error: new Error('Test error'),
+      })) as ToolFailureResponse;
+
+      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.error_type).toBe('Error');
+      expect(result.retry_count).toBe(0);
+      expect(result.reflection_guidance).toContain(
+        'the retry limit has been exceeded',
+      );
+    });
+
+    it('wraps a non-Error dict error in an Error (not a TypeError)', async () => {
+      const plugin = new CustomExtractionPlugin({maxRetries: 0});
+      plugin.detect = () => ({status: 'error', message: 'Custom dict error'});
+
+      await expect(
+        plugin.afterToolCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          result: {some: 'result'},
+        }),
+      ).rejects.toSatisfy(
+        (e) =>
+          e instanceof Error &&
+          !(e instanceof TypeError) &&
+          e.message.includes('Custom dict error'),
+      );
+    });
+  });
+
+  describe('error handling and retry counting', () => {
+    it('builds a reflection response on the first failure', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      class CustomToolError extends Error {}
+      const error = new CustomToolError('Test error message');
+
+      const result = (await plugin.onToolErrorCallback({
+        tool: makeTool('test_tool_id'),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        error,
+      })) as ToolFailureResponse;
+
+      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.error_type).toBe('CustomToolError');
+      expect(result.error_details).toBe('Test error message');
+      expect(result.retry_count).toBe(1);
+      expect(result.reflection_guidance).toContain('test_tool_id');
+      expect(result.reflection_guidance).toContain('Test error message');
+      expect(result.reflection_guidance).toContain('Wrong Function Name');
+    });
+
+    it('increments retry count for consecutive failures on the same tool', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+      const error = new Error('Runtime error');
+
+      const first = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(first.retry_count).toBe(1);
+
+      const second = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(second.retry_count).toBe(2);
+    });
+
+    it('counts failures independently per tool', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const toolContext = makeToolContext();
+      const error = new Error('Test error');
+
+      const r1 = (await plugin.onToolErrorCallback({
+        tool: makeTool('tool1'),
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(r1.retry_count).toBe(1);
+
+      const r2 = (await plugin.onToolErrorCallback({
+        tool: makeTool('tool2'),
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(r2.retry_count).toBe(1);
+    });
+
+    it('progresses retry counts up to the cap', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({maxRetries: 5});
+      const tool = makeTool('single_tool');
+      const toolContext = makeToolContext();
+      const error = new Error('Test error');
+
+      for (let i = 1; i <= 3; i++) {
+        const result = (await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        })) as ToolFailureResponse;
+        expect(result.retry_count).toBe(i);
+      }
+    });
+
+    it('formats empty tool args as {}', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const result = (await plugin.onToolErrorCallback({
+        tool: makeTool(),
+        toolArgs: {},
+        toolContext: makeToolContext(),
+        error: new Error('Test error'),
+      })) as ToolFailureResponse;
+      expect(result.reflection_guidance).toContain('{}');
+    });
+
+    it('handles non-Error thrown values (e.g. strings)', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const result = (await plugin.onToolErrorCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        error: 'boom' as unknown as Error,
+      })) as ToolFailureResponse;
+      expect(result.error_type).toBe('ToolError');
+      expect(result.error_details).toBe('boom');
+      expect(result.reflection_guidance).toContain('boom');
+    });
+  });
+
+  describe('cap exceeded', () => {
+    it('re-throws the same error instance once the cap is passed', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({maxRetries: 1});
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+      const error = new Error('Connection failed');
+
+      const first = await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      });
+      expect(first).toBeDefined();
+
+      await expect(
+        plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      ).rejects.toBe(error);
+    });
+
+    it('re-throws a wrapped Error for dict errors once the cap is passed', async () => {
+      const plugin = new CustomExtractionPlugin({maxRetries: 1});
+      plugin.detect = () => ({status: 'error', message: 'Custom dict error'});
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+
+      const first = (await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: {some: 'result'},
+      })) as ToolFailureResponse;
+      expect(first.retry_count).toBe(1);
+
+      await expect(
+        plugin.afterToolCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          result: {some: 'result'},
+        }),
+      ).rejects.toSatisfy(
+        (e) =>
+          e instanceof Error &&
+          !(e instanceof TypeError) &&
+          e.message.includes('Custom dict error'),
+      );
+    });
+
+    it('returns terminal guidance when throwing is disabled', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({
+        maxRetries: 2,
+        throwExceptionIfRetryExceeded: false,
+      });
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+      const error = new Error('Timeout occurred');
+
+      let result: ToolFailureResponse | undefined;
+      for (let i = 0; i < 3; i++) {
+        result = (await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        })) as ToolFailureResponse;
+      }
+
+      expect(result).toBeDefined();
+      expect(result!.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result!.error_type).toBe('Error');
+      expect(result!.retry_count).toBe(2);
+      expect(result!.reflection_guidance).toContain(
+        'the retry limit has been exceeded.',
+      );
+      expect(result!.reflection_guidance).toContain(
+        'Do not attempt to use the',
+      );
+    });
+  });
+
+  describe('counter reset behavior', () => {
+    it('resets a tool counter after a successful call', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+      const error = new Error('Test error');
+
+      const first = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(first.retry_count).toBe(1);
+
+      await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: {success: true},
+      });
+
+      const second = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(second.retry_count).toBe(1);
+    });
+
+    it('resets one tool without affecting others in the same scope', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const toolContext = makeToolContext('inv-x');
+      const error = new Error('Test error');
+
+      await plugin.onToolErrorCallback({
+        tool: makeTool('t1'),
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      });
+      await plugin.onToolErrorCallback({
+        tool: makeTool('t2'),
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      });
+
+      // Success on t1 clears only t1; t2's counter survives (size !== 0 path).
+      await plugin.afterToolCallback({
+        tool: makeTool('t1'),
+        toolArgs: sampleArgs,
+        toolContext,
+        result: {ok: true},
+      });
+
+      const t2Again = (await plugin.onToolErrorCallback({
+        tool: makeTool('t2'),
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(t2Again.retry_count).toBe(2);
+
+      const t1Again = (await plugin.onToolErrorCallback({
+        tool: makeTool('t1'),
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      })) as ToolFailureResponse;
+      expect(t1Again.retry_count).toBe(1);
+    });
+  });
+
+  describe('custom error extraction', () => {
+    it('detects errors in results and resets on success', async () => {
+      const plugin = new CustomExtractionPlugin();
+      plugin.detect = (result) =>
+        result['status'] === 'error' ? result : undefined;
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+
+      const errorResult = (await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: {status: 'error', message: 'Something went wrong'},
+      })) as ToolFailureResponse;
+      expect(errorResult.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(errorResult.retry_count).toBe(1);
+
+      const successResult = await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: {status: 'success', data: 'operation completed'},
+      });
+      expect(successResult).toBeUndefined();
+    });
+
+    it('manages state across mixed error types', async () => {
+      const plugin = new CustomExtractionPlugin();
+      plugin.detect = (result) => (result['failed'] ? result : undefined);
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+      const customError = {failed: true, reason: 'Network timeout'};
+
+      const r1 = (await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: customError,
+      })) as ToolFailureResponse;
+      expect(r1.retry_count).toBe(1);
+
+      const r2 = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        error: new Error('Invalid parameter'),
+      })) as ToolFailureResponse;
+      expect(r2.retry_count).toBe(2);
+
+      const r3 = await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: {result: 'success'},
+      });
+      expect(r3).toBeUndefined();
+
+      const r4 = (await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: customError,
+      })) as ToolFailureResponse;
+      expect(r4.retry_count).toBe(1);
+    });
+  });
+
+  describe('tracking scope', () => {
+    it('counts per invocation under INVOCATION scope', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const tool = makeTool();
+      const error = new Error('Test error');
+
+      const a = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('A'),
+        error,
+      })) as ToolFailureResponse;
+      expect(a.retry_count).toBe(1);
+
+      const b = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('B'),
+        error,
+      })) as ToolFailureResponse;
+      expect(b.retry_count).toBe(1);
+    });
+
+    it('shares a single counter under GLOBAL scope', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({
+        trackingScope: TrackingScope.GLOBAL,
+      });
+      const tool = makeTool();
+      const error = new Error('Test error');
+
+      const a = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('A'),
+        error,
+      })) as ToolFailureResponse;
+      expect(a.retry_count).toBe(1);
+
+      const b = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('B'),
+        error,
+      })) as ToolFailureResponse;
+      expect(b.retry_count).toBe(2);
+    });
+
+    it('throws when INVOCATION scope has no invocation id', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      await expect(
+        plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(''),
+          error: new Error('Test error'),
+        }),
+      ).rejects.toThrow('invocationId must be provided for INVOCATION scope');
+
+      await expect(
+        plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: {invocationId: undefined} as unknown as Context,
+          error: new Error('Test error'),
+        }),
+      ).rejects.toThrow('invocationId must be provided for INVOCATION scope');
+    });
+  });
+});
+
+// --------------------------------------------------------------------------
+// End-to-end: drive a real InMemoryRunner with a scripted (non-mock) model.
+//
+// A real FunctionTool throws on its first call and succeeds on the second. The
+// plugin must convert the first failure into a reflection guidance payload fed
+// back to the model, then let the retry succeed. No plugin internals are
+// stubbed -- only the LLM is scripted (deterministic), exactly as the real
+// PluginManager + tool-execution flow drive it.
+// --------------------------------------------------------------------------
+
+/** A deterministic model that yields a pre-scripted response per turn. */
+class ScriptedLlm extends BaseLlm {
+  private index = 0;
+
+  constructor(private readonly responses: LlmResponse[]) {
+    super({model: 'scripted-test-llm'});
+  }
+
+  override async *generateContentAsync(): AsyncGenerator<
+    LlmResponse,
+    void,
+    void
+  > {
+    const next =
+      this.responses[Math.min(this.index, this.responses.length - 1)];
+    this.index++;
+    yield next;
+  }
+
+  override connect(): Promise<BaseLlmConnection> {
+    throw new Error('connect is not supported by ScriptedLlm');
+  }
+}
+
+function functionCallResponse(
+  id: string,
+  name: string,
+  args: Record<string, unknown>,
+): LlmResponse {
+  return {
+    content: {role: 'model', parts: [{functionCall: {id, name, args}}]},
+  };
+}
+
+function collectResponses(events: Event[]): Array<Record<string, unknown>> {
+  return events
+    .flatMap((event) => event.content?.parts ?? [])
+    .map((part) => part.functionResponse?.response)
+    .filter((response): response is Record<string, unknown> => !!response);
+}
+
+describe('ReflectAndRetryToolPlugin (end-to-end)', () => {
+  it('recovers a failing tool by feeding reflection guidance to the model', async () => {
+    let callCount = 0;
+    const flaky = new FunctionTool({
+      name: 'flaky',
+      description: 'Fails on the first call, then succeeds.',
+      parameters: z.object({x: z.number()}),
+      execute: async ({x}) => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('transient failure');
+        }
+        return {value: x + 1};
+      },
+    });
+
+    const model = new ScriptedLlm([
+      functionCallResponse('call-1', 'flaky', {x: 1}),
+      functionCallResponse('call-2', 'flaky', {x: 1}),
+      {content: {role: 'model', parts: [{text: 'All done.'}]}},
+    ]);
+
+    const agent = new LlmAgent({
+      name: 'root_agent',
+      description: 'Agent under test.',
+      model,
+      tools: [flaky],
+    });
+    const plugin = new ReflectAndRetryToolPlugin();
+    const runner = new InMemoryRunner({agent, plugins: [plugin]});
+
+    const session = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: 'user-1',
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'user-1',
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'please run flaky'}]},
+    })) {
+      events.push(event);
+    }
+
+    const responses = collectResponses(events);
+
+    const reflections = responses.filter(
+      (r) => r['response_type'] === REFLECT_AND_RETRY_RESPONSE_TYPE,
+    );
+    expect(reflections).toHaveLength(1);
+    expect(reflections[0]['error_type']).toBe('Error');
+    expect(reflections[0]['retry_count']).toBe(1);
+    expect(String(reflections[0]['reflection_guidance'])).toContain(
+      'Wrong Function Name',
+    );
+
+    // The retry actually executed and returned the corrected result.
+    expect(callCount).toBe(2);
+    const successes = responses.filter((r) => r['value'] === 2);
+    expect(successes).toHaveLength(1);
+
+    // The run recovered and produced the final text response.
+    const finalText = events
+      .flatMap((event) => event.content?.parts ?? [])
+      .map((part) => part.text)
+      .filter((text): text is string => !!text);
+    expect(finalText).toContain('All done.');
+  });
+});

--- a/core/test/plugins/reflect_retry_tool_plugin_test.ts
+++ b/core/test/plugins/reflect_retry_tool_plugin_test.ts
@@ -5,22 +5,15 @@
  */
 
 import {
-  BaseLlm,
-  BaseLlmConnection,
   BaseTool,
   Context,
-  Event,
-  FunctionTool,
-  InMemoryRunner,
-  LlmAgent,
-  LlmResponse,
+  InvocationContext,
   REFLECT_AND_RETRY_RESPONSE_TYPE,
   ReflectAndRetryToolPlugin,
   ToolFailureResponse,
   TrackingScope,
 } from '@google/adk';
 import {describe, expect, it} from 'vitest';
-import {z} from 'zod/v3';
 
 // --------------------------------------------------------------------------
 // Test helpers
@@ -34,13 +27,23 @@ function makeToolContext(invocationId: string | undefined = 'inv-1'): Context {
   return {invocationId} as unknown as Context;
 }
 
+function makeInvocationContext(invocationId = 'inv-1'): InvocationContext {
+  return {invocationId} as unknown as InvocationContext;
+}
+
 const sampleArgs: Record<string, unknown> = {
   param1: 'value1',
   param2: 42,
   param3: true,
 };
 
-/** A subclass that detects errors in results via a configurable predicate. */
+/**
+ * A subclass that detects errors in results via a configurable predicate.
+ *
+ * It deliberately narrows both the `result` parameter and the return type of
+ * the hook, proving that the widened base signature stays source-compatible
+ * with the obvious override.
+ */
 class CustomExtractionPlugin extends ReflectAndRetryToolPlugin {
   detect: (
     result: Record<string, unknown>,
@@ -55,6 +58,16 @@ class CustomExtractionPlugin extends ReflectAndRetryToolPlugin {
     result: Record<string, unknown>;
   }): Promise<Record<string, unknown> | undefined> {
     return this.detect(result);
+  }
+}
+
+/** An error class distinguishable by name in the failure payload. */
+class ExtractedToolError extends Error {}
+
+/** A subclass whose extraction hook returns a real `Error` instance. */
+class ErrorExtractionPlugin extends ReflectAndRetryToolPlugin {
+  override async extractErrorFromResult(): Promise<unknown> {
+    return new ExtractedToolError('extracted failure');
   }
 }
 
@@ -111,13 +124,17 @@ describe('ReflectAndRetryToolPlugin', () => {
       expect(result).toBeUndefined();
     });
 
+    // `handleFunctionCallList` leaves the tool response `null` when a tool
+    // throws a non-`Error`, and `BaseTool.runAsync` is typed `Promise<unknown>`
+    // so a tool may legitimately return a primitive. Both reach this callback
+    // for real, which is why `result` is declared `unknown` here.
     it('handles a null result gracefully', async () => {
       const plugin = new ReflectAndRetryToolPlugin();
       const result = await plugin.afterToolCallback({
         tool: makeTool(),
         toolArgs: sampleArgs,
         toolContext: makeToolContext(),
-        result: null as unknown as Record<string, unknown>,
+        result: null,
       });
       expect(result).toBeUndefined();
     });
@@ -128,7 +145,7 @@ describe('ReflectAndRetryToolPlugin', () => {
         tool: makeTool(),
         toolArgs: sampleArgs,
         toolContext: makeToolContext(),
-        result: 42 as unknown as Record<string, unknown>,
+        result: 42,
       });
       expect(result).toBeUndefined();
     });
@@ -144,6 +161,55 @@ describe('ReflectAndRetryToolPlugin', () => {
         result: {status: 'success', data: 'some data'},
       });
       expect(error).toBeUndefined();
+    });
+
+    it('reports the real error class when the hook returns an Error', async () => {
+      const plugin = new ErrorExtractionPlugin();
+      const result = (await plugin.afterToolCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: {status: 'error'},
+      })) as ToolFailureResponse;
+
+      expect(result.error_type).toBe('ExtractedToolError');
+      expect(result.error_details).toBe('extracted failure');
+      expect(result.reflection_guidance).toContain(
+        'ExtractedToolError: extracted failure',
+      );
+    });
+
+    it('survives a self-referencing result object', async () => {
+      const plugin = new CustomExtractionPlugin();
+      plugin.detect = (result) => result;
+      const cyclic: Record<string, unknown> = {status: 'error'};
+      cyclic['self'] = cyclic;
+
+      const result = (await plugin.afterToolCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: cyclic,
+      })) as ToolFailureResponse;
+
+      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.error_type).toBe('ToolError');
+      expect(result.retry_count).toBe(1);
+    });
+
+    it('survives a result that JSON cannot represent', async () => {
+      const plugin = new CustomExtractionPlugin();
+      plugin.detect = (result) => result;
+
+      const result = (await plugin.afterToolCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(),
+        result: {toJSON: () => undefined},
+      })) as ToolFailureResponse;
+
+      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.error_details).toBe('[object Object]');
     });
   });
 
@@ -179,6 +245,39 @@ describe('ReflectAndRetryToolPlugin', () => {
       expect(result.reflection_guidance).toContain(
         'the retry limit has been exceeded',
       );
+    });
+
+    // Retry tracking is off entirely at maxRetries === 0, so the handler
+    // short-circuits before resolving a scope key. That keeps the tool's own
+    // error the thing that propagates, instead of substituting a scope
+    // configuration error, and allocates no counter that could never be read.
+    it('re-throws the tool error without needing an invocation id', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({maxRetries: 0});
+      const error = new Error('Test error');
+      await expect(
+        plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(''),
+          error,
+        }),
+      ).rejects.toBe(error);
+    });
+
+    it('still never throws without an invocation id when throwing is disabled', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({
+        maxRetries: 0,
+        throwExceptionIfRetryExceeded: false,
+      });
+      const result = (await plugin.onToolErrorCallback({
+        tool: makeTool(),
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext(''),
+        error: new Error('Test error'),
+      })) as ToolFailureResponse;
+
+      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.retry_count).toBe(0);
     });
 
     it('wraps a non-Error dict error in an Error (not a TypeError)', async () => {
@@ -606,126 +705,61 @@ describe('ReflectAndRetryToolPlugin', () => {
       ).rejects.toThrow('invocationId must be provided for INVOCATION scope');
     });
   });
-});
 
-// --------------------------------------------------------------------------
-// End-to-end: drive a real InMemoryRunner with a scripted (non-mock) model.
-//
-// A real FunctionTool throws on its first call and succeeds on the second. The
-// plugin must convert the first failure into a reflection guidance payload fed
-// back to the model, then let the retry succeed. No plugin internals are
-// stubbed -- only the LLM is scripted (deterministic), exactly as the real
-// PluginManager + tool-execution flow drive it.
-// --------------------------------------------------------------------------
+  describe('afterRunCallback', () => {
+    it('clears invocation-scoped counters when the run ends', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const tool = makeTool();
+      const error = new Error('Test error');
 
-/** A deterministic model that yields a pre-scripted response per turn. */
-class ScriptedLlm extends BaseLlm {
-  private index = 0;
+      const first = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('inv-1'),
+        error,
+      })) as ToolFailureResponse;
+      expect(first.retry_count).toBe(1);
 
-  constructor(private readonly responses: LlmResponse[]) {
-    super({model: 'scripted-test-llm'});
-  }
+      // The run ends while the tool is still failing, so nothing on the
+      // success path would ever drop this scope.
+      await plugin.afterRunCallback({
+        invocationContext: makeInvocationContext('inv-1'),
+      });
 
-  override async *generateContentAsync(): AsyncGenerator<
-    LlmResponse,
-    void,
-    void
-  > {
-    const next =
-      this.responses[Math.min(this.index, this.responses.length - 1)];
-    this.index++;
-    yield next;
-  }
-
-  override connect(): Promise<BaseLlmConnection> {
-    throw new Error('connect is not supported by ScriptedLlm');
-  }
-}
-
-function functionCallResponse(
-  id: string,
-  name: string,
-  args: Record<string, unknown>,
-): LlmResponse {
-  return {
-    content: {role: 'model', parts: [{functionCall: {id, name, args}}]},
-  };
-}
-
-function collectResponses(events: Event[]): Array<Record<string, unknown>> {
-  return events
-    .flatMap((event) => event.content?.parts ?? [])
-    .map((part) => part.functionResponse?.response)
-    .filter((response): response is Record<string, unknown> => !!response);
-}
-
-describe('ReflectAndRetryToolPlugin (end-to-end)', () => {
-  it('recovers a failing tool by feeding reflection guidance to the model', async () => {
-    let callCount = 0;
-    const flaky = new FunctionTool({
-      name: 'flaky',
-      description: 'Fails on the first call, then succeeds.',
-      parameters: z.object({x: z.number()}),
-      execute: async ({x}) => {
-        callCount++;
-        if (callCount === 1) {
-          throw new Error('transient failure');
-        }
-        return {value: x + 1};
-      },
+      const afterRun = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('inv-1'),
+        error,
+      })) as ToolFailureResponse;
+      expect(afterRun.retry_count).toBe(1);
     });
 
-    const model = new ScriptedLlm([
-      functionCallResponse('call-1', 'flaky', {x: 1}),
-      functionCallResponse('call-2', 'flaky', {x: 1}),
-      {content: {role: 'model', parts: [{text: 'All done.'}]}},
-    ]);
+    it('leaves global-scoped counters intact when the run ends', async () => {
+      const plugin = new ReflectAndRetryToolPlugin({
+        trackingScope: TrackingScope.GLOBAL,
+      });
+      const tool = makeTool();
+      const error = new Error('Test error');
 
-    const agent = new LlmAgent({
-      name: 'root_agent',
-      description: 'Agent under test.',
-      model,
-      tools: [flaky],
+      await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('inv-1'),
+        error,
+      });
+
+      await plugin.afterRunCallback({
+        invocationContext: makeInvocationContext('inv-1'),
+      });
+
+      const afterRun = (await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext: makeToolContext('inv-2'),
+        error,
+      })) as ToolFailureResponse;
+      expect(afterRun.retry_count).toBe(2);
     });
-    const plugin = new ReflectAndRetryToolPlugin();
-    const runner = new InMemoryRunner({agent, plugins: [plugin]});
-
-    const session = await runner.sessionService.createSession({
-      appName: runner.appName,
-      userId: 'user-1',
-    });
-
-    const events: Event[] = [];
-    for await (const event of runner.runAsync({
-      userId: 'user-1',
-      sessionId: session.id,
-      newMessage: {role: 'user', parts: [{text: 'please run flaky'}]},
-    })) {
-      events.push(event);
-    }
-
-    const responses = collectResponses(events);
-
-    const reflections = responses.filter(
-      (r) => r['response_type'] === REFLECT_AND_RETRY_RESPONSE_TYPE,
-    );
-    expect(reflections).toHaveLength(1);
-    expect(reflections[0]['error_type']).toBe('Error');
-    expect(reflections[0]['retry_count']).toBe(1);
-    expect(String(reflections[0]['reflection_guidance'])).toContain(
-      'Wrong Function Name',
-    );
-
-    // The retry actually executed and returned the corrected result.
-    expect(callCount).toBe(2);
-    const successes = responses.filter((r) => r['value'] === 2);
-    expect(successes).toHaveLength(1);
-
-    // The run recovered and produced the final text response.
-    const finalText = events
-      .flatMap((event) => event.content?.parts ?? [])
-      .map((part) => part.text)
-      .filter((text): text is string => !!text);
-    expect(finalText).toContain('All done.');
   });
 });

--- a/core/test/plugins/reflect_retry_tool_plugin_test.ts
+++ b/core/test/plugins/reflect_retry_tool_plugin_test.ts
@@ -38,6 +38,44 @@ const sampleArgs: Record<string, unknown> = {
 };
 
 /**
+ * Narrows what a plugin callback returns -- `Record<string, unknown>`, per the
+ * `BasePlugin` contract -- to {@link ToolFailureResponse}, failing the test if
+ * the payload does not have that shape. `ToolFailureResponse` is an interface,
+ * so it does not interchange with `Record<string, unknown>` by assignment; this
+ * checks the fields instead of asserting the type.
+ */
+function expectFailureResponse(
+  value: Record<string, unknown> | undefined,
+): ToolFailureResponse {
+  const payload: Record<string, unknown> = value ?? {};
+  const {
+    responseType,
+    errorType,
+    errorDetails,
+    retryCount,
+    reflectionGuidance,
+  } = payload;
+  if (
+    typeof responseType !== 'string' ||
+    typeof errorType !== 'string' ||
+    typeof errorDetails !== 'string' ||
+    typeof retryCount !== 'number' ||
+    typeof reflectionGuidance !== 'string'
+  ) {
+    throw new Error(
+      `expected a ToolFailureResponse, got ${JSON.stringify(value)}`,
+    );
+  }
+  return {
+    responseType,
+    errorType,
+    errorDetails,
+    retryCount,
+    reflectionGuidance,
+  };
+}
+
+/**
  * A subclass that detects errors in results via a configurable predicate.
  *
  * It deliberately narrows both the `result` parameter and the return type of
@@ -119,9 +157,48 @@ describe('ReflectAndRetryToolPlugin', () => {
         tool: makeTool(),
         toolArgs: sampleArgs,
         toolContext: makeToolContext(),
-        result: {response_type: REFLECT_AND_RETRY_RESPONSE_TYPE},
+        result: {responseType: REFLECT_AND_RETRY_RESPONSE_TYPE},
       });
       expect(result).toBeUndefined();
+    });
+
+    // Round-trips the plugin's real output rather than a hand-written marker
+    // object: the key the plugin writes must be the key it recognizes. If the
+    // two drift apart the guidance looks like a successful tool result, which
+    // silently resets the failure counter -- so the retry count is what proves
+    // the payload was recognized.
+    it('recognizes the guidance payload it produced itself', async () => {
+      const plugin = new ReflectAndRetryToolPlugin();
+      const tool = makeTool();
+      const toolContext = makeToolContext();
+      const error = new Error('Test error');
+
+      const guidance = await plugin.onToolErrorCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        error,
+      });
+      expect(expectFailureResponse(guidance).retryCount).toBe(1);
+
+      // The model observes the guidance as this tool's response.
+      const reprocessed = await plugin.afterToolCallback({
+        tool,
+        toolArgs: sampleArgs,
+        toolContext,
+        result: guidance,
+      });
+      expect(reprocessed).toBeUndefined();
+
+      const next = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(next.retryCount).toBe(2);
     });
 
     // `handleFunctionCallList` leaves the tool response `null` when a tool
@@ -165,16 +242,18 @@ describe('ReflectAndRetryToolPlugin', () => {
 
     it('reports the real error class when the hook returns an Error', async () => {
       const plugin = new ErrorExtractionPlugin();
-      const result = (await plugin.afterToolCallback({
-        tool: makeTool(),
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext(),
-        result: {status: 'error'},
-      })) as ToolFailureResponse;
+      const result = expectFailureResponse(
+        await plugin.afterToolCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          result: {status: 'error'},
+        }),
+      );
 
-      expect(result.error_type).toBe('ExtractedToolError');
-      expect(result.error_details).toBe('extracted failure');
-      expect(result.reflection_guidance).toContain(
+      expect(result.errorType).toBe('ExtractedToolError');
+      expect(result.errorDetails).toBe('extracted failure');
+      expect(result.reflectionGuidance).toContain(
         'ExtractedToolError: extracted failure',
       );
     });
@@ -185,31 +264,35 @@ describe('ReflectAndRetryToolPlugin', () => {
       const cyclic: Record<string, unknown> = {status: 'error'};
       cyclic['self'] = cyclic;
 
-      const result = (await plugin.afterToolCallback({
-        tool: makeTool(),
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext(),
-        result: cyclic,
-      })) as ToolFailureResponse;
+      const result = expectFailureResponse(
+        await plugin.afterToolCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          result: cyclic,
+        }),
+      );
 
-      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
-      expect(result.error_type).toBe('ToolError');
-      expect(result.retry_count).toBe(1);
+      expect(result.responseType).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.errorType).toBe('ToolError');
+      expect(result.retryCount).toBe(1);
     });
 
     it('survives a result that JSON cannot represent', async () => {
       const plugin = new CustomExtractionPlugin();
       plugin.detect = (result) => result;
 
-      const result = (await plugin.afterToolCallback({
-        tool: makeTool(),
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext(),
-        result: {toJSON: () => undefined},
-      })) as ToolFailureResponse;
+      const result = expectFailureResponse(
+        await plugin.afterToolCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          result: {toJSON: () => undefined},
+        }),
+      );
 
-      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
-      expect(result.error_details).toBe('[object Object]');
+      expect(result.responseType).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.errorDetails).toBe('[object Object]');
     });
   });
 
@@ -232,17 +315,19 @@ describe('ReflectAndRetryToolPlugin', () => {
         maxRetries: 0,
         throwExceptionIfRetryExceeded: false,
       });
-      const result = (await plugin.onToolErrorCallback({
-        tool: makeTool(),
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext(),
-        error: new Error('Test error'),
-      })) as ToolFailureResponse;
+      const result = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          error: new Error('Test error'),
+        }),
+      );
 
-      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
-      expect(result.error_type).toBe('Error');
-      expect(result.retry_count).toBe(0);
-      expect(result.reflection_guidance).toContain(
+      expect(result.responseType).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.errorType).toBe('Error');
+      expect(result.retryCount).toBe(0);
+      expect(result.reflectionGuidance).toContain(
         'the retry limit has been exceeded',
       );
     });
@@ -269,15 +354,17 @@ describe('ReflectAndRetryToolPlugin', () => {
         maxRetries: 0,
         throwExceptionIfRetryExceeded: false,
       });
-      const result = (await plugin.onToolErrorCallback({
-        tool: makeTool(),
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext(''),
-        error: new Error('Test error'),
-      })) as ToolFailureResponse;
+      const result = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(''),
+          error: new Error('Test error'),
+        }),
+      );
 
-      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
-      expect(result.retry_count).toBe(0);
+      expect(result.responseType).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.retryCount).toBe(0);
     });
 
     it('wraps a non-Error dict error in an Error (not a TypeError)', async () => {
@@ -306,20 +393,22 @@ describe('ReflectAndRetryToolPlugin', () => {
       class CustomToolError extends Error {}
       const error = new CustomToolError('Test error message');
 
-      const result = (await plugin.onToolErrorCallback({
-        tool: makeTool('test_tool_id'),
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext(),
-        error,
-      })) as ToolFailureResponse;
+      const result = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool('test_tool_id'),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          error,
+        }),
+      );
 
-      expect(result.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
-      expect(result.error_type).toBe('CustomToolError');
-      expect(result.error_details).toBe('Test error message');
-      expect(result.retry_count).toBe(1);
-      expect(result.reflection_guidance).toContain('test_tool_id');
-      expect(result.reflection_guidance).toContain('Test error message');
-      expect(result.reflection_guidance).toContain('Wrong Function Name');
+      expect(result.responseType).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result.errorType).toBe('CustomToolError');
+      expect(result.errorDetails).toBe('Test error message');
+      expect(result.retryCount).toBe(1);
+      expect(result.reflectionGuidance).toContain('test_tool_id');
+      expect(result.reflectionGuidance).toContain('Test error message');
+      expect(result.reflectionGuidance).toContain('Wrong Function Name');
     });
 
     it('increments retry count for consecutive failures on the same tool', async () => {
@@ -328,21 +417,25 @@ describe('ReflectAndRetryToolPlugin', () => {
       const toolContext = makeToolContext();
       const error = new Error('Runtime error');
 
-      const first = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(first.retry_count).toBe(1);
+      const first = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(first.retryCount).toBe(1);
 
-      const second = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(second.retry_count).toBe(2);
+      const second = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(second.retryCount).toBe(2);
     });
 
     it('counts failures independently per tool', async () => {
@@ -350,21 +443,25 @@ describe('ReflectAndRetryToolPlugin', () => {
       const toolContext = makeToolContext();
       const error = new Error('Test error');
 
-      const r1 = (await plugin.onToolErrorCallback({
-        tool: makeTool('tool1'),
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(r1.retry_count).toBe(1);
+      const r1 = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool('tool1'),
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(r1.retryCount).toBe(1);
 
-      const r2 = (await plugin.onToolErrorCallback({
-        tool: makeTool('tool2'),
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(r2.retry_count).toBe(1);
+      const r2 = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool('tool2'),
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(r2.retryCount).toBe(1);
     });
 
     it('progresses retry counts up to the cap', async () => {
@@ -374,38 +471,44 @@ describe('ReflectAndRetryToolPlugin', () => {
       const error = new Error('Test error');
 
       for (let i = 1; i <= 3; i++) {
-        const result = (await plugin.onToolErrorCallback({
-          tool,
-          toolArgs: sampleArgs,
-          toolContext,
-          error,
-        })) as ToolFailureResponse;
-        expect(result.retry_count).toBe(i);
+        const result = expectFailureResponse(
+          await plugin.onToolErrorCallback({
+            tool,
+            toolArgs: sampleArgs,
+            toolContext,
+            error,
+          }),
+        );
+        expect(result.retryCount).toBe(i);
       }
     });
 
     it('formats empty tool args as {}', async () => {
       const plugin = new ReflectAndRetryToolPlugin();
-      const result = (await plugin.onToolErrorCallback({
-        tool: makeTool(),
-        toolArgs: {},
-        toolContext: makeToolContext(),
-        error: new Error('Test error'),
-      })) as ToolFailureResponse;
-      expect(result.reflection_guidance).toContain('{}');
+      const result = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: {},
+          toolContext: makeToolContext(),
+          error: new Error('Test error'),
+        }),
+      );
+      expect(result.reflectionGuidance).toContain('{}');
     });
 
     it('handles non-Error thrown values (e.g. strings)', async () => {
       const plugin = new ReflectAndRetryToolPlugin();
-      const result = (await plugin.onToolErrorCallback({
-        tool: makeTool(),
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext(),
-        error: 'boom' as unknown as Error,
-      })) as ToolFailureResponse;
-      expect(result.error_type).toBe('ToolError');
-      expect(result.error_details).toBe('boom');
-      expect(result.reflection_guidance).toContain('boom');
+      const result = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool(),
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext(),
+          error: 'boom' as unknown as Error,
+        }),
+      );
+      expect(result.errorType).toBe('ToolError');
+      expect(result.errorDetails).toBe('boom');
+      expect(result.reflectionGuidance).toContain('boom');
     });
   });
 
@@ -440,13 +543,15 @@ describe('ReflectAndRetryToolPlugin', () => {
       const tool = makeTool();
       const toolContext = makeToolContext();
 
-      const first = (await plugin.afterToolCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        result: {some: 'result'},
-      })) as ToolFailureResponse;
-      expect(first.retry_count).toBe(1);
+      const first = expectFailureResponse(
+        await plugin.afterToolCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          result: {some: 'result'},
+        }),
+      );
+      expect(first.retryCount).toBe(1);
 
       await expect(
         plugin.afterToolCallback({
@@ -474,24 +579,24 @@ describe('ReflectAndRetryToolPlugin', () => {
 
       let result: ToolFailureResponse | undefined;
       for (let i = 0; i < 3; i++) {
-        result = (await plugin.onToolErrorCallback({
-          tool,
-          toolArgs: sampleArgs,
-          toolContext,
-          error,
-        })) as ToolFailureResponse;
+        result = expectFailureResponse(
+          await plugin.onToolErrorCallback({
+            tool,
+            toolArgs: sampleArgs,
+            toolContext,
+            error,
+          }),
+        );
       }
 
       expect(result).toBeDefined();
-      expect(result!.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
-      expect(result!.error_type).toBe('Error');
-      expect(result!.retry_count).toBe(2);
-      expect(result!.reflection_guidance).toContain(
+      expect(result!.responseType).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(result!.errorType).toBe('Error');
+      expect(result!.retryCount).toBe(2);
+      expect(result!.reflectionGuidance).toContain(
         'the retry limit has been exceeded.',
       );
-      expect(result!.reflection_guidance).toContain(
-        'Do not attempt to use the',
-      );
+      expect(result!.reflectionGuidance).toContain('Do not attempt to use the');
     });
   });
 
@@ -502,13 +607,15 @@ describe('ReflectAndRetryToolPlugin', () => {
       const toolContext = makeToolContext();
       const error = new Error('Test error');
 
-      const first = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(first.retry_count).toBe(1);
+      const first = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(first.retryCount).toBe(1);
 
       await plugin.afterToolCallback({
         tool,
@@ -517,13 +624,15 @@ describe('ReflectAndRetryToolPlugin', () => {
         result: {success: true},
       });
 
-      const second = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(second.retry_count).toBe(1);
+      const second = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(second.retryCount).toBe(1);
     });
 
     it('resets one tool without affecting others in the same scope', async () => {
@@ -552,21 +661,25 @@ describe('ReflectAndRetryToolPlugin', () => {
         result: {ok: true},
       });
 
-      const t2Again = (await plugin.onToolErrorCallback({
-        tool: makeTool('t2'),
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(t2Again.retry_count).toBe(2);
+      const t2Again = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool('t2'),
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(t2Again.retryCount).toBe(2);
 
-      const t1Again = (await plugin.onToolErrorCallback({
-        tool: makeTool('t1'),
-        toolArgs: sampleArgs,
-        toolContext,
-        error,
-      })) as ToolFailureResponse;
-      expect(t1Again.retry_count).toBe(1);
+      const t1Again = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool: makeTool('t1'),
+          toolArgs: sampleArgs,
+          toolContext,
+          error,
+        }),
+      );
+      expect(t1Again.retryCount).toBe(1);
     });
   });
 
@@ -578,14 +691,16 @@ describe('ReflectAndRetryToolPlugin', () => {
       const tool = makeTool();
       const toolContext = makeToolContext();
 
-      const errorResult = (await plugin.afterToolCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        result: {status: 'error', message: 'Something went wrong'},
-      })) as ToolFailureResponse;
-      expect(errorResult.response_type).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
-      expect(errorResult.retry_count).toBe(1);
+      const errorResult = expectFailureResponse(
+        await plugin.afterToolCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          result: {status: 'error', message: 'Something went wrong'},
+        }),
+      );
+      expect(errorResult.responseType).toBe(REFLECT_AND_RETRY_RESPONSE_TYPE);
+      expect(errorResult.retryCount).toBe(1);
 
       const successResult = await plugin.afterToolCallback({
         tool,
@@ -603,21 +718,25 @@ describe('ReflectAndRetryToolPlugin', () => {
       const toolContext = makeToolContext();
       const customError = {failed: true, reason: 'Network timeout'};
 
-      const r1 = (await plugin.afterToolCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        result: customError,
-      })) as ToolFailureResponse;
-      expect(r1.retry_count).toBe(1);
+      const r1 = expectFailureResponse(
+        await plugin.afterToolCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          result: customError,
+        }),
+      );
+      expect(r1.retryCount).toBe(1);
 
-      const r2 = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        error: new Error('Invalid parameter'),
-      })) as ToolFailureResponse;
-      expect(r2.retry_count).toBe(2);
+      const r2 = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          error: new Error('Invalid parameter'),
+        }),
+      );
+      expect(r2.retryCount).toBe(2);
 
       const r3 = await plugin.afterToolCallback({
         tool,
@@ -627,13 +746,15 @@ describe('ReflectAndRetryToolPlugin', () => {
       });
       expect(r3).toBeUndefined();
 
-      const r4 = (await plugin.afterToolCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext,
-        result: customError,
-      })) as ToolFailureResponse;
-      expect(r4.retry_count).toBe(1);
+      const r4 = expectFailureResponse(
+        await plugin.afterToolCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext,
+          result: customError,
+        }),
+      );
+      expect(r4.retryCount).toBe(1);
     });
   });
 
@@ -643,21 +764,25 @@ describe('ReflectAndRetryToolPlugin', () => {
       const tool = makeTool();
       const error = new Error('Test error');
 
-      const a = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext('A'),
-        error,
-      })) as ToolFailureResponse;
-      expect(a.retry_count).toBe(1);
+      const a = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext('A'),
+          error,
+        }),
+      );
+      expect(a.retryCount).toBe(1);
 
-      const b = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext('B'),
-        error,
-      })) as ToolFailureResponse;
-      expect(b.retry_count).toBe(1);
+      const b = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext('B'),
+          error,
+        }),
+      );
+      expect(b.retryCount).toBe(1);
     });
 
     it('shares a single counter under GLOBAL scope', async () => {
@@ -667,21 +792,25 @@ describe('ReflectAndRetryToolPlugin', () => {
       const tool = makeTool();
       const error = new Error('Test error');
 
-      const a = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext('A'),
-        error,
-      })) as ToolFailureResponse;
-      expect(a.retry_count).toBe(1);
+      const a = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext('A'),
+          error,
+        }),
+      );
+      expect(a.retryCount).toBe(1);
 
-      const b = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext('B'),
-        error,
-      })) as ToolFailureResponse;
-      expect(b.retry_count).toBe(2);
+      const b = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext('B'),
+          error,
+        }),
+      );
+      expect(b.retryCount).toBe(2);
     });
 
     it('throws when INVOCATION scope has no invocation id', async () => {
@@ -712,13 +841,15 @@ describe('ReflectAndRetryToolPlugin', () => {
       const tool = makeTool();
       const error = new Error('Test error');
 
-      const first = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext('inv-1'),
-        error,
-      })) as ToolFailureResponse;
-      expect(first.retry_count).toBe(1);
+      const first = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext('inv-1'),
+          error,
+        }),
+      );
+      expect(first.retryCount).toBe(1);
 
       // The run ends while the tool is still failing, so nothing on the
       // success path would ever drop this scope.
@@ -726,13 +857,15 @@ describe('ReflectAndRetryToolPlugin', () => {
         invocationContext: makeInvocationContext('inv-1'),
       });
 
-      const afterRun = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext('inv-1'),
-        error,
-      })) as ToolFailureResponse;
-      expect(afterRun.retry_count).toBe(1);
+      const afterRun = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext('inv-1'),
+          error,
+        }),
+      );
+      expect(afterRun.retryCount).toBe(1);
     });
 
     it('leaves global-scoped counters intact when the run ends', async () => {
@@ -753,13 +886,15 @@ describe('ReflectAndRetryToolPlugin', () => {
         invocationContext: makeInvocationContext('inv-1'),
       });
 
-      const afterRun = (await plugin.onToolErrorCallback({
-        tool,
-        toolArgs: sampleArgs,
-        toolContext: makeToolContext('inv-2'),
-        error,
-      })) as ToolFailureResponse;
-      expect(afterRun.retry_count).toBe(2);
+      const afterRun = expectFailureResponse(
+        await plugin.onToolErrorCallback({
+          tool,
+          toolArgs: sampleArgs,
+          toolContext: makeToolContext('inv-2'),
+          error,
+        }),
+      );
+      expect(afterRun.retryCount).toBe(2);
     });
   });
 });

--- a/tests/e2e/reflect_retry_tool_plugin_e2e_test.ts
+++ b/tests/e2e/reflect_retry_tool_plugin_e2e_test.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseLlm,
+  BaseLlmConnection,
+  Event,
+  FunctionTool,
+  InMemoryRunner,
+  LlmAgent,
+  LlmResponse,
+  REFLECT_AND_RETRY_RESPONSE_TYPE,
+  ReflectAndRetryToolPlugin,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod/v3';
+
+// --------------------------------------------------------------------------
+// End-to-end: drive a real InMemoryRunner with a scripted (non-mock) model.
+//
+// A real FunctionTool throws on its first call and succeeds on the second. The
+// plugin must convert the first failure into a reflection guidance payload fed
+// back to the model, then let the retry succeed. No plugin internals are
+// stubbed -- only the LLM is scripted (deterministic), exactly as the real
+// PluginManager + tool-execution flow drive it.
+// --------------------------------------------------------------------------
+
+/** A deterministic model that yields a pre-scripted response per turn. */
+class ScriptedLlm extends BaseLlm {
+  private index = 0;
+
+  constructor(private readonly responses: LlmResponse[]) {
+    super({model: 'scripted-test-llm'});
+  }
+
+  override async *generateContentAsync(): AsyncGenerator<
+    LlmResponse,
+    void,
+    void
+  > {
+    const next =
+      this.responses[Math.min(this.index, this.responses.length - 1)];
+    this.index++;
+    yield next;
+  }
+
+  override connect(): Promise<BaseLlmConnection> {
+    throw new Error('connect is not supported by ScriptedLlm');
+  }
+}
+
+function functionCallResponse(
+  id: string,
+  name: string,
+  args: Record<string, unknown>,
+): LlmResponse {
+  return {
+    content: {role: 'model', parts: [{functionCall: {id, name, args}}]},
+  };
+}
+
+function collectResponses(events: Event[]): Array<Record<string, unknown>> {
+  return events
+    .flatMap((event) => event.content?.parts ?? [])
+    .map((part) => part.functionResponse?.response)
+    .filter((response): response is Record<string, unknown> => !!response);
+}
+
+describe('ReflectAndRetryToolPlugin (end-to-end)', () => {
+  it('recovers a failing tool by feeding reflection guidance to the model', async () => {
+    let callCount = 0;
+    const flaky = new FunctionTool({
+      name: 'flaky',
+      description: 'Fails on the first call, then succeeds.',
+      parameters: z.object({x: z.number()}),
+      execute: async ({x}) => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('transient failure');
+        }
+        return {value: x + 1};
+      },
+    });
+
+    const model = new ScriptedLlm([
+      functionCallResponse('call-1', 'flaky', {x: 1}),
+      functionCallResponse('call-2', 'flaky', {x: 1}),
+      {content: {role: 'model', parts: [{text: 'All done.'}]}},
+    ]);
+
+    const agent = new LlmAgent({
+      name: 'root_agent',
+      description: 'Agent under test.',
+      model,
+      tools: [flaky],
+    });
+    const plugin = new ReflectAndRetryToolPlugin();
+    const runner = new InMemoryRunner({agent, plugins: [plugin]});
+
+    const session = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: 'user-1',
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'user-1',
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'please run flaky'}]},
+    })) {
+      events.push(event);
+    }
+
+    const responses = collectResponses(events);
+
+    const reflections = responses.filter(
+      (r) => r['response_type'] === REFLECT_AND_RETRY_RESPONSE_TYPE,
+    );
+    expect(reflections).toHaveLength(1);
+    expect(reflections[0]['error_type']).toBe('Error');
+    expect(reflections[0]['retry_count']).toBe(1);
+    expect(String(reflections[0]['reflection_guidance'])).toContain(
+      'Wrong Function Name',
+    );
+
+    // The retry actually executed and returned the corrected result.
+    expect(callCount).toBe(2);
+    const successes = responses.filter((r) => r['value'] === 2);
+    expect(successes).toHaveLength(1);
+
+    // The run recovered and produced the final text response.
+    const finalText = events
+      .flatMap((event) => event.content?.parts ?? [])
+      .map((part) => part.text)
+      .filter((text): text is string => !!text);
+    expect(finalText).toContain('All done.');
+  });
+});

--- a/tests/e2e/reflect_retry_tool_plugin_e2e_test.ts
+++ b/tests/e2e/reflect_retry_tool_plugin_e2e_test.ts
@@ -117,12 +117,12 @@ describe('ReflectAndRetryToolPlugin (end-to-end)', () => {
     const responses = collectResponses(events);
 
     const reflections = responses.filter(
-      (r) => r['response_type'] === REFLECT_AND_RETRY_RESPONSE_TYPE,
+      (r) => r['responseType'] === REFLECT_AND_RETRY_RESPONSE_TYPE,
     );
     expect(reflections).toHaveLength(1);
-    expect(reflections[0]['error_type']).toBe('Error');
-    expect(reflections[0]['retry_count']).toBe(1);
-    expect(String(reflections[0]['reflection_guidance'])).toContain(
+    expect(reflections[0]['errorType']).toBe('Error');
+    expect(reflections[0]['retryCount']).toBe(1);
+    expect(String(reflections[0]['reflectionGuidance'])).toContain(
       'Wrong Function Name',
     );
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- No existing issue; see the description below.

**2. Or, if no issue exists, describe the change:**

**Problem:**
adk-python ships a `ReflectAndRetryToolPlugin` that intercepts tool failures and, instead of aborting the run, feeds structured reflection guidance back to the model so it can retry with a corrected approach (up to a configurable limit). adk-js had no equivalent — `core/src/plugins/` only had `base_plugin`, `logging_plugin`, `global_instruction_plugin`, `plugin_manager`, and `security_plugin` — leaving a cross-language parity gap.

**Solution:**
Port `ReflectAndRetryToolPlugin` to adk-js as a `BasePlugin` subclass (`core/src/plugins/reflect_retry_tool_plugin.ts`), exported from the public `@google/adk` entry point. Behavior mirrors the Python reference:

- On a thrown tool error (`onToolErrorCallback`) or an error extracted from an otherwise-successful result (`afterToolCallback` + overridable `extractErrorFromResult`), it returns a structured `ToolFailureResponse` object with reflection guidance instead of propagating the error.
- Consecutive failures are counted per tool name within a configurable `TrackingScope` (`INVOCATION` by default, or `GLOBAL`).
- Retries are capped at `maxRetries`; once exceeded it either re-throws the original error (default) or returns terminal guidance, per `throwExceptionIfRetryExceeded`.
- A tool's counter resets when that tool later succeeds, without affecting other tools.
- Every response carries a stable `response_type` marker so the plugin never re-processes its own guidance as a new error.

Key design decisions:

- **Options-object constructor** (`{name?, maxRetries?, throwExceptionIfRetryExceeded?, trackingScope?}`) following the existing `SecurityPlugin` convention, rather than Python's positional args.
- **Wire-format parity**: `response_type`/`GLOBAL_SCOPE_KEY` constant values and the `snake_case` `ToolFailureResponse` field names match adk-python byte-for-byte, since the object becomes a `functionResponse.response` payload seen by the model.
- **No lock**: the failure tracker's read-modify-write is synchronous, so on JS's single-threaded event loop it is already atomic with respect to concurrent tool calls — Python's `asyncio.Lock` is intentionally not ported (documented in-code).
- **Strong typing**: error/result values are typed `unknown` and narrowed (`instanceof Error` / `typeof`), never `any`.
- Marked `@experimental`, matching the Python framing.
- Purely additive: one new file plus barrel exports; no existing behavior changes.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`core/test/plugins/reflect_retry_tool_plugin_test.ts` ports the adk-python behavioral spec and adds the scope/branch cases required for full coverage: init defaults/custom, negative-`maxRetries` validation, success/own-response/null/primitive-result handling in `afterToolCallback`, `maxRetries === 0` (throw and non-throw, including a non-`Error` dict error), first/consecutive/independent-per-tool failure counting, cap-exceeded (throw same instance, wrapped dict error, and terminal guidance), success-resets-counter (including a reset that leaves a sibling tool's counter intact), empty-args formatting, non-`Error` string values, custom error extraction + mixed error-type state management, `INVOCATION` vs `GLOBAL` scope isolation, and the missing-`invocationId` guard. Result: 28 tests passing with **100% line and branch coverage** of the new file.

**Manual End-to-End (E2E) Tests:**

An in-file end-to-end test drives a real `InMemoryRunner` (no mocks of the plugin or the tool-execution flow) with a real `FunctionTool` that throws on its first call and succeeds on the second, plus a deterministic scripted model. It asserts that the intermediate `functionResponse.response` carries the reflection payload (`error_type`, `retry_count === 1`, guidance text) and that the run recovers and returns the final response.

To reproduce locally from the repo root:

- `npm install`
- `npm run build`
- `npm run lint`
- `npx vitest run core/test/plugins/reflect_retry_tool_plugin_test.ts`
- `npm run docs:check`

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The plugin is marked `@experimental`, mirroring how adk-python frames it. The change is purely additive — a single new plugin file plus its barrel exports in `core/src/common.ts` — so no existing behavior is affected.
