### PR TITLE
Feat: Port GoogleSearchAgentTool + createGoogleSearchAgent to adk-js

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -244,6 +244,10 @@ export {
   GOOGLE_MAPS_GROUNDING,
   GoogleMapsGroundingTool,
 } from './tools/google_maps_grounding_tool.js';
+export {
+  GoogleSearchAgentTool,
+  createGoogleSearchAgent,
+} from './tools/google_search_agent_tool.js';
 export {GOOGLE_SEARCH, GoogleSearchTool} from './tools/google_search_tool.js';
 export {
   LOAD_ARTIFACTS,

--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Content, FunctionDeclaration, Type} from '@google/genai';
+import {
+  Content,
+  FunctionDeclaration,
+  GroundingMetadata,
+  Type,
+} from '@google/genai';
 
 import {BaseAgent} from '../agents/base_agent.js';
 import {isLlmAgent} from '../agents/llm_agent.js';
@@ -32,6 +37,12 @@ export interface AgentToolConfig {
    * Whether to skip summarization of the agent output.
    */
   skipSummarization?: boolean;
+
+  /**
+   * Whether to propagate the sub-agent's grounding metadata to the parent
+   * tool context state under `temp:_adk_grounding_metadata`.
+   */
+  propagateGroundingMetadata?: boolean;
 }
 
 /**
@@ -71,6 +82,8 @@ export class AgentTool extends BaseTool {
 
   private readonly skipSummarization: boolean;
 
+  private readonly propagateGroundingMetadata: boolean;
+
   constructor(config: AgentToolConfig) {
     super({
       name: config.agent.name,
@@ -78,6 +91,8 @@ export class AgentTool extends BaseTool {
     });
     this.agent = config.agent;
     this.skipSummarization = config.skipSummarization || false;
+    this.propagateGroundingMetadata =
+      config.propagateGroundingMetadata ?? false;
   }
 
   override _getDeclaration(): FunctionDeclaration {
@@ -169,6 +184,7 @@ export class AgentTool extends BaseTool {
     }
 
     let lastEvent: Event | undefined;
+    let lastGroundingMetadata: GroundingMetadata | undefined;
     for await (const event of runner.runAsync({
       userId: session.userId,
       sessionId: session.id,
@@ -190,7 +206,20 @@ export class AgentTool extends BaseTool {
         }
       }
 
+      if (event.groundingMetadata) {
+        lastGroundingMetadata = event.groundingMetadata;
+      }
+
       lastEvent = event;
+    }
+
+    // Reached only on normal (non-aborted) completion; aborted paths return
+    // inside/before the loop above.
+    if (this.propagateGroundingMetadata && lastGroundingMetadata) {
+      toolContext.state.set(
+        `${State.TEMP_PREFIX}_adk_grounding_metadata`,
+        lastGroundingMetadata,
+      );
     }
 
     if (!lastEvent?.content?.parts?.length) {

--- a/core/src/tools/google_search_agent_tool.ts
+++ b/core/src/tools/google_search_agent_tool.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LlmAgent} from '../agents/llm_agent.js';
+import {BaseLlm} from '../models/base_llm.js';
+
+import {AgentTool} from './agent_tool.js';
+import {GOOGLE_SEARCH} from './google_search_tool.js';
+
+/**
+ * Creates a sub-agent that only uses the `google_search` tool.
+ *
+ * @param model The model id string (e.g. `'gemini-2.0-flash'`) or a
+ *     {@link BaseLlm} instance to back the search sub-agent.
+ * @returns An {@link LlmAgent} named `google_search_agent` whose only tool is
+ *     the built-in `google_search` tool.
+ */
+export function createGoogleSearchAgent(model: string | BaseLlm): LlmAgent {
+  return new LlmAgent({
+    name: 'google_search_agent',
+    model,
+    description:
+      'An agent for performing Google search using the `google_search` tool',
+    instruction: `
+        You are a specialized Google search agent.
+
+        When given a search query, use the \`google_search\` tool to find the related information.
+      `,
+    tools: [GOOGLE_SEARCH],
+  });
+}
+
+/**
+ * A tool that wraps a sub-agent whose only tool is the built-in
+ * `google_search` tool.
+ *
+ * ## When you need this
+ *
+ * Built-in search tools are subject to a multi-tool limit: on Gemini 1.x
+ * models a built-in search tool may not be sent in the same request as any
+ * other tool. {@link VertexAiSearchTool} lets you opt out of that check with
+ * its `bypassMultiToolsLimit` option, but {@link GoogleSearchTool} has no
+ * equivalent escape hatch — adding `GOOGLE_SEARCH` to a Gemini 1.x agent that
+ * already has other tools always throws `Google search tool can not be used
+ * with other tools in Gemini 1.x.`
+ *
+ * `GoogleSearchAgentTool` sidesteps the limit rather than bypassing it. The
+ * search happens in an isolated sub-agent invocation whose request carries
+ * only `google_search`, and the parent agent calls that sub-agent as an
+ * ordinary function tool alongside its other tools — so neither request ever
+ * violates the limit.
+ *
+ * Reach for this when you need Google Search *and* other tools on a Gemini 1.x
+ * agent, or when you want search confined to a separate invocation (for
+ * example to keep its instructions and context out of the parent). On Gemini 2
+ * and later, ADK applies no multi-tool check, so plain `GOOGLE_SEARCH` on the
+ * agent is simpler and this wrapper is unnecessary.
+ *
+ * Grounding metadata produced by the sub-agent's search is propagated back to
+ * the parent invocation under the `temp:_adk_grounding_metadata` state key.
+ */
+export class GoogleSearchAgentTool extends AgentTool {
+  constructor(agent: LlmAgent) {
+    super({agent, propagateGroundingMetadata: true});
+  }
+}

