### PR TITLE
Feat: support clone() for RoutedAgent (Part 2/2)

### DIFF
--- a/core/src/agents/routed_agent.ts
+++ b/core/src/agents/routed_agent.ts
@@ -61,11 +61,10 @@ export interface RoutedAgentConfig extends BaseAgentConfig {
  * Routing is strictly limited to the agents passed in the config.
  *
  * @remarks
- * The inherited {@link BaseAgent.clone} does not support `RoutedAgent`: the
- * constructor derives its routing targets from `config.agents` (not
- * `subAgents`), so a rebuilt clone re-reads the already-parented originals and
- * throws. Cloning a `RoutedAgent` is tracked as a follow-up to
- * google/adk-js#534.
+ * Cloning is supported: {@link RoutedAgent.clone} deep-clones the routing
+ * targets from `config.agents` and re-parents the fresh copies onto the clone,
+ * so the clone is a detached root that routes identically to the original while
+ * leaving the original agent tree untouched.
  */
 @experimental
 export class RoutedAgent extends BaseAgent<RoutedAgentConfig> {
@@ -95,6 +94,30 @@ export class RoutedAgent extends BaseAgent<RoutedAgentConfig> {
   }
 
   /**
+   * Creates a detached copy of this routed agent.
+   *
+   * The inherited {@link BaseAgent.clone} only deep-clones `subAgents`, but a
+   * `RoutedAgent` derives its routing targets from `config.agents`. Rebuilding
+   * through the base clone alone would re-read the already-parented original
+   * agents and throw "already has a parent agent". This override deep-clones the
+   * routing targets (unless the caller overrides `agents`) so the rebuilt
+   * constructor re-parents fresh, detached copies. The array-vs-record shape
+   * and, for records, the keys are preserved so the router keeps selecting the
+   * same targets.
+   *
+   * @param overrides Config fields to override on the clone. Overriding
+   *     `parentAgent` is rejected by the base implementation.
+   * @returns A new detached `RoutedAgent` of the same concrete class.
+   */
+  override clone(overrides?: Partial<RoutedAgentConfig>): this {
+    const nextOverrides: Partial<RoutedAgentConfig> = {...overrides};
+    if (!('agents' in nextOverrides)) {
+      nextOverrides.agents = cloneRoutingTargets(this.config.agents);
+    }
+    return super.clone(nextOverrides);
+  }
+
+  /**
    * Runs the selected agent via text-based conversation.
    */
   protected async *runAsyncImpl(
@@ -115,4 +138,21 @@ export class RoutedAgent extends BaseAgent<RoutedAgentConfig> {
       agent.runLive(context),
     );
   }
+}
+
+/**
+ * Deep-clones a RoutedAgent's routing targets, preserving whether they were
+ * supplied as an array or a keyed record so the rebuilt constructor derives the
+ * same routing map. Each clone is detached (no parent), so the constructor can
+ * re-parent it without conflict.
+ */
+function cloneRoutingTargets(
+  agents: Readonly<Record<string, BaseAgent>> | BaseAgent[],
+): Readonly<Record<string, BaseAgent>> | BaseAgent[] {
+  if (Array.isArray(agents)) {
+    return agents.map((agent) => agent.clone());
+  }
+  return Object.fromEntries(
+    Object.entries(agents).map(([key, agent]) => [key, agent.clone()]),
+  );
 }

--- a/core/test/agents/base_agent_test.ts
+++ b/core/test/agents/base_agent_test.ts
@@ -13,7 +13,6 @@ import {
   InvocationContext,
   LlmAgent,
   PluginManager,
-  RoutedAgent,
   Session,
   createEvent,
 } from '@google/adk';
@@ -299,19 +298,6 @@ describe('BaseAgent', () => {
       expect(clone).toBeInstanceOf(MockAgent);
       expect(clone.name).toBe('mock');
       expect(clone.description).toBe('a mock');
-    });
-
-    it('does not support cloning a RoutedAgent (documented limitation)', () => {
-      const target = new LlmAgent({name: 'target'});
-      const routed = new RoutedAgent({
-        name: 'router',
-        agents: [target],
-        router: () => 'target',
-      });
-
-      // The constructor re-derives routing targets from the already-parented
-      // originals, so the rebuilt clone throws. Tracked as a follow-up.
-      expect(() => routed.clone()).toThrow('already has a parent agent');
     });
   });
 });

