### PR TITLE
feat: Add environment tools matching Python parity

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -436,3 +436,4 @@ export * from './features/feature_registry.js';
 export * from './memory/base_memory_service.js';
 export * from './sessions/base_session_service.js';
 export * from './tools/base_tool.js';
+export * from './tools/environment/index.js';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -45,6 +45,7 @@ export {RunSkillScriptTool} from './tools/skill/run_skill_script_tool.js';
 export * from './integrations/agent_registry/agent_registry.js';
 export * from './telemetry/google_cloud.js';
 export * from './telemetry/setup.js';
+export * from './tools/environment/index.js';
 // Also available as `@google/adk/tools/mcp`, which does not evaluate the rest
 // of this barrel.
 export * from './tools/mcp/index.js';

--- a/core/src/tools/environment/constants.ts
+++ b/core/src/tools/environment/constants.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// ---------------------------------------------------------------------------
+// Default limits
+// ---------------------------------------------------------------------------
+
+/** Default execution timeout in milliseconds. */
+export const DEFAULT_TIMEOUT_MS = 30000;
+
+/** Maximum characters returned to the LLM per tool call. */
+export const MAX_OUTPUT_CHARS = 30000;
+
+// ---------------------------------------------------------------------------
+// System instruction templates
+// ---------------------------------------------------------------------------
+
+export const ENVIRONMENT_INSTRUCTION = `\
+Your environment is at {working_dir}/
+
+# Environment Rules
+
+DO:
+- Chain sequential, dependent commands with \`&&\` in a single \`Execute\` call
+- To read existing files, always use the \`ReadFile\` tool. Use \`EditFile\` to modify existing files.
+
+DON'T:
+- Use \`Execute\` to run cat, head, or tail when \`ReadFile\` tools can do the job
+- Combine \`EditFile\` or \`ReadFile\` with \`Execute\` in the same response (Instead, call the file tool first, then \`Execute\` in the next turn)
+- Use multiple \`Execute\` calls for dependent commands (they run in parallel)
+`;

--- a/core/src/tools/environment/edit_file_tool.ts
+++ b/core/src/tools/environment/edit_file_tool.ts
@@ -8,8 +8,9 @@ import {FunctionDeclaration, Type} from '@google/genai';
 import * as fs from 'fs/promises';
 
 import {experimental} from '../../utils/experimental.js';
+import {resolveAndValidatePath} from '../../utils/file_utils.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
-import {isFileNotFoundError, resolveAndValidatePath, toError} from './utils.js';
+import {isFileNotFoundError, toError} from './utils.js';
 
 /**
  * Escapes every regular-expression metacharacter in `str` so that the result

--- a/core/src/tools/environment/edit_file_tool.ts
+++ b/core/src/tools/environment/edit_file_tool.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Type} from '@google/genai';
+import * as fs from 'fs/promises';
+
+import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
+import {resolveAndValidatePath} from './utils.js';
+
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&');
+}
+
+export interface EditFileToolParams {
+  workingDir: string;
+}
+
+/**
+ * EditFileTool for performing surgical text replacements in existing files.
+ */
+export class EditFileTool extends BaseTool {
+  private readonly workingDir: string;
+
+  constructor(params: EditFileToolParams) {
+    super({
+      name: 'EditFile',
+      description:
+        'Replace an exact substring in an existing file with new text. The old_string must appear exactly once in the file. To create new files, use the WriteFile tool.',
+    });
+    this.workingDir = params.workingDir;
+  }
+
+  override _getDeclaration(): FunctionDeclaration | undefined {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          path: {
+            type: Type.STRING,
+            description: 'Path of the file to edit within the environment.',
+          },
+          old_string: {
+            type: Type.STRING,
+            description:
+              'The exact text to find and replace. Must not be empty.',
+          },
+          new_string: {
+            type: Type.STRING,
+            description: 'The replacement text.',
+          },
+        },
+        required: ['path', 'old_string', 'new_string'],
+      },
+    };
+  }
+
+  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    const pathArg = args['path'];
+    const oldString = args['old_string'];
+    const newString = args['new_string'];
+
+    if (typeof pathArg !== 'string' || !pathArg) {
+      return {status: 'error', error: '`path` is required.'};
+    }
+    if (typeof oldString !== 'string' || !oldString) {
+      return {
+        status: 'error',
+        error:
+          '`old_string` cannot be empty. To create a new file, use the WriteFile tool.',
+      };
+    }
+    if (typeof newString !== 'string') {
+      return {status: 'error', error: '`new_string` must be a string.'};
+    }
+
+    let fullPath: string;
+    try {
+      fullPath = resolveAndValidatePath(this.workingDir, pathArg);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      return {status: 'error', error: String(e.message)};
+    }
+
+    let content: string;
+    try {
+      content = await fs.readFile(fullPath, 'utf8');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      if (e.code === 'ENOENT') {
+        return {status: 'error', error: `File not found: ${pathArg}`};
+      }
+      return {status: 'error', error: String(e.message)};
+    }
+
+    const normalizedOld = oldString.replace(/\r\n/g, '\n');
+    const patternStr = escapeRegExp(normalizedOld).replace(/\n/g, '\\r?\\n');
+    const pattern = new RegExp(patternStr, 'g');
+
+    const matches = [...content.matchAll(pattern)];
+    const count = matches.length;
+
+    if (count === 0) {
+      return {
+        status: 'error',
+        error:
+          '`old_string` not found in file. Read the file first to verify contents.',
+      };
+    }
+    if (count > 1) {
+      return {
+        status: 'error',
+        error: `\`old_string\` appears ${count} times. Provide more surrounding context to make it unique.`,
+      };
+    }
+
+    const newContent = content.replace(pattern, newString);
+    try {
+      await fs.writeFile(fullPath, newContent, 'utf8');
+      return {status: 'ok', message: `Edited ${pathArg}`};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      return {status: 'error', error: String(e.message)};
+    }
+  }
+}

--- a/core/src/tools/environment/edit_file_tool.ts
+++ b/core/src/tools/environment/edit_file_tool.ts
@@ -7,20 +7,37 @@
 import {FunctionDeclaration, Type} from '@google/genai';
 import * as fs from 'fs/promises';
 
+import {experimental} from '../../utils/experimental.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
-import {resolveAndValidatePath} from './utils.js';
+import {isFileNotFoundError, resolveAndValidatePath, toError} from './utils.js';
 
-function escapeRegExp(string: string) {
-  return string.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&');
+/**
+ * Escapes every regular-expression metacharacter in `str` so that the result
+ * matches the input as literal text. The JavaScript equivalent of Python's
+ * `re.escape`.
+ */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export interface EditFileToolParams {
   workingDir: string;
 }
 
+/** The result of an {@link EditFileTool} call. */
+export interface EditFileResult {
+  /** `'ok'` when the edit was applied, `'error'` otherwise. */
+  status: 'ok' | 'error';
+  /** Confirmation of what was edited. Set when `status` is `'ok'`. */
+  message?: string;
+  /** Why the call failed. Always set when `status` is `'error'`. */
+  error?: string;
+}
+
 /**
  * EditFileTool for performing surgical text replacements in existing files.
  */
+@experimental
 export class EditFileTool extends BaseTool {
   private readonly workingDir: string;
 
@@ -59,7 +76,9 @@ export class EditFileTool extends BaseTool {
     };
   }
 
-  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+  override async runAsync({
+    args,
+  }: RunAsyncToolRequest): Promise<EditFileResult> {
     const pathArg = args['path'];
     const oldString = args['old_string'];
     const newString = args['new_string'];
@@ -81,22 +100,22 @@ export class EditFileTool extends BaseTool {
     let fullPath: string;
     try {
       fullPath = resolveAndValidatePath(this.workingDir, pathArg);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      return {status: 'error', error: String(e.message)};
+    } catch (e) {
+      return {status: 'error', error: toError(e).message};
     }
 
     let content: string;
     try {
       content = await fs.readFile(fullPath, 'utf8');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      if (e.code === 'ENOENT') {
+    } catch (e) {
+      if (isFileNotFoundError(e)) {
         return {status: 'error', error: `File not found: ${pathArg}`};
       }
-      return {status: 'error', error: String(e.message)};
+      return {status: 'error', error: toError(e).message};
     }
 
+    // Newlines are not regex metacharacters, so they survive `escapeRegExp`
+    // unchanged and can be relaxed here to match either line ending.
     const normalizedOld = oldString.replace(/\r\n/g, '\n');
     const patternStr = escapeRegExp(normalizedOld).replace(/\n/g, '\\r?\\n');
     const pattern = new RegExp(patternStr, 'g');
@@ -118,13 +137,15 @@ export class EditFileTool extends BaseTool {
       };
     }
 
-    const newContent = content.replace(pattern, newString);
+    // A function replacement is used so that `$&`, `` $` `` and `$1` occurring
+    // in `new_string` are inserted literally instead of being expanded as
+    // replacement patterns.
+    const newContent = content.replace(pattern, () => newString);
     try {
       await fs.writeFile(fullPath, newContent, 'utf8');
       return {status: 'ok', message: `Edited ${pathArg}`};
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      return {status: 'error', error: String(e.message)};
+    } catch (e) {
+      return {status: 'error', error: toError(e).message};
     }
   }
 }

--- a/core/src/tools/environment/environment_toolset.ts
+++ b/core/src/tools/environment/environment_toolset.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context} from '../../agents/context.js';
+import {LlmRequest, appendInstructions} from '../../models/llm_request.js';
+import {experimental} from '../../utils/experimental.js';
+import {BaseTool} from '../base_tool.js';
+import {BaseToolset, ToolPredicate} from '../base_toolset.js';
+import {ENVIRONMENT_INSTRUCTION} from './constants.js';
+
+import {EditFileTool} from './edit_file_tool.js';
+import {ExecuteTool} from './execute_tool.js';
+import {ReadFileTool} from './read_file_tool.js';
+import {WriteFileTool} from './write_file_tool.js';
+
+export interface EnvironmentToolsetParams {
+  workingDir: string;
+  maxOutputChars?: number;
+  toolFilter?: ToolPredicate | string[];
+}
+
+/**
+ * Toolset providing tools to interact with an environment.
+ *
+ * Tools provided:
+ *   - Execute -- run shell commands
+ *   - ReadFile -- read file contents
+ *   - EditFile -- surgical text replacement
+ *   - WriteFile -- create/overwrite files
+ *
+ * The toolset injects an environment-level system instruction on each
+ * LLM call that establishes environment identity and tool selection rules.
+ */
+@experimental
+export class EnvironmentToolset extends BaseToolset {
+  private readonly workingDir: string;
+  private readonly maxOutputChars?: number;
+  private tools: BaseTool[] | undefined;
+
+  constructor(params: EnvironmentToolsetParams) {
+    super(params.toolFilter || []);
+    this.workingDir = params.workingDir;
+    this.maxOutputChars = params.maxOutputChars;
+  }
+
+  override async getTools(context?: Context): Promise<BaseTool[]> {
+    if (!this.tools) {
+      this.tools = [
+        new ExecuteTool({
+          workingDir: this.workingDir,
+          maxOutputChars: this.maxOutputChars,
+        }),
+        new ReadFileTool({
+          workingDir: this.workingDir,
+          maxOutputChars: this.maxOutputChars,
+        }),
+        new EditFileTool({workingDir: this.workingDir}),
+        new WriteFileTool({workingDir: this.workingDir}),
+      ];
+    }
+    if (context) {
+      return this.tools.filter((t) => this.isToolSelected(t, context));
+    }
+    return this.tools;
+  }
+
+  override async processLlmRequest(
+    toolContext: Context,
+    llmRequest: LlmRequest,
+  ): Promise<void> {
+    const instruction = ENVIRONMENT_INSTRUCTION.replace(
+      '{working_dir}',
+      this.workingDir,
+    );
+    appendInstructions(llmRequest, [instruction]);
+  }
+
+  override async close(): Promise<void> {
+    // No resources to close currently.
+  }
+}