--- a/core/test/tools/agent_tool_test.ts
+++ b/core/test/tools/agent_tool_test.ts
@@ -513,4 +513,137 @@ describe('AgentTool', () => {
       `${State.TEMP_PREFIX}tempKey`,
     );
   });
+
+  it('propagates grounding metadata when propagateGroundingMetadata is true', async () => {
+    const mockAgent = {name: 'sub-agent'} as unknown as LlmAgent;
+    const tool = new AgentTool({
+      agent: mockAgent,
+      propagateGroundingMetadata: true,
+    });
+
+    const session = createSession({
+      id: 'parent-session',
+      appName: 'sub-agent',
+      userId: 'parent-user',
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: mockAgent,
+      session,
+      pluginManager: new PluginManager([]),
+    });
+
+    const toolContext = new Context({invocationContext});
+
+    const groundingMetadata = {webSearchQueries: ['query']};
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {role: 'model', parts: [{text: 'grounded answer'}]},
+        groundingMetadata,
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation((config) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsync,
+      } as unknown as Runner;
+    });
+
+    await tool.runAsync({args: {request: 'hello'}, toolContext});
+
+    expect(
+      toolContext.state.get(`${State.TEMP_PREFIX}_adk_grounding_metadata`),
+    ).toBe(groundingMetadata);
+  });
+
+  it('does not write grounding metadata when the run yields none', async () => {
+    const mockAgent = {name: 'sub-agent'} as unknown as LlmAgent;
+    const tool = new AgentTool({
+      agent: mockAgent,
+      propagateGroundingMetadata: true,
+    });
+
+    const session = createSession({
+      id: 'parent-session',
+      appName: 'sub-agent',
+      userId: 'parent-user',
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: mockAgent,
+      session,
+      pluginManager: new PluginManager([]),
+    });
+
+    const toolContext = new Context({invocationContext});
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {role: 'model', parts: [{text: 'no grounding here'}]},
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation((config) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsync,
+      } as unknown as Runner;
+    });
+
+    await tool.runAsync({args: {request: 'hello'}, toolContext});
+
+    expect(
+      toolContext.state.has(`${State.TEMP_PREFIX}_adk_grounding_metadata`),
+    ).toBe(false);
+  });
+
+  it('does not propagate grounding metadata by default', async () => {
+    const mockAgent = {name: 'sub-agent'} as unknown as LlmAgent;
+    const tool = new AgentTool({agent: mockAgent});
+
+    const session = createSession({
+      id: 'parent-session',
+      appName: 'sub-agent',
+      userId: 'parent-user',
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent: mockAgent,
+      session,
+      pluginManager: new PluginManager([]),
+    });
+
+    const toolContext = new Context({invocationContext});
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'sub-agent',
+        content: {role: 'model', parts: [{text: 'answer'}]},
+        groundingMetadata: {webSearchQueries: ['query']},
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation((config) => {
+      return {
+        appName: config?.appName,
+        sessionService: config?.sessionService,
+        runAsync: mockRunAsync,
+      } as unknown as Runner;
+    });
+
+    await tool.runAsync({args: {request: 'hello'}, toolContext});
+
+    expect(
+      toolContext.state.has(`${State.TEMP_PREFIX}_adk_grounding_metadata`),
+    ).toBe(false);
+  });
 });