--- a/core/test/agents/routed_agent_test.ts
+++ b/core/test/agents/routed_agent_test.ts
@@ -6,9 +6,11 @@
 
 import {
   BaseAgent,
+  BaseAgentConfig,
   Event,
   InvocationContext,
   InvocationContextParams,
+  LlmAgent,
   RoutedAgent,
   Session,
   createEvent,
@@ -474,6 +476,166 @@ describe('RoutedAgent', () => {
 
     expect(result.value?.author).toBe('agent-success');
     expect(routerCalls).toBe(2);
+  });
+
+  describe('clone', () => {
+    // A clone-compatible mock: unlike the top-level `MockAgent` (whose
+    // constructor takes a bare `name`), this accepts a config object, so
+    // `BaseAgent.clone()` can rebuild it via `new ctor(config)`. It yields a
+    // deterministic event so routing can be verified without a model.
+    class CloneableAgent extends BaseAgent {
+      constructor(config: BaseAgentConfig) {
+        super(config);
+      }
+
+      protected async *runAsyncImpl(
+        context: InvocationContext,
+      ): AsyncGenerator<Event, void, void> {
+        yield createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          branch: context.branch,
+          content: {
+            role: 'model',
+            parts: [{text: `Response from ${this.name}`}],
+          },
+        });
+      }
+
+      protected async *runLiveImpl(
+        _context: InvocationContext,
+      ): AsyncGenerator<Event, void, void> {}
+    }
+
+    it('deep-clones and re-parents array-form routing targets (detached root)', () => {
+      const agentA = new CloneableAgent({name: 'agent-a'});
+      const agentB = new CloneableAgent({name: 'agent-b'});
+      const original = new RoutedAgent({
+        name: 'router',
+        agents: [agentA, agentB],
+        router: () => 'agent-a',
+      });
+
+      const clone = original.clone();
+
+      expect(clone).not.toBe(original);
+      expect(clone).toBeInstanceOf(RoutedAgent);
+      expect(clone.parentAgent).toBeUndefined();
+      expect(clone.subAgents).toHaveLength(2);
+      clone.subAgents.forEach((sub, i) => {
+        expect(sub).not.toBe(original.subAgents[i]);
+        expect(sub).toBeInstanceOf(CloneableAgent);
+        expect(sub.name).toBe(original.subAgents[i].name);
+        expect(sub.parentAgent).toBe(clone);
+      });
+      expect(clone.subAgents.map((s) => s.name)).toEqual([
+        'agent-a',
+        'agent-b',
+      ]);
+
+      // The originals are left untouched: still parented to the original router.
+      expect(agentA.parentAgent).toBe(original);
+      expect(agentB.parentAgent).toBe(original);
+      expect(original.subAgents).toHaveLength(2);
+      expect(original.subAgents[0]).toBe(agentA);
+      expect(original.subAgents[1]).toBe(agentB);
+    });
+
+    it('preserves record keys and routes to the cloned target for the selected key', async () => {
+      const primary = new CloneableAgent({name: 'primary-agent'});
+      const fallback = new CloneableAgent({name: 'fallback-agent'});
+      const original = new RoutedAgent({
+        name: 'router',
+        agents: {primary, fallback},
+        router: () => 'primary',
+      });
+
+      const clone = original.clone();
+
+      // The routing map keeps the record keys and maps them to cloned targets.
+      const routingMap = clone['agents'] as Readonly<Record<string, BaseAgent>>;
+      expect(Object.keys(routingMap)).toEqual(['primary', 'fallback']);
+      expect(routingMap['primary'].name).toBe('primary-agent');
+      expect(routingMap['primary']).not.toBe(primary);
+      expect(routingMap['primary'].parentAgent).toBe(clone);
+
+      // Functionally routes to the cloned primary target.
+      const context = createTestContext({agent: clone});
+      const result = await clone['runAsyncImpl'](context).next();
+      expect(result.value?.author).toBe('primary-agent');
+    });
+
+    it('uses an `agents` override verbatim without cloning it', async () => {
+      const target = new CloneableAgent({name: 'target'});
+      const original = new RoutedAgent({
+        name: 'router',
+        agents: [target],
+        router: () => 'replacement',
+      });
+      const replacement = new CloneableAgent({name: 'replacement'});
+
+      const clone = original.clone({agents: [replacement]});
+
+      expect(clone.subAgents).toHaveLength(1);
+      expect(clone.subAgents[0]).toBe(replacement);
+      expect(replacement.parentAgent).toBe(clone);
+
+      const context = createTestContext({agent: clone});
+      const result = await clone['runAsyncImpl'](context).next();
+      expect(result.value?.author).toBe('replacement');
+    });
+
+    it('applies non-`agents` overrides while still cloning targets', () => {
+      const agentA = new CloneableAgent({name: 'agent-a'});
+      const original = new RoutedAgent({
+        name: 'router',
+        agents: [agentA],
+        router: () => 'agent-a',
+      });
+
+      const clone = original.clone({name: 'router2'});
+
+      expect(clone.name).toBe('router2');
+      expect(original.name).toBe('router');
+      expect(clone.subAgents).toHaveLength(1);
+      expect(clone.subAgents[0]).not.toBe(agentA);
+      expect(clone.subAgents[0].name).toBe('agent-a');
+      expect(clone.subAgents[0].parentAgent).toBe(clone);
+    });
+
+    it('rejects a `parentAgent` override', () => {
+      const agentA = new CloneableAgent({name: 'agent-a'});
+      const original = new RoutedAgent({
+        name: 'router',
+        agents: [agentA],
+        router: () => 'agent-a',
+      });
+      const someParent = new CloneableAgent({name: 'some-parent'});
+
+      expect(() => original.clone({parentAgent: someParent})).toThrow(
+        'Cannot update `parentAgent` field in clone.',
+      );
+    });
+
+    it('clones a RoutedAgent whose targets are real LlmAgents (array form)', () => {
+      const target = new LlmAgent({name: 'target'});
+      const original = new RoutedAgent({
+        name: 'router',
+        agents: [target],
+        router: () => 'target',
+      });
+
+      const clone = original.clone();
+
+      expect(clone).not.toBe(original);
+      expect(clone).toBeInstanceOf(RoutedAgent);
+      expect(clone.parentAgent).toBeUndefined();
+      expect(clone.subAgents[0]).toBeInstanceOf(LlmAgent);
+      expect(clone.subAgents[0]).not.toBe(target);
+      expect(clone.subAgents[0].name).toBe('target');
+      expect(clone.subAgents[0].parentAgent).toBe(clone);
+      expect(target.parentAgent).toBe(original);
+    });
   });
 });
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #534
- Related: #545

