### PR TITLE
Fix: parse JSON bodies only in the toA2a server (drop express.urlencoded)

### DIFF
--- a/core/src/a2a/agent_to_a2a.ts
+++ b/core/src/a2a/agent_to_a2a.ts
@@ -181,7 +181,11 @@ export async function toA2a(
 
   const app = options.app ?? express();
   if (!options.app) {
-    app.use(express.urlencoded({limit: '50mb', extended: true}));
+    // Parse JSON bodies only. `application/x-www-form-urlencoded` is a
+    // CORS-safelisted content type, so a browser sends it cross-origin as a
+    // simple request with no preflight; parsing it would let any web page
+    // drive these endpoints with a drive-by form POST. Requiring JSON forces
+    // a preflight, which this app does not answer.
     app.use(express.json({limit: '50mb'}));
   }
 

--- a/core/test/a2a/agent_to_a2a_body_parsing_test.ts
+++ b/core/test/a2a/agent_to_a2a_body_parsing_test.ts
@@ -58,14 +58,6 @@ class TestAgent extends BaseAgent {
   ): AsyncGenerator<Event, void, void> {}
 }
 
-function post(port: number, path: string, contentType: string, body: string) {
-  return fetch(`http://127.0.0.1:${port}${path}`, {
-    method: 'POST',
-    headers: {'content-type': contentType},
-    body,
-  });
-}
-
 describe('toA2a body parsing', () => {
   let server: Server;
   let port: number;
@@ -89,27 +81,27 @@ describe('toA2a body parsing', () => {
     });
   });
 
+  function post(path: string, contentType: string, body: string) {
+    return fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers: {'content-type': contentType},
+      body,
+    });
+  }
+
   // `a[b][0][c]=d` is the crux of the bug: `qs` rebuilds it as
   // `{a: {b: [{c: 'd'}]}}`, so a form body — a CORS-safelisted content type
   // that needs no preflight — could carry a fully structured JSON-RPC request.
-  it.each(['/rest', '/jsonrpc'])(
-    'does not parse a form-encoded body posted to %s',
-    async (path) => {
-      await post(
-        port,
-        path,
-        'application/x-www-form-urlencoded',
-        'a[b][0][c]=d',
-      );
+  it('does not parse a form-encoded body', async () => {
+    await post('/rest', 'application/x-www-form-urlencoded', 'a[b][0][c]=d');
 
-      expect(receivedBodies[0]).toEqual({});
-    },
-  );
+    expect(receivedBodies[0]).toEqual({});
+  });
 
   it('still parses a JSON body', async () => {
     const payload = {jsonrpc: '2.0', id: 1, method: 'message/send'};
 
-    await post(port, '/rest', 'application/json', JSON.stringify(payload));
+    await post('/rest', 'application/json', JSON.stringify(payload));
 
     expect(receivedBodies[0]).toEqual(payload);
   });

--- a/core/test/a2a/agent_to_a2a_body_parsing_test.ts
+++ b/core/test/a2a/agent_to_a2a_body_parsing_test.ts
@@ -5,7 +5,8 @@
  */
 
 import express from 'express';
-import * as http from 'http';
+import type {Server} from 'http';
+import type {AddressInfo} from 'net';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {toA2a} from '../../src/a2a/agent_to_a2a.js';
 import {BaseAgent} from '../../src/agents/base_agent.js';
@@ -13,11 +14,7 @@ import {InvocationContext} from '../../src/agents/invocation_context.js';
 import {Event} from '../../src/events/event.js';
 import {logger} from '../../src/utils/logger.js';
 
-/**
- * Bodies observed by the A2A handlers, newest last. Populated by the
- * `@a2a-js/sdk/server/express` mock below, which stands in for the real A2A
- * handlers with middleware that only records what Express handed it.
- */
+// Bodies the A2A handlers saw, newest last; filled by the mock below.
 const {receivedBodies} = vi.hoisted(() => ({receivedBodies: [] as unknown[]}));
 
 // Express itself is deliberately NOT mocked: this file exercises the real