--- a/core/test/tools/google_search_agent_tool_test.ts
+++ b/core/test/tools/google_search_agent_tool_test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  AgentTool,
+  BaseLlm,
+  BaseLlmConnection,
+  Context,
+  createEvent,
+  createGoogleSearchAgent,
+  createSession,
+  GOOGLE_SEARCH,
+  GoogleSearchAgentTool,
+  GoogleSearchTool,
+  InvocationContext,
+  isLlmAgent,
+  LlmAgent,
+  LlmResponse,
+  PluginManager,
+  Runner,
+  State,
+} from '@google/adk';
+import {GroundingMetadata} from '@google/genai';
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('../../src/runner/runner.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/runner/runner.js')>();
+  return {
+    ...actual,
+    Runner: vi.fn().mockImplementation((config) => ({
+      appName: config?.appName,
+      sessionService: config?.sessionService,
+      runAsync: vi.fn(),
+    })),
+  };
+});
+
+/** A minimal concrete BaseLlm used to verify model pass-through. */
+class FakeLlm extends BaseLlm {
+  // eslint-disable-next-line require-yield
+  async *generateContentAsync(): AsyncGenerator<LlmResponse, void> {
+    throw new Error('not implemented');
+  }
+
+  connect(): Promise<BaseLlmConnection> {
+    throw new Error('not implemented');
+  }
+}
+
+describe('createGoogleSearchAgent', () => {
+  it('returns an LlmAgent named google_search_agent', () => {
+    const agent = createGoogleSearchAgent('gemini-2.0-flash');
+
+    expect(isLlmAgent(agent)).toBe(true);
+    expect(agent).toBeInstanceOf(LlmAgent);
+    expect(agent.name).toBe('google_search_agent');
+  });
+
+  it('passes a string model straight through', () => {
+    const agent = createGoogleSearchAgent('gemini-2.0-flash');
+
+    expect(agent.model).toBe('gemini-2.0-flash');
+  });
+
+  it('passes a BaseLlm instance straight through', () => {
+    const llm = new FakeLlm({model: 'gemini-2.0-flash'});
+    const agent = createGoogleSearchAgent(llm);
+
+    expect(agent.model).toBe(llm);
+  });
+
+  it('uses the exact Python description string', () => {
+    const agent = createGoogleSearchAgent('gemini-2.0-flash');
+
+    expect(agent.description).toBe(
+      'An agent for performing Google search using the `google_search` tool',
+    );
+  });
+
+  it('has an instruction guiding the specialized search agent', () => {
+    const agent = createGoogleSearchAgent('gemini-2.0-flash');
+
+    expect(agent.instruction).toContain('specialized Google search agent');
+    expect(agent.instruction).toContain('google_search');
+  });
+
+  it('wires up exactly the google_search built-in tool', () => {
+    const agent = createGoogleSearchAgent('gemini-2.0-flash');
+
+    expect(agent.tools).toHaveLength(1);
+    expect(agent.tools[0]).toBe(GOOGLE_SEARCH);
+    expect(agent.tools[0]).toBeInstanceOf(GoogleSearchTool);
+  });
+});
+
+describe('GoogleSearchAgentTool', () => {
+  it('is an AgentTool whose name mirrors the wrapped agent', () => {
+    const agent = createGoogleSearchAgent('gemini-2.0-flash');
+    const tool = new GoogleSearchAgentTool(agent);
+
+    expect(tool).toBeInstanceOf(AgentTool);
+    expect(tool.name).toBe('google_search_agent');
+    expect(tool.name).toBe(agent.name);
+  });
+
+  it('propagates the sub-agent grounding metadata to the parent state', async () => {
+    const agent = createGoogleSearchAgent('gemini-2.0-flash');
+    const tool = new GoogleSearchAgentTool(agent);
+
+    const session = createSession({
+      id: 'parent-session',
+      appName: 'google_search_agent',
+      userId: 'parent-user',
+    });
+
+    const invocationContext = new InvocationContext({
+      invocationId: 'test-invocation',
+      agent,
+      session,
+      pluginManager: new PluginManager([]),
+    });
+
+    const toolContext = new Context({invocationContext});
+
+    const groundingMetadata: GroundingMetadata = {
+      webSearchQueries: ['adk grounding'],
+    };
+
+    const mockRunAsync = async function* () {
+      yield createEvent({
+        author: 'google_search_agent',
+        content: {role: 'model', parts: [{text: 'the answer'}]},
+        groundingMetadata,
+      });
+    };
+
+    vi.mocked(Runner).mockImplementation(
+      (config) =>
+        ({
+          appName: config?.appName,
+          sessionService: config?.sessionService,
+          runAsync: mockRunAsync,
+        }) as unknown as Runner,
+    );
+
+    const result = await tool.runAsync({
+      args: {request: 'search please'},
+      toolContext,
+    });
+
+    expect(result).toBe('the answer');
+    expect(
+      toolContext.state.get(`${State.TEMP_PREFIX}_adk_grounding_metadata`),
+    ).toBe(groundingMetadata);
+  });
+});