--- a/core/src/tools/environment/environment_toolset.ts
+++ b/core/src/tools/environment/environment_toolset.ts
@@ -20,6 +20,11 @@ export interface EnvironmentToolsetParams {
   workingDir: string;
   maxOutputChars?: number;
   toolFilter?: ToolPredicate | string[];
+  /**
+   * The shell {@link ExecuteTool} hands commands to. Defaults to `/bin/sh` on
+   * POSIX and `cmd.exe` on Windows.
+   */
+  shell?: string;
 }
 
 /**
@@ -38,12 +43,14 @@ export interface EnvironmentToolsetParams {
 export class EnvironmentToolset extends BaseToolset {
   private readonly workingDir: string;
   private readonly maxOutputChars?: number;
+  private readonly shell?: string;
   private tools: BaseTool[] | undefined;
 
   constructor(params: EnvironmentToolsetParams) {
     super(params.toolFilter || []);
     this.workingDir = params.workingDir;
     this.maxOutputChars = params.maxOutputChars;
+    this.shell = params.shell;
   }
 
   override async getTools(context?: Context): Promise<BaseTool[]> {
@@ -52,6 +59,7 @@ export class EnvironmentToolset extends BaseToolset {
         new ExecuteTool({
           workingDir: this.workingDir,
           maxOutputChars: this.maxOutputChars,
+          shell: this.shell,
         }),
         new ReadFileTool({
           workingDir: this.workingDir,

--- a/core/src/tools/environment/execute_tool.ts
+++ b/core/src/tools/environment/execute_tool.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Type} from '@google/genai';
+import {exec} from 'child_process';
+import {promisify} from 'util';
+
+import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
+import {DEFAULT_TIMEOUT_MS, MAX_OUTPUT_CHARS} from './constants.js';
+import {truncate} from './utils.js';
+
+const execAsync = promisify(exec);
+
+const _EXECUTE_TOOL_DESCRIPTION = `
+Run a shell command in the environment. For running programs, tests, and build
+commands ONLY. WARNING: Do NOT use for file reading -- use the ReadFile tool
+instead. Shell commands like 'cat, head, tail will produce inferior results.
+Good: Execute("node script.js"), Execute("npm test"), Execute("find ...").
+Bad: Execute("head ..."), Execute("cat ...").
+`;
+
+export interface ExecuteToolParams {
+  workingDir: string;
+  maxOutputChars?: number;
+  executeTimeoutMs?: number;
+}
+
+/**
+ * ExecuteTool for running shell commands in the environment.
+ */
+export class ExecuteTool extends BaseTool {
+  private readonly workingDir: string;
+  private readonly maxOutputChars: number;
+  private readonly executeTimeoutMs: number;
+
+  constructor(params: ExecuteToolParams) {
+    super({
+      name: 'Execute',
+      description: _EXECUTE_TOOL_DESCRIPTION,
+    });
+    this.workingDir = params.workingDir;
+    this.maxOutputChars = params.maxOutputChars ?? MAX_OUTPUT_CHARS;
+    this.executeTimeoutMs = params.executeTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  override _getDeclaration(): FunctionDeclaration | undefined {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          command: {
+            type: Type.STRING,
+            description:
+              'The shell command to execute. Chain dependent commands with &&.',
+          },
+        },
+        required: ['command'],
+      },
+    };
+  }
+
+  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    const command = args['command'];
+    if (typeof command !== 'string' || !command) {
+      return {status: 'error', error: '`command` is required.'};
+    }
+
+    try {
+      const {stdout, stderr} = await execAsync(command, {
+        cwd: this.workingDir,
+        timeout: this.executeTimeoutMs,
+      });
+
+      const result: Record<string, unknown> = {status: 'ok'};
+      if (stdout) {
+        result['stdout'] = truncate(stdout, this.maxOutputChars);
+      }
+      if (stderr) {
+        result['stderr'] = truncate(stderr, this.maxOutputChars);
+      }
+      return result;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const result: Record<string, unknown> = {status: 'error'};
+      if (e.killed) {
+        result['error'] =
+          `Command timed out after ${this.executeTimeoutMs / 1000}s.`;
+      } else {
+        result['exit_code'] = e.code;
+        result['error'] = String(e.message);
+      }
+      if (e.stdout) {
+        result['stdout'] = truncate(e.stdout, this.maxOutputChars);
+      }
+      if (e.stderr) {
+        result['stderr'] = truncate(e.stderr, this.maxOutputChars);
+      }
+      return result;
+    }
+  }
+}

--- a/core/src/tools/environment/execute_tool.ts
+++ b/core/src/tools/environment/execute_tool.ts
@@ -5,22 +5,33 @@
  */
 
 import {FunctionDeclaration, Type} from '@google/genai';
-import {exec} from 'child_process';
+import {ExecException, exec} from 'child_process';
 import {promisify} from 'util';
 
+import {Context} from '../../agents/context.js';
+import {experimental} from '../../utils/experimental.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
 import {DEFAULT_TIMEOUT_MS, MAX_OUTPUT_CHARS} from './constants.js';
-import {truncate} from './utils.js';
+import {toError, truncate} from './utils.js';
 
 const execAsync = promisify(exec);
 
