### PR TITLE
Fix: restore event round trip in VertexAiSessionService

### DIFF
--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -48,6 +48,7 @@ import {createSession, Session} from './session.js';
 const DEFAULT_MAX_ATTEMPTS = 30;
 const GRPC_NOT_FOUND = 5;
 const HTTP_NOT_FOUND = 404;
+const HTTP_BAD_REQUEST = 400;
 
 /**
  * `eventMetadata.customMetadata` key carrying the workflow fields of an
@@ -456,11 +457,16 @@ export class VertexAiSessionService extends BaseSessionService {
     }
 
     const config = partialCopy<AppendAgentEngineSessionEventConfig>(event, [
-      'content',
       'errorCode',
       'errorMessage',
     ]);
     config.actions = toApiActions(event.actions);
+
+    // Strip Part fields the Sessions API rejects (e.g. `partMetadata`) from
+    // both the wire content and the `rawEvent` blob it is stored under, so the
+    // append is not rejected with 400 INVALID_ARGUMENT.
+    const content = dropUnsupportedPartFields(event.content);
+    config.content = content;
 
     config.eventMetadata = {
       ...partialCopy<EventMetadata>(event, [
@@ -475,7 +481,7 @@ export class VertexAiSessionService extends BaseSessionService {
         Object.keys(customMetadata).length > 0 ? customMetadata : undefined,
     };
 
-    config.rawEvent = JSON.parse(JSON.stringify(event)) as Record<
+    config.rawEvent = JSON.parse(JSON.stringify({...event, content})) as Record<
       string,
       unknown
     >;
@@ -491,6 +497,12 @@ export class VertexAiSessionService extends BaseSessionService {
     try {
       await this.sessions.events.append(params);
     } catch (error) {
+      // Only a rejected payload (400) is safe to retry without `rawEvent`. Any
+      // other failure may already have persisted the event, so re-appending
+      // would duplicate it; let it propagate.
+      if (!isInvalidArgumentError(error)) {
+        throw error;
+      }
       logger.warn(
         'Failed to append event with rawEvent; retrying without it. The event ' +
           'will be reconstructed from its structured fields and ' +
@@ -498,13 +510,7 @@ export class VertexAiSessionService extends BaseSessionService {
         error,
       );
       delete config.rawEvent;
-      await this.sessions.events.append({
-        name: `reasoningEngines/${reasoningEngineId}/sessions/${session.id}`,
-        author: event.author || 'user',
-        invocationId: event.invocationId || `inv-${Date.now()}`,
-        timestamp: new Date(event.timestamp).toISOString(),
-        config,
-      });
+      await this.sessions.events.append(params);
     }
 
     return event;
@@ -586,6 +592,42 @@ function toApiActions(
   } as ApiEventActions;
 }
 
+/**
+ * Returns a copy of `content` without Part fields the Agent Engine Sessions
+ * API rejects, passing `undefined` through unchanged.
+ *
+ * `partMetadata` is a Gemini Developer API-only field; the Sessions API fails
+ * appendEvent with 400 INVALID_ARGUMENT ("Unknown name \"part_metadata\"").
+ * The input is never mutated, so the caller's event keeps its metadata.
+ */
+function dropUnsupportedPartFields(
+  content: Content | undefined,
+): Content | undefined {
+  if (!content?.parts) {
+    return content;
+  }
+  return {
+    ...content,
+    parts: content.parts.map((part) => {
+      const copy = {...part};
+      delete copy.partMetadata;
+      return copy;
+    }),
+  };
+}
+
+/**
+ * True when the service rejected the request payload itself, which is what an
+ * API that does not know `rawEvent` returns. Any other failure must propagate:
+ * the event may already be persisted, so retrying would append it twice.
+ *
+ * Matched structurally on the `ApiError`'s `status`, for the reason given in
+ * getSession's catch.
+ */
+function isInvalidArgumentError(error: unknown): boolean {
+  return (error as {status?: number} | null)?.status === HTTP_BAD_REQUEST;
+}
+
 interface ExtendedEventActions extends EventActions {
   compaction?: {
     startTime: number;
@@ -664,7 +706,12 @@ function _fromApiEvent(apiEventObj: VertexAiSessionEvent): Event {
         'requestedToolConfirmations'
       ] as Record<string, ToolConfirmation>) || {},
     skipSummarization: actions['skipSummarization'] as boolean | undefined,
-    transferToAgent: actions['transferAgent'] as string | undefined,
+    // Earlier adk-js versions copied `event.actions` onto the request
+    // verbatim, so sessions they wrote store ADK's own `transferToAgent` key.
+    transferToAgent: (actions['transferAgent'] ??
+      (actions as Record<string, unknown>)['transferToAgent']) as
+      | string
+      | undefined,
     escalate: actions['escalate'] as boolean | undefined,
     compaction: compactionData || undefined,
   };

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -1375,6 +1375,116 @@ describe('VertexAiSessionService', () => {
         expect('transferAgent' in sent.config.actions).toBe(false);
       });
     });