--- a/tests/integration/tools/google_search_agent_tool_test.ts
+++ b/tests/integration/tools/google_search_agent_tool_test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  createGoogleSearchAgent,
+  FunctionTool,
+  GoogleSearchAgentTool,
+  LlmAgent,
+  State,
+} from '@google/adk';
+import {FinishReason, GroundingMetadata} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+
+import {
+  createRunner,
+  GeminiWithMockResponses,
+  RawGenerateContentResponse,
+} from '../test_case_utils.js';
+
+/**
+ * End-to-end test with no mocking of the code under test: a real `Runner`,
+ * `LlmAgent`, `AgentTool`, and `GoogleSearchAgentTool` run together. Only the
+ * network boundary (the Gemini model) is a canned in-process double, so no
+ * credentials or live calls are required.
+ */
+describe('GoogleSearchAgentTool (e2e)', () => {
+  it('runs alongside another tool and surfaces grounding metadata', async () => {
+    const groundingMetadata: GroundingMetadata = {
+      webSearchQueries: ['capital of France'],
+    };
+
+    // The isolated search sub-agent answers with grounding metadata, exactly
+    // as the built-in google_search tool would.
+    const subAgentResponses: RawGenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [{text: 'Paris is the capital of France.'}],
+              role: 'model',
+            },
+            groundingMetadata,
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+    ];
+
+    // The parent agent first calls the search tool, then a sibling tool that
+    // reads the propagated grounding metadata, then answers.
+    const rootResponses: RawGenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'google_search_agent',
+                    args: {request: 'capital of France'},
+                    id: 'call-search',
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'capture_grounding',
+                    args: {},
+                    id: 'call-capture',
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            content: {
+              parts: [{text: 'The capital of France is Paris.'}],
+              role: 'model',
+            },
+            finishReason: FinishReason.STOP,
+          },
+        ],
+      },
+    ];
+
+    let capturedGrounding: unknown;
+    const captureTool = new FunctionTool({
+      name: 'capture_grounding',
+      description: 'Records grounding metadata surfaced by the search tool.',
+      execute: (_input: string, toolContext?: Context) => {
+        capturedGrounding = toolContext?.state.get(
+          `${State.TEMP_PREFIX}_adk_grounding_metadata`,
+        );
+        return 'captured';
+      },
+    });
+
+    const searchAgent = createGoogleSearchAgent(
+      new GeminiWithMockResponses(subAgentResponses),
+    );
+    const searchTool = new GoogleSearchAgentTool(searchAgent);
+
+    const rootAgent = new LlmAgent({
+      name: 'root_agent',
+      model: new GeminiWithMockResponses(rootResponses),
+      description: 'A root agent that can search and use other tools.',
+      instruction:
+        'Use google_search_agent to search, then capture_grounding, then answer.',
+      // The whole point of the wrapper: google_search used ALONGSIDE another
+      // tool without the "cannot be combined with other tools" restriction.
+      tools: [searchTool, captureTool],
+    });
+
+    const runner = await createRunner(rootAgent);
+
+    const texts: string[] = [];
+    for await (const event of runner.run('What is the capital of France?')) {
+      for (const part of event.content?.parts ?? []) {
+        if (part.text) {
+          texts.push(part.text);
+        }
+      }
+    }
+
+    // Composition worked end-to-end: no mixing restriction error, and the
+    // parent produced its final grounded answer.
+    expect(texts.join(' ')).toContain('Paris');
+    // Grounding metadata produced by the sub-agent's search was propagated to
+    // the parent invocation and readable by a sibling tool.
+    expect(capturedGrounding).toEqual(groundingMetadata);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: _N/A_
- Related: _N/A — no existing issue; the change is described below._