-const _EXECUTE_TOOL_DESCRIPTION = `
+const EXECUTE_TOOL_DESCRIPTION = `
 Run a shell command in the environment. For running programs, tests, and build
 commands ONLY. WARNING: Do NOT use for file reading -- use the ReadFile tool
 instead. Shell commands like 'cat, head, tail will produce inferior results.
 Good: Execute("node script.js"), Execute("npm test"), Execute("find ...").
 Bad: Execute("head ..."), Execute("cat ...").
 `;
+
+/**
+ * Message returned while the tool call is paused waiting for the client to
+ * confirm (or reject) the command. Mirrors the intermediate message used by the
+ * tool-confirmation flow elsewhere in the codebase (see `SecurityPlugin` and
+ * `RunSkillInlineScriptTool`).
+ */
+const REQUIRE_CONFIRMATION_MESSAGE =
+  'This tool call needs external confirmation before completion.';
 
 export interface ExecuteToolParams {
   workingDir: string;
@@ -29,8 +40,46 @@ export interface ExecuteToolParams {
 }
 
 /**
- * ExecuteTool for running shell commands in the environment.
+ * The result of an {@link ExecuteTool} call.
+ *
+ * The field names are part of the response contract the model sees and mirror
+ * `adk-python`'s execute tool, hence the snake_case `exit_code`.
  */
+export interface ExecuteResult {
+  /** `'ok'` when the command exited successfully, `'error'` otherwise. */
+  status: 'ok' | 'error';
+  /** Captured stdout, truncated to `maxOutputChars`. */
+  stdout?: string;
+  /** Captured stderr, truncated to `maxOutputChars`. */
+  stderr?: string;
+  /** Exit code of the command, when it ran and exited non-zero. */
+  exit_code?: number;
+  /** Why the call failed. Always set when `status` is `'error'`. */
+  error?: string;
+}
+
+/**
+ * The intermediate result returned while an {@link ExecuteTool} call is paused
+ * waiting for the client to confirm the command.
+ */
+export interface ExecuteConfirmationRequired {
+  /** The message surfaced to the model while the call is paused. */
+  partial: string;
+}
+
+/** Everything {@link ExecuteTool.runAsync} can resolve to. */
+export type ExecuteToolResult = ExecuteResult | ExecuteConfirmationRequired;
+
+/**
+ * ExecuteTool for running shell commands in the environment.
+ *
+ * The command goes to the host shell, so a model-authored string is arbitrary
+ * code execution on the machine running the agent and `workingDir` is not a
+ * boundary. Every call therefore passes through the repo's standard
+ * tool-confirmation gate before it runs, the same way
+ * `RunSkillInlineScriptTool` gates model-provided scripts.
+ */
+@experimental
 export class ExecuteTool extends BaseTool {
   private readonly workingDir: string;
   private readonly maxOutputChars: number;
@@ -39,7 +88,7 @@ export class ExecuteTool extends BaseTool {
   constructor(params: ExecuteToolParams) {
     super({
       name: 'Execute',
-      description: _EXECUTE_TOOL_DESCRIPTION,
+      description: EXECUTE_TOOL_DESCRIPTION,
     });
     this.workingDir = params.workingDir;
     this.maxOutputChars = params.maxOutputChars ?? MAX_OUTPUT_CHARS;
@@ -64,10 +113,18 @@ export class ExecuteTool extends BaseTool {
     };
   }
 
-  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+  override async runAsync({
+    args,
+    toolContext,
+  }: RunAsyncToolRequest): Promise<ExecuteToolResult> {
     const command = args['command'];
     if (typeof command !== 'string' || !command) {
       return {status: 'error', error: '`command` is required.'};
+    }
+
+    const pending = this.enforceConfirmation(toolContext, command);
+    if (pending) {
+      return pending;
     }
 
     try {
@@ -76,31 +133,70 @@ export class ExecuteTool extends BaseTool {
         timeout: this.executeTimeoutMs,
       });
 
-      const result: Record<string, unknown> = {status: 'ok'};
+      const result: ExecuteResult = {status: 'ok'};
       if (stdout) {
-        result['stdout'] = truncate(stdout, this.maxOutputChars);
+        result.stdout = truncate(stdout, this.maxOutputChars);
       }
       if (stderr) {
-        result['stderr'] = truncate(stderr, this.maxOutputChars);
+        result.stderr = truncate(stderr, this.maxOutputChars);
       }
       return result;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      const result: Record<string, unknown> = {status: 'error'};
-      if (e.killed) {
-        result['error'] =
-          `Command timed out after ${this.executeTimeoutMs / 1000}s.`;
+    } catch (e) {
+      // `promisify(exec)` rejects with an `ExecException`: an `Error` carrying
+      // the child process's exit status and captured output.
+      const err: ExecException = toError(e);
+      const result: ExecuteResult = {status: 'error'};
+      if (err.killed) {
+        result.error = `Command timed out after ${
+          this.executeTimeoutMs / 1000
+        }s.`;
       } else {
-        result['exit_code'] = e.code;
-        result['error'] = String(e.message);
+        result.exit_code = err.code;
+        result.error = err.message;
       }
-      if (e.stdout) {
-        result['stdout'] = truncate(e.stdout, this.maxOutputChars);
+      if (err.stdout) {
+        result.stdout = truncate(err.stdout, this.maxOutputChars);
       }
-      if (e.stderr) {
-        result['stderr'] = truncate(e.stderr, this.maxOutputChars);
+      if (err.stderr) {
+        result.stderr = truncate(err.stderr, this.maxOutputChars);
       }
       return result;
     }
+  }
+
+  /**
+   * Requires an explicit client-side confirmation before a command runs, so
+   * that a prompt injection cannot silently execute code on the host.
+   *
+   * @return An intermediate result when the call must pause for confirmation,
+   *     an error result when the client rejected it, or `undefined` when the
+   *     caller may proceed.
+   */
+  private enforceConfirmation(
+    toolContext: Context,
+    command: string,
+  ): ExecuteToolResult | undefined {
+    const confirmation = toolContext.toolConfirmation;
+
+    if (!confirmation) {
+      toolContext.requestConfirmation({
+        hint:
+          'Confirmation is required before running a shell command. The agent ' +
+          `requested to run the following command in ${this.workingDir}. ` +
+          'Only approve if you trust it:\n\n' +
+          command,
+        payload: {command, workingDir: this.workingDir},
+      });
+      return {partial: REQUIRE_CONFIRMATION_MESSAGE};
+    }
+
+    if (!confirmation.confirmed) {
+      return {
+        status: 'error',
+        error: 'Command execution was not confirmed and was rejected.',
+      };
+    }
+
+    return undefined;
   }
 }

--- a/core/src/tools/environment/execute_tool.ts
+++ b/core/src/tools/environment/execute_tool.ts
@@ -37,6 +37,22 @@ export interface ExecuteToolParams {
   workingDir: string;
   maxOutputChars?: number;
   executeTimeoutMs?: number;
+  /**
+   * The shell the command is handed to, as a path or a name resolvable on
+   * `PATH`.
+   *
+   * Defaults to the platform shell `child_process.exec` picks: `/bin/sh` on
+   * POSIX and `%ComSpec%` (that is, `cmd.exe`) on Windows. Node only special
+   * cases `cmd`: any other shell is invoked as `<shell> -c <command>`, which
+   * covers `bash`, `zsh`, `pwsh` and `powershell.exe` (whose `-c` is the
+   * documented short form of `-Command`).
+   *
+   * Note that the environment instruction tells the model to chain dependent
+   * commands with `&&`. Windows PowerShell 5.1 (`powershell.exe`) has no `&&`
+   * operator -- it was added in PowerShell 7 -- so prefer `pwsh` when the
+   * model is expected to chain commands on Windows.
+   */
+  shell?: string;
 }
 
 /**
@@ -78,12 +94,17 @@ export type ExecuteToolResult = ExecuteResult | ExecuteConfirmationRequired;
  * boundary. Every call therefore passes through the repo's standard
  * tool-confirmation gate before it runs, the same way
  * `RunSkillInlineScriptTool` gates model-provided scripts.
+ *
+ * The command runs under `/bin/sh` on POSIX and under `cmd.exe` on Windows;
+ * pass {@link ExecuteToolParams.shell} to select another shell, such as
+ * `pwsh`.
  */
 @experimental
 export class ExecuteTool extends BaseTool {
   private readonly workingDir: string;
   private readonly maxOutputChars: number;
   private readonly executeTimeoutMs: number;
+  private readonly shell?: string;
 
   constructor(params: ExecuteToolParams) {
     super({
@@ -93,6 +114,7 @@ export class ExecuteTool extends BaseTool {
     this.workingDir = params.workingDir;
     this.maxOutputChars = params.maxOutputChars ?? MAX_OUTPUT_CHARS;
     this.executeTimeoutMs = params.executeTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.shell = params.shell;
   }
 
   override _getDeclaration(): FunctionDeclaration | undefined {
@@ -128,9 +150,12 @@ export class ExecuteTool extends BaseTool {
     }
 
     try {
+      // `shell: undefined` leaves `exec` on its platform default, so the
+      // option can be forwarded unconditionally.
       const {stdout, stderr} = await execAsync(command, {
         cwd: this.workingDir,
         timeout: this.executeTimeoutMs,
+        shell: this.shell,
       });
 
       const result: ExecuteResult = {status: 'ok'};

--- a/core/src/tools/environment/index.ts
+++ b/core/src/tools/environment/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './constants.js';
+export * from './edit_file_tool.js';
+export * from './environment_toolset.js';
+export * from './execute_tool.js';
+export * from './read_file_tool.js';
+export * from './write_file_tool.js';

--- a/core/src/tools/environment/read_file_tool.ts
+++ b/core/src/tools/environment/read_file_tool.ts
@@ -8,14 +8,10 @@ import {FunctionDeclaration, Type} from '@google/genai';
 import * as fs from 'fs/promises';
 
 import {experimental} from '../../utils/experimental.js';
+import {resolveAndValidatePath} from '../../utils/file_utils.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
 import {MAX_OUTPUT_CHARS} from './constants.js';
-import {
-  isFileNotFoundError,
-  resolveAndValidatePath,
-  toError,
-  truncate,
-} from './utils.js';
+import {isFileNotFoundError, toError, truncate} from './utils.js';
 
 export interface ReadFileToolParams {
   workingDir: string;

--- a/core/src/tools/environment/read_file_tool.ts
+++ b/core/src/tools/environment/read_file_tool.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Type} from '@google/genai';
+import * as fs from 'fs/promises';
+
+import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
+import {MAX_OUTPUT_CHARS} from './constants.js';
+import {resolveAndValidatePath, truncate} from './utils.js';
+
+export interface ReadFileToolParams {
+  workingDir: string;
+  maxOutputChars?: number;
+}
+
+/**
+ * ReadFileTool for reading file contents in the environment.
+ */
+export class ReadFileTool extends BaseTool {
+  private readonly workingDir: string;
+  private readonly maxOutputChars: number;
+
+  constructor(params: ReadFileToolParams) {
+    super({
+      name: 'ReadFile',
+      description:
+        'Read the contents of a file in the environment. Returns the file content with line numbers.',
+    });
+    this.workingDir = params.workingDir;
+    this.maxOutputChars = params.maxOutputChars ?? MAX_OUTPUT_CHARS;
+  }
+
+  override _getDeclaration(): FunctionDeclaration | undefined {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          path: {
+            type: Type.STRING,
+            description: 'Path of the file to read within the environment.',
+          },
+          start_line: {
+            type: Type.INTEGER,
+            description:
+              'First line to return (1-based, inclusive). Defaults to 1.',
+          },
+          end_line: {
+            type: Type.INTEGER,
+            description:
+              'Last line to return (1-based, inclusive). Defaults to end of file.',
+          },
+        },
+        required: ['path'],
+      },
+    };
+  }
+
+  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    const pathArg = args['path'];
+    if (typeof pathArg !== 'string' || !pathArg) {
+      return {status: 'error', error: '`path` is required.'};
+    }
+
+    const startLineRaw = args['start_line'];
+    const endLineRaw = args['end_line'];
+
+    const isValidLineNumber = (val: unknown) =>
+      typeof val === 'number' && Number.isInteger(val) && !isNaN(val);
+
+    for (const [name, val] of Object.entries({
+      start_line: startLineRaw,
+      end_line: endLineRaw,
+    })) {
+      if (val !== undefined && val !== null && !isValidLineNumber(val)) {
+        return {
+          status: 'error',
+          error: `\`${name}\` must be an integer if provided.`,
+        };
+      }
+    }
+
+    const startLine = (startLineRaw as number) || undefined;
+    const endLine = (endLineRaw as number) || undefined;
+
+    let fullPath: string;
+    try {
+      fullPath = resolveAndValidatePath(this.workingDir, pathArg);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      return {status: 'error', error: String(e.message)};
+    }
+
+    try {
+      const data = await fs.readFile(fullPath, 'utf8');
+      const lines = data.split(/(?<=\r?\n)/);
+      const total = lines.length;
+
+      const start = Math.max(1, startLine || 1);
+      const end = Math.min(total, endLine || total);
+
+      if (start > total) {
+        return {
+          status: 'error',
+          error: `\`start_line\` ${start} exceeds file length (${total} lines).`,
+          total_lines: total,
+        };
+      }
+      if (start > end) {
+        return {
+          status: 'error',
+          error: `\`start_line\` (${start}) is after \`end_line\` (${end}).`,
+          total_lines: total,
+        };
+      }
+
+      const selectedLines = lines.slice(start - 1, end);
+      const numbered = selectedLines
+        .map((line, i) => `${String(start + i).padStart(6, ' ')}\t${line}`)
+        .join('');
+
+      const result: Record<string, unknown> = {
+        status: 'ok',
+        content: truncate(numbered, this.maxOutputChars),
+      };
+
+      if (start > 1 || end < total) {
+        result['total_lines'] = total;
+      }
+      return result;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      if (e.code === 'ENOENT') {
+        return {status: 'error', error: `File not found: ${pathArg}`};
+      }
+      return {status: 'error', error: String(e.message)};
+    }
+  }
+}

--- a/core/src/tools/environment/read_file_tool.ts
+++ b/core/src/tools/environment/read_file_tool.ts
@@ -7,18 +7,47 @@
 import {FunctionDeclaration, Type} from '@google/genai';
 import * as fs from 'fs/promises';
 
+import {experimental} from '../../utils/experimental.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
 import {MAX_OUTPUT_CHARS} from './constants.js';
-import {resolveAndValidatePath, truncate} from './utils.js';
+import {
+  isFileNotFoundError,
+  resolveAndValidatePath,
+  toError,
+  truncate,
+} from './utils.js';
 
 export interface ReadFileToolParams {
   workingDir: string;
   maxOutputChars?: number;
 }
 
+/** The result of a {@link ReadFileTool} call. */
+export interface ReadFileResult {
+  /** `'ok'` when the file was read, `'error'` otherwise. */
+  status: 'ok' | 'error';
+  /** The selected lines, each prefixed with its 1-based line number. */
+  content?: string;
+  /** Total number of lines in the file, when only part of it was returned. */
+  total_lines?: number;
+  /** Why the call failed. Always set when `status` is `'error'`. */
+  error?: string;
+}
+
+/**
+ * Whether a raw tool argument is usable as a 1-based line number.
+ *
+ * `Number.isInteger` already rejects `NaN` and every non-number, so that is the
+ * only check needed.
+ */
+function isValidLineNumber(val: unknown): val is number {
+  return Number.isInteger(val);
+}
+
 /**
  * ReadFileTool for reading file contents in the environment.
  */
+@experimental
 export class ReadFileTool extends BaseTool {
   private readonly workingDir: string;
   private readonly maxOutputChars: number;
@@ -60,7 +89,9 @@ export class ReadFileTool extends BaseTool {
     };
   }
 
