### PR TITLE
Feat: Add bearerTokenUserBuilder for A2A authentication (Part 1/2)

### DIFF
--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {timingSafeEqual} from 'node:crypto';
+import {A2aUserBuilder} from './agent_to_a2a.js';
+
+/**
+ * The `userName` reported for a caller that presented the shared bearer token.
+ *
+ * A shared secret authenticates the deployment as a whole rather than an
+ * individual principal, so every accepted caller resolves to this same
+ * synthetic identity.
+ */
+const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
+
+const BEARER_SCHEME_PREFIX = 'bearer ';
+
+/**
+ * Extracts the credential from an `Authorization: Bearer <token>` header
+ * value, or returns `undefined` when the header is absent or uses a different
+ * scheme. The scheme is matched case-insensitively, as RFC 6750 requires.
+ */
+function extractBearerCredential(
+  header: string | undefined,
+): string | undefined {
+  if (!header?.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)) {
+    return undefined;
+  }
+  return header.slice(BEARER_SCHEME_PREFIX.length);
+}
+
+/** Compares two secrets without leaking their contents through timing. */
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  const left = Buffer.from(a, 'utf8');
+  const right = Buffer.from(b, 'utf8');
+  // `timingSafeEqual` throws on a length mismatch, so the lengths must be
+  // compared first. The length of a rejected credential is not a secret.
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/**
+ * Builds an {@link A2aUserBuilder} that authenticates A2A requests against a
+ * shared bearer token.
+ *
+ * Callers must send `Authorization: Bearer <token>`; the credential is
+ * compared against `token` in constant time. A request with a missing,
+ * malformed or incorrect credential is rejected before the agent or any of
+ * its tools is invoked.
+ *
+ * ```ts
+ * toA2a(agent, {authentication: bearerTokenUserBuilder(process.env.MY_TOKEN)});
+ * ```
+ *
+ * A shared secret is only as good as the transport carrying it: serve the A2A
+ * surface over HTTPS so the token is not exposed on the wire.
+ *
+ * @param token The shared secret callers must present. Must be non-empty.
+ * @throws If `token` is empty or contains only whitespace.
+ */
+export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
+  if (!token.trim()) {
+    throw new Error(
+      'bearerTokenUserBuilder: an empty A2A bearer token is not a valid ' +
+        'authenticator. Supply a real shared secret, or configure no token ' +
+        'at all to run the A2A surface unauthenticated.',
+    );
+  }
+
+  return async (req) => {
+    const credential = extractBearerCredential(req.headers.authorization);
+    if (
+      credential === undefined ||
+      !timingSafeEqualStrings(credential, token)
+    ) {
+      throw new Error(
+        'A2A request rejected: missing or invalid `Authorization: Bearer` ' +
+          'credential.',
+      );
+    }
+    return {isAuthenticated: true, userName: AUTHENTICATED_USER_NAME};
+  };
+}

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -57,6 +57,11 @@ function timingSafeEqualStrings(a: string, b: string): boolean {
  * A shared secret is only as good as the transport carrying it: serve the A2A
  * surface over HTTPS so the token is not exposed on the wire.
  *
+ * A rejected request surfaces as whatever the `@a2a-js/sdk` handler produces
+ * for a failing `UserBuilder`, which is an HTTP 500 rather than a 401. The
+ * guarantee this helper provides is that the agent is never reached, not that
+ * the caller gets a particular status code.
+ *
  * @param token The shared secret callers must present. Must be non-empty.
  * @throws If `token` is empty or contains only whitespace.
  */

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -7,21 +7,14 @@
 import {timingSafeEqual} from 'node:crypto';
 import {A2aUserBuilder} from './agent_to_a2a.js';
 
-/**
- * The `userName` reported for a caller that presented the shared bearer token.
- *
- * A shared secret authenticates the deployment as a whole rather than an
- * individual principal, so every accepted caller resolves to this same
- * synthetic identity.
- */
+/** A shared secret identifies a deployment, not an individual principal. */
 const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
 
 const BEARER_SCHEME_PREFIX = 'bearer ';
 
 /**
- * Extracts the credential from an `Authorization: Bearer <token>` header
- * value, or returns `undefined` when the header is absent or uses a different
- * scheme. The scheme is matched case-insensitively, as RFC 6750 requires.
+ * Reads the credential out of an `Authorization: Bearer <token>` header value,
+ * matching the scheme case-insensitively as RFC 6750 requires.
  */
 function extractBearerCredential(
   header: string | undefined,
@@ -62,11 +55,13 @@ function timingSafeEqualStrings(a: string, b: string): boolean {
  * guarantee this helper provides is that the agent is never reached, not that
  * the caller gets a particular status code.
  *
- * @param token The shared secret callers must present. Must be non-empty.
+ * @param token The shared secret callers must present. Surrounding whitespace
+ *   is trimmed, because HTTP strips it from header values anyway.
  * @throws If `token` is empty or contains only whitespace.
  */
 export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
-  if (!token.trim()) {
+  const expected = token.trim();
+  if (!expected) {
     throw new Error(
       'bearerTokenUserBuilder: an empty A2A bearer token is not a valid ' +
         'authenticator. Supply a real shared secret, or configure no token ' +
@@ -78,7 +73,7 @@ export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
     const credential = extractBearerCredential(req.headers.authorization);
     if (
       credential === undefined ||
-      !timingSafeEqualStrings(credential, token)
+      !timingSafeEqualStrings(credential, expected)
     ) {
       throw new Error(
         'A2A request rejected: missing or invalid `Authorization: Bearer` ' +

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -12,17 +12,6 @@ const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
 
 const BEARER_SCHEME_PREFIX = 'bearer ';
 
-/** Reads the credential out of an `Authorization: Bearer <token>` header. */
-function extractBearerCredential(
-  header: string | undefined,
-): string | undefined {
-  // RFC 6750 makes the scheme case-insensitive.
-  if (!header?.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)) {
-    return undefined;
-  }
-  return header.slice(BEARER_SCHEME_PREFIX.length);
-}
-
 /** Compares two secrets without leaking their contents through timing. */
 function timingSafeEqualStrings(a: string, b: string): boolean {
   const left = Buffer.from(a, 'utf8');
@@ -66,11 +55,12 @@ export function bearerTokenUserBuilder(token: string): A2aUserBuilder {
   }
 
   return async (req) => {
-    const credential = extractBearerCredential(req.headers.authorization);
-    if (
-      credential === undefined ||
-      !timingSafeEqualStrings(credential, expected)
-    ) {
+    const header = req.headers.authorization ?? '';
+    // RFC 6750 makes the bearer scheme case-insensitive.
+    const credential = header.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)
+      ? header.slice(BEARER_SCHEME_PREFIX.length)
+      : '';
+    if (!timingSafeEqualStrings(credential, expected)) {
       throw new Error(
         'A2A request rejected: missing or invalid `Authorization: Bearer` ' +
           'credential.',

--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -12,13 +12,11 @@ const AUTHENTICATED_USER_NAME = 'a2a-bearer-token';
 
 const BEARER_SCHEME_PREFIX = 'bearer ';
 
-/**
- * Reads the credential out of an `Authorization: Bearer <token>` header value,
- * matching the scheme case-insensitively as RFC 6750 requires.
- */
+/** Reads the credential out of an `Authorization: Bearer <token>` header. */
 function extractBearerCredential(
   header: string | undefined,
 ): string | undefined {
+  // RFC 6750 makes the scheme case-insensitive.
   if (!header?.toLowerCase().startsWith(BEARER_SCHEME_PREFIX)) {
     return undefined;
   }
@@ -39,23 +37,21 @@ function timingSafeEqualStrings(a: string, b: string): boolean {
  * shared bearer token.
  *
  * Callers must send `Authorization: Bearer <token>`; the credential is
- * compared against `token` in constant time. A request with a missing,
- * malformed or incorrect credential is rejected before the agent or any of
- * its tools is invoked.
+ * compared against `token` in constant time, and a request with a missing,
+ * malformed or incorrect one is rejected before the agent or any of its tools
+ * is invoked. Serve the surface over HTTPS, or the secret travels in clear
+ * text on every call.
  *
  * ```ts
  * toA2a(agent, {authentication: bearerTokenUserBuilder(process.env.MY_TOKEN)});
  * ```
  *
- * A shared secret is only as good as the transport carrying it: serve the A2A
- * surface over HTTPS so the token is not exposed on the wire.
- *
  * A rejected request surfaces as whatever the `@a2a-js/sdk` handler produces
  * for a failing `UserBuilder`, which is an HTTP 500 rather than a 401. The
- * guarantee this helper provides is that the agent is never reached, not that
- * the caller gets a particular status code.
+ * guarantee here is that the agent is never reached, not that the caller gets
+ * a particular status code.
  *
- * @param token The shared secret callers must present. Surrounding whitespace
+ * @param token The shared secret callers must present; surrounding whitespace
  *   is trimmed, because HTTP strips it from header values anyway.
  * @throws If `token` is empty or contains only whitespace.
  */

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -22,6 +22,7 @@ export type {
 } from './a2a/agent_executor.js';
 export {toA2a} from './a2a/agent_to_a2a.js';
 export type {A2aUserBuilder, ToA2aOptions} from './a2a/agent_to_a2a.js';
+export {bearerTokenUserBuilder} from './a2a/auth.js';
 export type {ExecutorContext} from './a2a/executor_context.js';
 export {InvocationContext} from './agents/invocation_context.js';
 export {FileArtifactService} from './artifacts/file_artifact_service.js';

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -86,19 +86,6 @@ describe('bearerTokenUserBuilder', () => {
     ).rejects.toThrow(/missing or invalid/);
   });
 
-  it('never discloses the configured token when rejecting', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    const rejection = await userBuilder(
-      requestWithHeaders({authorization: 'Bearer wrong'}),
-    ).then(
-      () => expect.fail('expected the authenticator to reject'),
-      (error: unknown) => String(error),
-    );
-
-    expect(rejection).not.toContain(TOKEN);
-  });
-
   it('trims surrounding whitespace from the configured token', async () => {
     // HTTP strips whitespace around header values, so an untrimmed token
     // would be impossible for any caller to present.

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Request} from 'express';
+import {IncomingHttpHeaders} from 'node:http';
+import {describe, expect, it, vi} from 'vitest';
+import {bearerTokenUserBuilder} from '../../src/a2a/auth.js';
+import {logger} from '../../src/utils/logger.js';
+
+const TOKEN = 's3cr3t';
+
+/**
+ * Builds the minimal Express request the authenticator reads: it only ever
+ * touches `headers`.
+ */
+function requestWithHeaders(headers: IncomingHttpHeaders): Request {
+  return {headers} as unknown as Request;
+}
+
+describe('bearerTokenUserBuilder', () => {
+  it('throws when the token is empty', () => {
+    expect(() => bearerTokenUserBuilder('')).toThrow(
+      /empty A2A bearer token is not a valid authenticator/,
+    );
+  });
+
+  it('throws when the token is whitespace only', () => {
+    expect(() => bearerTokenUserBuilder('   ')).toThrow(
+      /empty A2A bearer token is not a valid authenticator/,
+    );
+  });
+
+  it('authenticates a request carrying the configured token', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    const user = await userBuilder(
+      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
+    );
+
+    expect(user.isAuthenticated).toBe(true);
+    expect(user.userName).toBe('a2a-bearer-token');
+  });
+
+  it('accepts a case-insensitive bearer scheme', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    const user = await userBuilder(
+      requestWithHeaders({authorization: `bearer ${TOKEN}`}),
+    );
+
+    expect(user.isAuthenticated).toBe(true);
+  });
+
+  it('rejects a request with no Authorization header', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(userBuilder(requestWithHeaders({}))).rejects.toThrow(
+      /missing or invalid/,
+    );
+  });
+
+  it('rejects a non-bearer scheme', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(
+      userBuilder(requestWithHeaders({authorization: 'Basic czNjcjN0'})),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('rejects a wrong token of the same length', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+    const wrongToken = 'S3CR3T';
+    expect(wrongToken).toHaveLength(TOKEN.length);
+
+    await expect(
+      userBuilder(requestWithHeaders({authorization: `Bearer ${wrongToken}`})),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('rejects a wrong token of a different length', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(
+      userBuilder(
+        requestWithHeaders({authorization: `Bearer ${TOKEN}-and-more`}),
+      ),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('rejects a bearer scheme with an empty credential', async () => {
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    await expect(
+      userBuilder(requestWithHeaders({authorization: 'Bearer '})),
+    ).rejects.toThrow(/missing or invalid/);
+  });
+
+  it('never discloses the configured token', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const userBuilder = bearerTokenUserBuilder(TOKEN);
+
+    const rejection = await userBuilder(
+      requestWithHeaders({authorization: 'Bearer wrong'}),
+    ).catch((error: unknown) => error);
+
+    if (!(rejection instanceof Error)) {
+      expect.fail('expected the authenticator to reject with an Error');
+    }
+    expect(rejection.message).not.toContain(TOKEN);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -86,25 +86,17 @@ describe('bearerTokenUserBuilder', () => {
     ).rejects.toThrow(/missing or invalid/);
   });
 
-  it('rejects a bearer scheme with an empty credential', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    await expect(
-      userBuilder(requestWithHeaders({authorization: 'Bearer '})),
-    ).rejects.toThrow(/missing or invalid/);
-  });
-
   it('never discloses the configured token when rejecting', async () => {
     const userBuilder = bearerTokenUserBuilder(TOKEN);
 
     const rejection = await userBuilder(
       requestWithHeaders({authorization: 'Bearer wrong'}),
-    ).catch((error: unknown) => error);
+    ).then(
+      () => expect.fail('expected the authenticator to reject'),
+      (error: unknown) => String(error),
+    );
 
-    if (!(rejection instanceof Error)) {
-      expect.fail('expected the authenticator to reject with an Error');
-    }
-    expect(rejection.message).not.toContain(TOKEN);
+    expect(rejection).not.toContain(TOKEN);
   });
 
   it('trims surrounding whitespace from the configured token', async () => {

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -6,9 +6,8 @@
 
 import {Request} from 'express';
 import {IncomingHttpHeaders} from 'node:http';
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {bearerTokenUserBuilder} from '../../src/a2a/auth.js';
-import {logger} from '../../src/utils/logger.js';
 
 const TOKEN = 's3cr3t';
 
@@ -21,14 +20,11 @@ function requestWithHeaders(headers: IncomingHttpHeaders): Request {
 }
 
 describe('bearerTokenUserBuilder', () => {
-  it('throws when the token is empty', () => {
-    expect(() => bearerTokenUserBuilder('')).toThrow(
-      /empty A2A bearer token is not a valid authenticator/,
-    );
-  });
-
-  it('throws when the token is whitespace only', () => {
-    expect(() => bearerTokenUserBuilder('   ')).toThrow(
+  it.each([
+    ['empty', ''],
+    ['whitespace only', '   '],
+  ])('throws when the token is %s', (_label, token) => {
+    expect(() => bearerTokenUserBuilder(token)).toThrow(
       /empty A2A bearer token is not a valid authenticator/,
     );
   });
@@ -98,9 +94,7 @@ describe('bearerTokenUserBuilder', () => {
     ).rejects.toThrow(/missing or invalid/);
   });
 
-  it('never discloses the configured token', async () => {
-    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  it('never discloses the configured token when rejecting', async () => {
     const userBuilder = bearerTokenUserBuilder(TOKEN);
 
     const rejection = await userBuilder(
@@ -111,10 +105,17 @@ describe('bearerTokenUserBuilder', () => {
       expect.fail('expected the authenticator to reject with an Error');
     }
     expect(rejection.message).not.toContain(TOKEN);
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(errorSpy).not.toHaveBeenCalled();
+  });
 
-    warnSpy.mockRestore();
-    errorSpy.mockRestore();
+  it('trims surrounding whitespace from the configured token', async () => {
+    // HTTP strips whitespace around header values, so an untrimmed token
+    // would be impossible for any caller to present.
+    const userBuilder = bearerTokenUserBuilder(`  ${TOKEN}  `);
+
+    const user = await userBuilder(
+      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
+    );
+
+    expect(user.isAuthenticated).toBe(true);
   });
 });

--- a/core/test/a2a/auth_test.ts
+++ b/core/test/a2a/auth_test.ts
@@ -29,72 +29,35 @@ describe('bearerTokenUserBuilder', () => {
     );
   });
 
-  it('authenticates a request carrying the configured token', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
+  it.each([
+    ['the configured token', TOKEN, `Bearer ${TOKEN}`],
+    ['a case-insensitive bearer scheme', TOKEN, `bearer ${TOKEN}`],
+    // HTTP strips whitespace around header values, so a padded token would
+    // otherwise be impossible for any caller to present.
+    ['a token configured with padding', `  ${TOKEN}  `, `Bearer ${TOKEN}`],
+  ])('authenticates %s', async (_label, configuredToken, authorization) => {
+    const userBuilder = bearerTokenUserBuilder(configuredToken);
 
-    const user = await userBuilder(
-      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
-    );
+    const user = await userBuilder(requestWithHeaders({authorization}));
 
-    expect(user.isAuthenticated).toBe(true);
-    expect(user.userName).toBe('a2a-bearer-token');
+    expect(user).toEqual({
+      isAuthenticated: true,
+      userName: 'a2a-bearer-token',
+    });
   });
 
-  it('accepts a case-insensitive bearer scheme', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    const user = await userBuilder(
-      requestWithHeaders({authorization: `bearer ${TOKEN}`}),
-    );
-
-    expect(user.isAuthenticated).toBe(true);
-  });
-
-  it('rejects a request with no Authorization header', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    await expect(userBuilder(requestWithHeaders({}))).rejects.toThrow(
-      /missing or invalid/,
-    );
-  });
-
-  it('rejects a non-bearer scheme', async () => {
+  it.each([
+    ['no Authorization header', undefined],
+    ['a non-bearer scheme', 'Basic czNjcjN0'],
+    // Same length as TOKEN, so this exercises the comparison itself rather
+    // than the length guard in front of it.
+    ['a wrong token of the same length', 'Bearer S3CR3T'],
+    ['a wrong token of a different length', `Bearer ${TOKEN}-and-more`],
+  ])('rejects %s', async (_label, authorization) => {
     const userBuilder = bearerTokenUserBuilder(TOKEN);
 
     await expect(
-      userBuilder(requestWithHeaders({authorization: 'Basic czNjcjN0'})),
+      userBuilder(requestWithHeaders({authorization})),
     ).rejects.toThrow(/missing or invalid/);
-  });
-
-  it('rejects a wrong token of the same length', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-    const wrongToken = 'S3CR3T';
-    expect(wrongToken).toHaveLength(TOKEN.length);
-
-    await expect(
-      userBuilder(requestWithHeaders({authorization: `Bearer ${wrongToken}`})),
-    ).rejects.toThrow(/missing or invalid/);
-  });
-
-  it('rejects a wrong token of a different length', async () => {
-    const userBuilder = bearerTokenUserBuilder(TOKEN);
-
-    await expect(
-      userBuilder(
-        requestWithHeaders({authorization: `Bearer ${TOKEN}-and-more`}),
-      ),
-    ).rejects.toThrow(/missing or invalid/);
-  });
-
-  it('trims surrounding whitespace from the configured token', async () => {
-    // HTTP strips whitespace around header values, so an untrimmed token
-    // would be impossible for any caller to present.
-    const userBuilder = bearerTokenUserBuilder(`  ${TOKEN}  `);
-
-    const user = await userBuilder(
-      requestWithHeaders({authorization: `Bearer ${TOKEN}`}),
-    );
-
-    expect(user.isAuthenticated).toBe(true);
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

_No existing issue._

**2. Or, if no issue exists, describe the change:**

**Problem:**
`toA2a()` fails closed — it refuses to mount the A2A surface unless the caller
supplies an `authentication` `UserBuilder` or explicitly opts out with
`allowUnauthenticated: true`. But the library ships no `UserBuilder`
implementation, so every caller who wants an authenticated A2A surface has to
write the credential check (and a constant-time comparison) themselves, or take
the escape hatch. That is also what blocks the operator-facing half of the
contract: `adk web --a2a` / `adk api_server --a2a` hardcode
`allowUnauthenticated: true` because there is no authenticator they could be
handed from a command line.

**Solution:**
Add `bearerTokenUserBuilder(token)` in `core/src/a2a/auth.ts`, exported from
`@google/adk`. It returns an `A2aUserBuilder` that validates
`Authorization: Bearer <token>` against a shared secret with
`crypto.timingSafeEqual`, and rejects any request whose credential is missing,
uses a different scheme, or does not match — before the agent or any of its
tools is invoked.

Design notes:

- **It rejects by throwing, not by returning `isAuthenticated: false`.** The
  installed `@a2a-js/sdk@0.3.13` express handlers do not act on that flag:
  `jsonRpcHandler` and `restHandler` build a `ServerCallContext` from whatever
  user the `UserBuilder` returns and continue to the agent regardless
  (`node_modules/@a2a-js/sdk/dist/server/express/index.js`, the
  `await options.userBuilder(req)` call sites). Returning an unauthenticated
  user would therefore let a bad token reach the agent, which is the one outcome
  that is not acceptable. Throwing is also the first option the existing
  `A2aUserBuilder` TSDoc names.
- **The rejection surfaces as HTTP 500, not 401.** The SDK's `mapErrorToStatus`
  has no auth case, and the JSON-RPC handler always answers 500 on a handler
  exception. This is documented in the TSDoc so callers do not infer a guarantee
  the SDK does not make; the guarantee is that the agent is never reached.
- **The token is trimmed once, up front.** HTTP strips whitespace around header
  values, so an untrimmed token would build an authenticator no client could
  ever satisfy.
- The comparison guards the length before calling `timingSafeEqual`, which
  throws on a length mismatch. The length of a rejected credential is not a
  secret.

This is part 1 of 2. Part 2 (`feat/a2a-cli-auth-token-part2`) wires it into the
dev server, the CLI and `adk deploy cloud_run`.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`core/test/a2a/auth_test.ts` covers every branch of the new module —
construction with an empty and a whitespace-only token; acceptance of the
configured token, of a case-insensitive `bearer` scheme, and of a token
configured with padding; rejection of a missing `Authorization` header, a
non-bearer scheme, a wrong token of the same length (which exercises the
comparison itself) and of a different length (which exercises the length guard
in front of it).

```
$ npx vitest run --project unit:core core/test/a2a/auth_test.ts core/test/a2a/agent_to_a2a_test.ts
 ✓ |unit:core| core/test/a2a/auth_test.ts (9 tests)
 ✓ |unit:core| core/test/a2a/agent_to_a2a_test.ts (8 tests)
 Test Files  2 passed (2)
      Tests  17 passed (17)
```

Line and branch coverage of `core/src/a2a/auth.ts` is 100%:

```
File      | % Stmts | % Branch | % Funcs | % Lines
auth.ts   |     100 |      100 |     100 |     100
```

Also run on this commit: `npm run build`, `npm run lint`, `npm run format:check`,
`npm run docs:check` — all clean.

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

The authenticator was exercised through a real dev server over real HTTP (this
is the wiring added in part 2, but it is what proves the core builder works in
the live handler chain). With an agent directory containing an agent that
answers `pong`:

```bash
$ npx adk api_server ./agents --a2a --a2a_auth_token=hunter2 --port 8124
# No "SECURITY WARNING: Mounting the A2A server WITHOUT authentication" at startup.

$ PAYLOAD='{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"ping"}]}}}'

# No credential -> rejected, agent never invoked.
$ curl -s -w 'HTTP %{http_code}\n' -X POST localhost:8124/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -d "$PAYLOAD"
{"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
HTTP 500

# Wrong credential -> rejected.
$ curl -s -w 'HTTP %{http_code}\n' -X POST localhost:8124/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer wrong' -d "$PAYLOAD"
HTTP 500

# Valid credential -> the agent runs.
$ curl -s -X POST localhost:8124/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer hunter2' -d "$PAYLOAD"
{"jsonrpc":"2.0","id":"1","result":{"kind":"task","id":"a51d75ff-...","history":[...]}}
HTTP 200

# Lower-case scheme is accepted (RFC 6750).
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X POST localhost:8124/a2a/my_agent/jsonrpc \
    -H 'Content-Type: application/json' -H 'Authorization: bearer hunter2' -d "$PAYLOAD"
HTTP 200

# The token never appears in the server log, at any level.
$ grep -c hunter2 server.log
0
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is Part 1/2 of a stacked series: Part 2/2
(`feat/a2a-cli-auth-token-part2`), which wires the builder into the dev server,
the CLI and `adk deploy cloud_run`, builds on this PR and should be reviewed
after it.
