### PR TITLE
Fix: accept the derived allowedTools alias in skill frontmatter validation

### DIFF
--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -22,8 +22,9 @@ const ALLOWED_FRONTMATTER_KEYS = new Set([
   'description',
   'license',
   'allowed-tools',
-  // Alias of 'allowed-tools' derived by FrontmatterSchema's preprocessor and
-  // preserved on the parsed frontmatter because the schema is `.loose()`.
+  // Camel-case alias of 'allowed-tools': FrontmatterSchema accepts it from the
+  // author and otherwise derives it in its preprocessor, and the schema is
+  // `.loose()`, so either way it reaches the parsed frontmatter.
   'allowedTools',
   'metadata',
   'compatibility',

--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -22,6 +22,9 @@ const ALLOWED_FRONTMATTER_KEYS = new Set([
   'description',
   'license',
   'allowed-tools',
+  // Alias of 'allowed-tools' derived by FrontmatterSchema's preprocessor and
+  // preserved on the parsed frontmatter because the schema is `.loose()`.
+  'allowedTools',
   'metadata',
   'compatibility',
 ]);

--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -22,9 +22,8 @@ const ALLOWED_FRONTMATTER_KEYS = new Set([
   'description',
   'license',
   'allowed-tools',
-  // Camel-case alias of 'allowed-tools': FrontmatterSchema accepts it from the
-  // author and otherwise derives it in its preprocessor, and the schema is
-  // `.loose()`, so either way it reaches the parsed frontmatter.
+  // Camel-case alias: FrontmatterSchema's preprocessor derives `allowedTools`
+  // from `allowed-tools`, and `.loose()` passes either spelling through.
   'allowedTools',
   'metadata',
   'compatibility',

--- a/core/test/skills/loader_test.ts
+++ b/core/test/skills/loader_test.ts
@@ -362,7 +362,7 @@ Instructions`,
       },
     );
 
-    it('still reports unknown fields alongside allowed-tools', async () => {
+    it('omits the allowedTools alias from the unknown fields message', async () => {
       tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
       const skillDir = path.join(tempDir, 'test-skill');
       await fs.mkdir(skillDir);

--- a/core/test/skills/loader_test.ts
+++ b/core/test/skills/loader_test.ts
@@ -170,27 +170,6 @@ Instructions content`,
       },
     );
 
-    it('exposes allowed-tools as allowedTools', async () => {
-      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
-      const skillDir = path.join(tempDir, 'test-skill');
-      await fs.mkdir(skillDir);
-
-      await fs.writeFile(
-        path.join(skillDir, 'SKILL.md'),
-        `---
-name: test-skill
-description: A test skill
-allowed-tools: "some-tool-*"
----
-Instructions content`,
-      );
-
-      const skill = await loadSkillFromDir(skillDir);
-      expect(skill.frontmatter.allowedTools).toBe('some-tool-*');
-
-      await fs.rm(tempDir, {recursive: true, force: true});
-    });
-
     it('throws error if SKILL.md not found', async () => {
       tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
       const skillDir = path.join(tempDir, 'test-skill');
@@ -359,47 +338,29 @@ Instructions`,
       await fs.rm(tempDir, {recursive: true, force: true});
     });
 
-    it('returns no problems for a skill declaring allowed-tools', async () => {
-      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
-      const skillDir = path.join(tempDir, 'test-skill');
-      await fs.mkdir(skillDir);
+    it.each(['allowed-tools', 'allowedTools'])(
+      'returns no problems for a skill declaring %s',
+      async (key) => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
+        const skillDir = path.join(tempDir, 'test-skill');
+        await fs.mkdir(skillDir);
 
-      await fs.writeFile(
-        path.join(skillDir, 'SKILL.md'),
-        `---
+        await fs.writeFile(
+          path.join(skillDir, 'SKILL.md'),
+          `---
 name: test-skill
 description: A test skill
-allowed-tools: "some-tool-*"
+${key}: "some-tool-*"
 ---
 Instructions`,
-      );
+        );
 
-      const problems = await validateSkillDir(skillDir);
-      expect(problems).toEqual([]);
+        const problems = await validateSkillDir(skillDir);
+        expect(problems).toEqual([]);
 
-      await fs.rm(tempDir, {recursive: true, force: true});
-    });
-
-    it('returns no problems for a skill declaring allowedTools', async () => {
-      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
-      const skillDir = path.join(tempDir, 'test-skill');
-      await fs.mkdir(skillDir);
-
-      await fs.writeFile(
-        path.join(skillDir, 'SKILL.md'),
-        `---
-name: test-skill
-description: A test skill
-allowedTools: "some-tool-*"
----
-Instructions`,
-      );
-
-      const problems = await validateSkillDir(skillDir);
-      expect(problems).toEqual([]);
-
-      await fs.rm(tempDir, {recursive: true, force: true});
-    });
+        await fs.rm(tempDir, {recursive: true, force: true});
+      },
+    );
 
     it('still reports unknown fields alongside allowed-tools', async () => {
       tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));