-  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+  override async runAsync({
+    args,
+  }: RunAsyncToolRequest): Promise<ReadFileResult> {
     const pathArg = args['path'];
     if (typeof pathArg !== 'string' || !pathArg) {
       return {status: 'error', error: '`path` is required.'};
@@ -68,9 +99,6 @@ export class ReadFileTool extends BaseTool {
 
     const startLineRaw = args['start_line'];
     const endLineRaw = args['end_line'];
-
-    const isValidLineNumber = (val: unknown) =>
-      typeof val === 'number' && Number.isInteger(val) && !isNaN(val);
 
     for (const [name, val] of Object.entries({
       start_line: startLineRaw,
@@ -84,15 +112,16 @@ export class ReadFileTool extends BaseTool {
       }
     }
 
-    const startLine = (startLineRaw as number) || undefined;
-    const endLine = (endLineRaw as number) || undefined;
+    const startLine = isValidLineNumber(startLineRaw)
+      ? startLineRaw
+      : undefined;
+    const endLine = isValidLineNumber(endLineRaw) ? endLineRaw : undefined;
 
     let fullPath: string;
     try {
       fullPath = resolveAndValidatePath(this.workingDir, pathArg);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      return {status: 'error', error: String(e.message)};
+    } catch (e) {
+      return {status: 'error', error: toError(e).message};
     }
 
     try {
@@ -123,21 +152,20 @@ export class ReadFileTool extends BaseTool {
         .map((line, i) => `${String(start + i).padStart(6, ' ')}\t${line}`)
         .join('');
 
-      const result: Record<string, unknown> = {
+      const result: ReadFileResult = {
         status: 'ok',
         content: truncate(numbered, this.maxOutputChars),
       };
 
       if (start > 1 || end < total) {
-        result['total_lines'] = total;
+        result.total_lines = total;
       }
       return result;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      if (e.code === 'ENOENT') {
+    } catch (e) {
+      if (isFileNotFoundError(e)) {
         return {status: 'error', error: `File not found: ${pathArg}`};
       }
-      return {status: 'error', error: String(e.message)};
+      return {status: 'error', error: toError(e).message};
     }
   }
 }

--- a/core/src/tools/environment/utils.ts
+++ b/core/src/tools/environment/utils.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path';
+
+/**
+ * Truncate a string to a max length, adding a suffix if truncated.
+ * @param str The string to truncate.
+ * @param limit The maximum number of characters.
+ * @return The truncated string.
+ */
+export function truncate(str: string, limit: number): string {
+  if (limit <= 0) {
+    return '';
+  }
+  if (str.length <= limit) {
+    return str;
+  }
+  const suffix = `\n... (truncated to ${str.length} chars)`;
+  return str.substring(0, limit) + suffix;
+}
+
+/**
+ * Validates and resolves a path against a base working directory, ensuring
+ * that the resolved path does not escape the working directory.
+ * @param workingDir The base working directory.
+ * @param relativeOrAbsolutePath The path to check.
+ * @return The resolved absolute path.
+ */
+export function resolveAndValidatePath(
+  workingDir: string,
+  relativeOrAbsolutePath: string,
+): string {
+  // If it's absolute, check it directly. Otherwise resolve relative to workingDir
+  const resolvedWorkingDir = path.resolve(workingDir);
+  const resolvedPath = path.resolve(resolvedWorkingDir, relativeOrAbsolutePath);
+  const relative = path.relative(resolvedWorkingDir, resolvedPath);
+
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(
+      `Path ${relativeOrAbsolutePath} escapes the working directory.`,
+    );
+  }
+  return resolvedPath;
+}

--- a/core/src/tools/environment/utils.ts
+++ b/core/src/tools/environment/utils.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from 'path';
-
 /**
  * Truncate a string to a max length, adding a suffix if truncated.
  * @param str The string to truncate.
@@ -52,38 +50,4 @@ export function toError(e: unknown): Error {
  */
 export function isFileNotFoundError(e: unknown): boolean {
   return e instanceof Error && 'code' in e && e.code === 'ENOENT';
-}
-
-/**
- * Validates and resolves a path against a base working directory, ensuring
- * that the resolved path does not escape the working directory.
- *
- * The check is lexical: `path.resolve` and `path.relative` normalize `..`
- * segments but never touch the filesystem, so a symlink stored inside
- * `workingDir` that points elsewhere still resolves to a path outside it. That
- * is deliberate -- reading through symlinks is normal and necessary for real
- * workspace layouts, such as the package links npm creates under
- * `node_modules`. This guards against traversal in the *argument*; it is not a
- * sandbox, and callers who need one should point the tools at an isolated
- * filesystem.
- *
- * @param workingDir The base working directory.
- * @param relativeOrAbsolutePath The path to check.
- * @return The resolved absolute path.
- */
-export function resolveAndValidatePath(
-  workingDir: string,
-  relativeOrAbsolutePath: string,
-): string {
-  // If it's absolute, check it directly. Otherwise resolve relative to workingDir
-  const resolvedWorkingDir = path.resolve(workingDir);
-  const resolvedPath = path.resolve(resolvedWorkingDir, relativeOrAbsolutePath);
-  const relative = path.relative(resolvedWorkingDir, resolvedPath);
-
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(
-      `Path ${relativeOrAbsolutePath} escapes the working directory.`,
-    );
-  }
-  return resolvedPath;
 }

--- a/core/src/tools/environment/utils.ts
+++ b/core/src/tools/environment/utils.ts
@@ -19,13 +19,54 @@ export function truncate(str: string, limit: number): string {
   if (str.length <= limit) {
     return str;
   }
-  const suffix = `\n... (truncated to ${str.length} chars)`;
+  const suffix = `\n... (truncated, ${str.length} total chars)`;
   return str.substring(0, limit) + suffix;
+}
+
+/**
+ * Narrows a caught value to an `Error`, wrapping anything else.
+ *
+ * `catch` binds `unknown` because any value can be thrown. Node rejects with
+ * `Error` subtypes whose extra fields are all optional, such as
+ * `child_process.ExecException`, so the result of this function can be
+ * assigned straight to one of those without a type assertion.
+ *
+ * @param e The caught value.
+ * @return `e` itself when it is an `Error`, otherwise a new `Error` describing
+ *     it.
+ */
+export function toError(e: unknown): Error {
+  return e instanceof Error ? e : new Error(String(e));
+}
+
+/**
+ * Whether a caught value is Node's "no such file or directory" system error.
+ *
+ * `fs/promises` rejects with an `Error` carrying a string `code`. The property
+ * is checked at runtime rather than asserted, because the ambient
+ * `NodeJS.ErrnoException` type is not usable here: it has no runtime binding
+ * and the lint config's `no-undef` rejects the `NodeJS` namespace.
+ *
+ * @param e The caught value.
+ * @return Whether `e` reports `ENOENT`.
+ */
+export function isFileNotFoundError(e: unknown): boolean {
+  return e instanceof Error && 'code' in e && e.code === 'ENOENT';
 }
 
 /**
  * Validates and resolves a path against a base working directory, ensuring
  * that the resolved path does not escape the working directory.
+ *
+ * The check is lexical: `path.resolve` and `path.relative` normalize `..`
+ * segments but never touch the filesystem, so a symlink stored inside
+ * `workingDir` that points elsewhere still resolves to a path outside it. That
+ * is deliberate -- reading through symlinks is normal and necessary for real
+ * workspace layouts, such as the package links npm creates under
+ * `node_modules`. This guards against traversal in the *argument*; it is not a
+ * sandbox, and callers who need one should point the tools at an isolated
+ * filesystem.
+ *
  * @param workingDir The base working directory.
  * @param relativeOrAbsolutePath The path to check.
  * @return The resolved absolute path.

--- a/core/src/tools/environment/write_file_tool.ts
+++ b/core/src/tools/environment/write_file_tool.ts
@@ -7,16 +7,28 @@
 import {FunctionDeclaration, Type} from '@google/genai';
 import * as fs from 'fs/promises';
 
+import {experimental} from '../../utils/experimental.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
-import {resolveAndValidatePath} from './utils.js';
+import {resolveAndValidatePath, toError} from './utils.js';
 
 export interface WriteFileToolParams {
   workingDir: string;
 }
 
+/** The result of a {@link WriteFileTool} call. */
+export interface WriteFileResult {
+  /** `'ok'` when the file was written, `'error'` otherwise. */
+  status: 'ok' | 'error';
+  /** Confirmation of what was written. Set when `status` is `'ok'`. */
+  message?: string;
+  /** Why the call failed. Always set when `status` is `'error'`. */
+  error?: string;
+}
+
 /**
  * WriteFileTool for creating or overwriting files in the environment.
  */
+@experimental
 export class WriteFileTool extends BaseTool {
   private readonly workingDir: string;
 
@@ -50,7 +62,9 @@ export class WriteFileTool extends BaseTool {
     };
   }
 
-  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+  override async runAsync({
+    args,
+  }: RunAsyncToolRequest): Promise<WriteFileResult> {
     const pathArg = args['path'];
     const content = args['content'];
 
@@ -64,17 +78,15 @@ export class WriteFileTool extends BaseTool {
     let fullPath: string;
     try {
       fullPath = resolveAndValidatePath(this.workingDir, pathArg);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      return {status: 'error', error: String(e.message)};
+    } catch (e) {
+      return {status: 'error', error: toError(e).message};
     }
 
     try {
       await fs.writeFile(fullPath, content, 'utf8');
       return {status: 'ok', message: `Wrote ${pathArg}`};
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      return {status: 'error', error: String(e.message)};
+    } catch (e) {
+      return {status: 'error', error: toError(e).message};
     }
   }
 }

--- a/core/src/tools/environment/write_file_tool.ts
+++ b/core/src/tools/environment/write_file_tool.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Type} from '@google/genai';
+import * as fs from 'fs/promises';
+
+import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
+import {resolveAndValidatePath} from './utils.js';
+
+export interface WriteFileToolParams {
+  workingDir: string;
+}
+
+/**
+ * WriteFileTool for creating or overwriting files in the environment.
+ */
+export class WriteFileTool extends BaseTool {
+  private readonly workingDir: string;
+
+  constructor(params: WriteFileToolParams) {
+    super({
+      name: 'WriteFile',
+      description:
+        'Create or overwrite a file in the environment. Use for new files or full rewrites. For small changes to existing files, prefer EditFile.',
+    });
+    this.workingDir = params.workingDir;
+  }
+
+  override _getDeclaration(): FunctionDeclaration | undefined {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          path: {
+            type: Type.STRING,
+            description: 'Path to the file within the environment.',
+          },
+          content: {
+            type: Type.STRING,
+            description: 'The full file content to write.',
+          },
+        },
+        required: ['path', 'content'],
+      },
+    };
+  }
+
+  override async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    const pathArg = args['path'];
+    const content = args['content'];
+
+    if (typeof pathArg !== 'string' || !pathArg) {
+      return {status: 'error', error: '`path` is required.'};
+    }
+    if (typeof content !== 'string') {
+      return {status: 'error', error: '`content` must be a string.'};
+    }
+
+    let fullPath: string;
+    try {
+      fullPath = resolveAndValidatePath(this.workingDir, pathArg);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      return {status: 'error', error: String(e.message)};
+    }
+
+    try {
+      await fs.writeFile(fullPath, content, 'utf8');
+      return {status: 'ok', message: `Wrote ${pathArg}`};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      return {status: 'error', error: String(e.message)};
+    }
+  }
+}

--- a/core/src/tools/environment/write_file_tool.ts
+++ b/core/src/tools/environment/write_file_tool.ts
@@ -8,8 +8,9 @@ import {FunctionDeclaration, Type} from '@google/genai';
 import * as fs from 'fs/promises';
 
 import {experimental} from '../../utils/experimental.js';
+import {resolveAndValidatePath} from '../../utils/file_utils.js';
 import {BaseTool, RunAsyncToolRequest} from '../base_tool.js';