**2. Or, if no issue exists, describe the change:**

**Problem:**
`adk-python` ships a convenience wrapper (`GoogleSearchAgentTool` +
`create_google_search_agent`) that lets developers use the built-in
`google_search` tool _alongside other tools_, which the raw built-in tool
cannot always do. On Gemini 1.x, `core/src/tools/google_search_tool.ts` throws
`Google search tool can not be used with other tools in Gemini 1.x.` as soon as
any other tool is present, and — unlike `VertexAiSearchTool`, which exposes a
`bypassMultiToolsLimit` option — `GoogleSearchTool` has no escape hatch for
that check. `adk-js` had all the building blocks (`AgentTool`, `GOOGLE_SEARCH`,
`LlmAgent`, `BaseLlm`) but lacked this wrapper, leaving a cross-language parity
gap.

**Solution:**
Port the wrapper to `adk-js` by adding `core/src/tools/google_search_agent_tool.ts`
with two public symbols:

- `createGoogleSearchAgent(model: string | BaseLlm): LlmAgent` — builds an
  `LlmAgent` named `google_search_agent` whose only tool is the built-in
  `GOOGLE_SEARCH`, with a description/instruction mirroring the Python version.
- `class GoogleSearchAgentTool extends AgentTool` — wraps that sub-agent as an
  `AgentTool` with grounding-metadata propagation enabled.