--- a/core/test/skills/loader_test.ts
+++ b/core/test/skills/loader_test.ts
@@ -170,6 +170,27 @@ Instructions content`,
       },
     );
 
+    it('exposes allowed-tools as allowedTools', async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
+      const skillDir = path.join(tempDir, 'test-skill');
+      await fs.mkdir(skillDir);
+
+      await fs.writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: test-skill
+description: A test skill
+allowed-tools: "some-tool-*"
+---
+Instructions content`,
+      );
+
+      const skill = await loadSkillFromDir(skillDir);
+      expect(skill.frontmatter.allowedTools).toBe('some-tool-*');
+
+      await fs.rm(tempDir, {recursive: true, force: true});
+    });
+
     it('throws error if SKILL.md not found', async () => {
       tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
       const skillDir = path.join(tempDir, 'test-skill');
@@ -334,6 +355,70 @@ Instructions`,
       expect(
         problems.some((p) => p.includes('Unknown frontmatter fields')),
       ).toBe(true);
+
+      await fs.rm(tempDir, {recursive: true, force: true});
+    });
+
+    it('returns no problems for a skill declaring allowed-tools', async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
+      const skillDir = path.join(tempDir, 'test-skill');
+      await fs.mkdir(skillDir);
+
+      await fs.writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: test-skill
+description: A test skill
+allowed-tools: "some-tool-*"
+---
+Instructions`,
+      );
+
+      const problems = await validateSkillDir(skillDir);
+      expect(problems).toEqual([]);
+
+      await fs.rm(tempDir, {recursive: true, force: true});
+    });
+
+    it('returns no problems for a skill declaring allowedTools', async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
+      const skillDir = path.join(tempDir, 'test-skill');
+      await fs.mkdir(skillDir);
+
+      await fs.writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: test-skill
+description: A test skill
+allowedTools: "some-tool-*"
+---
+Instructions`,
+      );
+
+      const problems = await validateSkillDir(skillDir);
+      expect(problems).toEqual([]);
+
+      await fs.rm(tempDir, {recursive: true, force: true});
+    });
+
+    it('still reports unknown fields alongside allowed-tools', async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
+      const skillDir = path.join(tempDir, 'test-skill');
+      await fs.mkdir(skillDir);
+
+      await fs.writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: test-skill
+description: A test skill
+allowed-tools: "some-tool-*"
+unknown_field: value
+---
+Instructions`,
+      );
+
+      const problems = await validateSkillDir(skillDir);
+      expect(problems).toEqual(['Unknown frontmatter fields: [unknown_field]']);
 
       await fs.rm(tempDir, {recursive: true, force: true});
     });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue is tracking this; see the description below.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`validateSkillDir()` reports a spurious problem for every otherwise valid skill whose `SKILL.md` declares the spec-defined `allowed-tools` frontmatter key:

```
Unknown frontmatter fields: [allowedTools]
```