-import {resolveAndValidatePath, toError} from './utils.js';
+import {toError} from './utils.js';
 
 export interface WriteFileToolParams {
   workingDir: string;

--- a/core/src/utils/file_utils.ts
+++ b/core/src/utils/file_utils.ts
@@ -107,6 +107,40 @@ export async function materializeFiles(
   return createdFiles;
 }
 
+/**
+ * Validates and resolves a path against a base working directory, ensuring
+ * that the resolved path does not escape the working directory.
+ *
+ * The check is lexical: `path.resolve` and `path.relative` normalize `..`
+ * segments but never touch the filesystem, so a symlink stored inside
+ * `workingDir` that points elsewhere still resolves to a path outside it. That
+ * is deliberate -- reading through symlinks is normal and necessary for real
+ * workspace layouts, such as the package links npm creates under
+ * `node_modules`. This guards against traversal in the *argument*; it is not a
+ * sandbox, and callers who need one should point at an isolated filesystem.
+ *
+ * @param workingDir The base working directory.
+ * @param relativeOrAbsolutePath The path to check.
+ * @return The resolved absolute path.
+ */
+export function resolveAndValidatePath(
+  workingDir: string,
+  relativeOrAbsolutePath: string,
+): string {
+  // If it's absolute, check it directly. Otherwise resolve relative to
+  // workingDir.
+  const resolvedWorkingDir = path.resolve(workingDir);
+  const resolvedPath = path.resolve(resolvedWorkingDir, relativeOrAbsolutePath);
+  const relative = path.relative(resolvedWorkingDir, resolvedPath);
+
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(
+      `Path ${relativeOrAbsolutePath} escapes the working directory.`,
+    );
+  }
+  return resolvedPath;
+}
+
 export const EXTENSION_TO_MIME_TYPE: Record<string, string> = {
   'pdf': 'application/pdf',
   'jpg': 'image/jpeg',

--- a/core/test/tools/environment/tools_test.ts
+++ b/core/test/tools/environment/tools_test.ts
@@ -22,15 +22,20 @@ import * as path from 'path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 // `truncate`, `toError` and `resolveAndValidatePath` are implementation
-// details of the environment tools and are deliberately not part of the
-// package's public surface, so they are imported from the module directly.
-import {
-  resolveAndValidatePath,
-  toError,
-  truncate,
-} from '../../../src/tools/environment/utils.js';
+// details and are deliberately not part of the package's public surface, so
+// they are imported from their modules directly.
+import {toError, truncate} from '../../../src/tools/environment/utils.js';
+import {resolveAndValidatePath} from '../../../src/utils/file_utils.js';
 
 const FUNCTION_CALL_ID = 'fc-1';
+
+const IS_WINDOWS = os.platform() === 'win32';
+
+/**
+ * PowerShell start-up dominates these runs, and a cold Windows CI agent can
+ * take several seconds before the first statement executes.
+ */
+const WINDOWS_SHELL_TIMEOUT_MS = 60_000;
 
 const REQUIRE_CONFIRMATION_MESSAGE =
   'This tool call needs external confirmation before completion.';
@@ -187,6 +192,99 @@ describe('Environment Tools Parity', () => {
       await expect(
         fs.access(path.join(tmpDir, 'marker.txt')),
       ).rejects.toThrowError();
+    });
+
+    describe('shell selection', () => {
+      it.skipIf(IS_WINDOWS)(
+        'hands the command to the configured shell instead of the default',
+        async () => {
+          // A stand-in shell that echoes back the command it was invoked
+          // with. `child_process.exec` runs `<shell> -c <command>`, so the
+          // command lands in `$2`. Seeing it here proves the configured shell
+          // ran the command rather than the platform default.
+          const fakeShell = path.join(tmpDir, 'fake-shell.sh');
+          await fs.writeFile(
+            fakeShell,
+            '#!/bin/sh\necho "fake-shell ran: $2"\n',
+            'utf8',
+          );
+          await fs.chmod(fakeShell, 0o755);
+
+          const tool = new ExecuteTool({workingDir: tmpDir, shell: fakeShell});
+          const res = await runExecute(tool, {command: 'echo hello'});
+
+          expect(res.status).toBe('ok');
+          expect((res.stdout ?? '').trim()).toBe('fake-shell ran: echo hello');
+        },
+      );
+
+      it.skipIf(!IS_WINDOWS)(
+        'runs through cmd.exe by default on Windows',
+        async () => {
+          // `%VAR%` is only expanded by `cmd.exe`; PowerShell and POSIX
+          // shells would echo the text back verbatim.
+          const tool = new ExecuteTool({workingDir: tmpDir});
+          const res = await runExecute(tool, {command: 'echo %COMSPEC%'});
+
+          expect(res.status).toBe('ok');
+          expect((res.stdout ?? '').toLowerCase()).toContain('cmd.exe');
+        },
+        WINDOWS_SHELL_TIMEOUT_MS,
+      );
+
+      it.skipIf(!IS_WINDOWS)(
+        'runs through cmd.exe when it is selected explicitly',
+        async () => {
+          const tool = new ExecuteTool({
+            workingDir: tmpDir,
+            shell: 'cmd.exe',
+            executeTimeoutMs: WINDOWS_SHELL_TIMEOUT_MS,
+          });
+          const res = await runExecute(tool, {
+            command: 'echo %COMSPEC% && exit 0',
+          });
+
+          expect(res.status).toBe('ok');
+          expect((res.stdout ?? '').toLowerCase()).toContain('cmd.exe');
+        },
+        WINDOWS_SHELL_TIMEOUT_MS,
+      );
+
+      it.skipIf(!IS_WINDOWS)(
+        'runs through powershell when it is selected',
+        async () => {
+          // `Write-Output` and parenthesised arithmetic are PowerShell
+          // syntax; `cmd.exe` would report an unrecognised command.
+          const tool = new ExecuteTool({
+            workingDir: tmpDir,
+            shell: 'powershell.exe',
+            executeTimeoutMs: WINDOWS_SHELL_TIMEOUT_MS,
+          });
+          const res = await runExecute(tool, {command: 'Write-Output (3 + 4)'});
+
+          expect(res.status).toBe('ok');
+          expect(
+            (res.stdout ?? '').split(/\r?\n/).map((l) => l.trim()),
+          ).toContain('7');
+        },
+        WINDOWS_SHELL_TIMEOUT_MS * 2,
+      );
+
+      it.skipIf(!IS_WINDOWS)(
+        'reports a nonzero exit code from powershell',
+        async () => {
+          const tool = new ExecuteTool({
+            workingDir: tmpDir,
+            shell: 'powershell.exe',
+            executeTimeoutMs: WINDOWS_SHELL_TIMEOUT_MS,
+          });
+          const res = await runExecute(tool, {command: 'exit 3'});
+
+          expect(res.status).toBe('error');
+          expect(res.exit_code).toBe(3);
+        },
+        WINDOWS_SHELL_TIMEOUT_MS * 2,
+      );
     });
   });
 
@@ -529,6 +627,40 @@ describe('Environment Tools Parity', () => {
       expect(tools.length).toBe(1);
       expect(tools[0].name).toBe('Execute');
     });