@@ -61,40 +58,16 @@ class TestAgent extends BaseAgent {
   ): AsyncGenerator<Event, void, void> {}
 }
 
-/** A nested `qs` payload: parsed, it would become `{a: {b: [{c: 'd'}]}}`. */
-const NESTED_FORM_BODY = 'a[b][0][c]=d';
-
-function post(
-  port: number,
-  path: string,
-  contentType: string,
-  body: string,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const request = http.request(
-      {
-        host: '127.0.0.1',
-        port,
-        path,
-        method: 'POST',
-        headers: {
-          'content-type': contentType,
-          'content-length': Buffer.byteLength(body),
-        },
-      },
-      (response) => {
-        response.resume();
-        response.on('end', resolve);
-        response.on('error', reject);
-      },
-    );
-    request.on('error', reject);
-    request.end(body);
+function post(port: number, path: string, contentType: string, body: string) {
+  return fetch(`http://127.0.0.1:${port}${path}`, {
+    method: 'POST',
+    headers: {'content-type': contentType},
+    body,
   });
 }
 
 describe('toA2a body parsing', () => {
-  let server: http.Server;
+  let server: Server;
   let port: number;
 
   beforeEach(async () => {
@@ -104,21 +77,21 @@ describe('toA2a body parsing', () => {
     const app = await toA2a(new TestAgent(), {allowUnauthenticated: true});
     server = app.listen(0);
     await new Promise<void>((resolve) => server.once('listening', resolve));
-
-    const address = server.address();
-    if (address === null || typeof address === 'string') {
-      expect.fail('server did not bind to a TCP port');
-    }
-    port = address.port;
+    port = (server.address() as AddressInfo).port;
   });
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    // `fetch` keeps the socket alive, which would stall `close()`.
+    server.closeAllConnections();
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
   });
 
+  // `a[b][0][c]=d` is the crux of the bug: `qs` rebuilds it as
+  // `{a: {b: [{c: 'd'}]}}`, so a form body — a CORS-safelisted content type
+  // that needs no preflight — could carry a fully structured JSON-RPC request.
   it.each(['/rest', '/jsonrpc'])(
     'does not parse a form-encoded body posted to %s',
     async (path) => {
@@ -126,15 +99,10 @@ describe('toA2a body parsing', () => {
         port,
         path,
         'application/x-www-form-urlencoded',
-        NESTED_FORM_BODY,
+        'a[b][0][c]=d',
       );
 
-      // body-parser leaves `req.body` as `{}` (express 4) or `undefined`
-      // (express 5) for a request it declines to parse; either is fine as long
-      // as nothing from the form was reconstructed.
-      const body = receivedBodies[0];
-      expect(body ?? {}).toEqual({});
-      expect(body).not.toHaveProperty('a');
+      expect(receivedBodies[0]).toEqual({});
     },
   );
 

--- a/core/test/a2a/agent_to_a2a_test.ts
+++ b/core/test/a2a/agent_to_a2a_test.ts
@@ -85,18 +85,18 @@ describe('toA2a', () => {
     agent = new TestAgent();
   });
 
-  it('should create an express app with handlers when unauthenticated access is explicitly allowed', async () => {
+  it('creates an express app that parses JSON bodies only', async () => {
     const app = await toA2a(agent, {allowUnauthenticated: true});
 
     expect(express).toHaveBeenCalled();
     const expressMock = express as unknown as MockExpress;
-    expect(expressMock.urlencoded).toHaveBeenCalledWith({
-      limit: '50mb',
-      extended: true,
-    });
-    expect(expressMock.json).toHaveBeenCalledWith({limit: '50mb'});
+    // `application/x-www-form-urlencoded` is CORS-safelisted, so parsing it
+    // would make these endpoints reachable by a cross-origin form POST that
+    // never triggers a preflight.
+    expect(expressMock.urlencoded).not.toHaveBeenCalled();
+    expect(app.use).not.toHaveBeenCalledWith('urlencoded_middleware');
 
-    expect(app.use).toHaveBeenCalledWith('urlencoded_middleware');
+    expect(expressMock.json).toHaveBeenCalledWith({limit: '50mb'});
     expect(app.use).toHaveBeenCalledWith('json_middleware');
 
     expect(getA2AAgentCard).toHaveBeenCalledWith(agent, [

--- a/core/test/a2a/agent_to_a2a_test.ts
+++ b/core/test/a2a/agent_to_a2a_test.ts
@@ -85,7 +85,7 @@ describe('toA2a', () => {
     agent = new TestAgent();
   });
 
-  it('creates an express app that parses JSON bodies only', async () => {
+  it('creates an express app with JSON-only body parsing and handlers', async () => {
     const app = await toA2a(agent, {allowUnauthenticated: true});
 
     expect(express).toHaveBeenCalled();

--- a/core/test/a2a/agent_to_a2a_test.ts
+++ b/core/test/a2a/agent_to_a2a_test.ts
@@ -94,7 +94,6 @@ describe('toA2a', () => {
     // would make these endpoints reachable by a cross-origin form POST that
     // never triggers a preflight.
     expect(expressMock.urlencoded).not.toHaveBeenCalled();
-    expect(app.use).not.toHaveBeenCalledWith('urlencoded_middleware');
 
     expect(expressMock.json).toHaveBeenCalledWith({limit: '50mb'});
     expect(app.use).toHaveBeenCalledWith('json_middleware');

--- a/core/test/a2a/agent_to_a2a_urlencoded_test.ts
+++ b/core/test/a2a/agent_to_a2a_urlencoded_test.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import express from 'express';
+import * as http from 'http';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {toA2a} from '../../src/a2a/agent_to_a2a.js';
+import {BaseAgent} from '../../src/agents/base_agent.js';
+import {InvocationContext} from '../../src/agents/invocation_context.js';
+import {Event} from '../../src/events/event.js';
+import {logger} from '../../src/utils/logger.js';
+
+/**
+ * Bodies observed by the A2A handlers, newest last. Populated by the
+ * `@a2a-js/sdk/server/express` mock below, which stands in for the real A2A
+ * handlers with middleware that only records what Express handed it.
+ */
+const {receivedBodies} = vi.hoisted(() => ({receivedBodies: [] as unknown[]}));
+
+// Express itself is deliberately NOT mocked: this file exercises the real
+// middleware stack that `toA2a` installs, over a real loopback socket.
+vi.mock('@a2a-js/sdk/server/express', () => {
+  const recordBody: express.RequestHandler = (req, res) => {
+    receivedBodies.push(req.body);
+    res.status(204).end();
+  };
+  return {
+    agentCardHandler: () => recordBody,
+    restHandler: () => recordBody,
+    jsonRpcHandler: () => recordBody,
+    UserBuilder: {noAuthentication: 'noAuthentication'},
+  };
+});
+
+vi.mock('@a2a-js/sdk/server', () => ({
+  DefaultRequestHandler: vi.fn().mockImplementation(() => ({})),
+  InMemoryTaskStore: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/a2a/agent_executor.js', () => ({
+  A2AAgentExecutor: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/a2a/agent_card.js', () => ({
+  getA2AAgentCard: vi.fn().mockResolvedValue({name: 'mocked_card'}),
+  resolveAgentCard: vi.fn().mockResolvedValue({name: 'resolved_card'}),
+}));
+
+class TestAgent extends BaseAgent {
+  constructor() {
+    super({name: 'test-agent'});
+  }
+  protected async *runAsyncImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {}
+  protected async *runLiveImpl(
+    _context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {}
+}
+
+/** A nested `qs` payload: parsed, it would become `{a: {b: [{c: 'd'}]}}`. */
+const NESTED_FORM_BODY = 'a[b][0][c]=d';
+
+function post(
+  port: number,
+  path: string,
+  contentType: string,
+  body: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: 'POST',
+        headers: {
+          'content-type': contentType,
+          'content-length': Buffer.byteLength(body),
+        },
+      },
+      (response) => {
+        response.resume();
+        response.on('end', resolve);
+        response.on('error', reject);
+      },
+    );
+    request.on('error', reject);
+    request.end(body);
+  });
+}
+
+describe('toA2a body parsing', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    receivedBodies.length = 0;
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const app = await toA2a(new TestAgent(), {allowUnauthenticated: true});
+    server = app.listen(0);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+      expect.fail('server did not bind to a TCP port');
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it.each(['/rest', '/jsonrpc'])(
+    'does not parse a form-encoded body posted to %s',
+    async (path) => {
+      await post(
+        port,
+        path,
+        'application/x-www-form-urlencoded',
+        NESTED_FORM_BODY,
+      );
+
+      // body-parser leaves `req.body` as `{}` (express 4) or `undefined`
+      // (express 5) for a request it declines to parse; either is fine as long
+      // as nothing from the form was reconstructed.
+      const body = receivedBodies[0];
+      expect(body ?? {}).toEqual({});
+      expect(body).not.toHaveProperty('a');
+    },
+  );
+
+  it('still parses a JSON body', async () => {
+    const payload = {jsonrpc: '2.0', id: 1, method: 'message/send'};
+
+    await post(port, '/rest', 'application/json', JSON.stringify(payload));
+
+    expect(receivedBodies[0]).toEqual(payload);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #378

**2. Or, if no issue exists, describe the change:**

**Problem:**

When `toA2a()` creates its own Express app (i.e. the caller does not pass `options.app`), it mounts `express.urlencoded({limit: '50mb', extended: true})` alongside `express.json()`. That makes the A2A surface reachable by a drive-by cross-origin form `POST`:

- `application/x-www-form-urlencoded` is a **CORS-safelisted** request content type, so a cross-origin `POST` carrying it is a _simple request_: the browser sends it with no preflight and no opt-in from the target server. The attacker cannot read the response, but the side effects of the agent run — tool invocations, session mutations, artifact writes — still happen.
- `extended: true` routes the body through `qs`, which reconstructs arbitrarily nested objects from flat keys (`a[b][0][c]=d`). That gives a form body enough expressiveness to hand-build a complete JSON-RPC request object.

This was verified against a real server rather than assumed. With the parser mounted, a pure form-encoded `POST` to `/jsonrpc` **invoked the agent and returned a completed task**:

```
$ # body: jsonrpc=2.0&id=1&method=message/send&params[message][messageId]=m1
$ #       &params[message][role]=user&params[message][kind]=message
$ #       &params[message][parts][0][kind]=text&params[message][parts][0][text]=pwned
!!! AGENT WAS INVOKED BY THE FORM POST !!!
HTTP 200 {"jsonrpc":"2.0","id":"1","result":{"kind":"task","id":"c695a1e0-...","history":[...]}}
```

After the change the same request is rejected at the JSON-RPC envelope and the agent never runs:

```
HTTP 200 {"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid JSON-RPC Request."}}
```

**Solution:**

Drop the `express.urlencoded` mount and keep `express.json({limit: '50mb'})` unchanged. Nothing in the A2A contract needs form bodies — the JSON-RPC transport is `application/json` by definition, the `HTTP+JSON` (REST) transport is likewise JSON, and the agent-card route is a `GET` with no request body. With only `express.json()` mounted, a cross-origin `POST` is no longer a simple request: the browser must first send a CORS preflight, and `toA2a` mounts no CORS policy, so the preflight goes unanswered and the real request is never issued.

I chose removal over adding a CORS policy or a content-type-rejecting middleware because the preflight already blocks the cross-origin case; either addition would be extra surface area for no security gain. This is the same one-line fix already applied to the dev API server's identical mount in #378, which landed without a regression test — this PR adds one so the mount cannot come back silently.

A short comment is left in place of the deleted line explaining _why_ the parser is absent, since the natural future "why can't I POST a form to my agent?" fix is to re-add it.

**Behavior change (intentional, security-motivated):** no public API, type, signature or export changes, and the set and order of mounted routes are identical. A caller who used the app returned by `toA2a()` as a general-purpose Express app and mounted their own routes reading `req.body` from form posts will no longer see a parsed body. The migration path is one line and already supported: create your own `express()` app, add whatever middleware you need, and pass it as `options.app` — in which case `toA2a` installs no parsers at all. The `options.app` branch is untouched by this PR. The only in-repo caller, `dev/src/server/adk_api_server.ts`, passes `options.app` and is therefore unaffected.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`core/test/a2a/agent_to_a2a_test.ts` mocks `express` wholesale, so it can only prove `toA2a` never _calls_ `express.urlencoded`. Its two assertions that previously required the mount were inverted rather than deleted, keeping `urlencoded` on the mock so "never called" stays meaningful:

```
npx vitest run --project unit:core core/test/a2a/agent_to_a2a_test.ts
   ✓ 8 passed
```

`core/test/a2a/agent_to_a2a_body_parsing_test.ts` (new) leaves `express` **real** and mocks only the A2A SDK handlers, so it asserts the actual behavior of the assembled middleware stack over a real loopback socket: a form-encoded `POST` carrying the nested `qs` payload `a[b][0][c]=d` reaches the handler with an empty `req.body`, while a JSON `POST` still arrives fully parsed. That JSON positive control is what stops the test from also passing if the whole middleware stack were removed.

```
npx vitest run --project unit:core core/test/a2a/agent_to_a2a_body_parsing_test.ts
   ✓ 2 passed
```

Both guards were mutation-tested: with the `urlencoded` mount restored, they fail (`expected { a: { b: [ { c: 'd' } ] } } to deeply equal {}`), confirming they actually detect a regression rather than passing vacuously.

Whole A2A suite, lint and format on the exact pushed commit:

```
npx vitest run --project unit:core core/test/a2a/    → 14 files, 191 passed
npm run build                                        → success
npx eslint core/src/a2a/agent_to_a2a.ts core/test/a2a/agent_to_a2a_test.ts \
           core/test/a2a/agent_to_a2a_body_parsing_test.ts   → clean
npx prettier --check <same three files>              → clean
```

`tsc --noEmit` reports the same 308 pre-existing errors before and after this branch (they come from `core/dist` type duplication after a build and are unrelated to these files), so this change introduces none.

No integration test was added: the guarantee is purely about the HTTP middleware stack, and the new unit test already runs a real Express app over a real socket, so a second slower copy of the same assertion would be redundant. No new dependency was added — the test uses global `fetch`, matching `dev/test/server/adk_api_server_test.ts`.

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any necessary setup or configuration._

1. `npm run build` at the repo root.
2. In a scratch script, stand up a server the documented standalone way:
   ```ts
   const app = await toA2a(myAgent, {allowUnauthenticated: true});
   app.listen(8000);
   ```
3. Send the attack request — a CORS-safelisted content type, so a browser would send this cross-origin with no preflight:
   ```bash
   curl -i -X POST http://localhost:8000/jsonrpc \
     -H 'Content-Type: application/x-www-form-urlencoded' \
     --data 'jsonrpc=2.0&id=1&method=message/send&params[message][messageId]=m1&params[message][role]=user&params[message][kind]=message&params[message][parts][0][kind]=text&params[message][parts][0][text]=pwned'
   ```
   Before this change the agent runs and a completed task is returned. After it, the body is never parsed and the response is `{"code":-32600,"message":"Invalid JSON-RPC Request."}` with the agent never invoked.
4. Confirm the legitimate path is unchanged:
   ```bash
   curl -i -X POST http://localhost:8000/jsonrpc \
     -H 'Content-Type: application/json' \
     --data '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{}}'
   ```
   Still dispatched into the JSON-RPC method exactly as before. `GET /.well-known/agent-card.json` also still serves the card.
5. Regression check on the untouched path: run `adk api_server --a2a` and confirm the dev server's A2A routes behave identically — it passes `options.app`, so nothing about it changes.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_None beyond the above._