> This is Part 2/2 of the agent `clone()` work. Part 1 — #545 (`feat(agents): add
> clone() to BaseAgent`) — is **already merged** into `main`, so this PR is rebased
> directly onto `main` and contains only the `RoutedAgent.clone()` change plus its
> tests.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`BaseAgent.clone()` (added in #545) could not clone a `RoutedAgent`. A
`RoutedAgent` derives its routing targets from `config.agents` (not
`config.subAgents`), and forwards those same instances to `super(...)` purely for
parent tracking. The inherited clone only deep-clones `subAgents`, so it rebuilt
the `RoutedAgent` from the **original, already-parented** target instances, and
the constructor's `setParentAgentForSubAgents()` threw:

```
Agent "target" already has a parent agent, current parent: "router", trying to add: "router"
```

This was previously captured as a documented limitation (a negative test asserting
the throw).

**Solution:**

Add a `RoutedAgent.clone()` override that deep-clones the routing targets from
`this.config.agents` and passes them through the `agents` override, then delegates
everything else to `super.clone()`:

- A private module-level helper `cloneRoutingTargets()` clones each target,
  preserving whether they were supplied as an array or a keyed record (and, for
  records, the keys) so the rebuilt constructor derives the same routing map. Each
  cloned target is detached (`clone()` always sets `parentAgent = undefined`), so
  the rebuilt constructor re-parents fresh copies with no conflict.
- Because `agents` is now present in the overrides, `super.clone()` skips its
  generic list shallow-copy for that field, and the `parentAgent`-override
  rejection plus the detached-root guarantee remain owned by `BaseAgent.clone()`
  (no logic duplicated).

The override deliberately does not juggle `subAgents`: `super.clone()` still runs
its recursive `subAgents` clone once, but those throwaway detached copies are
immediately discarded by the `RoutedAgent` constructor (which rebuilds `subAgents`
from `config.agents`). This is harmless and keeps the override minimal.

The class `@remarks` is updated to document that cloning is now supported. This is
a non-breaking change: a previously-throwing call now succeeds; no public API or
export changes.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added a `describe('clone', ...)` suite in `core/test/agents/routed_agent_test.ts`
covering: array and record forms, deep-clone + re-parenting of targets, originals
left untouched (detached root), functional routing on the clone (record form),
verbatim `agents` override, non-`agents` overrides, `parentAgent`-override
rejection, and a no-mock end-to-end case that clones a `RoutedAgent` whose targets
are real `LlmAgent`s. Removed the obsolete "documented limitation" negative test
(and its now-unused `RoutedAgent` import) from `base_agent_test.ts`.

Command (targeted, per the repo's `unit:core` project):

```
npx vitest run --project unit:core \
  core/test/agents/routed_agent_test.ts \
  core/test/agents/base_agent_test.ts