+
+    it.skipIf(IS_WINDOWS)(
+      'forwards the configured shell to Execute',
+      async () => {
+        const fakeShell = path.join(tmpDir, 'fake-shell.sh');
+        await fs.writeFile(
+          fakeShell,
+          '#!/bin/sh\necho "fake-shell ran: $2"\n',
+          'utf8',
+        );
+        await fs.chmod(fakeShell, 0o755);
+
+        const set = new EnvironmentToolset({
+          workingDir: tmpDir,
+          shell: fakeShell,
+        });
+        const execute = (await set.getTools()).find(
+          (t) => t.name === 'Execute',
+        );
+        if (!(execute instanceof ExecuteTool)) {
+          throw new Error('Execute tool missing from the toolset.');
+        }
+
+        const res = await execute.runAsync({
+          args: {command: 'echo hello'},
+          toolContext: confirmedContext(),
+        });
+        if (!('status' in res)) {
+          throw new Error('Execute unexpectedly paused for confirmation.');
+        }
+        expect(res.status).toBe('ok');
+        expect((res.stdout ?? '').trim()).toBe('fake-shell ran: echo hello');
+      },
+    );
 
     it('closes without error', async () => {
       const set = new EnvironmentToolset({workingDir: tmpDir});

--- a/core/test/tools/environment/tools_test.ts
+++ b/core/test/tools/environment/tools_test.ts
@@ -37,6 +37,14 @@ const IS_WINDOWS = os.platform() === 'win32';
  */
 const WINDOWS_SHELL_TIMEOUT_MS = 60_000;
 
+/**
+ * Renders a tool result for an assertion message, so that a shell failure that
+ * only reproduces on a CI agent still reports why the command failed.
+ */
+function describeResult(result: ExecuteResult): string {
+  return `Execute returned ${JSON.stringify(result)}`;
+}
+
 const REQUIRE_CONFIRMATION_MESSAGE =
   'This tool call needs external confirmation before completion.';
 
@@ -69,7 +77,15 @@ describe('Environment Tools Parity', () => {
   });
 
   afterEach(async () => {
-    await fs.rm(tmpDir, {recursive: true, force: true});
+    // A command that was killed on timeout can still hold `tmpDir` as its
+    // working directory for a moment after the kill returns, which makes
+    // `rmdir` fail with EBUSY on Windows. Retry rather than fail teardown.
+    await fs.rm(tmpDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    });
   });
 
   describe('utils', () => {
@@ -223,10 +239,13 @@ describe('Environment Tools Parity', () => {
         async () => {
           // `%VAR%` is only expanded by `cmd.exe`; PowerShell and POSIX
           // shells would echo the text back verbatim.
-          const tool = new ExecuteTool({workingDir: tmpDir});
+          const tool = new ExecuteTool({
+            workingDir: tmpDir,
+            executeTimeoutMs: WINDOWS_SHELL_TIMEOUT_MS,
+          });
           const res = await runExecute(tool, {command: 'echo %COMSPEC%'});
 
-          expect(res.status).toBe('ok');
+          expect(res.status, describeResult(res)).toBe('ok');
           expect((res.stdout ?? '').toLowerCase()).toContain('cmd.exe');
         },
         WINDOWS_SHELL_TIMEOUT_MS,
@@ -244,7 +263,7 @@ describe('Environment Tools Parity', () => {
             command: 'echo %COMSPEC% && exit 0',
           });
 
-          expect(res.status).toBe('ok');
+          expect(res.status, describeResult(res)).toBe('ok');
           expect((res.stdout ?? '').toLowerCase()).toContain('cmd.exe');
         },
         WINDOWS_SHELL_TIMEOUT_MS,
@@ -254,7 +273,9 @@ describe('Environment Tools Parity', () => {
         'runs through powershell when it is selected',
         async () => {
           // `Write-Output` and parenthesised arithmetic are PowerShell
-          // syntax; `cmd.exe` would report an unrecognised command.
+          // syntax; `cmd.exe` would report an unrecognised command. Node
+          // spawns any non-`cmd` shell as `<shell> -c <command>`, and `-c`
+          // is PowerShell's short form of `-Command`.
           const tool = new ExecuteTool({
             workingDir: tmpDir,
             shell: 'powershell.exe',
@@ -262,26 +283,10 @@ describe('Environment Tools Parity', () => {
           });
           const res = await runExecute(tool, {command: 'Write-Output (3 + 4)'});
 
-          expect(res.status).toBe('ok');
+          expect(res.status, describeResult(res)).toBe('ok');
           expect(
             (res.stdout ?? '').split(/\r?\n/).map((l) => l.trim()),
           ).toContain('7');
-        },
-        WINDOWS_SHELL_TIMEOUT_MS * 2,
-      );
-
-      it.skipIf(!IS_WINDOWS)(
-        'reports a nonzero exit code from powershell',
-        async () => {
-          const tool = new ExecuteTool({
-            workingDir: tmpDir,
-            shell: 'powershell.exe',
-            executeTimeoutMs: WINDOWS_SHELL_TIMEOUT_MS,
-          });
-          const res = await runExecute(tool, {command: 'exit 3'});
-
-          expect(res.status).toBe('error');
-          expect(res.exit_code).toBe(3);
         },
         WINDOWS_SHELL_TIMEOUT_MS * 2,
       );

--- a/core/test/tools/environment/tools_test.ts
+++ b/core/test/tools/environment/tools_test.ts
@@ -1,0 +1,385 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {EditFileTool} from '../../../src/tools/environment/edit_file_tool.js';
+import {EnvironmentToolset} from '../../../src/tools/environment/environment_toolset.js';
+import {ExecuteTool} from '../../../src/tools/environment/execute_tool.js';
+import {ReadFileTool} from '../../../src/tools/environment/read_file_tool.js';
+import {
+  resolveAndValidatePath,
+  truncate,
+} from '../../../src/tools/environment/utils.js';
+import {WriteFileTool} from '../../../src/tools/environment/write_file_tool.js';
+
+describe('Environment Tools Parity', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-env-tools-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {recursive: true, force: true});
+  });
+
+  describe('utils', () => {
+    it('truncates correctly', () => {
+      expect(truncate('1234567890', 5)).toBe(
+        '12345\n... (truncated to 10 chars)',
+      );
+      expect(truncate('12', 5)).toBe('12');
+      expect(truncate('1234567890', 0)).toBe('');
+    });
+
+    it('validates paths to not escape working dir', () => {
+      expect(() => resolveAndValidatePath(tmpDir, '../root')).toThrowError(
+        'escapes',
+      );
+      expect(() => resolveAndValidatePath(tmpDir, '/etc/passwd')).toThrowError(
+        'escapes',
+      );
+      expect(resolveAndValidatePath(tmpDir, 'ok/file.txt')).toBe(
+        path.join(tmpDir, 'ok', 'file.txt'),
+      );
+    });
+  });
+
+  describe('ExecuteTool', () => {
+    // `cmd.exe` terminates lines with CRLF and preserves the trailing space
+    // before `&&`, so normalize shell output before comparing.
+    const normalizeShellOutput = (value: string) =>
+      value.replace(/\r\n/g, '\n').replace(/[ \t]+\n/g, '\n');
+
+    it('executes successfully', async () => {
+      const tool = new ExecuteTool({workingDir: tmpDir});
+      expect(tool._getDeclaration()).toBeDefined();
+
+      let res: any = await tool.runAsync({args: {}, toolContext: {} as any});
+      expect(res.status).toBe('error');
+
+      res = await tool.runAsync({
+        args: {command: 'echo test && echo err >&2'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('ok');
+      expect(normalizeShellOutput(res.stdout)).toBe('test\n');
+      expect(normalizeShellOutput(res.stderr)).toBe('err\n');
+    });
+
+    it('reports failure on nonzero exit code with stdout/err', async () => {
+      const tool = new ExecuteTool({workingDir: tmpDir});
+      const res: any = await tool.runAsync({
+        args: {command: 'echo out && echo err >&2 && exit 10'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.exit_code).toBe(10);
+      expect(normalizeShellOutput(res.stdout)).toBe('out\n');
+      expect(normalizeShellOutput(res.stderr)).toBe('err\n');
+    });
+
+    it('reports timeout', async () => {
+      const tool = new ExecuteTool({workingDir: tmpDir, executeTimeoutMs: 100});
+      const res: any = await tool.runAsync({
+        args: {command: 'sleep 1'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toMatch(/timed out/i);
+    });
+
+    it('handles spawn errors and includes stdout/stderr on exit code', async () => {
+      const tool = new ExecuteTool({workingDir: tmpDir});
+      const res: any = await tool.runAsync({
+        args: {command: 'non_existent_command_123'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+  });
+
+  describe('WriteFileTool', () => {
+    it('writes files', async () => {
+      const tool = new WriteFileTool({workingDir: tmpDir});
+      expect(tool._getDeclaration()).toBeDefined();
+
+      const res: any = await tool.runAsync({
+        args: {path: 'test.txt', content: 'hello'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('ok');
+      const content = await fs.readFile(path.join(tmpDir, 'test.txt'), 'utf8');
+      expect(content).toBe('hello');
+    });
+
+    it('fails if path invalid', async () => {
+      const tool = new WriteFileTool({workingDir: tmpDir});
+      const res: any = await tool.runAsync({
+        args: {path: '../test.txt', content: 'hello'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+
+    it('fails on missing arguments', async () => {
+      const tool = new WriteFileTool({workingDir: tmpDir});
+      let res: any = await tool.runAsync({args: {}, toolContext: {} as any});
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('path');
+
+      res = await tool.runAsync({
+        args: {path: 'test.txt'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('content');
+    });
+
+    it('handles write errors', async () => {
+      const tool = new WriteFileTool({
+        workingDir: '/invalid/path/that/does_not_exist',
+      });
+      const res: any = await tool.runAsync({
+        args: {path: 'test.txt', content: 'hello'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+  });
+
+  describe('ReadFileTool', () => {
+    beforeEach(async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'lines.txt'),
+        'line1\nline2\nline3\nline4',
+        'utf8',
+      );
+    });
+
+    it('reads all lines', async () => {
+      const tool = new ReadFileTool({workingDir: tmpDir});
+      expect(tool._getDeclaration()).toBeDefined();
+
+      const res: any = await tool.runAsync({
+        args: {path: 'lines.txt'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('ok');
+      expect(res.content).toContain('1\tline1\n');
+      expect(res.content).toContain('4\tline4');
+    });
+
+    it('reads specific lines', async () => {
+      const tool = new ReadFileTool({workingDir: tmpDir});
+      const res: any = await tool.runAsync({
+        args: {path: 'lines.txt', start_line: 2, end_line: 3},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('ok');
+      expect(res.content.trim()).toBe('2\tline2\n     3\tline3'.trim());
+      expect(res.total_lines).toBe(4);
+    });
+
+    it('handles out of bounds', async () => {
+      const tool = new ReadFileTool({workingDir: tmpDir});
+      let res: any = await tool.runAsync({
+        args: {path: 'lines.txt', start_line: 10},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.total_lines).toBe(4);
+
+      res = await tool.runAsync({
+        args: {path: 'lines.txt', start_line: 2, end_line: 1},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+
+    it('fails if path invalid or missing', async () => {
+      const tool = new ReadFileTool({workingDir: tmpDir});
+      let res: any = await tool.runAsync({args: {}, toolContext: {} as any});
+      expect(res.status).toBe('error');
+
+      res = await tool.runAsync({
+        args: {path: '../escape'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+
+    it('fails if file not found or read error', async () => {
+      const tool = new ReadFileTool({workingDir: tmpDir});
+      let res: any = await tool.runAsync({
+        args: {path: 'notfound.txt'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('File not found');
+
+      // non-ENOENT error (like EISDIR)
+      res = await tool.runAsync({args: {path: '.'}, toolContext: {} as any});
+      expect(res.status).toBe('error');
+    });
+
+    it('validates args', async () => {
+      const tool = new ReadFileTool({workingDir: tmpDir});
+      const res: any = await tool.runAsync({
+        args: {path: 'lines.txt', start_line: 'not_number'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('integer');
+    });
+  });
+
+  describe('EditFileTool', () => {
+    beforeEach(async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'edit.txt'),
+        'hello world\nhello universe\n',
+        'utf8',
+      );
+    });
+
+    it('replaces exact match', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+      expect(tool._getDeclaration()).toBeDefined();
+
+      const res: any = await tool.runAsync({
+        args: {path: 'edit.txt', old_string: 'world', new_string: 'mars'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('ok');
+
+      const content = await fs.readFile(path.join(tmpDir, 'edit.txt'), 'utf8');
+      expect(content).toContain('hello mars');
+      expect(content).toContain('universe');
+    });
+
+    it('fails if non-unique match', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+      const res: any = await tool.runAsync({
+        args: {path: 'edit.txt', old_string: 'hello', new_string: 'hi'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('appears 2 times');
+    });
+
+    it('fails if zero matches', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+      const res: any = await tool.runAsync({
+        args: {path: 'edit.txt', old_string: 'notfound', new_string: 'hi'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('not found');
+    });
+
+    it('validates args', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+      let res: any = await tool.runAsync({
+        args: {path: 'edit.txt', old_string: '', new_string: 'hi'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('cannot be empty');
+
+      res = await tool.runAsync({args: {}, toolContext: {} as any});
+      expect(res.status).toBe('error');
+
+      res = await tool.runAsync({
+        args: {path: 'edit.txt', old_string: 'hello'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+
+    it('fails if path invalid or file does not exist', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+      let res: any = await tool.runAsync({
+        args: {path: '../escape', old_string: 'h', new_string: 'b'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+
+      res = await tool.runAsync({
+        args: {path: 'missing.txt', old_string: 'h', new_string: 'b'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('File not found');
+
+      res = await tool.runAsync({
+        args: {path: '.', old_string: 'h', new_string: 'b'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+
+    it('handles write errors', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+
+      // We need to trigger an error writing to an existing file.
+      // We can make the file read-only!
+      await fs.chmod(path.join(tmpDir, 'edit.txt'), 0o444);
+      const res: any = await tool.runAsync({
+        args: {path: 'edit.txt', old_string: 'world', new_string: 'mars'},
+        toolContext: {} as any,
+      });
+      expect(res.status).toBe('error');
+    });
+  });
+
+  describe('EnvironmentToolset', () => {
+    it('provides tools and injects instructions', async () => {
+      const set = new EnvironmentToolset({workingDir: tmpDir});
+      const tools = await set.getTools();
+      expect(tools.length).toBe(4);
+      expect(tools.some((t) => t.name === 'Execute')).toBe(true);
+
+      const request: any = {
+        config: {},
+        toolsDict: {},
+        contents: [],
+      };
+      const appendInstructionsSpy = vi.fn();
+
+      // Override or mock it? No, wait! `appendInstructions` is a utility method imported by the toolset.
+      // Wait, let's just observe if the config is updated! The actual `appendInstructions` method updates llmRequest.config.systemInstruction.
+
+      await set.processLlmRequest({} as any, request);
+      expect(request.config.systemInstruction).toContain('Environment Rules');
+      expect(request.config.systemInstruction).toContain(tmpDir);
+    });
+
+    it('returns filtered and unfiltered tools', async () => {
+      const set = new EnvironmentToolset({
+        workingDir: tmpDir,
+        toolFilter: ['Execute'],
+      });
+      let tools = await set.getTools(); // no context, unfiltered
+      expect(tools.length).toBeGreaterThan(1);
+
+      tools = await set.getTools({} as any); // filtered
+      expect(tools.length).toBe(1);
+      expect(tools[0].name).toBe('Execute');
+    });
+
+    it('closes without error', async () => {
+      const set = new EnvironmentToolset({workingDir: tmpDir});
+      await expect(set.close()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/core/test/tools/environment/tools_test.ts
+++ b/core/test/tools/environment/tools_test.ts
@@ -4,22 +4,57 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  Context,
+  EditFileTool,
+  EnvironmentToolset,
+  ExecuteResult,
+  ExecuteTool,
+  InvocationContext,
+  LlmRequest,
+  ReadFileTool,
+  ToolConfirmation,
+  WriteFileTool,
+} from '@google/adk';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
-import {EditFileTool} from '../../../src/tools/environment/edit_file_tool.js';
-import {EnvironmentToolset} from '../../../src/tools/environment/environment_toolset.js';
-import {ExecuteTool} from '../../../src/tools/environment/execute_tool.js';
-import {ReadFileTool} from '../../../src/tools/environment/read_file_tool.js';
+// `truncate`, `toError` and `resolveAndValidatePath` are implementation
+// details of the environment tools and are deliberately not part of the
+// package's public surface, so they are imported from the module directly.
 import {
   resolveAndValidatePath,
+  toError,
   truncate,
 } from '../../../src/tools/environment/utils.js';
-import {WriteFileTool} from '../../../src/tools/environment/write_file_tool.js';
+
+const FUNCTION_CALL_ID = 'fc-1';
+
+const REQUIRE_CONFIRMATION_MESSAGE =
+  'This tool call needs external confirmation before completion.';
+
+/**
+ * Builds the `Context` the framework hands to a tool call. Only the fields the
+ * environment tools read are populated; the surrounding invocation is stubbed,
+ * matching `run_skill_inline_script_tool_test.ts`.
+ */
+function createContext(toolConfirmation?: ToolConfirmation): Context {
+  return new Context({
+    invocationContext: {
+      session: {state: {}},
+      agent: {name: 'test-agent'},
+    } as unknown as InvocationContext,
+    functionCallId: FUNCTION_CALL_ID,
+    toolConfirmation,
+  });
+}
+
+/** A context whose tool call the client has already approved. */
+function confirmedContext(): Context {
+  return createContext(new ToolConfirmation({confirmed: true}));
+}
 
 describe('Environment Tools Parity', () => {
   let tmpDir: string;
@@ -35,7 +70,7 @@ describe('Environment Tools Parity', () => {
   describe('utils', () => {
     it('truncates correctly', () => {
       expect(truncate('1234567890', 5)).toBe(
-        '12345\n... (truncated to 10 chars)',
+        '12345\n... (truncated, 10 total chars)',
       );
       expect(truncate('12', 5)).toBe('12');
       expect(truncate('1234567890', 0)).toBe('');
@@ -52,6 +87,12 @@ describe('Environment Tools Parity', () => {
         path.join(tmpDir, 'ok', 'file.txt'),
       );
     });
+
+    it('normalizes thrown values to Error', () => {
+      const err = new Error('boom');
+      expect(toError(err)).toBe(err);
+      expect(toError('boom').message).toBe('boom');
+    });
   });
 
   describe('ExecuteTool', () => {
@@ -60,51 +101,92 @@ describe('Environment Tools Parity', () => {
     const normalizeShellOutput = (value: string) =>
       value.replace(/\r\n/g, '\n').replace(/[ \t]+\n/g, '\n');
 
+    /**
+     * Runs the tool with an approved confirmation and narrows away the
+     * confirmation-pending branch of the result union.
+     */
+    async function runExecute(
+      tool: ExecuteTool,
+      args: Record<string, unknown>,
+    ): Promise<ExecuteResult> {
+      const res = await tool.runAsync({args, toolContext: confirmedContext()});
+      if (!('status' in res)) {
+        throw new Error('Execute unexpectedly paused for confirmation.');
+      }
+      return res;
+    }
+
     it('executes successfully', async () => {
       const tool = new ExecuteTool({workingDir: tmpDir});
       expect(tool._getDeclaration()).toBeDefined();
 
-      let res: any = await tool.runAsync({args: {}, toolContext: {} as any});
-      expect(res.status).toBe('error');
+      const missingArgs = await runExecute(tool, {});
+      expect(missingArgs.status).toBe('error');
 
-      res = await tool.runAsync({
-        args: {command: 'echo test && echo err >&2'},
-        toolContext: {} as any,
+      const res = await runExecute(tool, {
+        command: 'echo test && echo err >&2',
       });
       expect(res.status).toBe('ok');
-      expect(normalizeShellOutput(res.stdout)).toBe('test\n');
-      expect(normalizeShellOutput(res.stderr)).toBe('err\n');
+      expect(normalizeShellOutput(res.stdout ?? '')).toBe('test\n');
+      expect(normalizeShellOutput(res.stderr ?? '')).toBe('err\n');
     });
 
     it('reports failure on nonzero exit code with stdout/err', async () => {
       const tool = new ExecuteTool({workingDir: tmpDir});
-      const res: any = await tool.runAsync({
-        args: {command: 'echo out && echo err >&2 && exit 10'},
-        toolContext: {} as any,
+      const res = await runExecute(tool, {
+        command: 'echo out && echo err >&2 && exit 10',
       });
       expect(res.status).toBe('error');
       expect(res.exit_code).toBe(10);
-      expect(normalizeShellOutput(res.stdout)).toBe('out\n');
-      expect(normalizeShellOutput(res.stderr)).toBe('err\n');
+      expect(normalizeShellOutput(res.stdout ?? '')).toBe('out\n');
+      expect(normalizeShellOutput(res.stderr ?? '')).toBe('err\n');
     });
 
     it('reports timeout', async () => {
       const tool = new ExecuteTool({workingDir: tmpDir, executeTimeoutMs: 100});
-      const res: any = await tool.runAsync({
-        args: {command: 'sleep 1'},
-        toolContext: {} as any,
-      });
+      const res = await runExecute(tool, {command: 'sleep 1'});
       expect(res.status).toBe('error');
       expect(res.error).toMatch(/timed out/i);
     });
 
     it('handles spawn errors and includes stdout/stderr on exit code', async () => {
       const tool = new ExecuteTool({workingDir: tmpDir});
-      const res: any = await tool.runAsync({
-        args: {command: 'non_existent_command_123'},
-        toolContext: {} as any,
-      });
+      const res = await runExecute(tool, {command: 'non_existent_command_123'});
       expect(res.status).toBe('error');
+    });
+
+    it('requests confirmation and runs nothing until it is granted', async () => {
+      const tool = new ExecuteTool({workingDir: tmpDir});
+      const toolContext = createContext();
+
+      const res = await tool.runAsync({
+        args: {command: 'echo marker > marker.txt'},
+        toolContext,
+      });
+
+      expect(res).toEqual({partial: REQUIRE_CONFIRMATION_MESSAGE});
+      expect(
+        toolContext.actions.requestedToolConfirmations[FUNCTION_CALL_ID],
+      ).toBeDefined();
+      await expect(
+        fs.access(path.join(tmpDir, 'marker.txt')),
+      ).rejects.toThrowError();
+    });
+
+    it('refuses to run when the confirmation was rejected', async () => {
+      const tool = new ExecuteTool({workingDir: tmpDir});
+      const res = await tool.runAsync({
+        args: {command: 'echo marker > marker.txt'},
+        toolContext: createContext(new ToolConfirmation({confirmed: false})),
+      });
+
+      expect(res).toEqual({
+        status: 'error',
+        error: 'Command execution was not confirmed and was rejected.',
+      });
+      await expect(
+        fs.access(path.join(tmpDir, 'marker.txt')),
+      ).rejects.toThrowError();
     });
   });
 
@@ -113,9 +195,9 @@ describe('Environment Tools Parity', () => {
       const tool = new WriteFileTool({workingDir: tmpDir});
       expect(tool._getDeclaration()).toBeDefined();
 
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'test.txt', content: 'hello'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('ok');
       const content = await fs.readFile(path.join(tmpDir, 'test.txt'), 'utf8');
@@ -124,34 +206,37 @@ describe('Environment Tools Parity', () => {
 
     it('fails if path invalid', async () => {
       const tool = new WriteFileTool({workingDir: tmpDir});
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: '../test.txt', content: 'hello'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('error');
     });
 
     it('fails on missing arguments', async () => {
       const tool = new WriteFileTool({workingDir: tmpDir});
-      let res: any = await tool.runAsync({args: {}, toolContext: {} as any});
-      expect(res.status).toBe('error');
-      expect(res.error).toContain('path');
-
-      res = await tool.runAsync({
-        args: {path: 'test.txt'},
-        toolContext: {} as any,
+      const missingPath = await tool.runAsync({
+        args: {},
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
-      expect(res.error).toContain('content');
+      expect(missingPath.status).toBe('error');
+      expect(missingPath.error).toContain('path');
+
+      const missingContent = await tool.runAsync({
+        args: {path: 'test.txt'},
+        toolContext: createContext(),
+      });
+      expect(missingContent.status).toBe('error');
+      expect(missingContent.error).toContain('content');
     });
 
     it('handles write errors', async () => {
       const tool = new WriteFileTool({
         workingDir: '/invalid/path/that/does_not_exist',
       });
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'test.txt', content: 'hello'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('error');
     });
@@ -170,9 +255,9 @@ describe('Environment Tools Parity', () => {
       const tool = new ReadFileTool({workingDir: tmpDir});
       expect(tool._getDeclaration()).toBeDefined();
 
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'lines.txt'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('ok');
       expect(res.content).toContain('1\tline1\n');
@@ -181,62 +266,68 @@ describe('Environment Tools Parity', () => {
 
     it('reads specific lines', async () => {
       const tool = new ReadFileTool({workingDir: tmpDir});
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'lines.txt', start_line: 2, end_line: 3},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('ok');
-      expect(res.content.trim()).toBe('2\tline2\n     3\tline3'.trim());
+      expect((res.content ?? '').trim()).toBe('2\tline2\n     3\tline3'.trim());
       expect(res.total_lines).toBe(4);
     });
 
     it('handles out of bounds', async () => {
       const tool = new ReadFileTool({workingDir: tmpDir});
-      let res: any = await tool.runAsync({
+      const pastEnd = await tool.runAsync({
         args: {path: 'lines.txt', start_line: 10},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
-      expect(res.total_lines).toBe(4);
+      expect(pastEnd.status).toBe('error');
+      expect(pastEnd.total_lines).toBe(4);
 
-      res = await tool.runAsync({
+      const inverted = await tool.runAsync({
         args: {path: 'lines.txt', start_line: 2, end_line: 1},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
+      expect(inverted.status).toBe('error');
     });
 
     it('fails if path invalid or missing', async () => {
       const tool = new ReadFileTool({workingDir: tmpDir});
-      let res: any = await tool.runAsync({args: {}, toolContext: {} as any});
-      expect(res.status).toBe('error');
-
-      res = await tool.runAsync({
-        args: {path: '../escape'},
-        toolContext: {} as any,
+      const missingPath = await tool.runAsync({
+        args: {},
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
+      expect(missingPath.status).toBe('error');
+
+      const escaping = await tool.runAsync({
+        args: {path: '../escape'},
+        toolContext: createContext(),
+      });
+      expect(escaping.status).toBe('error');
     });
 
     it('fails if file not found or read error', async () => {
       const tool = new ReadFileTool({workingDir: tmpDir});
-      let res: any = await tool.runAsync({
+      const notFound = await tool.runAsync({
         args: {path: 'notfound.txt'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
-      expect(res.error).toContain('File not found');
+      expect(notFound.status).toBe('error');
+      expect(notFound.error).toContain('File not found');
 
       // non-ENOENT error (like EISDIR)
-      res = await tool.runAsync({args: {path: '.'}, toolContext: {} as any});
-      expect(res.status).toBe('error');
+      const directory = await tool.runAsync({
+        args: {path: '.'},
+        toolContext: createContext(),
+      });
+      expect(directory.status).toBe('error');
     });
 
     it('validates args', async () => {
       const tool = new ReadFileTool({workingDir: tmpDir});
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'lines.txt', start_line: 'not_number'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('error');
       expect(res.error).toContain('integer');
@@ -256,9 +347,9 @@ describe('Environment Tools Parity', () => {
       const tool = new EditFileTool({workingDir: tmpDir});
       expect(tool._getDeclaration()).toBeDefined();
 
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'edit.txt', old_string: 'world', new_string: 'mars'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('ok');
 
@@ -267,11 +358,71 @@ describe('Environment Tools Parity', () => {
       expect(content).toContain('universe');
     });
 
+    it('matches old_string literally rather than as a regex', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'meta.txt'),
+        'value = compute(a.b)\n',
+        'utf8',
+      );
+      const tool = new EditFileTool({workingDir: tmpDir});
+      const res = await tool.runAsync({
+        args: {
+          path: 'meta.txt',
+          old_string: 'compute(a.b)',
+          new_string: 'compute(c)',
+        },
+        toolContext: createContext(),
+      });
+      expect(res.status).toBe('ok');
+      expect(await fs.readFile(path.join(tmpDir, 'meta.txt'), 'utf8')).toBe(
+        'value = compute(c)\n',
+      );
+    });
+
+    it('does not edit text that only matches when metacharacters are live', async () => {
+      await fs.writeFile(path.join(tmpDir, 'meta.txt'), 'axb\n', 'utf8');
+      const tool = new EditFileTool({workingDir: tmpDir});
+      const res = await tool.runAsync({
+        args: {path: 'meta.txt', old_string: 'a.b', new_string: 'zzz'},
+        toolContext: createContext(),
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('not found');
+      expect(await fs.readFile(path.join(tmpDir, 'meta.txt'), 'utf8')).toBe(
+        'axb\n',
+      );
+    });
+
+    it('reports an unbalanced old_string as a missing match, not a crash', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+      const res = await tool.runAsync({
+        args: {path: 'edit.txt', old_string: 'foo(bar', new_string: 'x'},
+        toolContext: createContext(),
+      });
+      expect(res.status).toBe('error');
+      expect(res.error).toContain('not found');
+    });
+
+    it('inserts new_string literally when it contains $ patterns', async () => {
+      const tool = new EditFileTool({workingDir: tmpDir});
+      const res = await tool.runAsync({
+        args: {
+          path: 'edit.txt',
+          old_string: 'world',
+          new_string: 'cost is $& dollars',
+        },
+        toolContext: createContext(),
+      });
+      expect(res.status).toBe('ok');
+      const content = await fs.readFile(path.join(tmpDir, 'edit.txt'), 'utf8');
+      expect(content).toContain('hello cost is $& dollars');
+    });
+
     it('fails if non-unique match', async () => {
       const tool = new EditFileTool({workingDir: tmpDir});
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'edit.txt', old_string: 'hello', new_string: 'hi'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('error');
       expect(res.error).toContain('appears 2 times');
@@ -279,9 +430,9 @@ describe('Environment Tools Parity', () => {
 
     it('fails if zero matches', async () => {
       const tool = new EditFileTool({workingDir: tmpDir});
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'edit.txt', old_string: 'notfound', new_string: 'hi'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('error');
       expect(res.error).toContain('not found');
@@ -289,43 +440,46 @@ describe('Environment Tools Parity', () => {
 
     it('validates args', async () => {
       const tool = new EditFileTool({workingDir: tmpDir});
-      let res: any = await tool.runAsync({
+      const emptyOldString = await tool.runAsync({
         args: {path: 'edit.txt', old_string: '', new_string: 'hi'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
-      expect(res.error).toContain('cannot be empty');
+      expect(emptyOldString.status).toBe('error');
+      expect(emptyOldString.error).toContain('cannot be empty');
 
-      res = await tool.runAsync({args: {}, toolContext: {} as any});
-      expect(res.status).toBe('error');
+      const noArgs = await tool.runAsync({
+        args: {},
+        toolContext: createContext(),
+      });
+      expect(noArgs.status).toBe('error');
 
-      res = await tool.runAsync({
+      const missingNewString = await tool.runAsync({
         args: {path: 'edit.txt', old_string: 'hello'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
+      expect(missingNewString.status).toBe('error');
     });
 
     it('fails if path invalid or file does not exist', async () => {
       const tool = new EditFileTool({workingDir: tmpDir});
-      let res: any = await tool.runAsync({
+      const escaping = await tool.runAsync({
         args: {path: '../escape', old_string: 'h', new_string: 'b'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
+      expect(escaping.status).toBe('error');
 
-      res = await tool.runAsync({
+      const missingFile = await tool.runAsync({
         args: {path: 'missing.txt', old_string: 'h', new_string: 'b'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
-      expect(res.error).toContain('File not found');
+      expect(missingFile.status).toBe('error');
+      expect(missingFile.error).toContain('File not found');
 
-      res = await tool.runAsync({
+      const directory = await tool.runAsync({
         args: {path: '.', old_string: 'h', new_string: 'b'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
-      expect(res.status).toBe('error');
+      expect(directory.status).toBe('error');
     });
 
     it('handles write errors', async () => {
@@ -334,9 +488,9 @@ describe('Environment Tools Parity', () => {
       // We need to trigger an error writing to an existing file.
       // We can make the file read-only!
       await fs.chmod(path.join(tmpDir, 'edit.txt'), 0o444);
-      const res: any = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {path: 'edit.txt', old_string: 'world', new_string: 'mars'},
-        toolContext: {} as any,
+        toolContext: createContext(),
       });
       expect(res.status).toBe('error');
     });
@@ -349,19 +503,18 @@ describe('Environment Tools Parity', () => {
       expect(tools.length).toBe(4);
       expect(tools.some((t) => t.name === 'Execute')).toBe(true);
 
-      const request: any = {
+      // `appendInstructions` writes through to `config.systemInstruction`, so
+      // the injected instruction is observable on the request itself.
+      const request: LlmRequest = {
         config: {},
         toolsDict: {},
         contents: [],
+        liveConnectConfig: {},
       };
-      const appendInstructionsSpy = vi.fn();
 
-      // Override or mock it? No, wait! `appendInstructions` is a utility method imported by the toolset.
-      // Wait, let's just observe if the config is updated! The actual `appendInstructions` method updates llmRequest.config.systemInstruction.
-
-      await set.processLlmRequest({} as any, request);
-      expect(request.config.systemInstruction).toContain('Environment Rules');
-      expect(request.config.systemInstruction).toContain(tmpDir);
+      await set.processLlmRequest(createContext(), request);
+      expect(request.config?.systemInstruction).toContain('Environment Rules');
+      expect(request.config?.systemInstruction).toContain(tmpDir);
     });
 
     it('returns filtered and unfiltered tools', async () => {
@@ -372,7 +525,7 @@ describe('Environment Tools Parity', () => {
       let tools = await set.getTools(); // no context, unfiltered
       expect(tools.length).toBeGreaterThan(1);
 
-      tools = await set.getTools({} as any); // filtered
+      tools = await set.getTools(createContext()); // filtered
       expect(tools.length).toBe(1);
       expect(tools[0].name).toBe('Execute');
     });

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -183,7 +183,13 @@ export class AgentFile {
       const moduleType =
         this.options.moduleType || (await getFileModuleType(filePath));
       const parsedPath = path.parse(filePath);
-      const outputDir = await createTempDir('adk_agent_loader');
+      // Emit the bundle inside the agent project (rather than the OS temp
+      // directory) so that dependencies hoisted above the agent directory
+      // still resolve from the compiled output.
+      const outputDir = await createTempDir(
+        'adk_agent_loader',
+        path.join(parsedPath.dir, '.adk_build_cache'),
+      );
       const compiledFilePath = path.join(
         outputDir,
         parsedPath.name + FILE_MODULE_TYPE_EXTENSION_MAP[moduleType],

--- a/dev/src/utils/file_utils.ts
+++ b/dev/src/utils/file_utils.ts
@@ -116,18 +116,33 @@ export async function saveToFile<T>(filePath: string, data: T): Promise<void> {
 /**
  * Atomically creates a private temporary directory and returns its path.
  *
- * The directory is created by a single `mkdtemp` call directly under the system
- * temp root, with a random name and, on POSIX, mode 0700. Composing the path
- * from a fixed prefix and materialising it later with a recursive `mkdir` would
- * leave a predictable intermediate directory that another local user can
- * pre-create or replace with a symlink, placing everything written afterwards
- * under their control.
+ * The directory is created by a single `mkdtemp` call with a random name and,
+ * on POSIX, mode 0700. Composing the path from a fixed prefix and materialising
+ * it later with a recursive `mkdir` would leave a predictable intermediate
+ * directory that another local user can pre-create or replace with a symlink,
+ * placing everything written afterwards under their control.
+ *
+ * By default the directory is created directly under the system temp root. Pass
+ * `baseDir` to create it under a different parent instead -- for example inside
+ * an agent project so that dependencies hoisted above the agent directory still
+ * resolve from the compiled output. `baseDir` is created first (recursively) if
+ * it does not exist; the random leaf is still created atomically with `mkdtemp`.
  *
  * @param prefix Name prefix for the directory. Must be a single path segment.
+ * @param baseDir Optional parent directory. Defaults to the OS temp directory.
  * @returns The absolute path of the newly created directory.
  */
-export async function createTempDir(prefix: string): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+export async function createTempDir(
+  prefix: string,
+  baseDir?: string,
+): Promise<string> {
+  const parent = baseDir ?? os.tmpdir();
+
+  if (baseDir) {
+    await fs.mkdir(baseDir, {recursive: true});
+  }
+
+  return fs.mkdtemp(path.join(parent, `${prefix}-`));
 }
 
 /**

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -331,7 +331,10 @@ describe('AgentLoader', () => {
       const agentFile = new AgentFile(agentPath);
       await agentFile.load();
 
-      expect(fileUtils.createTempDir).toHaveBeenCalledWith('adk_agent_loader');
+      expect(fileUtils.createTempDir).toHaveBeenCalledWith(
+        'adk_agent_loader',
+        path.join(tempAgentsDir, '.adk_build_cache'),
+      );
       expect(
         (esbuild.build as Mock).mock.calls[0][0].allowOverwrite,
       ).toBeUndefined();


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A — no existing issue tracks this work.

**2. Or, if no issue exists, describe the change:**

**Problem:**
The JS variant of ADK lacks parity with the `adk-python` environment tools, missing
necessary functionality for agent local file manipulation and shell execution.

**Solution:**
Added Node.js parity environment tools (`ExecuteTool`, `ReadFileTool`,
`WriteFileTool`, `EditFileTool`) and a bundled `EnvironmentToolset` in
`core/src/tools/environment/`. The toolset also injects the
`ENVIRONMENT_INSTRUCTION` into the LLM system requests for bounded contextual
usage.

**One deliberate deviation from `adk-python`, please read:**
`ExecuteTool` requires an explicit tool confirmation before it runs a command.
`adk-python`'s execute tool has no such gate, but it also does not run anything
itself: it delegates to `BaseEnvironment.execute()`, so "run on the host" is one
backend an embedder selects. This port collapses that seam into a hardcoded
`child_process` implementation behind `workingDir: string`, which makes host
execution the only option — a model-authored string becomes arbitrary code
execution on the machine running the agent, and `cwd` is not a boundary. The gate
uses the same mechanism `RunSkillInlineScriptTool` already uses on `main` for
model-provided scripts. Restoring the `BaseEnvironment` seam would be the better
long-term answer and is a reasonable follow-up.

All four tool classes carry `@experimental`, matching `adk-python` and reflecting
that they became public API here via `core/src/common.ts` and `core/src/index.ts`.
Each tool exports its result type (`ExecuteResult`, `ReadFileResult`,
`WriteFileResult`, `EditFileResult`) rather than returning the base class's
`Promise<unknown>`.

There are no `any`, `as any`, `eslint-disable`, `@ts-ignore` or `@ts-expect-error`
uses anywhere in this diff, in `src/` or in the tests.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `core/test/tools/environment/tools_test.ts`, covering boundaries across
reading, writing, editing and shell execution, plus the confirmation gate and
literal-text matching in `EditFile`. Local run:

```
$ npx vitest run --project unit:core core/test/tools/environment/tools_test.ts

 ✓ |unit:core| core/test/tools/environment/tools_test.ts (32 tests) 216ms

 Test Files  1 passed (1)
      Tests  32 passed (32)
```

**Manual End-to-End (E2E) Tests:**

1. Build the workspace with `npm run build`.
2. Run `npx vitest run --project unit:core core/test/tools/environment/tools_test.ts`
   to exercise the tools against a temporary working directory.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

`resolveAndValidatePath` performs a **lexical** containment check. It rejects `..`
and absolute-path arguments, but `path.resolve`/`path.relative` never touch the
filesystem, so a symlink inside `workingDir` that points elsewhere still resolves
through. That is intentional — reading through symlinks is necessary for real
workspace layouts such as the package links npm creates under `node_modules` — and
the docstring says so explicitly. It is not a sandbox; callers who need one should
point the tools at an isolated filesystem.

This branch also carries one small, independent fix commit:
`fix(dev): output agent bundle in project .adk_build_cache for hoisted dependencies`,
which changes `dev/src/utils/agent_loader.ts` to emit the compiled agent bundle into
a project-local `.adk_build_cache` directory instead of the system temp directory, so
that hoisted `node_modules` dependencies resolve correctly. Happy to split this into a
separate PR if reviewers prefer.
