### PR TITLE
feat(dev): add Origin validation to the dev server (DNS-rebinding defense in depth)

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -123,7 +123,9 @@ const PORT_OPTION = new Option(
 ).default('8000');
 const ORIGINS_OPTION = new Option(
   '--allow_origins <string>',
-  'Optional. The allow origins of the server',
+  'Optional. Comma-separated list of origins allowed to send cross-origin ' +
+    "requests to the server. Each origin's host is also accepted by the " +
+    'DNS-rebinding guard.',
 ).default('');
 const ALLOWED_HOSTS_OPTION = new Option(
   '--allowed_hosts <string>',

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -54,6 +54,7 @@ import {
   getAllowedRequestHosts,
   isDnsRebindingRequest,
 } from './dns_rebinding_guard.js';
+import {createOriginCheckMiddleware, normalizeOrigin} from './origin_check.js';
 import {renderStructureGraphAsDot} from './structure_graph.js';
 
 /**
@@ -126,7 +127,7 @@ export class AdkApiServer {
   private readonly memoryService: BaseMemoryService;
   private readonly artifactService: BaseArtifactService;
   private readonly serveDebugUI: boolean;
-  private readonly allowOrigins?: string;
+  private readonly allowedOrigins: string[];
   private readonly allowedHosts?: string[];
   private readonly otelToCloud: boolean;
   private readonly registerProcessors?: (
@@ -158,7 +159,14 @@ export class AdkApiServer {
         options.reloadAgents ?? false,
       );
     this.serveDebugUI = options.serveDebugUI ?? false;
-    this.allowOrigins = options.allowOrigins;
+    // A browser sends one Origin per request, so a comma-separated
+    // `--allow_origins` must become a list: `cors` never matches the joined
+    // string, and the DNS-rebinding guard reads only its first host from it.
+    this.allowedOrigins = (options.allowOrigins ?? '')
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0)
+      .map(normalizeOrigin);
     this.allowedHosts = options.allowedHosts;
     this.otelToCloud = options.otelToCloud ?? false;
     this.registerProcessors = options.registerProcessors;
@@ -229,6 +237,22 @@ export class AdkApiServer {
     }
   }
 
+  /**
+   * The hosts of every configured origin, so the DNS-rebinding guard vouches
+   * for each one. Naming an origin in `--allow_origins` vouches for its host.
+   */
+  private allowOriginHosts(): string[] {
+    return this.allowedOrigins
+      .map((origin) => {
+        try {
+          return new URL(origin).hostname;
+        } catch {
+          return '';
+        }
+      })
+      .filter((host) => host.length > 0);
+  }
+
   private async init() {
     const app = this.app;
     await this.setupTelemetry();
@@ -240,8 +264,8 @@ export class AdkApiServer {
     // omits Origin for them, so safe methods (GET/HEAD/OPTIONS) get the
     // same check as everything else.
     const allowedRequestHosts = getAllowedRequestHosts(
-      this.allowOrigins,
-      this.allowedHosts,
+      this.allowedOrigins.includes('*') ? '*' : undefined,
+      [...this.allowOriginHosts(), ...(this.allowedHosts ?? [])],
     );
     app.use((req: Request, res: Response, next: express.NextFunction) => {
       if (
@@ -261,6 +285,22 @@ export class AdkApiServer {
       }
       next();
     });
+
+    // The Origin gate covers cross-origin state-changing requests, which the
+    // Host guard above does not. Registered before the CORS block so a rejected
+    // origin never receives Access-Control-Allow-Origin headers.
+    app.use(createOriginCheckMiddleware(this.allowedOrigins, this.logger));
+
+    // Registered before any route so that /, /health, /dev-ui and /version all
+    // carry CORS headers, not only the routes declared further down.
+    if (this.allowedOrigins.length > 0) {
+      app.use(
+        cors({
+          // `cors` only emits the wildcard header for the literal '*' string.
+          origin: this.allowedOrigins.includes('*') ? '*' : this.allowedOrigins,
+        }),
+      );
+    }
 
     if (this.serveDebugUI) {
       app.get('/', (req: Request, res: Response) => {
@@ -288,14 +328,6 @@ export class AdkApiServer {
     app.get('/version', (req: Request, res: Response) => {
       res.status(200).json({version});
     });
-
-    if (this.allowOrigins) {
-      app.use(
-        cors({
-          origin: this.allowOrigins!,
-        }),
-      );
-    }
 
     app.use(
       express.json({

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -35,6 +35,7 @@ import * as path from 'node:path';
 import {version} from '../version.js';
 
 import {AgentFileOptions, AgentLoader} from '../utils/agent_loader.js';
+import {formatHeaderForLog} from '../utils/log_utils.js';
 import {AdkLogger} from '../utils/logger.js';
 import {
   ApiServerSpanExporter,
@@ -54,7 +55,10 @@ import {
   getAllowedRequestHosts,
   isDnsRebindingRequest,
 } from './dns_rebinding_guard.js';
-import {createOriginCheckMiddleware, normalizeOrigin} from './origin_check.js';
+import {
+  createOriginCheckMiddleware,
+  parseAllowedOrigins,
+} from './origin_check.js';
 import {renderStructureGraphAsDot} from './structure_graph.js';
 
 /**
@@ -74,6 +78,13 @@ interface ServerOptions {
   agentLoader?: AgentLoader;
   agentFileLoadOptions?: AgentFileOptions;
   serveDebugUI?: boolean;
+  /**
+   * Comma-separated list of origins allowed to send cross-origin requests.
+   * More than a CORS header: an entry both allows that origin at the request
+   * gate and adds its host to the DNS-rebinding allowlist. Each entry must be
+   * an `http://` or `https://` origin; a scheme-less entry is dropped with a
+   * warning. `'*'` allows every origin and disables the DNS-rebinding guard.
+   */
   allowOrigins?: string;
   /**
    * Additional Host header values the DNS-rebinding guard accepts besides
@@ -162,11 +173,9 @@ export class AdkApiServer {
     // A browser sends one Origin per request, so a comma-separated
     // `--allow_origins` must become a list: `cors` never matches the joined
     // string, and the DNS-rebinding guard reads only its first host from it.
-    this.allowedOrigins = (options.allowOrigins ?? '')
-      .split(',')
-      .map((origin) => origin.trim())
-      .filter((origin) => origin.length > 0)
-      .map(normalizeOrigin);
+    const {origins: allowedOrigins, rejected: rejectedOrigins} =
+      parseAllowedOrigins(options.allowOrigins);
+    this.allowedOrigins = allowedOrigins;
     this.allowedHosts = options.allowedHosts;
     this.otelToCloud = options.otelToCloud ?? false;
     this.registerProcessors = options.registerProcessors;
@@ -182,6 +191,12 @@ export class AdkApiServer {
         },
       });
     this.logger.setLogLevel(options.logLevel ?? LogLevel.INFO);
+    for (const rejected of rejectedOrigins) {
+      this.logger.warn(
+        `Ignoring --allow_origins entry ${formatHeaderForLog(rejected)}: ` +
+          'only http:// and https:// origins are allowed.',
+      );
+    }
     this.a2a = options.a2a ?? false;
     // An exported-but-empty value means "no token"; anything else is handed
     // to the authenticator, which rejects a token that is not usable.
@@ -237,22 +252,6 @@ export class AdkApiServer {
     }
   }
 
-  /**
-   * The hosts of every configured origin, so the DNS-rebinding guard vouches
-   * for each one. Naming an origin in `--allow_origins` vouches for its host.
-   */
-  private allowOriginHosts(): string[] {
-    return this.allowedOrigins
-      .map((origin) => {
-        try {
-          return new URL(origin).hostname;
-        } catch {
-          return '';
-        }
-      })
-      .filter((host) => host.length > 0);
-  }
-
   private async init() {
     const app = this.app;
     await this.setupTelemetry();
@@ -264,15 +263,15 @@ export class AdkApiServer {
     // omits Origin for them, so safe methods (GET/HEAD/OPTIONS) get the
     // same check as everything else.
     const allowedRequestHosts = getAllowedRequestHosts(
-      this.allowedOrigins.includes('*') ? '*' : undefined,
-      [...this.allowOriginHosts(), ...(this.allowedHosts ?? [])],
+      this.allowedOrigins,
+      this.allowedHosts,
     );
     app.use((req: Request, res: Response, next: express.NextFunction) => {
       if (
         isDnsRebindingRequest(req.headers.host, this.host, allowedRequestHosts)
       ) {
         this.logger.warn(
-          `Rejected request with Host ${JSON.stringify(String(req.headers.host).slice(0, 128))}: the server is bound to ` +
+          `Rejected request with Host ${formatHeaderForLog(req.headers.host)}: the server is bound to ` +
             `${this.host} and only loopback hosts are accepted. Set the ` +
             `allowedHosts server option (or --allowed_hosts on the CLI) to ` +
             `the host you are reaching this server through.`,

--- a/dev/src/server/dns_rebinding_guard.ts
+++ b/dev/src/server/dns_rebinding_guard.ts
@@ -78,18 +78,17 @@ export function isLoopbackAddress(host: string): boolean {
  * --allowed_hosts) vouches for any host explicitly listed there -- the
  * latter exists so an embedder behind a proxy can widen the guard without
  * having to open CORS to every origin on the internet just to get a Host
- * header through. Only "*" in allowOrigins opts out of the guard entirely.
+ * header through. Any "*" among *allowOrigins* opts out of the guard entirely.
  */
 export function getAllowedRequestHosts(
-  allowOrigins: string | undefined,
+  allowOrigins: readonly string[],
   extraAllowedHosts?: readonly string[],
 ): Set<string> | null {
-  const origin = (allowOrigins ?? '').trim();
-  if (origin === '*') {
+  if (allowOrigins.includes('*')) {
     return null;
   }
   const hosts = new Set<string>();
-  if (origin) {
+  for (const origin of allowOrigins) {
     try {
       const host = new URL(origin).hostname;
       if (host) {

--- a/dev/src/server/origin_check.ts
+++ b/dev/src/server/origin_check.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Logger} from '@google/adk';
+import {NextFunction, Request, RequestHandler, Response} from 'express';
+import * as http from 'node:http';
+
+/** Methods that cannot change server state and are therefore not origin-checked. */
+const SAFE_HTTP_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+/**
+ * Canonicalizes an `--allow_origins` entry to its origin form, so the gate and
+ * `cors()` compare it against the browser's `Origin` consistently. A browser
+ * sends `http://localhost:4200`, never the `http://localhost:4200/` a user may
+ * type, so a raw string comparison silently never matches. The `*` wildcard and
+ * any non-URL entry pass through unchanged.
+ */
+export function normalizeOrigin(origin: string): string {
+  if (origin === '*') {
+    return origin;
+  }
+  try {
+    return new URL(origin).origin;
+  } catch {
+    return origin;
+  }
+}
+
+/**
+ * Returns true if the `Origin` header is allowed: it is on the allowlist, the
+ * allowlist is the `*` wildcard, or it is same-origin with the request's `Host`.
+ *
+ * Same-origin compares authorities, not full URLs. A TLS-terminating front end
+ * (Cloud Run, ngrok, Codespaces) serves the UI over https while the container
+ * sees a plain-http `Host`, so the scheme differs but the host is identical. The
+ * browser cannot forge `Host`, so a matching authority is a real same-origin
+ * request. Forwarding headers stay ignored, as `X-Forwarded-Host` is
+ * attacker-controlled.
+ */
+export function isRequestOriginAllowed(
+  origin: string,
+  headers: http.IncomingHttpHeaders,
+  allowedOrigins: string[],
+): boolean {
+  if (allowedOrigins.includes('*') || allowedOrigins.includes(origin)) {
+    return true;
+  }
+  if (headers.host === undefined) {
+    return false;
+  }
+  try {
+    return new URL(origin).host === headers.host.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Express middleware rejecting cross-origin state-changing requests. This gate
+ * covers the `Origin` header only; the `Host` header defence against DNS
+ * rebinding lives in `dns_rebinding_guard.ts` and runs on every request.
+ *
+ * A request without an `Origin` (curl, the ADK CLI) is not cross-origin, so it
+ * passes here and is covered by the Host guard instead.
+ */
+export function createOriginCheckMiddleware(
+  allowedOrigins: string[],
+  logger: Logger,
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const origin = req.headers.origin;
+    if (
+      SAFE_HTTP_METHODS.has(req.method) ||
+      origin === undefined ||
+      isRequestOriginAllowed(origin, req.headers, allowedOrigins)
+    ) {
+      return next();
+    }
+    const reason = 'Forbidden: origin not allowed';
+    logger.warn(
+      `${reason}: ${req.method} ${req.originalUrl} (host: ${req.headers.host}, origin: ${req.headers.origin})`,
+    );
+    res.status(403).type('text/plain').send(reason);
+  };
+}

--- a/dev/src/server/origin_check.ts
+++ b/dev/src/server/origin_check.ts
@@ -8,6 +8,8 @@ import {Logger} from '@google/adk';
 import {NextFunction, Request, RequestHandler, Response} from 'express';
 import * as http from 'node:http';
 
+import {formatHeaderForLog} from '../utils/log_utils.js';
+
 /** Methods that cannot change server state and are therefore not origin-checked. */
 const SAFE_HTTP_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
@@ -15,18 +17,60 @@ const SAFE_HTTP_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
  * Canonicalizes an `--allow_origins` entry to its origin form, so the gate and
  * `cors()` compare it against the browser's `Origin` consistently. A browser
  * sends `http://localhost:4200`, never the `http://localhost:4200/` a user may
- * type, so a raw string comparison silently never matches. The `*` wildcard and
- * any non-URL entry pass through unchanged.
+ * type, so a raw string comparison silently never matches. The `*` wildcard is
+ * returned unchanged.
+ *
+ * Returns `null` for anything that is not an `http:`/`https:` URL. A scheme-less
+ * entry like `localhost:4200` parses to the opaque origin `"null"`, so accepting
+ * it would put the literal string `"null"` on the allowlist and grant every
+ * opaque origin: sandboxed iframes, `data:`/`file:` documents, and
+ * cross-origin-redirected requests all send `Origin: null`.
  */
-export function normalizeOrigin(origin: string): string {
+export function normalizeOrigin(origin: string): string | null {
   if (origin === '*') {
     return origin;
   }
+  let url: URL;
   try {
-    return new URL(origin).origin;
+    url = new URL(origin);
   } catch {
-    return origin;
+    return null;
   }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return null;
+  }
+  return url.origin;
+}
+
+/**
+ * Parses a raw `--allow_origins` value into the origins the gate enforces and
+ * the entries dropped as invalid. The value is a comma-separated list because a
+ * browser sends one `Origin` per request, so `cors()` never matches the joined
+ * string and the DNS-rebinding guard reads only its first host from it. Each
+ * entry is canonicalized by {@link normalizeOrigin}; an entry that is neither
+ * `*` nor an `http:`/`https:` URL is dropped, so a scheme-less typo cannot reach
+ * the allowlist. The caller warns on each dropped entry so the typo surfaces at
+ * startup.
+ */
+export function parseAllowedOrigins(raw: string | undefined): {
+  origins: string[];
+  rejected: string[];
+} {
+  const origins: string[] = [];
+  const rejected: string[] = [];
+  for (const entry of (raw ?? '').split(',')) {
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const normalized = normalizeOrigin(trimmed);
+    if (normalized === null) {
+      rejected.push(trimmed);
+    } else {
+      origins.push(normalized);
+    }
+  }
+  return {origins, rejected};
 }
 
 /**
@@ -81,7 +125,9 @@ export function createOriginCheckMiddleware(
     }
     const reason = 'Forbidden: origin not allowed';
     logger.warn(
-      `${reason}: ${req.method} ${req.originalUrl} (host: ${req.headers.host}, origin: ${req.headers.origin})`,
+      `${reason}: ${req.method} ${formatHeaderForLog(req.originalUrl)} ` +
+        `(host: ${formatHeaderForLog(req.headers.host)}, origin: ` +
+        `${formatHeaderForLog(req.headers.origin)})`,
     );
     res.status(403).type('text/plain').send(reason);
   };

--- a/dev/src/utils/log_utils.ts
+++ b/dev/src/utils/log_utils.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Longest header value written to a log line before it is truncated. */
+const MAX_LOGGED_HEADER_LENGTH = 128;
+
+/**
+ * Formats an untrusted request header value for a log line. The value is
+ * coerced to a string, capped at {@link MAX_LOGGED_HEADER_LENGTH} characters,
+ * and quoted with `JSON.stringify` so an injected newline or control character
+ * cannot forge a second log line. The Host guard and the Origin gate both log
+ * through this, so a rejected request reads the same wherever it is refused.
+ */
+export function formatHeaderForLog(value: unknown): string {
+  return JSON.stringify(String(value).slice(0, MAX_LOGGED_HEADER_LENGTH));
+}

--- a/dev/test/server/adk_api_server_origin_check_test.ts
+++ b/dev/test/server/adk_api_server_origin_check_test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LlmAgent} from '@google/adk';
+import * as http from 'node:http';
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {AdkApiServer} from '../../src/server/adk_api_server.js';
+import {AgentLoader} from '../../src/utils/agent_loader.js';
+
+const TEST_AGENT = new LlmAgent({name: 'testAgent', description: 'test agent'});
+
+const AGENT_LOADER = {
+  listAgents: () => Promise.resolve(['testApp']),
+  getAgentFile: () =>
+    Promise.resolve({
+      load: () => Promise.resolve(TEST_AGENT),
+      async [Symbol.asyncDispose](): Promise<void> {
+        return;
+      },
+    }),
+} as unknown as AgentLoader;
+
+interface TestResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+/**
+ * Issues a request with `node:http` rather than `fetch`, because undici
+ * silently drops a caller-supplied `Host` header.
+ */
+function request(
+  port: number,
+  path: string,
+  options: {method?: string; headers?: http.OutgoingHttpHeaders} = {},
+): Promise<TestResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: 'localhost',
+        port,
+        path,
+        method: options.method ?? 'GET',
+        headers: options.headers,
+      },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk: string) => (body += chunk));
+        res.on('end', () =>
+          resolve({status: res.statusCode ?? 0, headers: res.headers, body}),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('AdkApiServer origin validation', () => {
+  let server: AdkApiServer;
+
+  async function startServer(
+    options: {allowOrigins?: string} = {},
+  ): Promise<number> {
+    server = new AdkApiServer({agentLoader: AGENT_LOADER, ...options});
+    await server.start();
+    return Number(new URL(server.url).port);
+  }
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('rejects a state-changing request from a foreign origin', async () => {
+    const port = await startServer();
+
+    const response = await request(port, '/apps/testApp/users/u/sessions', {
+      method: 'POST',
+      headers: {origin: 'http://evil.com'},
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toBe('Forbidden: origin not allowed');
+  });
+
+  it('allows a state-changing request from its own origin', async () => {
+    const port = await startServer();
+
+    const response = await request(port, '/apps/testApp/users/u/sessions', {
+      method: 'POST',
+      headers: {origin: `http://localhost:${port}`},
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it.each([
+    ['http://evil.com', 'http://evil.com'],
+    ['*', '*'],
+    // A comma-separated list used to reach `cors` as one unmatchable string.
+    ['http://other.example, http://evil.com', 'http://evil.com'],
+  ])(
+    'lets a configured origin through and echoes the CORS header for %s',
+    async (allowOrigins, expected) => {
+      const port = await startServer({allowOrigins});
+
+      const response = await request(port, '/apps/testApp/users/u/sessions', {
+        method: 'POST',
+        headers: {origin: 'http://evil.com'},
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers['access-control-allow-origin']).toBe(expected);
+    },
+  );
+
+  it('sends CORS headers on routes declared before the middleware, like /version', async () => {
+    const port = await startServer({allowOrigins: 'http://localhost:4200'});
+
+    const response = await request(port, '/version', {
+      headers: {origin: 'http://localhost:4200'},
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['access-control-allow-origin']).toBe(
+      'http://localhost:4200',
+    );
+  });
+});

--- a/dev/test/server/adk_api_server_origin_check_test.ts
+++ b/dev/test/server/adk_api_server_origin_check_test.ts
@@ -100,6 +100,33 @@ describe('AdkApiServer origin validation', () => {
     expect(response.status).toBe(200);
   });
 
+  it('allows a state-changing request that carries no Origin', async () => {
+    // Compat contract for curl, the ADK CLI and AdkApiClient: a POST with no
+    // Origin is not cross-origin, so the gate must let it through.
+    const port = await startServer();
+
+    const response = await request(port, '/apps/testApp/users/u/sessions', {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('does not allowlist Origin: null from a scheme-less allow_origins entry', async () => {
+    // A scheme-less `--allow_origins localhost:4200` used to normalize to the
+    // opaque "null" origin and grant every `Origin: null` request. The entry is
+    // now dropped, so the opaque origin is refused.
+    const port = await startServer({allowOrigins: 'localhost:4200'});
+
+    const response = await request(port, '/apps/testApp/users/u/sessions', {
+      method: 'POST',
+      headers: {origin: 'null'},
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toBe('Forbidden: origin not allowed');
+  });
+
   it.each([
     ['http://evil.com', 'http://evil.com'],
     ['*', '*'],

--- a/dev/test/server/dns_rebinding_guard_test.ts
+++ b/dev/test/server/dns_rebinding_guard_test.ts
@@ -58,44 +58,58 @@ describe('isLoopbackAddress', () => {
 
 describe('getAllowedRequestHosts', () => {
   it('vouches for the hostname of a real configured origin', () => {
-    const hosts = getAllowedRequestHosts('http://proxy.example');
+    const hosts = getAllowedRequestHosts(['http://proxy.example']);
     expect(hosts).toEqual(new Set(['proxy.example']));
   });
 
+  it('vouches for the hostname of every configured origin', () => {
+    const hosts = getAllowedRequestHosts([
+      'http://proxy.example',
+      'https://ui.example',
+    ]);
+    expect(hosts).toEqual(new Set(['proxy.example', 'ui.example']));
+  });
+
   it('disables the guard entirely for a wildcard origin', () => {
-    expect(getAllowedRequestHosts('*')).toBeNull();
+    expect(getAllowedRequestHosts(['*'])).toBeNull();
+  });
+
+  it('disables the guard when the wildcard appears alongside a real origin', () => {
+    // `--allow_origins 'http://localhost:4200,*'` opts out of the guard: the
+    // wildcard anywhere in the list turns it off, deliberately.
+    expect(getAllowedRequestHosts(['http://localhost:4200', '*'])).toBeNull();
   });
 
   it('vouches for no host on a malformed origin', () => {
-    expect(getAllowedRequestHosts('not a valid url')).toEqual(new Set());
+    expect(getAllowedRequestHosts(['not a valid url'])).toEqual(new Set());
   });
 
-  it('vouches for no host when allowOrigins is unset', () => {
-    expect(getAllowedRequestHosts(undefined)).toEqual(new Set());
+  it('vouches for no host when no origins are configured', () => {
+    expect(getAllowedRequestHosts([])).toEqual(new Set());
   });
 
   it('merges extraAllowedHosts with the origin-derived host', () => {
-    const hosts = getAllowedRequestHosts('http://proxy.example', [
-      'Other.Example',
-      '  padded.example  ',
-    ]);
+    const hosts = getAllowedRequestHosts(
+      ['http://proxy.example'],
+      ['Other.Example', '  padded.example  '],
+    );
     expect(hosts).toEqual(
       new Set(['proxy.example', 'other.example', 'padded.example']),
     );
   });
 
-  it('accepts extraAllowedHosts with no allowOrigins set at all', () => {
-    const hosts = getAllowedRequestHosts(undefined, ['proxy.example']);
+  it('accepts extraAllowedHosts with no origins set at all', () => {
+    const hosts = getAllowedRequestHosts([], ['proxy.example']);
     expect(hosts).toEqual(new Set(['proxy.example']));
   });
 
   it('ignores empty/whitespace-only entries in extraAllowedHosts', () => {
-    const hosts = getAllowedRequestHosts(undefined, ['', '   ']);
+    const hosts = getAllowedRequestHosts([], ['', '   ']);
     expect(hosts).toEqual(new Set());
   });
 
   it('still disables the guard for "*" even with extraAllowedHosts set', () => {
-    expect(getAllowedRequestHosts('*', ['proxy.example'])).toBeNull();
+    expect(getAllowedRequestHosts(['*'], ['proxy.example'])).toBeNull();
   });
 });
 

--- a/dev/test/server/origin_check_test.ts
+++ b/dev/test/server/origin_check_test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as http from 'node:http';
+import {describe, expect, it} from 'vitest';
+
+import {
+  isRequestOriginAllowed,
+  normalizeOrigin,
+} from '../../src/server/origin_check.js';
+
+const PORT = 8000;
+
+function headers(host?: string): http.IncomingHttpHeaders {
+  return {host};
+}
+
+describe('normalizeOrigin', () => {
+  it('strips a trailing slash so the browser Origin matches', () => {
+    expect(normalizeOrigin('http://localhost:4200/')).toBe(
+      'http://localhost:4200',
+    );
+  });
+
+  it('passes the wildcard and non-URL entries through unchanged', () => {
+    expect(normalizeOrigin('*')).toBe('*');
+    expect(normalizeOrigin('not a url')).toBe('not a url');
+  });
+});
+
+describe('isRequestOriginAllowed', () => {
+  it('blocks a cross-origin request', () => {
+    expect(
+      isRequestOriginAllowed(
+        'http://evil.com',
+        headers(`localhost:${PORT}`),
+        [],
+      ),
+    ).toBe(false);
+  });
+
+  it('allows a same-origin request', () => {
+    expect(
+      isRequestOriginAllowed(
+        `http://localhost:${PORT}`,
+        headers(`localhost:${PORT}`),
+        [],
+      ),
+    ).toBe(true);
+  });
+
+  it('allows an explicitly configured origin', () => {
+    expect(
+      isRequestOriginAllowed(
+        'http://localhost:4200',
+        headers(`localhost:${PORT}`),
+        ['http://localhost:4200'],
+      ),
+    ).toBe(true);
+  });
+
+  it('allows any origin when the wildcard is configured', () => {
+    expect(
+      isRequestOriginAllowed('http://evil.com', headers(`localhost:${PORT}`), [
+        '*',
+      ]),
+    ).toBe(true);
+  });
+
+  it('blocks a request whose own origin cannot be determined', () => {
+    expect(
+      isRequestOriginAllowed('http://evil.com', headers(undefined), []),
+    ).toBe(false);
+  });
+
+  // A TLS-terminating front end (Cloud Run) serves the UI over https while the
+  // container sees a plain-http Host, so the same-origin check must compare
+  // authorities, not full URLs including the scheme.
+  it('allows an https Origin whose authority matches the Host', () => {
+    expect(
+      isRequestOriginAllowed(
+        'https://svc.a.run.app',
+        headers('svc.a.run.app'),
+        [],
+      ),
+    ).toBe(true);
+  });
+
+  it('blocks an Origin whose authority differs from the Host', () => {
+    expect(
+      isRequestOriginAllowed(
+        'https://other.a.run.app',
+        headers('svc.a.run.app'),
+        [],
+      ),
+    ).toBe(false);
+  });
+
+  it('allows an origin configured with a trailing slash once normalized', () => {
+    expect(
+      isRequestOriginAllowed(
+        'http://localhost:4200',
+        headers(`localhost:${PORT}`),
+        [normalizeOrigin('http://localhost:4200/')],
+      ),
+    ).toBe(true);
+  });
+});

--- a/dev/test/server/origin_check_test.ts
+++ b/dev/test/server/origin_check_test.ts
@@ -10,6 +10,7 @@ import {describe, expect, it} from 'vitest';
 import {
   isRequestOriginAllowed,
   normalizeOrigin,
+  parseAllowedOrigins,
 } from '../../src/server/origin_check.js';
 
 const PORT = 8000;
@@ -25,9 +26,51 @@ describe('normalizeOrigin', () => {
     );
   });
 
-  it('passes the wildcard and non-URL entries through unchanged', () => {
+  it('passes the wildcard through unchanged', () => {
     expect(normalizeOrigin('*')).toBe('*');
-    expect(normalizeOrigin('not a url')).toBe('not a url');
+  });
+
+  it('rejects a scheme-less entry whose opaque origin is "null"', () => {
+    // `new URL('localhost:4200').origin` is the string "null"; accepting it
+    // would allowlist every opaque origin.
+    expect(normalizeOrigin('localhost:4200')).toBeNull();
+  });
+
+  it('rejects a non-http(s) scheme and an unparseable entry', () => {
+    expect(normalizeOrigin('file:///etc/passwd')).toBeNull();
+    expect(normalizeOrigin('not a url')).toBeNull();
+  });
+});
+
+describe('parseAllowedOrigins', () => {
+  it('normalizes and keeps http(s) origins and the wildcard', () => {
+    expect(
+      parseAllowedOrigins('http://localhost:4200/, https://a.example, *'),
+    ).toEqual({
+      origins: ['http://localhost:4200', 'https://a.example', '*'],
+      rejected: [],
+    });
+  });
+
+  it('drops a scheme-less entry so it never reaches the allowlist', () => {
+    // The blocking bug: `localhost:4200` otherwise normalizes to the opaque
+    // "null" origin and grants every `Origin: null` request.
+    expect(parseAllowedOrigins('localhost:4200')).toEqual({
+      origins: [],
+      rejected: ['localhost:4200'],
+    });
+  });
+
+  it('drops an invalid entry while keeping a valid sibling', () => {
+    expect(parseAllowedOrigins('file:///x, https://ok.example')).toEqual({
+      origins: ['https://ok.example'],
+      rejected: ['file:///x'],
+    });
+  });
+
+  it('returns empty lists for an unset or blank value', () => {
+    expect(parseAllowedOrigins(undefined)).toEqual({origins: [], rejected: []});
+    expect(parseAllowedOrigins('  ,  ')).toEqual({origins: [], rejected: []});
   });
 });
 
@@ -76,6 +119,14 @@ describe('isRequestOriginAllowed', () => {
     ).toBe(false);
   });
 
+  it('blocks a literal "null" Origin via the malformed-URL path', () => {
+    // A sandboxed iframe or a data:/file: document sends `Origin: null`. It is
+    // not on the allowlist and `new URL('null')` throws, so it is refused.
+    expect(
+      isRequestOriginAllowed('null', headers(`localhost:${PORT}`), []),
+    ).toBe(false);
+  });
+
   // A TLS-terminating front end (Cloud Run) serves the UI over https while the
   // container sees a plain-http Host, so the same-origin check must compare
   // authorities, not full URLs including the scheme.
@@ -104,7 +155,7 @@ describe('isRequestOriginAllowed', () => {
       isRequestOriginAllowed(
         'http://localhost:4200',
         headers(`localhost:${PORT}`),
-        [normalizeOrigin('http://localhost:4200/')],
+        parseAllowedOrigins('http://localhost:4200/').origins,
       ),
     ).toBe(true);
   });

--- a/dev/test/utils/log_utils_test.ts
+++ b/dev/test/utils/log_utils_test.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+
+import {formatHeaderForLog} from '../../src/utils/log_utils.js';
+
+describe('formatHeaderForLog', () => {
+  it('quotes the value so an injected newline cannot forge a log line', () => {
+    expect(formatHeaderForLog('evil.example\ninjected')).toBe(
+      '"evil.example\\ninjected"',
+    );
+  });
+
+  it('truncates a value longer than the cap', () => {
+    const long = 'a'.repeat(200);
+    expect(formatHeaderForLog(long)).toBe(`"${'a'.repeat(128)}"`);
+  });
+
+  it('coerces a missing or array-valued header to a string', () => {
+    expect(formatHeaderForLog(undefined)).toBe('"undefined"');
+    expect(formatHeaderForLog(['a', 'b'])).toBe('"a,b"');
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**Describe the change:**

**Problem**

The dev server's DNS-rebinding guard (from #744) inspects the `Host` header but not `Origin`, so a page on another origin can still drive state-changing requests (create a session, run an agent) that the browser sends with an `Origin`. `--allow_origins` was wired only to `cors()`, which sets response headers and never rejects a request. A comma-separated value also reached `cors()` as one string that no browser `Origin` can equal.

**Solution**

Add an Origin gate (`dev/src/server/origin_check.ts`) registered before every route, alongside the existing Host guard. A state-changing request (any method outside `GET`/`HEAD`/`OPTIONS`) that carries an `Origin` must be same-origin or on the allowlist; a request with no `Origin` passes, so curl, the ADK CLI and `AdkApiClient` are unaffected. `--allow_origins` is parsed as a comma-separated list of `http:`/`https:` origins, each origin's host is also added to the DNS-rebinding allowlist, and `'*'` allows every origin and turns that guard off. A rejected request returns `403 Forbidden: origin not allowed`.

**Behavioural change, intentional.** A cross-origin state-changing browser request that used to succeed now returns `403`. The escape hatch is `--allow_origins <origin>`.

This mirrors the request gate in the adk-python dev server (`_OriginCheckMiddleware`).

### Testing Plan

- `dev/test/server/origin_check_test.ts` — `normalizeOrigin`, `parseAllowedOrigins` and `isRequestOriginAllowed`, including the opaque `Origin: null` path.
- `dev/test/server/adk_api_server_origin_check_test.ts` — the gate end to end over `node:http`, including a no-`Origin` POST (200) and a scheme-less `--allow_origins` entry that must not allowlist `Origin: null`.
- `dev/test/server/dns_rebinding_guard_test.ts` — updated for the `string[]` signature, plus the wildcard-in-list opt-out.
- `dev/test/utils/log_utils_test.ts` — the shared header-logging helper.

```
npx vitest run --project unit:dev dev/test
npm run ts:check && npm run lint && npm run format:check
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.