### PR TITLE
Fix: hoist @google/genai 2.x to the workspace root to end the version duality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^9.37.0",
+        "@google/genai": "^2.9.0",
         "@secretlint/secretlint-rule-pattern": "^11.3.1",
         "@secretlint/secretlint-rule-preset-recommend": "^11.3.1",
         "@types/js-yaml": "^4.0.9",
@@ -86,29 +87,6 @@
         "@mikro-orm/mysql": "^6.6.6",
         "@mikro-orm/postgresql": "^6.6.6",
         "@mikro-orm/sqlite": "^6.6.6"
-      }
-    },
-    "core/node_modules/@google/genai": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.9.0.tgz",
-      "integrity": "sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "dev": {
@@ -1576,6 +1554,79 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@google-cloud/vertexai/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/@google/genai/node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@google-cloud/vertexai/node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -1593,6 +1644,43 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/vertexai/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/@google/adk": {
       "resolved": "core",
       "link": true
@@ -1606,11 +1694,10 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.9.0.tgz",
+      "integrity": "sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
         "p-retry": "^4.6.2",
@@ -5207,7 +5294,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.37.0",
+    "@google/genai": "^2.9.0",
     "@secretlint/secretlint-rule-pattern": "^11.3.1",
     "@secretlint/secretlint-rule-preset-recommend": "^11.3.1",
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #517 (the earlier attempt that widened these annotations to `any`; correctly rejected — the annotations were never the bug)

**2. Or, if no issue exists, describe the change:**

**Problem:**

Two different copies of `@google/genai` are visible to two halves of this repository.

`core/package.json` declares `"@google/genai": "^2.9.0"`. `core` also depends on `@google-cloud/vertexai@^1.12.0`, which in turn depends on `"@google/genai": "^1.45.0"`. The root `package.json` declares `workspaces: ["core", "dev", "integrations"]` and does **not** declare `@google/genai` itself, and `tests/` is not a workspace. npm therefore hoists the 1.x copy to the top and nests the 2.x copy under `core`:

```
node_modules/@google/genai          -> 1.52.0   (hoisted, from @google-cloud/vertexai)
core/node_modules/@google/genai     -> 2.9.0    (nested, core's own declared range)
```

Everything under `tests/` resolves upward to the root copy (1.52.0), while `core` resolves its own nested copy (2.9.0). `GoogleGenAI` is a class with private members, so TypeScript compares it **nominally**, and the two declarations differ (2.x adds `_agents` / `agents`). Every test that overrides `Gemini.apiClient` — declared as `get apiClient(): GoogleGenAI` at `core/src/models/google_llm.ts:218` — therefore fails to typecheck:

```
tests/integration/test_case_utils.ts(124,16): error TS2416: Property 'apiClient' in type
  'GeminiWithMockResponses' is not assignable to the same property in base type 'Gemini'.
tests/integration/tools/google_maps_grounding_tool_test.ts(48,16): error TS2416: (same, 'SpyGemini')
tests/integration/tools/vertex_ai_search_tool_test.ts(55,16):   error TS2416: (same, 'SpyGemini')
```

This is a **runtime** duality too, not only a typecheck one. `vitest.config.ts` aliases `@google/adk` to `./core/src` for every project, so agent code loaded genai from `core/node_modules` (2.9.0) while the test file constructing the fixtures loaded genai from the root (1.52.0) — two live module instances of the same package in one process. Verified before this change:

```
resolved from tests/ : node_modules/@google/genai/dist/node/index.cjs
resolved from core/  : core/node_modules/@google/genai/dist/node/index.cjs
same file            : false
GoogleGenAI identical: false
has 2.x `agents`     : false
```

**Solution:**

Declare `@google/genai` as a root `devDependency` with the range `^2.9.0` — byte-identical to what `core/package.json` already declares, so the two manifests cannot drift. That hoists 2.9.0 to the workspace root, `core` dedupes onto it, and `@google-cloud/vertexai` keeps a private nested 1.52.0 copy so its `^1.45.0` range is still honoured:

```
$ npm ls @google/genai
adk@1.4.0
├─┬ @google/adk@1.4.0 -> ./core
│ ├─┬ @google-cloud/vertexai@1.12.0
│ │ └── @google/genai@1.52.0
│ └── @google/genai@2.9.0 deduped
└── @google/genai@2.9.0
```

After the change there is a single genai instance shared by `core/src` and the test tree:

```
resolved from tests/ : node_modules/@google/genai/dist/node/index.cjs
resolved from core/  : node_modules/@google/genai/dist/node/index.cjs
same file            : true
GoogleGenAI identical: true
has 2.x `agents`     : true
```

Why this lever and not another:

- **No source or test file is touched.** Those three tests were correct all along; the dependency graph was the bug. No `any`, no `as unknown as`, no `@ts-expect-error` / `@ts-ignore` / `eslint-disable` anywhere in this diff.
- **Not an `overrides` block.** Forcing genai to 2.x globally would violate `@google-cloud/vertexai`'s declared `^1.45.0` range.
- **Not promoting `tests/` to a workspace.** Far larger diff for the same outcome.
- **The version is pinned deliberately.** The root genai node does not exist in the committed lockfile, so a bare `npm install` after a hand-edit resolves fresh and picks the newest `^2.9.0` (currently 2.13.0), silently bumping `core`'s genai inside a PR whose purpose is _dedupe_. Installing `@google/genai@2.9.0` explicitly pins the lockfile to 2.9.0; the integrity hash of the hoisted node is identical to the `core/node_modules/@google/genai` node it replaces, i.e. the exact same tarball, relocated. A deliberate 2.9.0 → latest-2.x bump belongs in its own PR.
- **No effect on published artifacts.** `core/package.json` is untouched — same declared range, same resolved version, same emitted types — and root `devDependencies` are never installed by consumers of `@google/adk`.

Two files change, and only these two:

```
 package-lock.json | 142 +++++++++++++++++++++++++++++++++--------
 package.json      |   1 +
```

Two incidental lockfile hunks are npm's own output, not hand edits, and reverting either would make the committed lockfile diverge from what `npm install` produces:

- `adm-zip` loses a stale `"dev": true` marker. `core/package.json` declares `adm-zip` in `dependencies`, so the flag was wrong on `main` and npm corrects it on any install. With it corrected, a clean `npm install` now leaves the working tree completely clean (verified below).
- The relocated `@google/genai` node is written without a `license` metadata field. `main` already carried exactly this for the same package at `core/node_modules/@google/genai`. `license-check.yml` runs `scripts/check_license.sh`, which scans `*.js` / `*.ts` source files for headers and never reads lockfile metadata.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes._

This change adds no executable source lines — it is a dependency-graph fix — so there is nothing new to unit test. A test asserting on `package.json` contents would be noise. The verification is the typecheck delta, the module-identity check, and a regression run against a measured baseline.

**Typecheck delta (the primary gate).** `npm run ts:check` is not run by CI today, which is why these three errors were able to persist. Measured with `npx tsc --noEmit --pretty false` on a freshly built tree, before and after:

|                      | before (`main`) | after   |
| -------------------- | --------------- | ------- |
| total `error TS`     | **308**         | **305** |
| `core/test/**`       | 278             | 278     |
| `tests/**`           | 30              | 27      |
| `TS2416 … apiClient` | 3               | **0**   |

Diffing the two full error sets line by line: exactly the three `apiClient` errors disappear and **no new error appears at any path**. The remaining 305 are pre-existing and out of scope for this PR (the `core/test/**` bulk is a separate `core/dist/types` vs `core/src` dual-identity artifact caused by the root `tsconfig.json` having no `paths` mapping).

**Dependency tree postconditions** (all verified):

```
node -p "require('./node_modules/@google/genai/package.json').version"                          -> 2.9.0
ls core/node_modules/@google/genai                                                              -> does not exist
node -p "require('./node_modules/@google-cloud/vertexai/node_modules/@google/genai/package.json').version" -> 1.52.0
```

**Clean-tree developer loop from `CONTRIBUTING.md`** — all four steps exit 0, and `git status` is empty afterwards, i.e. the committed lockfile is self-consistent and `npm install` no longer dirties the tree:

```
rm -rf node_modules core/node_modules dev/node_modules integrations/node_modules
npm install           # exit 0
npm run build         # exit 0
npm run lint          # exit 0
npm run format:check  # exit 0  ("All matched files use Prettier code style!")
```

Also run green: `npm run docs:check` (exit 0) and `npx secretlint` on both manifests (exit 0).

**CI (`validation.yaml`) is green on all three platforms** — `run-tests (ubuntu-latest)`, `(macos-latest)` and `(windows-latest)` all pass, reporting `Test Files 214 passed | 20 skipped (234)` with zero failures. For reference, the run on the same base commit without this change had `macos-latest` and `windows-latest` **failing** on `tests/integration/app_loader/app_loader_test.ts`, so this branch is strictly better than its baseline. Note CI never runs `ts:check`, which is why the three `TS2416` errors were able to persist unnoticed; the typecheck delta above is the gate that matters here, not the CI signal.

**Unit Tests:**