```

Result: `Test Files 2 passed (2)`, `Tests 37 passed (37)`. New code
(`RoutedAgent.clone()` and `cloneRoutingTargets`) has 100% line and branch
coverage (verified via `--coverage --coverage.include='core/src/agents/routed_agent.ts'`;
the only uncovered branches are pre-existing `runAsync`/`runLive` callback lines).

Additional local validation of the rebased commits, mirroring the `run-tests` job
in `.github/workflows/validation.yaml`:

- `npm run build` — clean (`tsc --emitDeclarationOnly` + bundle, all workspaces).
- `npx secretlint "**/*"` — clean.
- `npm run lint` (eslint) — clean.
- `npm run format:check` (prettier) — clean.
- `npm run docs:check` (typedoc `--treatWarningsAsErrors`) — clean.
- The full `unit:core` project — no failures.

**Manual End-to-End (E2E) Tests:**

Ran the bug-reproduction snippet plus the record-form variant against the built
`@google/adk` package (no mocks); both return a working, detached clone and leave
the originals parented to the original router:

```ts
import {LlmAgent, RoutedAgent} from '@google/adk';

// Array form (the original repro that used to throw):
const target = new LlmAgent({name: 'target'});
const routed = new RoutedAgent({
  name: 'router',
  agents: [target],
  router: () => 'target',
});
const clone = routed.clone();
// clone !== routed, clone instanceof RoutedAgent, clone.parentAgent === undefined,
// clone.subAgents[0] !== target, clone.subAgents[0].parentAgent === clone,
// target.parentAgent === routed (original untouched)

// Record form:
const primary = new LlmAgent({name: 'primary'});
const fallback = new LlmAgent({name: 'fallback'});
const routed2 = new RoutedAgent({
  name: 'router',
  agents: {a: primary, b: fallback},
  router: () => 'a',
});
const clone2 = routed2.clone(); // keys preserved, targets deep-cloned + re-parented, originals untouched
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Part 1 (#545) is already merged, so this PR is a plain, self-contained change
against `main`: it touches only `core/src/agents/routed_agent.ts` and the two
corresponding test files, with no dependency or lockfile changes.