Because the search runs in an isolated sub-agent invocation whose request
carries only `google_search`, a parent agent can call it as an ordinary
function tool without ever tripping the multi-tool limit. This sidesteps the
limit rather than bypassing it, which is why it is the right answer for
`google_search` even though `VertexAiSearchTool` can instead set
`bypassMultiToolsLimit`. The class JSDoc spells out exactly when you need this
wrapper (Gemini 1.x with other tools, or when you want search confined to a
separate invocation) and when you do not (Gemini 2+, where ADK applies no
multi-tool check and plain `GOOGLE_SEARCH` is simpler).

This required a prerequisite change to `AgentTool` (the feature is incorrect
without it): the Python `GoogleSearchAgentTool` opts into
`propagate_grounding_metadata=True`, but `adk-js`'s `AgentTool` had no such
option. This PR adds an additive, opt-in `propagateGroundingMetadata` flag
(default `false`) to `AgentToolConfig`. When enabled, `AgentTool.runAsync`
tracks the last sub-agent event's grounding metadata and, on normal
(non-aborted) completion, writes it to the parent tool context state under
`temp:_adk_grounding_metadata` — mirroring Python semantics (invocation-scoped
via the `temp:` prefix, not persisted). The default remains `false`, so all
existing `AgentTool` behavior is unchanged (no breaking changes). Both new
symbols are exported from the public API via `core/src/common.ts`.

Commits are split for easy review: (1) the additive `AgentTool` prerequisite,
(2) the feature module, exports, and tests.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

- `core/test/tools/google_search_agent_tool_test.ts` (new): verifies
  `createGoogleSearchAgent` returns an `LlmAgent` named `google_search_agent`,
  passes both `string` and `BaseLlm` models straight through, uses the exact
  Python description string, has the specialized-search instruction, wires up
  exactly `[GOOGLE_SEARCH]`, and that `GoogleSearchAgentTool` is an `AgentTool`
  whose name mirrors the wrapped agent and propagates grounding metadata to the
  parent state.
- `core/test/tools/agent_tool_test.ts` (updated): adds positive/negative branch
  coverage for `propagateGroundingMetadata` (propagates when enabled + metadata
  present; does not write when the run yields no metadata; does not propagate
  by default).
- New production code is at 100% line/branch coverage; the additive `AgentTool`
  branch is fully covered.

Ran locally:

- `npx vitest run --project unit:core core/test/tools/google_search_agent_tool_test.ts core/test/tools/agent_tool_test.ts` — pass (20 tests).
- `npx vitest run --project integration tests/integration/tools/google_search_agent_tool_test.ts` — pass.
- `npx eslint` on all touched files — clean.
- `npx tsc --noEmit -p core/tsconfig.json` — clean.
- `npm run docs:check` (TypeDoc, `--treatWarningsAsErrors`) — clean.

**Manual End-to-End (E2E) Tests:**

A no-mock end-to-end test (`tests/integration/tools/google_search_agent_tool_test.ts`)
exercises the real `Runner`, `LlmAgent`, `AgentTool`, and
`GoogleSearchAgentTool` together; only the Gemini network boundary is a canned
in-process double (`GeminiWithMockResponses`), so no credentials or live calls
are needed. It proves the two value propositions: (1) the wrapped
`google_search` runs _alongside another tool_ on the parent agent without the
mixing-restriction error, and (2) grounding metadata produced by the
sub-agent's search is propagated to the parent invocation and readable by a
sibling tool.

To run it:

```
npx vitest run --project integration tests/integration/tools/google_search_agent_tool_test.ts
```

For a live manual check, construct `createGoogleSearchAgent('gemini-2.0-flash')`,
wrap it with `GoogleSearchAgentTool`, attach it alongside another tool on an
`LlmAgent`, and confirm no "google_search cannot be combined with other tools"
error is raised.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Supersedes #316, which covered the same work and was closed by the author
before it landed. This re-files it rebased onto current `main`, with the two
review points from that round addressed: the new tool uses only top-level
static imports (no inline `import()`), and the `GoogleSearchAgentTool` JSDoc now
documents precisely when the multi-tool limit applies and when
`bypassMultiToolsLimit` is (and is not) the right tool for it.