+
+    describe('unsupported fields and fallback', () => {
+      const appendSession = () =>
+        ({
+          id: 'append-session',
+          appName: '12345',
+          userId: 'testUser',
+          events: [],
+          lastUpdateTime: Date.now(),
+        }) as unknown as Session;
+
+      /** The request config captured by the first appendEvent call. */
+      const appendedConfig = () =>
+        mockClient.events.append.mock.calls[0][0].config;
+
+      it('strips partMetadata from content and rawEvent without mutating the event', async () => {
+        const event = createEvent({
+          timestamp: 1620000000000,
+          content: {
+            role: 'user',
+            parts: [
+              {text: 'hello', partMetadata: {source: 'portal'}},
+              {text: 'world', partMetadata: {source: 'portal'}},
+            ],
+          },
+        });
+
+        await service.appendEvent({session: appendSession(), event});
+
+        const config = appendedConfig();
+        expect(config.content).toEqual({
+          role: 'user',
+          parts: [{text: 'hello'}, {text: 'world'}],
+        });
+        expect(config.rawEvent?.content).toEqual({
+          role: 'user',
+          parts: [{text: 'hello'}, {text: 'world'}],
+        });
+        expect(event.content?.parts?.[0].partMetadata).toEqual({
+          source: 'portal',
+        });
+      });
+
+      it('handles content without parts', async () => {
+        const event = createEvent({
+          timestamp: 1620000000000,
+          content: {role: 'user'},
+        });
+
+        await service.appendEvent({session: appendSession(), event});
+
+        expect(appendedConfig().content).toEqual({role: 'user'});
+      });
+
+      it('handles an event without content', async () => {
+        const event = createEvent({timestamp: 1620000000000});
+        delete event.content;
+
+        await service.appendEvent({session: appendSession(), event});
+
+        const config = appendedConfig();
+        expect(config.content).toBeUndefined();
+        expect(config.rawEvent).not.toHaveProperty('content');
+      });
+
+      it('retries without rawEvent when the API rejects it with 400', async () => {
+        const loggerSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+        // The retry reuses the request object, so record what each attempt
+        // actually carried instead of inspecting it afterwards.
+        const sentRawEvent: boolean[] = [];
+        mockClient.events.append
+          .mockImplementationOnce(async (params) => {
+            sentRawEvent.push(params.config?.rawEvent !== undefined);
+            throw new ApiError({message: 'Unknown name', status: 400});
+          })
+          .mockImplementationOnce(async (params) => {
+            sentRawEvent.push(params.config?.rawEvent !== undefined);
+            return {};
+          });
+        const event = createEvent({
+          timestamp: 1620000000000,
+          content: {role: 'user', parts: [{text: 'hello'}]},
+        });
+
+        await service.appendEvent({session: appendSession(), event});
+
+        expect(sentRawEvent).toEqual([true, false]);
+        // Reusing the request is what keeps the retry's invocation id and
+        // timestamp identical to the first attempt's.
+        const [first, second] = mockClient.events.append.mock.calls;
+        expect(second[0]).toBe(first[0]);
+        loggerSpy.mockRestore();
+      });
+
+      it.each([
+        ['a server error', new ApiError({message: 'try later', status: 503})],
+        ['a network error', new Error('socket hang up')],
+      ])('rethrows %s without re-appending', async (_label, failure) => {
+        mockClient.events.append.mockRejectedValueOnce(failure);
+        const event = createEvent({
+          timestamp: 1620000000000,
+          content: {role: 'user', parts: [{text: 'hello'}]},
+        });
+
+        await expect(
+          service.appendEvent({session: appendSession(), event}),
+        ).rejects.toBe(failure);
+        expect(mockClient.events.append).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe('workflow event fields', () => {
@@ -1584,6 +1694,33 @@ describe('VertexAiSessionService', () => {
       expect(isFastForwardable(states.get('fetch')!)).toBe(true);
       expect([...states.get('gate')!.interruptIds]).toEqual(['gate-1']);
       expect(states.get('gate')?.input).toBe('A(x)');
+    });
+  });
+
+  describe('legacy read path', () => {
+    it('restores transferToAgent from a legacy transferToAgent key', async () => {
+      // Sessions written by earlier adk-js versions stored ADK's own
+      // `transferToAgent` key rather than the API's `transferAgent`.
+      mockClient.events.listInternal.mockResolvedValue({
+        sessionEvents: [
+          {
+            name: 'reasoningEngines/12345/sessions/s/events/e1',
+            author: 'model',
+            actions: {transferToAgent: 'legacy-specialist'},
+          },
+        ],
+      });
+
+      const session = await service.getSession({
+        appName: '12345',
+        userId: 'testUser',
+        sessionId: 'my-session-id',
+      });
+
+      expect(session?.events).toHaveLength(1);
+      expect(session!.events[0].actions.transferToAgent).toBe(
+        'legacy-specialist',
+      );
     });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**

Four independent defects in `VertexAiSessionService` break the `appendEvent()` -> `getSession()` round trip on the legacy (non-`rawEvent`) read path and make the write path unsafe. `adk-python` already handles all four correctly.

1. **`groundingMetadata` is written but never restored.** `appendEvent` copies it into `config.eventMetadata`, but the legacy branch of `_fromApiEvent` never reads it back, so a replayed event always comes back with `groundingMetadata === undefined`.
2. **Write/read naming asymmetry on the agent-transfer action.** `appendEvent` copied `event.actions` verbatim, so the wire payload carried ADK's `transferToAgent`, while the read path looks for `transferAgent` (the name the API's `EventActions` declares, and the camelCase form of the `transfer_agent` field `adk-python` writes). The two names never met, so an agent transfer written by adk-js was silently dropped when the session was replayed through the legacy path.
3. **The `rawEvent` fallback caught everything.** The append was wrapped in an undiscriminated `try`/`catch` that retried on _any_ throw. A transient failure (5xx, 429, timeout, socket reset) that may already have persisted the event triggered a second `appendEvent`, duplicating it in the session, and callers saw the failure of the retry rather than of the first attempt. It also rebuilt the request, so the retry could carry a different `inv-${Date.now()}` invocation id than the first attempt.
4. **`partMetadata` was not stripped before append.** `partMetadata` is a Gemini Developer API-only `Part` field that adk-js populates for streamed/partial parts; the Agent Engine Sessions API rejects it with `400 INVALID_ARGUMENT` (`Unknown name "part_metadata" at 'event.content.parts[0]'`).

**Solution:**

All four fixes live in `core/src/sessions/vertex_ai_session_service.ts`; the service is `@experimental`, so the wire-format corrections are in scope. No new dependency, no new export, no signature change.

- `_fromApiEvent` now restores `groundingMetadata` from `eventMetadata` — a direct property read, since the two `@google/genai` copies in the tree declare a structurally compatible `GroundingMetadata`, so no cast is needed.
- `appendEvent` emits the transfer action as `actions.transferAgent` via a small `toApiEventActions` mapper; every other action field, including `requestedToolConfirmations`, keeps its name. The read path maps `transferAgent` back to `Event.actions.transferToAgent` and **still accepts a legacy `transferToAgent` key**: the released write path copied `event.actions` onto the request verbatim and the SDK converter forwards that object unchanged, so already-stored sessions can carry the ADK key and dropping the fallback would silently lose their transfers.
- The `rawEvent` retry is now gated on the service rejecting the payload itself (HTTP `400`), which is what an API that does not know `rawEvent` returns. **This is a deliberate behaviour change**: transient failures now propagate unchanged instead of being quietly re-appended. The error is matched structurally on `status` rather than with `instanceof ApiError`, because `core` and `@google-cloud/vertexai` resolve separate `@google/genai` copies and `instanceof` is false at runtime. The retry also reuses the already-built request, so both attempts share the same `name`, `author`, `invocationId` and `timestamp` and differ only in `rawEvent`.
- `appendEvent` strips `partMetadata` from every `Part` in both `config.content` and `config.rawEvent.content`, building a copy so the caller's `event` is never mutated (`partialCopy` shares `content` by reference, so stripping in place would corrupt the caller's event).

Compatibility: new writes emit `actions.transferAgent` and omit `partMetadata`, aligning adk-js with `adk-python` and with the API's declared schema. Old data keeps working because the read path accepts both action key names.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added to `core/test/sessions/vertex_ai_session_service_test.ts`, reusing the existing mock `Sessions` fixture and the `createEvent` / `createEventActions` / `createSession` factories (the append mock is typed with the SDK's request-parameter type, so the captured payload is checked by the compiler rather than cast):

- `sends transferToAgent as transferAgent and keeps every other action` — asserts the entire captured `config.actions`, which pins both the rename and the absence of a `transferToAgent` key, and guards `requestedToolConfirmations`, which the SDK type omits so the compiler cannot catch its loss.
- `strips partMetadata from content and rawEvent without mutating the event`, `handles content without parts`, `handles an event without content`.
- `retries without rawEvent when the API rejects it with 400` — records what each attempt actually carried and asserts the retry reuses the same request object (which is what keeps the invocation id and timestamp identical; the previous code minted a fresh one).
- `rethrows a server error / a network error without re-appending` — the regression guard for the duplicate append, asserting exactly one call.
- `restores groundingMetadata from eventMetadata`, `restores transferToAgent from actions.transferAgent`, `restores transferToAgent from a legacy transferToAgent key`.

Commands run locally on the pushed commit:

- `npx vitest run --project unit:core core/test/sessions/vertex_ai_session_service_test.ts` — 61 passed.
- Coverage of the changed file (`--coverage.include='core/src/sessions/vertex_ai_session_service.ts'`): every new line and branch is executed; the only uncovered branches in the file are pre-existing ones this change does not touch.
- `npm run build`, `npm run lint`, `npm run format:check` — all pass.

**Manual End-to-End (E2E) Tests:**

The Agent Engine Sessions backend cannot be exercised in CI, so this needs a real Vertex AI project with an Agent Engine. With `projectId` / `location` / `agentEngineId` pointed at a live reasoning engine:

1. `createSession`, then `appendEvent` with an event that carries `actions.transferToAgent`, a `groundingMetadata` payload, and a part with `partMetadata` set.
2. Confirm the append succeeds — before this change the `partMetadata` part fails with `400 INVALID_ARGUMENT` (`Unknown name "part_metadata"`).
3. `getSession` and confirm the event comes back with `actions.transferToAgent` and `groundingMetadata` intact, and with the part's `text` preserved (`partMetadata` is intentionally not persisted, matching `adk-python`).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The service is marked `@experimental`, so the wire-format corrections (emitting `actions.transferAgent`, omitting `partMetadata`) are in scope. The read path stays backward compatible with sessions written by earlier adk-js versions.