Two components disagree about which key names are legitimate. `FrontmatterSchema` (`core/src/skills/skill.ts`) is a `z.preprocess()` wrapper that deliberately derives a camelCase `allowedTools` alias when the input has `allowed-tools` and not `allowedTools` — `allowedTools` is the field name the public `Frontmatter` interface exposes. Because the inner object schema is `.loose()`, that derived key is passed through onto the parsed frontmatter alongside the original `allowed-tools`. `validateSkillDir()` then filters `Object.keys(skill.frontmatter)` against `ALLOWED_FRONTMATTER_KEYS` (`core/src/skills/loader.ts`), which listed `'allowed-tools'` but not `'allowedTools'` — so a key the schema itself synthesized is reported as unknown. Only validation is affected: `loadSkillFromDir()`, `loadAllSkillsInDir()`, and `loadSkillFromZipBuffer()` never consult that set, so such a skill loads fine and only fails validation.

**Solution:**

Add `'allowedTools'` to `ALLOWED_FRONTMATTER_KEYS`. This mirrors adk-python, where `_ALLOWED_FRONTMATTER_KEYS` (`src/google/adk/skills/_utils.py`) likewise lists both the hyphenated `allowed-tools` and the aliased `allowed_tools` spelling precisely so the alias can never be mistaken for an unknown field. The one-line allow-list entry keeps `ALLOWED_FRONTMATTER_KEYS` the single source of truth and keeps it consistent with the keys `FrontmatterSchema` can produce.

Unknown-field detection is otherwise unchanged: a skill declaring both `allowed-tools` and a genuinely unknown key still reports exactly `Unknown frontmatter fields: [unknown_field]`. No API signature, type, or parsed-object shape changes, and no new dependencies.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added to `core/test/skills/loader_test.ts`, inside the existing `describe('validateSkillDir')` block and following its established inline `mkdtemp` / `writeFile` / `rm` pattern:

- `'returns no problems for a skill declaring %s'` (`it.each` over `allowed-tools` and `allowedTools`) — the primary regression test. The hyphenated case fails on `main` with `[ "Unknown frontmatter fields: [allowedTools]" ]`; the camelCase case covers the alias arriving author-supplied rather than preprocessor-derived, which the schema already accepts.
- `'omits the allowedTools alias from the unknown fields message'` — declares `allowed-tools` alongside `unknown_field` and asserts the exact result `['Unknown frontmatter fields: [unknown_field]']`. The pre-existing unknown-fields test only asserts that _some_ `Unknown frontmatter fields` problem is reported, so it stayed green on `main` while the alias leaked into the message; this test pins the message contents and proves the fix did not weaken unknown-field detection.

Commands run locally on the pushed commit:

```
npx vitest run --project unit:core core/test/skills/    # 3 files, 56 tests passed
npm run build                                           # succeeds
npx eslint core/src/skills/loader.ts core/test/skills/loader_test.ts   # clean
npx prettier --check core/src/skills/loader.ts core/test/skills/loader_test.ts   # clean
```

`npm run ts:check` reports 308 pre-existing errors in unrelated test files, identical in count before and after this change (verified by stashing the diff); none are in the files touched here.

**Manual End-to-End (E2E) Tests:**

```
npm install && npm run build
```

Create a skill directory whose name matches the frontmatter `name`, e.g. `test-skill/SKILL.md`:

```
---
name: test-skill
description: A test skill
allowed-tools: "some-tool-*"
---
Instructions
```

Then drive the public API and check the output:

```ts
import {validateSkillDir} from '@google/adk';
console.log(await validateSkillDir('<path>/test-skill'));
```

Observed before this change: `[ 'Unknown frontmatter fields: [allowedTools]' ]`. Observed after: `[]`. Re-running with `allowedTools: "some-tool-*"` in place of the hyphenated key also prints `[]`, and adding a bogus `unknown_field: value` line prints exactly `[ 'Unknown frontmatter fields: [unknown_field]' ]`, confirming real unknown fields are still caught.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Two alternatives were considered and rejected. Normalizing to a single key (having the preprocessor delete `allowed-tools` after copying it) would silently remove `allowed-tools` from the parsed frontmatter handed to every caller of the load APIs — an observable break — and diverges from adk-python, which keeps `allowed-tools` as the serialization alias. Validating the raw YAML keys before schema parsing (as adk-python does) is arguably more principled, but in this codebase it means plumbing the pre-schema object out of `parseSkillMdContent()` / `loadSkillFile()` and changing public signatures to fix a one-line defect.
