### PR TITLE
Feat: Add ExampleTool for few-shot examples (adk-python parity)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -232,6 +232,7 @@ export type {
 export {BaseToolset, isBaseToolset} from './tools/base_toolset.js';
 export type {ToolPredicate} from './tools/base_toolset.js';
 export {ConsolidateContextTool} from './tools/consolidate_context_tool.js';
+export {ExampleTool} from './tools/example_tool.js';
 export {EXIT_LOOP, ExitLoopTool} from './tools/exit_loop_tool.js';
 export {FunctionTool, isFunctionTool} from './tools/function_tool.js';
 export type {

--- a/core/src/tools/example_tool.ts
+++ b/core/src/tools/example_tool.ts
@@ -23,16 +23,13 @@ import {
  * from the latest user query.
  */
 export class ExampleTool extends BaseTool {
-  readonly examples: Example[] | BaseExampleProvider;
-
-  constructor(examples: Example[] | BaseExampleProvider) {
+  constructor(readonly examples: Example[] | BaseExampleProvider) {
     super({
       // Name and description are not used because this tool only changes
       // llmRequest.
       name: 'example_tool',
       description: 'example tool',
     });
-    this.examples = examples;
   }
 
   override async runAsync(_request: RunAsyncToolRequest): Promise<unknown> {

--- a/core/src/tools/example_tool.ts
+++ b/core/src/tools/example_tool.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseExampleProvider} from '../examples/base_example_provider.js';
+import {Example} from '../examples/example.js';
+import {buildExampleSi} from '../examples/example_util.js';
+import {appendInstructions} from '../models/llm_request.js';
+
+import {
+  BaseTool,
+  RunAsyncToolRequest,
+  ToolProcessLlmRequest,
+} from './base_tool.js';
+
+/**
+ * A tool that adds (few-shot) examples to the LLM request.
+ *
+ * This tool is executed for each LLM request and is never called by the model;
+ * it only mutates the outgoing request by appending few-shot instructions built
+ * from the latest user query.
+ */
+export class ExampleTool extends BaseTool {
+  readonly examples: Example[] | BaseExampleProvider;
+
+  constructor(examples: Example[] | BaseExampleProvider) {
+    super({
+      // Name and description are not used because this tool only changes
+      // llmRequest.
+      name: 'example_tool',
+      description: 'example tool',
+    });
+    this.examples = examples;
+  }
+
+  override async runAsync(_request: RunAsyncToolRequest): Promise<unknown> {
+    // Should not be called by model because it's not declared in LLM tools list.
+    throw new Error('ExampleTool should not be called by model');
+  }
+
+  override async processLlmRequest({
+    toolContext,
+    llmRequest,
+  }: ToolProcessLlmRequest): Promise<void> {
+    const parts = toolContext.userContent?.parts;
+    if (!parts || !parts[0]?.text) {
+      return;
+    }
+    appendInstructions(llmRequest, [
+      buildExampleSi(this.examples, parts[0].text, llmRequest.model),
+    ]);
+  }
+}

--- a/core/test/tools/example_tool_test.ts
+++ b/core/test/tools/example_tool_test.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+
+import {
+  BaseAgent,
+  BaseExampleProvider,
+  Context,
+  createSession,
+  Example,
+  ExampleTool,
+  InvocationContext,
+  LlmRequest,
+  PluginManager,
+} from '@google/adk';
+import {Content} from '@google/genai';
+
+const SIMPLE_EXAMPLE: Example = {
+  input: {parts: [{text: 'What is 2+2?'}]},
+  output: [{role: 'model', parts: [{text: '4'}]}],
+};
+
+const FUNCTION_CALL_EXAMPLE: Example = {
+  input: {parts: [{text: 'Search for cats'}]},
+  output: [
+    {
+      role: 'model',
+      parts: [{functionCall: {name: 'search', args: {query: 'cats'}}}],
+    },
+    {role: 'model', parts: [{text: 'Found cats!'}]},
+  ],
+};
+
+class FixedExampleProvider extends BaseExampleProvider {
+  constructor(private readonly examples: Example[]) {
+    super();
+  }
+  override getExamples(_query: string): Example[] {
+    return this.examples;
+  }
+}
+
+/**
+ * Builds a `toolContext` stub exposing only the `userContent` used by
+ * ExampleTool, cast to `Context` (mirrors `StubToolContext` in
+ * `preload_memory_tool_test.ts`).
+ */
+function makeToolContext(userContent: unknown): Context {
+  return {userContent} as unknown as Context;
+}
+
+function makeLlmRequest(model?: string): LlmRequest {
+  return {
+    contents: [],
+    toolsDict: {},
+    liveConnectConfig: {},
+    config: {},
+    model,
+  };
+}
+
+describe('ExampleTool', () => {
+  it('appends few-shot instructions from a static list of examples', async () => {
+    const tool = new ExampleTool([SIMPLE_EXAMPLE]);
+    const toolContext = makeToolContext({
+      role: 'user',
+      parts: [{text: 'What is 2+2?'}],
+    });
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    const instruction = llmRequest.config?.systemInstruction;
+    expect(instruction).toBeDefined();
+    expect(instruction).toContain('<EXAMPLES>');
+    expect(instruction).toContain('What is 2+2?');
+    expect(instruction).toContain('4');
+  });
+
+  it('appends instructions from a BaseExampleProvider and threads the query', async () => {
+    const provider = new FixedExampleProvider([SIMPLE_EXAMPLE]);
+    const getExamplesSpy = vi.spyOn(provider, 'getExamples');
+    const tool = new ExampleTool(provider);
+    const toolContext = makeToolContext({
+      role: 'user',
+      parts: [{text: 'What is 2+2?'}],
+    });
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    expect(getExamplesSpy).toHaveBeenCalledWith('What is 2+2?');
+    expect(llmRequest.config?.systemInstruction).toContain('What is 2+2?');
+  });
+
+  it('forwards llmRequest.model to buildExampleSi (function-call fence style)', async () => {
+    const tool = new ExampleTool([FUNCTION_CALL_EXAMPLE]);
+    const toolContext = makeToolContext({
+      role: 'user',
+      parts: [{text: 'Search for cats'}],
+    });
+    const llmRequest = makeLlmRequest('gemini-1.5-pro');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    expect(llmRequest.config?.systemInstruction).toContain('```tool_code');
+  });
+
+  it('is a no-op when userContent is undefined', async () => {
+    const tool = new ExampleTool([SIMPLE_EXAMPLE]);
+    const toolContext = makeToolContext(undefined);
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    expect(llmRequest.config?.systemInstruction).toBeUndefined();
+  });
+
+  it('is a no-op when userContent has no parts', async () => {
+    const tool = new ExampleTool([SIMPLE_EXAMPLE]);
+    const toolContext = makeToolContext({role: 'user', parts: []});
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    expect(llmRequest.config?.systemInstruction).toBeUndefined();
+  });
+
+  it('is a no-op when the first part has no text', async () => {
+    const tool = new ExampleTool([SIMPLE_EXAMPLE]);
+    const toolContext = makeToolContext({role: 'user', parts: [{}]});
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    expect(llmRequest.config?.systemInstruction).toBeUndefined();
+  });
+
+  it('throws in runAsync because it is not meant to be called by the model', async () => {
+    const tool = new ExampleTool([SIMPLE_EXAMPLE]);
+    const toolContext = makeToolContext(undefined);
+
+    await expect(tool.runAsync({args: {}, toolContext})).rejects.toThrow(
+      'ExampleTool should not be called by model',
+    );
+  });
+
+  it('is importable from @google/adk (public export)', () => {
+    expect(new ExampleTool([])).toBeInstanceOf(ExampleTool);
+  });
+});
+
+/**
+ * Builds a real `Context` backed by a real `InvocationContext`/`Session` (no
+ * stubs), so the tool is exercised against genuine ADK plumbing exactly as the
+ * agent request loop invokes it (llm_agent.ts).
+ */
+function makeRealContext(userContent?: Content): Context {
+  const session = createSession({id: 'test-session', appName: 'test-app'});
+  const invocationContext = new InvocationContext({
+    invocationId: 'test-invocation',
+    agent: {} as BaseAgent,
+    session,
+    pluginManager: new PluginManager([]),
+    userContent,
+  });
+  return new Context({invocationContext});
+}
+
+describe('ExampleTool (end-to-end with real framework objects)', () => {
+  it('appends the few-shot block when driven through a real Context', async () => {
+    const tool = new ExampleTool([SIMPLE_EXAMPLE]);
+    const toolContext = makeRealContext({
+      role: 'user',
+      parts: [{text: 'What is 2+2?'}],
+    });
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    const instruction = llmRequest.config?.systemInstruction;
+    expect(instruction).toContain('<EXAMPLES>');
+    expect(instruction).toContain('What is 2+2?');
+    expect(instruction).toContain('4');
+  });
+
+  it('selects provider examples using the real user query end-to-end', async () => {
+    const provider = new FixedExampleProvider([SIMPLE_EXAMPLE]);
+    const getExamplesSpy = vi.spyOn(provider, 'getExamples');
+    const tool = new ExampleTool(provider);
+    const toolContext = makeRealContext({
+      role: 'user',
+      parts: [{text: 'What is 2+2?'}],
+    });
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    expect(getExamplesSpy).toHaveBeenCalledWith('What is 2+2?');
+    expect(llmRequest.config?.systemInstruction).toContain('4');
+  });
+
+  it('is a no-op when the real invocation has no user content', async () => {
+    const tool = new ExampleTool([SIMPLE_EXAMPLE]);
+    const toolContext = makeRealContext(undefined);
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
+
+    await tool.processLlmRequest({toolContext, llmRequest});
+
+    expect(llmRequest.config?.systemInstruction).toBeUndefined();
+  });
+});

--- a/core/test/tools/example_tool_test.ts
+++ b/core/test/tools/example_tool_test.ts
@@ -188,22 +188,6 @@ describe('ExampleTool (end-to-end with real framework objects)', () => {
     expect(instruction).toContain('4');
   });
 
-  it('selects provider examples using the real user query end-to-end', async () => {
-    const provider = new FixedExampleProvider([SIMPLE_EXAMPLE]);
-    const getExamplesSpy = vi.spyOn(provider, 'getExamples');
-    const tool = new ExampleTool(provider);
-    const toolContext = makeRealContext({
-      role: 'user',
-      parts: [{text: 'What is 2+2?'}],
-    });
-    const llmRequest = makeLlmRequest('gemini-2.0-flash');
-
-    await tool.processLlmRequest({toolContext, llmRequest});
-
-    expect(getExamplesSpy).toHaveBeenCalledWith('What is 2+2?');
-    expect(llmRequest.config?.systemInstruction).toContain('4');
-  });
-
   it('is a no-op when the real invocation has no user content', async () => {
     const tool = new ExampleTool([SIMPLE_EXAMPLE]);
     const toolContext = makeRealContext(undefined);


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue — see the description below.

**2. Or, if no issue exists, describe the change:**

**Problem:**
adk-python ships an `ExampleTool` (`class ExampleTool(BaseTool)`) that injects few-shot examples into the outgoing LLM request. adk-js already ships the entire underlying `examples` subsystem (the `Example` type, `BaseExampleProvider`, and `example_util` with `buildExampleSi`/`convertExamplesToText`) but exposes **no tool** that wires those examples into a request. This is a cross-language parity gap: adk-js users cannot add few-shot examples to an agent the way adk-python users can.

**Solution:**
Add a thin, idiomatic `ExampleTool` to adk-js that closes the gap by reusing the existing few-shot building blocks:

- The constructor accepts either a static `Example[]` **or** a `BaseExampleProvider` (stored by reference, so a provider's `getExamples(query)` is invoked lazily per request for dynamic selection).
- `processLlmRequest(...)` reads the latest user query text (`toolContext.userContent?.parts[0]?.text`) and appends a few-shot instruction block — produced by the existing `buildExampleSi(examples, queryText, model)` — to the request's system instruction via the standalone `appendInstructions(...)` helper.
- No-op when there is no user text (never mutates `llmRequest`).
- Never declared to the model (no `_getDeclaration`); `runAsync` throws if invoked. This mirrors the existing `PreloadMemoryTool`.
- Exported from the public `@google/adk` API (one line in `core/src/common.ts`).

This is a non-breaking, additive change: one new file, one new export line, one new test file. It intentionally excludes the Python-only `from_config`/`ExampleToolConfig` declarative loader (adk-js has no tool config-loading subsystem yet) and does not add any new dependencies.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New file `core/test/tools/example_tool_test.ts` (Vitest) achieves 100% line/branch/function coverage of `core/src/tools/example_tool.ts`, covering: the static-list path, the `BaseExampleProvider` path (asserting the latest user query is threaded through to `getExamples`), model-style passthrough to `buildExampleSi` (`gemini-1.5-pro` -> `tool_code` fence), the three no-op branches (missing `userContent`, empty `parts`, text-less first part), `runAsync` throwing, and the public export.

Summary of passed test results (run locally, targeted):

- `npx vitest run --project unit:core core/test/tools/example_tool_test.ts` -> `Test Files 1 passed (1)`, `Tests 10 passed (10)`
- `npx vitest run --project unit:core core/test/tools/example_tool_test.ts --coverage --coverage.include='core/src/tools/example_tool.ts'` -> `example_tool.ts` 100% statements / 100% branches / 100% functions / 100% lines
- `npx eslint` on the changed files -> clean
- `npx prettier --check` on the changed files -> `All matched files use Prettier code style!`
- `npm run docs:check` (typedoc `--treatWarningsAsErrors`) -> passes

**Manual End-to-End (E2E) Tests:**

An automated, mock-free end-to-end block is included in the same test file: it builds a **real** `Context`/`InvocationContext`/`Session` (via `createSession` + `PluginManager`, no stubs) and drives `processLlmRequest` exactly as the agent request loop does in `llm_agent.ts`, asserting that the real `Context.userContent` getter feeds the tool and that the `<EXAMPLES>` block lands in `llmRequest.config.systemInstruction` (and that a real invocation with no user content is a no-op).

To reproduce manually:

1. `npm install && npm run build`
2. Attach the tool to an agent:

   ```ts
   import {ExampleTool, LlmAgent} from '@google/adk';

   const exampleTool = new ExampleTool([
     {
       input: {parts: [{text: 'What is 2+2?'}]},
       output: [{role: 'model', parts: [{text: '4'}]}],
     },
   ]);
   const agent = new LlmAgent({
     name: 'demo',
     model: 'gemini-2.0-flash',
     tools: [exampleTool],
   });
   ```

3. Send a user message and confirm the built request's system instruction contains the `<EXAMPLES>…</EXAMPLES>` few-shot block built from the latest user query.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This change is additive and self-contained: it adds `core/src/tools/example_tool.ts`, one export line in `core/src/common.ts`, and `core/test/tools/example_tool_test.ts`. No existing behavior, public type, or dependency is modified.
