### PR TITLE
Feat: CLI-level A2A authenticator for the dev server and Cloud Run deploy (Part 2/2)

### DIFF
--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {timingSafeEqual} from 'node:crypto';
+import {A2aUserBuilder} from './agent_to_a2a.js';
+
+/**
+ * The `userName` reported for a caller that presented the shared bearer token.
+ *
+ * A shared secret authenticates the deployment as a whole rather than an
+ * individual principal, so every accepted caller resolves to this same
+ * synthetic identity.
+ */
+const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
+
+const BEARER_SCHEME_PREFIX = 'bearer ';
+
+/**
+ * Extracts the credential from an `Authorization: Bearer <token>` header
+ * value, or returns `undefined` when the header is absent or uses a different
+ * scheme. The scheme is matched case-insensitively, as RFC 6750 requires.
+ */
+function extractBearerCredential(
+  header: string | undefined,
+): string | undefined {
+  if (!header?.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)) {
+    return undefined;
+  }
+  return header.slice(BEARER_SCHEME_PREFIX.length);
+}
+
+/** Compares two secrets without leaking their contents through timing. */
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  const left = Buffer.from(a, 'utf8');
+  const right = Buffer.from(b, 'utf8');
+  // `timingSafeEqual` throws on a length mismatch, so the lengths must be
+  // compared first. The length of a rejected credential is not a secret.
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/**
+ * Builds an {@link A2aUserBuilder} that authenticates A2A requests against a
+ * shared bearer token.
+ *
+ * Callers must send `Authorization: Bearer <token>`; the credential is
+ * compared against `token` in constant time. A request with a missing,
+ * malformed or incorrect credential is rejected before the agent or any of
+ * its tools is invoked.
+ *
+ * ```ts
+ * toA2a(agent, {authentication: bearerTokenUserBuilder(process.env.MY_TOKEN)});
+ * ```
+ *
+ * A shared secret is only as good as the transport carrying it: serve the A2A
+ * surface over HTTPS so the token is not exposed on the wire.
+ *
+ * @param token The shared secret callers must present. Must be non-empty.
+ * @throws If `token` is empty or contains only whitespace.
+ */
+export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
+  if (!token.trim()) {
+    throw new Error(
+      'bearerTokenUserBuilder: an empty A2A bearer token is not a valid ' +
+        'authenticator. Supply a real shared secret, or configure no token ' +
+        'at all to run the A2A surface unauthenticated.',
+    );
+  }
+
+  return async (req) => {
+    const credential = extractBearerCredential(req.headers.authorization);
+    if (
+      credential === undefined ||
+      !timingSafeEqualStrings(credential, token)
+    ) {
+      throw new Error(
+        'A2A request rejected: missing or invalid `Authorization: Bearer` ' +
+          'credential.',
+      );
+    }
+    return {isAuthenticated: true, userName: AUTHENTICATED_USER_NAME};
+  };
+}

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -57,6 +57,11 @@ function timingSafeEqualStrings(a: string, b: string): boolean {
  * A shared secret is only as good as the transport carrying it: serve the A2A
  * surface over HTTPS so the token is not exposed on the wire.
  *
+ * A rejected request surfaces as whatever the `@a2a-js/sdk` handler produces
+ * for a failing `UserBuilder`, which is an HTTP 500 rather than a 401. The
+ * guarantee this helper provides is that the agent is never reached, not that
+ * the caller gets a particular status code.
+ *
  * @param token The shared secret callers must present. Must be non-empty.
  * @throws If `token` is empty or contains only whitespace.
  */

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -7,21 +7,14 @@
 import {timingSafeEqual} from 'node:crypto';
 import {A2aUserBuilder} from './agent_to_a2a.js';
 
-/**
- * The `userName` reported for a caller that presented the shared bearer token.
- *
- * A shared secret authenticates the deployment as a whole rather than an
- * individual principal, so every accepted caller resolves to this same
- * synthetic identity.
- */
+/** A shared secret identifies a deployment, not an individual principal. */
 const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
 
 const BEARER_SCHEME_PREFIX = 'bearer ';
 
 /**
- * Extracts the credential from an `Authorization: Bearer <token>` header
- * value, or returns `undefined` when the header is absent or uses a different
- * scheme. The scheme is matched case-insensitively, as RFC 6750 requires.
+ * Reads the credential out of an `Authorization: Bearer <token>` header value,
+ * matching the scheme case-insensitively as RFC 6750 requires.
  */
 function extractBearerCredential(
   header: string | undefined,
@@ -62,11 +55,13 @@ function timingSafeEqualStrings(a: string, b: string): boolean {
  * guarantee this helper provides is that the agent is never reached, not that
  * the caller gets a particular status code.
  *
- * @param token The shared secret callers must present. Must be non-empty.
+ * @param token The shared secret callers must present. Surrounding whitespace
+ *   is trimmed, because HTTP strips it from header values anyway.
  * @throws If `token` is empty or contains only whitespace.
  */
 export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
-  if (!token.trim()) {
+  const expected = token.trim();
+  if (!expected) {
     throw new Error(
       'bearerTokenUserBuilder: an empty A2A bearer token is not a valid ' +
         'authenticator. Supply a real shared secret, or configure no token ' +
@@ -78,7 +73,7 @@ export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
     const credential = extractBearerCredential(req.headers.authorization);
     if (
       credential === undefined ||
-      !timingSafeEqualStrings(credential, token)
+      !timingSafeEqualStrings(credential, expected)
     ) {
       throw new Error(
         'A2A request rejected: missing or invalid `Authorization: Bearer` ' +

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -12,17 +12,6 @@ const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
 
 const BEARER_SCHEME_PREFIX = 'bearer ';
 
-/** Reads the credential out of an `Authorization: Bearer <token>` header. */
-function extractBearerCredential(
-  header: string | undefined,
-): string | undefined {
-  // RFC 6750 makes the scheme case-insensitive.
-  if (!header?.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)) {
-    return undefined;
-  }
-  return header.slice(BEARER_SCHEME_PREFIX.length);
-}
-
 /** Compares two secrets without leaking their contents through timing. */
 function timingSafeEqualStrings(a: string, b: string): boolean {
   const left = Buffer.from(a, 'utf8');
@@ -66,11 +55,12 @@ export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
   }
 
   return async (req) => {
-    const credential = extractBearerCredential(req.headers.authorization);
-    if (
-      credential === undefined ||
-      !timingSafeEqualStrings(credential, expected)
-    ) {
+    const header = req.headers.authorization ?? '';
+    // RFC 6750 makes the bearer scheme case-insensitive.
+    const credential = header.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)
+      ? header.slice(BEARER_SCHEME_PREFIX.length)
+      : '';
+    if (!timingSafeEqualStrings(credential, expected)) {
       throw new Error(
         'A2A request rejected: missing or invalid `Authorization: Bearer` ' +
           'credential.',

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -12,13 +12,11 @@ const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
 
 const BEARER_SCHEME_PREFIX = 'bearer ';
 
-/**
- * Reads the credential out of an `Authorization: Bearer <token>` header value,
- * matching the scheme case-insensitively as RFC 6750 requires.
- */
+/** Reads the credential out of an `Authorization: Bearer <token>` header. */
 function extractBearerCredential(
   header: string | undefined,
 ): string | undefined {
+  // RFC 6750 makes the scheme case-insensitive.
   if (!header?.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)) {
     return undefined;
   }
@@ -39,23 +37,21 @@ function timingSafeEqualStrings(a: string, b: string): boolean {
  * shared bearer token.
  *
  * Callers must send `Authorization: Bearer <token>`; the credential is
- * compared against `token` in constant time. A request with a missing,
- * malformed or incorrect credential is rejected before the agent or any of
- * its tools is invoked.
+ * compared against `token` in constant time, and a request with a missing,
+ * malformed or incorrect one is rejected before the agent or any of its tools
+ * is invoked. Serve the surface over HTTPS, or the secret travels in clear
+ * text on every call.
  *
  * ```ts
  * toA2a(agent, {authentication: bearerTokenUserBuilder(process.env.MY_TOKEN)});
  * ```
  *
- * A shared secret is only as good as the transport carrying it: serve the A2A
- * surface over HTTPS so the token is not exposed on the wire.
- *
  * A rejected request surfaces as whatever the `@a2a-js/sdk` handler produces
  * for a failing `UserBuilder`, which is an HTTP 500 rather than a 401. The
- * guarantee this helper provides is that the agent is never reached, not that
- * the caller gets a particular status code.
+ * guarantee here is that the agent is never reached, not that the caller gets
+ * a particular status code.
  *
- * @param token The shared secret callers must present. Surrounding whitespace
+ * @param token The shared secret callers must present; surrounding whitespace
  *   is trimmed, because HTTP strips it from header values anyway.
  * @throws If `token` is empty or contains only whitespace.
  */

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -22,6 +22,7 @@ export type {
 } from './a2a/agent_executor.js';
 export {toA2a} from './a2a/agent_to_a2a.js';
 export type {A2aUserBuilder, ToA2aOptions} from './a2a/agent_to_a2a.js';
+export {bearerTokenUserBuilder} from './a2a/auth.js';
 export type {ExecutorContext} from './a2a/executor_context.js';
 export {InvocationContext} from './agents/invocation_context.js';
 export {FileArtifactService} from './artifacts/file_artifact_service.js';

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -86,19 +86,6 @@ describe('bearerTokenUserBuilder', () => {
     ).rejects.toThrow(/missing or invalid/);
   });
 
-  it('never discloses the configured token when rejecting', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    const rejection = await userBuilder(
-      requestWithHeaders({authorization: 'Bearer wrong'}),
-    ).then(
-      () => expect.fail('expected the authenticator to reject'),
-      (error: unknown) => String(error),
-    );
-
-    expect(rejection).not.toContain(TOKEN);
-  });
-
   it('trims surrounding whitespace from the configured token', async () => {
     // HTTP strips whitespace around header values, so an untrimmed token
     // would be impossible for any caller to present.

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Request} from 'express';
+import {IncomingHttpHeaders} from 'node:http';
+import {describe, expect, it, vi} from 'vitest';
+import {bearerTokenUserBuilder} from '../../src/a2a/auth.js';
+import {logger} from '../../src/utils/logger.js';
+
+const TOKEN = 's3cr3t';
+
+/**
+ * Builds the minimal Express request the authenticator reads: it only ever
+ * touches `headers`.
+ */
+function requestWithHeaders(headers: IncomingHttpHeaders): Request {
+  return {headers} as unknown as Request;
+}
+
+describe('bearerTokenUserBuilder', () => {
+  it('throws when the token is empty', () => {
+    expect(() => bearerTokenUserBuilder('')).toThrow(
+      /empty A2A bearer token is not a valid authenticator/,
+    );
+  });
+
+  it('throws when the token is whitespace only', () => {
+    expect(() => bearerTokenUserBuilder('   ')).toThrow(
+      /empty A2A bearer token is not a valid authenticator/,
+    );
+  });
+
+  it('authenticates a request carrying the configured token', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    const user = await userBuilder(
+      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
+    );
+
+    expect(user.isAuthenticated).toBe(true);
+    expect(user.userName).toBe('a2a-bearer-token');
+  });
+
+  it('accepts a case-insensitive bearer scheme', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    const user = await userBuilder(
+      requestWithHeaders({authorization: `bearer ${TOKEN}`}),
+    );
+
+    expect(user.isAuthenticated).toBe(true);
+  });
+
+  it('rejects a request with no Authorization header', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(userBuilder(requestWithHeaders({}))).rejects.toThrow(
+      /missing or invalid/,
+    );
+  });
+
+  it('rejects a non-bearer scheme', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(
+      userBuilder(requestWithHeaders({authorization: 'Basic czNjcjN0'})),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('rejects a wrong token of the same length', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+    const wrongToken = 'S3CR3T';
+    expect(wrongToken).toHaveLength(TOKEN.length);
+
+    await expect(
+      userBuilder(requestWithHeaders({authorization: `Bearer ${wrongToken}`})),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('rejects a wrong token of a different length', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(
+      userBuilder(
+        requestWithHeaders({authorization: `Bearer ${TOKEN}-and-more`}),
+      ),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('rejects a bearer scheme with an empty credential', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(
+      userBuilder(requestWithHeaders({authorization: 'Bearer '})),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('never discloses the configured token', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    const rejection = await userBuilder(
+      requestWithHeaders({authorization: 'Bearer wrong'}),
+    ).catch((error: unknown) => error);
+
+    if (!(rejection instanceof Error)) {
+      expect.fail('expected the authenticator to reject with an Error');
+    }
+    expect(rejection.message).not.toContain(TOKEN);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -86,25 +86,17 @@ describe('bearerTokenUserBuilder', () => {
     ).rejects.toThrow(/missing or invalid/);
   });
 
-  it('rejects a bearer scheme with an empty credential', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    await expect(
-      userBuilder(requestWithHeaders({authorization: 'Bearer '})),
-    ).rejects.toThrow(/missing or invalid/);
-  });
-
   it('never discloses the configured token when rejecting', async () => {
     const userBuilder = bearerTokenUserBuilder(TOKEN);
 
     const rejection = await userBuilder(
       requestWithHeaders({authorization: 'Bearer wrong'}),
-    ).catch((error: unknown) => error);
+    ).then(
+      () => expect.fail('expected the authenticator to reject'),
+      (error: unknown) => String(error),
+    );
 
-    if (!(rejection instanceof Error)) {
-      expect.fail('expected the authenticator to reject with an Error');
-    }
-    expect(rejection.message).not.toContain(TOKEN);
+    expect(rejection).not.toContain(TOKEN);
   });
 
   it('trims surrounding whitespace from the configured token', async () => {

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -6,9 +6,8 @@
 
 import {Request} from 'express';
 import {IncomingHttpHeaders} from 'node:http';
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {bearerTokenUserBuilder} from '../../src/a2a/auth.js';
-import {logger} from '../../src/utils/logger.js';
 
 const TOKEN = 's3cr3t';
 
@@ -21,14 +20,11 @@ function requestWithHeaders(headers: IncomingHttpHeaders): Request {
 }
 
 describe('bearerTokenUserBuilder', () => {
-  it('throws when the token is empty', () => {
-    expect(() => bearerTokenUserBuilder('')).toThrow(
-      /empty A2A bearer token is not a valid authenticator/,
-    );
-  });
-
-  it('throws when the token is whitespace only', () => {
-    expect(() => bearerTokenUserBuilder('   ')).toThrow(
+  it.each([
+    ['empty', ''],
+    ['whitespace only', '   '],
+  ])('throws when the token is %s', (_label, token) => {
+    expect(() => bearerTokenUserBuilder(token)).toThrow(
       /empty A2A bearer token is not a valid authenticator/,
     );
   });
@@ -98,9 +94,7 @@ describe('bearerTokenUserBuilder', () => {
     ).rejects.toThrow(/missing or invalid/);
   });
 
-  it('never discloses the configured token', async () => {
-    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  it('never discloses the configured token when rejecting', async () => {
     const userBuilder = bearerTokenUserBuilder(TOKEN);
 
     const rejection = await userBuilder(
@@ -111,10 +105,17 @@ describe('bearerTokenUserBuilder', () => {
       expect.fail('expected the authenticator to reject with an Error');
     }
     expect(rejection.message).not.toContain(TOKEN);
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(errorSpy).not.toHaveBeenCalled();
+  });
 
-    warnSpy.mockRestore();
-    errorSpy.mockRestore();
+  it('trims surrounding whitespace from the configured token', async () => {
+    // HTTP strips whitespace around header values, so an untrimmed token
+    // would be impossible for any caller to present.
+    const userBuilder = bearerTokenUserBuilder(`  ${TOKEN}  `);
+
+    const user = await userBuilder(
+      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
+    );
+
+    expect(user.isAuthenticated).toBe(true);
   });
 });

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -29,72 +29,35 @@ describe('bearerTokenUserBuilder', () => {
     );
   });
 
-  it('authenticates a request carrying the configured token', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
+  it.each([
+    ['the configured token', TOKEN, `Bearer ${TOKEN}`],
+    ['a case-insensitive bearer scheme', TOKEN, `bearer ${TOKEN}`],
+    // HTTP strips whitespace around header values, so a padded token would
+    // otherwise be impossible for any caller to present.
+    ['a token configured with padding', `  ${TOKEN}  `, `Bearer ${TOKEN}`],
+  ])('authenticates %s', async (_label, configuredToken, authorization) => {
+    const userBuilder = bearerTokenUserBuilder(configuredToken);
 
-    const user = await userBuilder(
-      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
-    );
+    const user = await userBuilder(requestWithHeaders({authorization}));
 
-    expect(user.isAuthenticated).toBe(true);
-    expect(user.userName).toBe('a2a-bearer-token');
+    expect(user).toEqual({
+      isAuthenticated: true,
+      userName: 'a2a-bearer-token',
+    });
   });
 
-  it('accepts a case-insensitive bearer scheme', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    const user = await userBuilder(
-      requestWithHeaders({authorization: `bearer ${TOKEN}`}),
-    );
-
-    expect(user.isAuthenticated).toBe(true);
-  });
-
-  it('rejects a request with no Authorization header', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    await expect(userBuilder(requestWithHeaders({}))).rejects.toThrow(
-      /missing or invalid/,
-    );
-  });
-
-  it('rejects a non-bearer scheme', async () => {
+  it.each([
+    ['no Authorization header', undefined],
+    ['a non-bearer scheme', 'Basic czNjcjN0'],
+    // Same length as TOKEN, so this exercises the comparison itself rather
+    // than the length guard in front of it.
+    ['a wrong token of the same length', 'Bearer S3CR3T'],
+    ['a wrong token of a different length', `Bearer ${TOKEN}-and-more`],
+  ])('rejects %s', async (_label, authorization) => {
     const userBuilder = bearerTokenUserBuilder(TOKEN);
 
     await expect(
-      userBuilder(requestWithHeaders({authorization: 'Basic czNjcjN0'})),
+      userBuilder(requestWithHeaders({authorization})),
     ).rejects.toThrow(/missing or invalid/);
-  });
-
-  it('rejects a wrong token of the same length', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-    const wrongToken = 'S3CR3T';
-    expect(wrongToken).toHaveLength(TOKEN.length);
-
-    await expect(
-      userBuilder(requestWithHeaders({authorization: `Bearer ${wrongToken}`})),
-    ).rejects.toThrow(/missing or invalid/);
-  });
-
-  it('rejects a wrong token of a different length', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    await expect(
-      userBuilder(
-        requestWithHeaders({authorization: `Bearer ${TOKEN}-and-more`}),
-      ),
-    ).rejects.toThrow(/missing or invalid/);
-  });
-
-  it('trims surrounding whitespace from the configured token', async () => {
-    // HTTP strips whitespace around header values, so an untrimmed token
-    // would be impossible for any caller to present.
-    const userBuilder = bearerTokenUserBuilder(`  ${TOKEN}  `);
-
-    const user = await userBuilder(
-      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
-    );
-
-    expect(user.isAuthenticated).toBe(true);
   });
 });

--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -143,6 +143,14 @@ const A2A_OPTION = new Option(
   '--a2a [boolean]',
   'Optional. Whether to enable A2A for web/api server. Default: false',
 ).default(false);
+const A2A_AUTH_TOKEN_OPTION = new Option(
+  '--a2a_auth_token <string>',
+  'Optional. Shared bearer token used to authenticate the A2A surface. Callers must send "Authorization: Bearer <token>". Can also be set via the ADK_A2A_AUTH_TOKEN environment variable. If unset, the A2A surface is served WITHOUT authentication.',
+);
+const A2A_AUTH_TOKEN_DEPLOY_OPTION = new Option(
+  '--a2a_auth_token <string>',
+  'Optional. Shared bearer token used to authenticate the deployed A2A surface. Callers must send "Authorization: Bearer <token>". It is sent to Cloud Run as the ADK_A2A_AUTH_TOKEN environment variable and is never written into the image. If unset, the deployed A2A surface is served WITHOUT authentication.',
+);
 const RELOAD_AGENTS_OPTION = new Option(
   '--reload_agents [boolean]',
   'Optional. Watch agent files for changes and automatically reload them. Default: false. To see any changes to your agent file, you need to initiate a new agent run.',
@@ -218,6 +226,7 @@ export function createProgram(): Command {
     .addOption(BUNDLE_AGENT_FILE)
     .addOption(AGENT_FILE_MODULE_TYPE)
     .addOption(A2A_OPTION)
+    .addOption(A2A_AUTH_TOKEN_OPTION)
     .addOption(RELOAD_AGENTS_OPTION)
     .action(async (agentsDir: string, options: Record<string, string>) => {
       const logLevel = getLogLevelFromOptions(options);
@@ -236,6 +245,7 @@ export function createProgram(): Command {
           otelToCloud: options['otel_to_cloud'] ? true : false,
           agentFileLoadOptions: getAgentFileOptions(options),
           a2a: getBoolean(options['a2a']),
+          a2aAuthToken: options['a2a_auth_token'],
           reloadAgents: getBoolean(options['reload_agents']),
         });
 
@@ -262,6 +272,7 @@ export function createProgram(): Command {
     .addOption(BUNDLE_AGENT_FILE)
     .addOption(AGENT_FILE_MODULE_TYPE)
     .addOption(A2A_OPTION)
+    .addOption(A2A_AUTH_TOKEN_OPTION)
     .addOption(RELOAD_AGENTS_OPTION)
     .action(async (agentsDir: string, options: Record<string, string>) => {
       const logLevel = getLogLevelFromOptions(options);
@@ -280,6 +291,7 @@ export function createProgram(): Command {
           otelToCloud: options['otel_to_cloud'] ? true : false,
           agentFileLoadOptions: getAgentFileOptions(options),
           a2a: getBoolean(options['a2a']),
+          a2aAuthToken: options['a2a_auth_token'],
           reloadAgents: getBoolean(options['reload_agents']),
         });
         await server.start();
@@ -412,6 +424,7 @@ export function createProgram(): Command {
     .addOption(BUNDLE_AGENT_FILE)
     .addOption(AGENT_FILE_MODULE_TYPE)
     .addOption(A2A_OPTION)
+    .addOption(A2A_AUTH_TOKEN_DEPLOY_OPTION)
     .action(async (agentPath: string, options: Record<string, string>) => {
       const extraGcloudArgs = [];
       for (const arg of process.argv.slice(5)) {
@@ -442,6 +455,7 @@ export function createProgram(): Command {
           artifactServiceUri: options['artifact_service_uri'],
           agentFileLoadOptions: getAgentFileOptions(options),
           a2a: getBoolean(options['a2a']),
+          a2aAuthToken: options['a2a_auth_token'],
           extraGcloudArgs,
         });
       } catch (error) {

--- a/dev/src/cli/deploy/cli_deploy_cloud_run.ts
+++ b/dev/src/cli/deploy/cli_deploy_cloud_run.ts
@@ -6,6 +6,7 @@
 import fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import {A2A_AUTH_TOKEN_ENV_VAR} from '../../server/adk_api_server.js';
 import {AgentLoader} from '../../utils/agent_loader.js';
 import {isFile, isFolderExists} from '../../utils/file_utils.js';
 import {
@@ -24,6 +25,12 @@ export {createDockerFileContent, type CreateDockerFileContentOptions};
 export interface DeployToCloudRunOptions extends BaseDeployOptions {
   serviceName: string;
   extraGcloudArgs?: string[];
+  /**
+   * Shared bearer token for the A2A surface; forwarded to Cloud Run as the
+   * `ADK_A2A_AUTH_TOKEN` environment variable. It is deliberately never
+   * written into the generated Dockerfile or any image layer.
+   */
+  a2aAuthToken?: string;
 }
 
 function validateGcloudExtraArgs(
@@ -45,7 +52,7 @@ function validateGcloudExtraArgs(
     throw new Error(
       `The argument(s) ${conflicts.join(
         ', ',
-      )} conflict with ADK's automatic configuration. ADK will set these arguments automatically, so please remove them from your command.`,
+      )} conflict with ADK's automatic configuration. ADK manages these arguments itself, so please remove them from your command.`,
     );
   }
 }
@@ -57,6 +64,16 @@ function prepareGCloudArguments(options: DeployToCloudRunOptions): string[] {
   const adkManagedArgs = ['--source', '--project', '--port', '--verbosity'];
   if (options.region) {
     adkManagedArgs.push('--region');
+  }
+  if (options.a2aAuthToken) {
+    // Any gcloud env-var flag can drop the injected token, so claim them all.
+    adkManagedArgs.push(
+      '--update-env-vars',
+      '--set-env-vars',
+      '--remove-env-vars',
+      '--clear-env-vars',
+      '--env-vars-file',
+    );
   }
 
   if (options.extraGcloudArgs) {
@@ -77,6 +94,13 @@ function prepareGCloudArguments(options: DeployToCloudRunOptions): string[] {
     '--verbosity',
     options.logLevel.toLowerCase(),
   ];
+
+  if (options.a2aAuthToken) {
+    gcloudCommands.push(
+      '--update-env-vars',
+      `${A2A_AUTH_TOKEN_ENV_VAR}=${options.a2aAuthToken}`,
+    );
+  }
 
   const userLabels = [];
   const extraArgsWithoutLabels = [];
@@ -129,6 +153,15 @@ export async function deployToCloudRun(options: DeployToCloudRunOptions) {
   }
 
   const gcloudCommands = prepareGCloudArguments(options);
+
+  if (options.a2a && !options.a2aAuthToken) {
+    console.warn(
+      'SECURITY WARNING: deploying the A2A surface WITHOUT authentication, ' +
+        'so any caller that can reach the service can invoke the agent and ' +
+        'its tools. Pass --a2a_auth_token=<secret> to require a bearer ' +
+        'credential.',
+    );
+  }
 
   // Request to bundle any js or ts file into a single cjs file to be able to
   // copy file with all it's dependencies correctly.

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -10,6 +10,7 @@ import {
   BaseArtifactService,
   BaseMemoryService,
   BaseSessionService,
+  bearerTokenUserBuilder,
   Event,
   getFunctionCalls,
   getFunctionResponses,
@@ -42,6 +43,13 @@ import {
 } from '../utils/telemetry_utils.js';
 import {getAgentGraphAsDot} from './agent_graph.js';
 
+/**
+ * Environment variable holding the shared bearer token used to authenticate
+ * the A2A surface, for operators who prefer not to put the secret on the
+ * command line.
+ */
+export const A2A_AUTH_TOKEN_ENV_VAR = 'ADK_A2A_AUTH_TOKEN';
+
 interface ServerOptions {
   agentsDir?: string;
   host?: string;
@@ -57,6 +65,12 @@ interface ServerOptions {
   logger?: Logger;
   logLevel?: LogLevel;
   a2a?: boolean;
+  /**
+   * Shared bearer token used to authenticate the A2A surface. Falls back to
+   * the `ADK_A2A_AUTH_TOKEN` environment variable. When neither is set and
+   * `a2a` is enabled, the A2A surface is mounted WITHOUT authentication.
+   */
+  a2aAuthToken?: string;
   reloadAgents?: boolean;
   registerProcessors?: (tracerProvider: TracerProvider) => void;
 }
@@ -93,6 +107,7 @@ export class AdkApiServer {
   private memoryExporter: InMemoryExporter;
   private readonly logger: Logger;
   private readonly a2a: boolean;
+  private readonly a2aAuthToken?: string;
 
   constructor(options: ServerOptions) {
     this.host = options.host ?? 'localhost';
@@ -126,6 +141,10 @@ export class AdkApiServer {
       });
     this.logger.setLogLevel(options.logLevel ?? LogLevel.INFO);
     this.a2a = options.a2a ?? false;
+    // An exported-but-empty value means "no token"; anything else is handed
+    // to the authenticator, which rejects a token that is not usable.
+    this.a2aAuthToken =
+      options.a2aAuthToken || process.env[A2A_AUTH_TOKEN_ENV_VAR] || undefined;
     this.app = express();
   }
 
@@ -145,6 +164,9 @@ export class AdkApiServer {
 
   private async initA2A() {
     const appNames = await this.agentLoader.listAgents();
+    const authentication = this.a2aAuthToken
+      ? bearerTokenUserBuilder(this.a2aAuthToken)
+      : undefined;
 
     for (const appName of appNames) {
       const agentFile = await this.agentLoader.getAgentFile(appName);
@@ -163,11 +185,12 @@ export class AdkApiServer {
         artifactService: this.artifactService,
         runner,
         app: this.app,
-        // This is the local development API server. `toA2a` fails closed by
-        // default, so explicitly opt out of authentication
-        // here; a loud warning is logged at startup. Production A2A deployments
-        // should instead pass an `authentication` UserBuilder.
-        allowUnauthenticated: true,
+        // `toA2a` fails closed by default. When the operator configured a
+        // shared bearer token the A2A surface is authenticated with it;
+        // otherwise this local development server explicitly opts out and a
+        // loud warning is logged at startup.
+        authentication,
+        allowUnauthenticated: authentication === undefined,
       });
     }
   }

--- a/dev/test/cli/cli_deploy_cloud_run_test.ts
+++ b/dev/test/cli/cli_deploy_cloud_run_test.ts
@@ -11,6 +11,7 @@ import {
   CreateDockerFileContentOptions,
   deployToCloudRun,
 } from '../../src/cli/deploy/cli_deploy_cloud_run.js';
+import {A2A_AUTH_TOKEN_ENV_VAR} from '../../src/server/adk_api_server.js';
 import {AgentLoader} from '../../src/utils/agent_loader.js';
 import {
   isFile,
@@ -21,8 +22,11 @@ import {
 
 type Callback = (error: Error | null, result?: unknown) => void;
 
+const A2A_TOKEN = 'test-a2a-token';
+
 const execMock = vi.fn();
-const spawnMock = vi.fn();
+const spawnMock =
+  vi.fn<(cmd: string, args: string[], opts: unknown) => unknown>();
 
 vi.mock('node:child_process', () => ({
   exec: (cmd: string, callback: Callback) => execMock(cmd, callback),
@@ -127,6 +131,7 @@ describe('deployToCloudRun', () => {
     vi.clearAllMocks();
     vi.spyOn(console, 'info').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // Default mock behavior
     (isFile as Mock).mockResolvedValue(false);
@@ -282,6 +287,67 @@ describe('deployToCloudRun', () => {
         'Package "@google/adk" is required but not found',
       ),
       expect.stringContaining('\x1b[0m'),
+    );
+  });
+
+  it('should forward the A2A token to Cloud Run as an environment variable', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn');
+
+    await deployToCloudRun({
+      ...defaultOptions,
+      a2a: true,
+      a2aAuthToken: A2A_TOKEN,
+    });
+
+    const gcloudArgs = spawnMock.mock.calls[0][1];
+    const flagIndex = gcloudArgs.indexOf('--update-env-vars');
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(gcloudArgs[flagIndex + 1]).toBe(
+      `${A2A_AUTH_TOKEN_ENV_VAR}=${A2A_TOKEN}`,
+    );
+    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('WITHOUT authentication'),
+    );
+  });
+
+  it('should not touch environment variables when no A2A token is given', async () => {
+    await deployToCloudRun(defaultOptions);
+
+    const gcloudArgs = spawnMock.mock.calls[0][1];
+    expect(gcloudArgs).not.toContain('--update-env-vars');
+    expect(gcloudArgs.join(' ')).not.toContain(A2A_AUTH_TOKEN_ENV_VAR);
+  });
+
+  it.each(['--set-env-vars=FOO=bar', '--remove-env-vars=FOO'])(
+    'should reject %s, which would clobber the A2A token',
+    async (extraGcloudArg) => {
+      await expect(
+        deployToCloudRun({
+          ...defaultOptions,
+          a2a: true,
+          a2aAuthToken: A2A_TOKEN,
+          extraGcloudArgs: [extraGcloudArg],
+        }),
+      ).rejects.toThrow(/conflict with ADK's automatic configuration/);
+    },
+  );
+
+  it('should still allow user env-var flags when no A2A token is given', async () => {
+    await deployToCloudRun({
+      ...defaultOptions,
+      extraGcloudArgs: ['--set-env-vars=FOO=bar'],
+    });
+
+    expect(spawnMock.mock.calls[0][1]).toContain('--set-env-vars=FOO=bar');
+  });
+
+  it('should warn when deploying an A2A surface with no token', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn');
+
+    await deployToCloudRun({...defaultOptions, a2a: true});
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('WITHOUT authentication'),
     );
   });
 

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -147,6 +147,13 @@ describe('CLI Entrypoint', () => {
       const args = (AdkApiServer as unknown as Mock).mock.calls[0][0];
       expect(args.a2a).toBe(true);
     });
+
+    it('should pass a2aAuthToken when --a2a_auth_token is set', async () => {
+      await parse(['web', '--a2a', '--a2a_auth_token', 'tok']);
+
+      const args = (AdkApiServer as unknown as Mock).mock.calls[0][0];
+      expect(args.a2aAuthToken).toBe('tok');
+    });
   });
 
   describe('command: api_server', () => {
@@ -166,6 +173,13 @@ describe('CLI Entrypoint', () => {
 
       const args = (AdkApiServer as unknown as Mock).mock.calls[0][0];
       expect(args.a2a).toBe(true);
+    });
+
+    it('should pass a2aAuthToken when --a2a_auth_token is set', async () => {
+      await parse(['api_server', '--a2a', '--a2a_auth_token', 'tok']);
+
+      const args = (AdkApiServer as unknown as Mock).mock.calls[0][0];
+      expect(args.a2aAuthToken).toBe('tok');
     });
   });
 
@@ -302,6 +316,24 @@ describe('CLI Entrypoint', () => {
       expect((deployToCloudRun as Mock).mock.calls[0][0]).toMatchObject({
         a2a: true,
       });
+    });
+
+    it('should pass a2aAuthToken to deployToCloudRun when --a2a_auth_token is set', async () => {
+      await parse([
+        'deploy',
+        'cloud_run',
+        './my-agent-path',
+        '--project=my-proj',
+        '--region=us-west1',
+        '--a2a',
+        '--a2a_auth_token=tok',
+      ]);
+
+      const args = (deployToCloudRun as Mock).mock.calls[0][0];
+      expect(args).toMatchObject({a2a: true, a2aAuthToken: 'tok'});
+      // A recognised flag must not also be passed through as an unknown one,
+      // which gcloud would reject.
+      expect(args.extraGcloudArgs).toEqual([]);
     });
   });
 

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -25,8 +25,52 @@ import {ReadableSpan} from '@opentelemetry/sdk-trace-base';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 
-import {AdkApiServer} from '../../src/server/adk_api_server.js';
+import {
+  A2A_AUTH_TOKEN_ENV_VAR,
+  AdkApiServer,
+} from '../../src/server/adk_api_server.js';
 import {AgentLoader} from '../../src/utils/agent_loader.js';
+
+interface JsonRpcResponse {
+  result?: unknown;
+  error?: {code: number; message: string};
+}
+
+/**
+ * Sends a genuine A2A `message/send` JSON-RPC call, optionally with an
+ * `Authorization` header, and reports the raw HTTP status so authentication
+ * failures can be told apart from agent responses.
+ */
+async function sendA2aMessage(
+  baseUrl: string,
+  authorization?: string,
+): Promise<{status: number; body: JsonRpcResponse}> {
+  const response = await fetch(`${baseUrl}/a2a/testApp/jsonrpc`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(authorization ? {Authorization: authorization} : {}),
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'a2a-test-request',
+      method: 'message/send',
+      params: {
+        message: {
+          kind: 'message',
+          messageId: 'a2a-test-message',
+          role: 'user',
+          parts: [{kind: 'text', text: 'Hello'}],
+        },
+      },
+    }),
+  });
+
+  return {
+    status: response.status,
+    body: (await response.json()) as JsonRpcResponse,
+  };
+}
 
 /**
  * Http client for testing the AdkWebServer. It makes real http requests to the
@@ -900,6 +944,36 @@ describe('AdkWebServer', () => {
   });
 
   describe('A2A', () => {
+    const A2A_TOKEN = 'test-a2a-token';
+    let a2aServer: AdkApiServer | undefined;
+
+    const startA2aServer = async (a2aAuthToken?: string) => {
+      a2aServer = new AdkApiServer({
+        agentLoader,
+        sessionService,
+        memoryService,
+        artifactService,
+        a2a: true,
+        a2aAuthToken,
+      });
+      await a2aServer.start();
+      return a2aServer.url;
+    };
+
+    beforeEach(() => {
+      vi.stubEnv(A2A_AUTH_TOKEN_ENV_VAR, undefined);
+      // The SDK logs the rejection thrown by the authenticator; keep it out of
+      // the test output.
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(async () => {
+      await a2aServer?.stop();
+      a2aServer = undefined;
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+    });
+
     it('should return 404 for A2A endpoints when disabled', async () => {
       try {
         await client.get(`/a2a/testApp/${AGENT_CARD_PATH}`);
@@ -908,24 +982,75 @@ describe('AdkWebServer', () => {
       }
     });
 
-    it('should return Agent Card when enabled', async () => {
-      const a2aServer = new AdkApiServer({
-        agentLoader,
-        sessionService,
-        memoryService,
-        artifactService,
-        a2a: true,
-      });
-      await a2aServer.start();
-      const a2aClient = new HttpClient(a2aServer.url);
+    // The agent card route is mounted without a user builder, so it stays
+    // readable whether or not the rest of the surface is authenticated.
+    it.each([undefined, A2A_TOKEN])(
+      'should serve the agent card publicly (auth token: %s)',
+      async (a2aAuthToken) => {
+        const a2aClient = new HttpClient(await startA2aServer(a2aAuthToken));
 
-      const response = await a2aClient.get<AgentCard>(
-        `/a2a/testApp/${AGENT_CARD_PATH}`,
-      );
+        const response = await a2aClient.get<AgentCard>(
+          `/a2a/testApp/${AGENT_CARD_PATH}`,
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.name).toBe('testAgent');
+      },
+    );
+
+    it('should run the agent for a call carrying the configured token', async () => {
+      const url = await startA2aServer(A2A_TOKEN);
+
+      const response = await sendA2aMessage(url, `Bearer ${A2A_TOKEN}`);
+
       expect(response.status).toBe(200);
-      expect(response.data?.name).toBe('testAgent');
+      expect(response.body.error).toBeUndefined();
+      expect(response.body.result).toBeDefined();
+    });
 
-      await a2aServer.stop();
+    it('should reject a call with a missing or wrong token', async () => {
+      const url = await startA2aServer(A2A_TOKEN);
+
+      for (const authorization of [undefined, 'Bearer wrong-token']) {
+        const response = await sendA2aMessage(url, authorization);
+
+        // The SDK picks the status; all that matters is that the agent was
+        // not reached.
+        expect(response.status).toBeGreaterThanOrEqual(400);
+        expect(response.body.result).toBeUndefined();
+        expect(response.body.error).toBeDefined();
+      }
+    });
+
+    it(`should honour the ${A2A_AUTH_TOKEN_ENV_VAR} environment variable`, async () => {
+      vi.stubEnv(A2A_AUTH_TOKEN_ENV_VAR, A2A_TOKEN);
+      const url = await startA2aServer();
+
+      expect((await sendA2aMessage(url)).status).toBeGreaterThanOrEqual(400);
+      expect((await sendA2aMessage(url, `Bearer ${A2A_TOKEN}`)).status).toBe(
+        200,
+      );
+    });
+
+    it('should prefer the explicit token over the environment variable', async () => {
+      vi.stubEnv(A2A_AUTH_TOKEN_ENV_VAR, 'env-token');
+      const url = await startA2aServer(A2A_TOKEN);
+
+      expect(
+        (await sendA2aMessage(url, 'Bearer env-token')).status,
+      ).toBeGreaterThanOrEqual(400);
+      expect((await sendA2aMessage(url, `Bearer ${A2A_TOKEN}`)).status).toBe(
+        200,
+      );
+    });
+
+    it('should serve an unauthenticated surface when no token is configured', async () => {
+      const url = await startA2aServer();
+
+      const response = await sendA2aMessage(url);
+
+      expect(response.status).toBe(200);
+      expect(response.body.result).toBeDefined();
     });
   });
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

_No existing issue._

This is **Part 2/2** of a stacked series. It builds on Part 1/2 (branch
`feat/a2a-cli-auth-token-part1`), which adds the `bearerTokenUserBuilder` that
this PR consumes, and should be reviewed and merged **after** Part 1/2. Because
the two branches are stacked, the commit range here also contains Part 1's six
`core/` commits; the only commit new to this PR is `feat(dev): authenticate the
A2A surface from the command line`, which touches `dev/` exclusively.

**2. Or, if no issue exists, describe the change:**

**Problem:**
`toA2a()` fails closed, which protects library users who call it from their own
code — but it does nothing for operators who never write TypeScript.
`dev/src/server/adk_api_server.ts` `initA2A()` hardcoded
`allowUnauthenticated: true` precisely because there was no way to hand it an
authenticator from the command line. `adk deploy cloud_run --a2a` then generated
a container whose `CMD` is `npx adk api_server ... --a2a`, so the deployed
service exposed an app-layer-unauthenticated A2A surface guarded only by
whatever Cloud Run IAM the operator happened to configure. There was no way to
authenticate that surface without writing code.

**Solution:**
Give the operator a flag.

- `AdkApiServer` accepts an `a2aAuthToken` option, falling back to the
  `ADK_A2A_AUTH_TOKEN` environment variable. When a token is present,
  `initA2A()` passes `authentication: bearerTokenUserBuilder(token)` to
  `toA2a()` instead of `allowUnauthenticated: true`. The builder is constructed
  once, outside the per-app loop.
- `--a2a_auth_token <string>` is added to `adk web`, `adk api_server` and
  `adk deploy cloud_run`. It takes a required value (`<string>`, not
  `[string]`) so a bare flag is a parse error rather than a silently empty
  token.
- `adk deploy cloud_run --a2a --a2a_auth_token=<secret>` forwards the token to
  Cloud Run as `--update-env-vars ADK_A2A_AUTH_TOKEN=<secret>`. The generated
  Dockerfile is byte-identical to today's, so the secret never lands in an image
  layer.
- Deploying `--a2a` with no token warns loudly instead of failing, so no
  existing workflow breaks.

Design notes:

- **Passing a token makes ADK the owner of the deployed service's
  environment.** `prepareGCloudArguments()` then adds all five gcloud env-var
  flags to `adkManagedArgs`, so a user-supplied one raises the repo's existing
  "conflict with ADK's automatic configuration" error. This is not defensive
  padding: `--remove-env-vars` is _not_ mutually exclusive with
  `--update-env-vars`, so gcloud itself would have accepted
  `--remove-env-vars ADK_A2A_AUTH_TOKEN` and left an unauthenticated service
  behind. With no token configured `adkManagedArgs` is untouched, so users who
  pass their own `--set-env-vars` today keep working.
- **`allowUnauthenticated: authentication === undefined`** rather than a bare
  `true`. It costs nothing and keeps the opt-out tied to the absence of an
  authenticator instead of depending on `resolveA2aUserBuilder`'s precedence.
- **An empty option or environment variable means "no token"**, so an
  exported-but-unset `ADK_A2A_AUTH_TOKEN` (or a blank line in a `.env`, which
  the CLI loads via dotenv) behaves like unset. Anything else is handed to
  `bearerTokenUserBuilder`, which fails startup loudly rather than silently
  degrading to an unauthenticated surface.
- **The deploy flag gets its own help text**, because the environment-variable
  fallback is a property of the serving commands only — `deployToCloudRun` does
  not read `ADK_A2A_AUTH_TOKEN`, and a single shared description would have
  promised otherwise.
- **Known limitation, unchanged from any other gcloud env-var usage:** the token
  appears in the local `gcloud run deploy` argv, so it is visible to `ps` on the
  deploying machine for the duration of the deploy. It does not reach the image
  or any ADK log line. Operators who need to avoid that can set the variable on
  the service out of band and deploy without the flag.
- Out of scope, as agreed during design: `adk deploy agent_engine` /
  `reasoning_engine` ship through `gcloud builds submit` and have no
  `--update-env-vars` hook, so the flag is deliberately not added there.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

- `dev/test/server/adk_api_server_test.ts` boots a **real** `AdkApiServer` and
  sends genuine `message/send` JSON-RPC calls over HTTP — no mocks — asserting
  that an authenticated call produces an agent response while a call with a
  missing or wrong token is rejected without reaching the agent, that the agent
  card stays publicly readable with and without a token, that
  `ADK_A2A_AUTH_TOKEN` is honoured, that an explicit option wins over it, and
  that the unauthenticated default is preserved.
- `dev/test/cli/cli_test.ts` covers `--a2a_auth_token` passthrough for `web`,
  `api_server` and `deploy cloud_run`, including that the recognised flag is not
  also forwarded to gcloud as an unknown argument.
- `dev/test/cli/cli_deploy_cloud_run_test.ts` covers the
  `--update-env-vars ADK_A2A_AUTH_TOKEN=<token>` argv pair, that neither the
  flag nor the variable appears when no token is given, that
  `--set-env-vars`/`--remove-env-vars` conflict _only_ when a token is
  configured, and the no-token warning.

The rejection tests assert `status >= 400` rather than a specific code, because
the status is the SDK's to choose; what matters is that the agent was not
reached.

```
$ npx vitest run --project unit:core --project unit:dev \
    core/test/a2a/auth_test.ts core/test/a2a/agent_to_a2a_test.ts \
    dev/test/server/adk_api_server_test.ts dev/test/cli/cli_test.ts \
    dev/test/cli/cli_deploy_cloud_run_test.ts
 ✓ |unit:core| core/test/a2a/auth_test.ts (9 tests)
 ✓ |unit:core| core/test/a2a/agent_to_a2a_test.ts (8 tests)
 ✓ |unit:dev| dev/test/cli/cli_deploy_cloud_run_test.ts (18 tests)
 ✓ |unit:dev| dev/test/cli/cli_test.ts (24 tests)
 ✓ |unit:dev| dev/test/server/adk_api_server_test.ts (51 tests)
 Test Files  5 passed (5)
      Tests  110 passed (110)
```

Every line and branch added to `cli.ts`, `adk_api_server.ts` and
`cli_deploy_cloud_run.ts` is covered; the residual uncovered lines those files
report are all pre-existing.

Also run on this commit: `npm run build`, `npm run lint`,
`npm run format:check`, `npm run docs:check` — all clean.

> **Note:** the commands above were run locally against the exact commit pushed
> to this branch.

**Manual End-to-End (E2E) Tests:**

Build the workspace (`npm run build`) and point the CLI at a directory
containing an agent (below, one that answers `pong`).

**1. Unauthenticated (unchanged behaviour) — the core warning still fires.**

```bash
$ node dev/dist/esm/cli_entrypoint.js api_server ./agents --a2a --port 8123
WARN: [ADK] SECURITY WARNING: Mounting the A2A server WITHOUT authentication because
`allowUnauthenticated: true` was set. ...

$ PAYLOAD='{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"ping"}]}}}'
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X POST localhost:8123/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -d "$PAYLOAD"
HTTP 200
```

**2. Authenticated with `--a2a_auth_token`.**

```bash
$ node dev/dist/esm/cli_entrypoint.js api_server ./agents --a2a --a2a_auth_token=hunter2 --port 8124
# (no SECURITY WARNING)

$ curl -s -w 'HTTP %{http_code}\n' -X POST localhost:8124/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -d "$PAYLOAD"
{"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
HTTP 500

$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X POST localhost:8124/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer wrong' -d "$PAYLOAD"
HTTP 500

$ curl -s -X POST localhost:8124/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer hunter2' -d "$PAYLOAD"
{"jsonrpc":"2.0","id":"1","result":{"kind":"task","id":"a51d75ff-...","history":[...]}}
HTTP 200

# Agent card stays public, by design.
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' localhost:8124/a2a/my_agent/.well-known/agent-card.json
HTTP 200

# The token is never logged.
$ grep -c hunter2 server.log
0
```

**3. Environment-variable form.**

```bash
$ ADK_A2A_AUTH_TOKEN=envsecret node dev/dist/esm/cli_entrypoint.js api_server ./agents --a2a --port 8125
# (no SECURITY WARNING)
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X POST localhost:8125/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -d "$PAYLOAD"
HTTP 500
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X POST localhost:8125/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer envsecret' -d "$PAYLOAD"
HTTP 200
```

**4. Deploy plumbing, verified without actually deploying** (a stub `gcloud` on
`PATH` recorded its argv and copied the generated Dockerfile out of the temp
folder before cleanup).

```bash
$ adk deploy cloud_run ./agents --project=example-project --region=us-central1 \
    --a2a --a2a_auth_token=hunter2

# recorded gcloud argv:
run deploy adk-default-service-name --source /tmp/cloud_run_deploy_src/<uuid>
  --project example-project --region us-central1 --port 8000 --verbosity info
  --update-env-vars ADK_A2A_AUTH_TOKEN=hunter2 --labels created-by=adk

# the generated Dockerfile mentions neither the secret, the variable, nor the flag:
$ grep -c 'hunter2\|ADK_A2A_AUTH_TOKEN\|a2a_auth_token' Dockerfile
0
$ grep '^CMD' Dockerfile
CMD npx adk api_server /app/agents/agents --port=8000 --host=0.0.0.0 --log_level=info --a2a
```

```bash
# --a2a with no token warns and touches no env-var flags:
$ adk deploy cloud_run ./agents --project=example-project --region=us-central1 --a2a
SECURITY WARNING: deploying the A2A surface WITHOUT authentication, so any caller that can
reach the service can invoke the agent and its tools. Pass --a2a_auth_token=<secret> to
require a bearer credential.
$ grep -c env-vars gcloud_argv.txt
0

# a user env-var flag alongside a token is refused, including the one gcloud would accept:
$ adk deploy cloud_run ./agents --project=example-project --region=us-central1 \
    --a2a --a2a_auth_token=hunter2 --remove-env-vars=FOO
[ADK CLI] Error deploying agent: The argument(s) --remove-env-vars conflict with ADK's
automatic configuration. ADK manages these arguments itself, so please remove them from
your command.

# ... but with no token, a user env-var flag is passed through as before:
$ adk deploy cloud_run ./agents --project=example-project --region=us-central1 \
    --set-env-vars=FOO=bar
$ grep -c 'FOO=bar' gcloud_argv.txt
1
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Part 1/2 (`feat/a2a-cli-auth-token-part1`) is the dependent change: it adds
`bearerTokenUserBuilder` in `core/`. It has not been merged yet, which is why
the last checklist item above is unchecked.