- [ ] I have added or updated unit tests for my change. — _No new source lines exist to cover; deliberately not adding a test that asserts on manifest contents._
- [x] All unit tests pass locally. — _`npm run test:unit`: `Test Files 2 failed | 172 passed (174)`, `Tests 4 failed | 2408 passed (2412)`. Both failing files are pre-existing and environment-sensitive: `core/test/code_executors/unsafe_local_code_executor_test.ts` (shells out to a local interpreter) and `dev/test/cli/cli_create_test.ts` (reads gcloud defaults). `core`'s genai binding is unchanged by this PR (2.9.0 both before and after), and the `dev` failure was re-run on an unmodified checkout with genai 1.52.0 and reproduces identically. No failure output mentions `genai`, `GoogleGenAI` or `_agents`._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any necessary setup or configuration._

Reproduce the bug and confirm the fix:

```bash
git clone https://github.com/google/adk-js.git && cd adk-js
npm install
npm run build                                                   # required: without it @google/adk can't resolve
npx tsc --noEmit --pretty false | grep -c "error TS"            # 308 before, 305 after
npx tsc --noEmit --pretty false | grep -c "apiClient"           # 3 before,   0 after
npm ls @google/genai                                            # split before, deduped after
node -p "require('./node_modules/@google/genai/package.json').version"  # 1.52.0 before, 2.9.0 after
```

Integration suite (`vitest --project integration`), run on the subset that exercises the `GeminiWithMockResponses` harness from `tests/integration/test_case_utils.ts` and does not shell out to fixture `npm install` hooks:

```bash
npx vitest run --project integration tests/integration/tools tests/integration/context_compaction \
  tests/integration/streaming tests/integration/streaming_sse tests/integration/agent_registry \
  tests/integration/skills/inline tests/integration/skills/loader
# Test Files  3 failed | 16 passed (19)
# Tests       7 failed | 28 passed | 4 skipped (39)
```

The three failing files — `tools/run_skill_inline_script_tool_test.ts`, `tools/run_skill_script_tool_test.ts`, `tools/skills_registry_integration_test.ts` — were re-run on an unmodified checkout and produce **the identical 7 failures**; all are `UnsafeLocalCodeExecutor` sandbox limitations, the same root cause as the pre-existing unit failure. Spot-checking the two previously-broken files on their own:

```bash
npx vitest run --project integration \
  tests/integration/tools/google_maps_grounding_tool_test.ts \
  tests/integration/tools/vertex_ai_search_tool_test.ts
# Test Files  2 passed (2)
```

**Credentialed e2e was NOT run — no credentials were available in this environment.** `GOOGLE_GENAI_API_KEY` and `GEMINI_API_KEY` are both unset and there is no ADC, so every live-model test fails at `Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.` The 16 genai-importing files under `tests/e2e/**` that were therefore **not** exercised against a live model are:

```
tests/e2e/context_compaction/agent_controlled_e2e_test.ts
tests/e2e/context_compaction/e2e_anchored_compaction_test.ts
tests/e2e/context_compaction/e2e_compaction_test.ts
tests/e2e/context_compaction/e2e_compaction_vertexai_test.ts
tests/e2e/custom_metadata/custom_metadata_test.ts
tests/e2e/live_model_test.ts
tests/e2e/routing/lro_resumption_routing_e2e_test.ts
tests/e2e/streaming/streaming_e2e_test.ts
tests/e2e/tools/agent_registry_e2e_test.ts
tests/e2e/tools/agent_tool_e2e_test.ts
tests/e2e/tools/before_tool_selection_test.ts
tests/e2e/tools/load_artifacts_tool_test.ts
tests/e2e/tools/load_memory_tool_test.ts
tests/e2e/tools/preload_memory_tool_test.ts
tests/e2e/tools/rest_api_tool_auth_e2e_test.ts
tests/e2e/tools/skills_registry_e2e_test.ts
```

`npm run test:e2e` was still executed to check the 1.x → 2.x flip at module load: every one of those files **collected and imported cleanly** under genai 2.9.0 with zero resolution errors, and all 22 test failures trace to the missing API key. A reviewer with credentials should re-run `npm run test:e2e` to confirm request/response shaping.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas. — _No code was written; the rationale lives in this description._
- [ ] I have added tests that prove my fix is effective or that my feature works. — _No new source lines to test. The proof is the typecheck delta (308 → 305, the three `TS2416` errors gone, zero new errors) plus the module-identity check showing `core` and `tests/` now load the same `GoogleGenAI` class._
- [x] New and existing unit tests pass locally with my changes. — _Same pass/fail set as the pre-change baseline; every failure was reproduced on an unmodified checkout._
- [ ] I have manually tested my changes end-to-end. — _The reproduction steps and the integration subset above were run; credentialed e2e was **not** run, as no credentials were available in this environment._
- [ ] Any dependent changes have been merged and published in downstream modules. — _Not applicable: `core/package.json` is untouched, so no downstream module changes._

### Additional context

None.
