### PR TITLE
Fix: pass -NoProfile to spawned PowerShell and /D to cmd.exe in UnsafeLocalCodeExecutor

### DIFF
--- a/core/src/code_executors/unsafe_local_code_executor.ts
+++ b/core/src/code_executors/unsafe_local_code_executor.ts
@@ -21,13 +21,8 @@ import {
 const IS_WINDOWS = os.platform() === 'win32';
 
 /**
- * Arguments prepended to every PowerShell invocation.
- *
- * `-NoLogo` suppresses the startup banner, `-NoProfile` skips the machine and
- * user profile scripts so startup stays fast and the executed script is not
- * affected by ambient profile state (PATH, aliases, preference variables) or
- * polluted by profile output, and `-ExecutionPolicy Bypass` lets the generated
- * script file run. The script path is appended after `-File`.
+ * Prepended to every PowerShell invocation; `-NoProfile` keeps ambient profile
+ * state (PATH, aliases, preference variables, stray output) out of the script.
  */
 const POWERSHELL_BASE_ARGS = [
   '-NoLogo',
@@ -38,11 +33,8 @@ const POWERSHELL_BASE_ARGS = [
 ] as const;
 
 /**
- * Arguments prepended to every cmd.exe invocation.
- *
- * `/D` skips the AutoRun commands configured in the registry — the cmd.exe
- * analogue of PowerShell's `-NoProfile` — and `/c` runs the script and exits.
- * The script path is appended after `/c`.
+ * Prepended to every cmd.exe invocation; `/D` skips the registry AutoRun
+ * commands, the `-NoProfile` analogue.
  */
 const CMD_BASE_ARGS = ['/D', '/c'] as const;
 

--- a/core/src/code_executors/unsafe_local_code_executor.ts
+++ b/core/src/code_executors/unsafe_local_code_executor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {spawn} from 'child_process';
+import {spawn} from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -19,6 +19,32 @@ import {
 } from './code_execution_utils.js';
 
 const IS_WINDOWS = os.platform() === 'win32';
+
+/**
+ * Arguments prepended to every PowerShell invocation.
+ *
+ * `-NoLogo` suppresses the startup banner, `-NoProfile` skips the machine and
+ * user profile scripts so startup stays fast and the executed script is not
+ * affected by ambient profile state (PATH, aliases, preference variables) or
+ * polluted by profile output, and `-ExecutionPolicy Bypass` lets the generated
+ * script file run. The script path is appended after `-File`.
+ */
+const POWERSHELL_BASE_ARGS = [
+  '-NoLogo',
+  '-NoProfile',
+  '-ExecutionPolicy',
+  'Bypass',
+  '-File',
+] as const;
+
+/**
+ * Arguments prepended to every cmd.exe invocation.
+ *
+ * `/D` skips the AutoRun commands configured in the registry — the cmd.exe
+ * analogue of PowerShell's `-NoProfile` — and `/c` runs the script and exits.
+ * The script path is appended after `/c`.
+ */
+const CMD_BASE_ARGS = ['/D', '/c'] as const;
 
 /**
  * Options for UnsafeLocalCodeExecutor.
@@ -101,7 +127,7 @@ function getExtensionForLanguage(
  * **Execution Details**:
  * - **JavaScript**: Executed via `node` (defaults to `process.execPath`).
  * - **Python**: Executed via `python3` on Unix, and `python` on Windows.
- * - **Shell**: Executed via `bash` on Unix, and defaults to `powershell` (injecting ExecutionPolicy Bypass) or `cmd.exe` on Windows.
+ * - **Shell**: Executed via `bash` on Unix, and defaults to `powershell` (injecting `-NoProfile` and `-ExecutionPolicy Bypass`) or `cmd.exe` (injecting `/D`) on Windows.
  *
  * WARNING: This executor runs code in the local environment without sandboxing or security restrictions.
  * Use with caution and only for trusted code.
@@ -172,16 +198,16 @@ export class UnsafeLocalCodeExecutor extends BaseCodeExecutor {
       } else if (language === CodeExecutionLanguage.SHELL) {
         command = this.shellCommandPath;
         if (this.shellCommandPath.toLowerCase().includes('powershell')) {
-          args = ['-NoLogo', '-ExecutionPolicy', 'Bypass', '-File', filePath];
+          args = [...POWERSHELL_BASE_ARGS, filePath];
         } else if (this.shellCommandPath.toLowerCase().includes('cmd')) {
-          args = ['/c', filePath];
+          args = [...CMD_BASE_ARGS, filePath];
         }
       } else if (language === CodeExecutionLanguage.POWERSHELL) {
         command = IS_WINDOWS ? 'powershell' : 'pwsh';
-        args = ['-NoLogo', '-ExecutionPolicy', 'Bypass', '-File', filePath];
+        args = [...POWERSHELL_BASE_ARGS, filePath];
       } else if (language === CodeExecutionLanguage.WINDOWS_CMD) {
         command = 'cmd.exe';
-        args = ['/c', filePath];
+        args = [...CMD_BASE_ARGS, filePath];
       }
 
       if (params.codeExecutionInput.args) {

--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -17,19 +17,13 @@ import {EventEmitter} from 'node:events';
 import * as os from 'node:os';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
-const spawnMock = vi.fn();
-
-// Spread the real module so unrelated core modules keep the genuine exports;
-// only `spawn` is routed through the mock, which defaults to the real
-// implementation (see `beforeEach`) so the existing tests still run scripts.
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:child_process')>();
-  return {
-    ...actual,
-    spawn: (command: string, args: string[], options: unknown) =>
-      spawnMock(command, args, options),
-  };
-});
+// Only `spawn` is mocked; it defaults to the real implementation (see
+// `beforeEach`) so the pre-existing tests still execute real scripts.
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: spawnMock,
+}));
 
 const {spawn: realSpawn} =
   await vi.importActual<typeof import('node:child_process')>(
@@ -38,23 +32,18 @@ const {spawn: realSpawn} =
 
 const POWERSHELL_COMMAND = os.platform() === 'win32' ? 'powershell' : 'pwsh';
 
-const EXPECTED_POWERSHELL_ARGS = [
+const POWERSHELL_FLAGS = [
   '-NoLogo',
   '-NoProfile',
   '-ExecutionPolicy',
   'Bypass',
   '-File',
-  expect.stringMatching(/script\.ps1$/),
 ];
 
-/** Makes `spawn` return a child process that immediately exits with code 0. */
-function stubSpawnSuccess(): void {
-  spawnMock.mockImplementation(() => {
-    const child = new EventEmitter();
-    setImmediate(() => child.emit('close', 0, null));
-    return child;
-  });
-}
+const EXPECTED_POWERSHELL_ARGS = [
+  ...POWERSHELL_FLAGS,
+  expect.stringMatching(/script\.ps1$/),
+];
 
 function createMockInvocationContext(): InvocationContext {
   const agent = new LlmAgent({
@@ -354,7 +343,13 @@ describe('UnsafeLocalCodeExecutor', () => {
 
   describe('spawn arguments', () => {
     beforeEach(() => {
-      stubSpawnSuccess();
+      // Return a child process that immediately exits with code 0, so the
+      // interpreters under test need not be installed on the host.
+      spawnMock.mockImplementation(() => {
+        const child = new EventEmitter();
+        setImmediate(() => child.emit('close', 0, null));
+        return child;
+      });
     });
 
     it('should pass -NoProfile when shell code runs through powershell', async () => {
@@ -373,67 +368,23 @@ describe('UnsafeLocalCodeExecutor', () => {
 
       expect(spawnMock).toHaveBeenCalledWith(
         'powershell',
-        [
-          '-NoLogo',
-          '-NoProfile',
-          '-ExecutionPolicy',
-          'Bypass',
-          '-File',
-          // `.ps1` on Windows, `.sh` elsewhere: the extension follows the host
-          // platform while the command follows `shellCommandPath`.
-          expect.stringMatching(/script\.(ps1|sh)$/),
-        ],
+        // The extension follows the host platform, the command follows
+        // `shellCommandPath`.
+        [...POWERSHELL_FLAGS, expect.stringMatching(/script\.(ps1|sh)$/)],
         expect.anything(),
       );
     });
 
-    it('should pass -NoProfile for the powershell language', async () => {
-      await executor.executeCode({
-        invocationContext,
-        codeExecutionInput: {
-          code: 'Write-Output "hi"',
-          language: CodeExecutionLanguage.POWERSHELL,
-          inputFiles: [],
-        },
-      });
-
-      expect(spawnMock).toHaveBeenCalledWith(
-        POWERSHELL_COMMAND,
-        EXPECTED_POWERSHELL_ARGS,
-        expect.anything(),
-      );
-    });
-
-    it('should append user args after the powershell script path', async () => {
+    it('should pass -NoProfile for the powershell language, appending user args after the script path without accumulating them across executions', async () => {
       await executor.executeCode({
         invocationContext,
         codeExecutionInput: {
           code: 'Write-Output $args',
           language: CodeExecutionLanguage.POWERSHELL,
           inputFiles: [],
-          args: ['alpha', 'beta'],
-        },
-      });
-
-      expect(spawnMock).toHaveBeenCalledWith(
-        POWERSHELL_COMMAND,
-        [...EXPECTED_POWERSHELL_ARGS, 'alpha', 'beta'],
-        expect.anything(),
-      );
-    });
-
-    it('should not accumulate args across executions', async () => {
-      const params: ExecuteCodeParams = {
-        invocationContext,
-        codeExecutionInput: {
-          code: 'Write-Output "hi"',
-          language: CodeExecutionLanguage.POWERSHELL,
-          inputFiles: [],
           args: ['first-run-only'],
         },
-      };
-
-      await executor.executeCode(params);
+      });
       await executor.executeCode({
         invocationContext,
         codeExecutionInput: {
@@ -443,8 +394,14 @@ describe('UnsafeLocalCodeExecutor', () => {
         },
       });
 
-      expect(spawnMock).toHaveBeenCalledTimes(2);
-      expect(spawnMock).toHaveBeenLastCalledWith(
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        1,
+        POWERSHELL_COMMAND,
+        [...EXPECTED_POWERSHELL_ARGS, 'first-run-only'],
+        expect.anything(),
+      );
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        2,
         POWERSHELL_COMMAND,
         EXPECTED_POWERSHELL_ARGS,
         expect.anything(),

--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -13,7 +13,48 @@ import {
   UnsafeLocalCodeExecutor,
   createSession,
 } from '@google/adk';
-import {beforeEach, describe, expect, it} from 'vitest';
+import {EventEmitter} from 'node:events';
+import * as os from 'node:os';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const spawnMock = vi.fn();
+
+// Spread the real module so unrelated core modules keep the genuine exports;
+// only `spawn` is routed through the mock, which defaults to the real
+// implementation (see `beforeEach`) so the existing tests still run scripts.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (command: string, args: string[], options: unknown) =>
+      spawnMock(command, args, options),
+  };
+});
+
+const {spawn: realSpawn} =
+  await vi.importActual<typeof import('node:child_process')>(
+    'node:child_process',
+  );
+
+const POWERSHELL_COMMAND = os.platform() === 'win32' ? 'powershell' : 'pwsh';
+
+const EXPECTED_POWERSHELL_ARGS = [
+  '-NoLogo',
+  '-NoProfile',
+  '-ExecutionPolicy',
+  'Bypass',
+  '-File',
+  expect.stringMatching(/script\.ps1$/),
+];
+
+/** Makes `spawn` return a child process that immediately exits with code 0. */
+function stubSpawnSuccess(): void {
+  spawnMock.mockImplementation(() => {
+    const child = new EventEmitter();
+    setImmediate(() => child.emit('close', 0, null));
+    return child;
+  });
+}
 
 function createMockInvocationContext(): InvocationContext {
   const agent = new LlmAgent({
@@ -39,6 +80,8 @@ describe('UnsafeLocalCodeExecutor', () => {
   const invocationContext = createMockInvocationContext();
 
   beforeEach(() => {
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(realSpawn);
     executor = new UnsafeLocalCodeExecutor();
   });
 
@@ -307,5 +350,143 @@ describe('UnsafeLocalCodeExecutor', () => {
     expect(result.outputFiles![0].content).toBe('{"hello":"world"}');
     expect(result.outputFiles![0].contentEncoding).toBe('utf-8');
     expect(result.outputFiles![0].mimeType).toBe('application/json');
+  });
+
+  describe('spawn arguments', () => {
+    beforeEach(() => {
+      stubSpawnSuccess();
+    });
+
+    it('should pass -NoProfile when shell code runs through powershell', async () => {
+      const shellExecutor = new UnsafeLocalCodeExecutor({
+        shellCommandPath: 'powershell',
+      });
+
+      await shellExecutor.executeCode({
+        invocationContext,
+        codeExecutionInput: {
+          code: 'Write-Output "hi"',
+          language: CodeExecutionLanguage.SHELL,
+          inputFiles: [],
+        },
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'powershell',
+        [
+          '-NoLogo',
+          '-NoProfile',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-File',
+          // `.ps1` on Windows, `.sh` elsewhere: the extension follows the host
+          // platform while the command follows `shellCommandPath`.
+          expect.stringMatching(/script\.(ps1|sh)$/),
+        ],
+        expect.anything(),
+      );
+    });
+
+    it('should pass -NoProfile for the powershell language', async () => {
+      await executor.executeCode({
+        invocationContext,
+        codeExecutionInput: {
+          code: 'Write-Output "hi"',
+          language: CodeExecutionLanguage.POWERSHELL,
+          inputFiles: [],
+        },
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        POWERSHELL_COMMAND,
+        EXPECTED_POWERSHELL_ARGS,
+        expect.anything(),
+      );
+    });
+
+    it('should append user args after the powershell script path', async () => {
+      await executor.executeCode({
+        invocationContext,
+        codeExecutionInput: {
+          code: 'Write-Output $args',
+          language: CodeExecutionLanguage.POWERSHELL,
+          inputFiles: [],
+          args: ['alpha', 'beta'],
+        },
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        POWERSHELL_COMMAND,
+        [...EXPECTED_POWERSHELL_ARGS, 'alpha', 'beta'],
+        expect.anything(),
+      );
+    });
+
+    it('should not accumulate args across executions', async () => {
+      const params: ExecuteCodeParams = {
+        invocationContext,
+        codeExecutionInput: {
+          code: 'Write-Output "hi"',
+          language: CodeExecutionLanguage.POWERSHELL,
+          inputFiles: [],
+          args: ['first-run-only'],
+        },
+      };
+
+      await executor.executeCode(params);
+      await executor.executeCode({
+        invocationContext,
+        codeExecutionInput: {
+          code: 'Write-Output "hi"',
+          language: CodeExecutionLanguage.POWERSHELL,
+          inputFiles: [],
+        },
+      });
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      expect(spawnMock).toHaveBeenLastCalledWith(
+        POWERSHELL_COMMAND,
+        EXPECTED_POWERSHELL_ARGS,
+        expect.anything(),
+      );
+    });
+
+    it('should pass /D when shell code runs through cmd', async () => {
+      const shellExecutor = new UnsafeLocalCodeExecutor({
+        shellCommandPath: 'cmd.exe',
+      });
+
+      await shellExecutor.executeCode({
+        invocationContext,
+        codeExecutionInput: {
+          code: 'echo hi',
+          language: CodeExecutionLanguage.SHELL,
+          inputFiles: [],
+        },
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/D', '/c', expect.stringMatching(/script\.(bat|sh)$/)],
+        expect.anything(),
+      );
+    });
+
+    it('should pass /D for the windows_cmd language', async () => {
+      await executor.executeCode({
+        invocationContext,
+        codeExecutionInput: {
+          code: 'echo hi',
+          language: CodeExecutionLanguage.WINDOWS_CMD,
+          inputFiles: [],
+        },
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/D', '/c', expect.stringMatching(/script\.bat$/)],
+        expect.anything(),
+      );
+    });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue found.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`UnsafeLocalCodeExecutor` spawns PowerShell as
`['-NoLogo', '-ExecutionPolicy', 'Bypass', '-File', <script>]` — without
`-NoProfile`. Every `executeCode` call therefore runs the machine and user
profile chain (`$PROFILE.AllUsersAllHosts` … `$PROFILE.CurrentUserCurrentHost`)
before it opens the script. That breaks two properties callers expect:

- **Latency**: profile loading is startup work paid on every invocation, which
  for the short snippets this executor runs can dominate the wall-clock cost.
- **Reproducibility**: a profile is arbitrary code. It can mutate `$env:PATH`,
  define or shadow aliases and functions, change preference variables
  (`$ErrorActionPreference`, `$ProgressPreference`, `$OutputEncoding`), and
  write to the output streams. Since the executor captures `stdout`/`stderr` and
  returns them to the model, profile output is silently mixed into the
  code-execution result.

`cmd.exe` has the same class of problem: it runs the commands configured in the
`HKLM`/`HKCU` `Software\Microsoft\Command Processor\AutoRun` registry values at
startup. `cmd /?` documents `/D` as "Disable execution of AutoRun commands from
registry" — the exact analogue of `-NoProfile`.

The argument vector was also duplicated across four call sites, which is how a
fix ends up applied to only some of them.

**Solution:**

Add `-NoProfile` to every spawned PowerShell and `/D` to every spawned
`cmd.exe`, hoisting the two vectors into module-level `POWERSHELL_BASE_ARGS` /
`CMD_BASE_ARGS` constants (`as const`) so the four call sites cannot drift.
Each site spreads a _fresh_ array (`[...POWERSHELL_BASE_ARGS, filePath]`)
because `executeCode` later does `args.push(...codeExecutionInput.args)`;
assigning the constant directly would accumulate arguments across every call in
the process. `as const` makes that mistake a compile error and a unit test locks
the behaviour in. `-File`/`/c` stay last in the base vector so caller-supplied
args still reach the script rather than the interpreter. The class JSDoc is
updated to match.

Notes for review:

- **The `cmd.exe` `/D` change is deliberate and worth weighing on its own.**
  AutoRun is rarely set, but when it is it is precisely the kind of ambient
  mutation that breaks reproducible execution, so it is fixed alongside
  `-NoProfile` rather than left as a known gap.
- **Behavioural change**: a script that today implicitly depends on state
  established by the host's PowerShell profile (a `PATH` entry, an alias, a
  function, `$ErrorActionPreference`) will no longer see it. That is the
  non-reproducibility being fixed — the executor's contract is to run the
  submitted code, not the host's profile. Callers who need such state can set it
  up inside the submitted code. No API, option, or return-shape changes.
- `import {spawn} from 'child_process'` became `from 'node:child_process'` to
  match every other builtin import in the file and so the test's
  `vi.mock('node:child_process', …)` resolves the same specifier the module
  under test imports.
- Out of scope (left as-is): `shellCommandPath: 'pwsh'` does not match the
  `includes('powershell')` check and so gets neither the PowerShell flags nor
  the `.ps1` extension. That is a real gap but an independent behaviour change.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Four tests were added to
`core/test/code_executors/unsafe_local_code_executor_test.ts`, one per changed
branch, asserting the exact spawn argument vector: `SHELL` routed through
PowerShell, the `POWERSHELL` language (which also asserts user args are appended
after the script path and are not accumulated across executions), `SHELL` routed
through `cmd`, and the `WINDOWS_CMD` language. `spawn` is mocked for the file but
defaults to the real implementation, so the 14 pre-existing tests keep executing
real `node`/`python3`/`bash` child processes unchanged.

```
$ npx vitest run --project unit:core core/test/code_executors/unsafe_local_code_executor_test.ts
Test Files  1 passed (1)      Tests  18 passed (18)
```

Verified the new tests actually fail without the fix: reverting `-NoProfile` and
`/D` in the source turns all four red (`Tests  4 failed | 14 passed`).

Coverage of the changed lines (`v8`, scoped to the modified source file): all
four changed assignments and both constant declarations are covered. The only
partially-covered branch in that region is the pre-existing
`IS_WINDOWS ? 'powershell' : 'pwsh'` ternary, whose Windows arm is exercised by
the `windows-latest` leg of the CI matrix.

No regression in the suite that consumes this executor:

```
$ npx vitest run --project integration tests/integration/tools/run_skill_script_tool_test.ts
Test Files  1 passed (1)      Tests  8 passed | 4 skipped (12)
```

Repository gates, all clean on the pushed commit: `npm run build`,
`npm run lint`, `npm run format:check`, `npm run docs:check`. `npm run ts:check`
reports the same pre-existing errors before and after this change (none in the
touched files).

**Manual End-to-End (E2E) Tests:**

On a Windows host, or any host with `pwsh` installed:

1. Add `Write-Output 'hello from profile'` to `$PROFILE` (on Linux/macOS,
   `~/.config/powershell/profile.ps1`).
2. Run a snippet that executes `Write-Output "script output"` with
   `CodeExecutionLanguage.POWERSHELL` through `UnsafeLocalCodeExecutor`.
3. Before this change `result.stdout` contains `hello from profile`; after it,
   only `script output`. The post-change invocation also starts measurably
   faster.

No Windows host or `pwsh` was available on the development machine, so the
argument vector was instead verified end-to-end with no mocks by pointing
`shellCommandPath` at real executables named `fake-powershell` / `fake-cmd`
that echo their argv, and running the built executor against them. The real
`spawn` delivered exactly:

```
fake-powershell -> ARGV: -NoLogo -NoProfile -ExecutionPolicy Bypass -File /tmp/adk_js_unsafe_code_executor/<id>/script.sh user-arg
fake-cmd        -> ARGV: /D /c /tmp/adk_js_unsafe_code_executor/<id>/script.sh user-arg
```

confirming that `-NoProfile` and `/D` reach the interpreter and that
caller-supplied args still land after the script path.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This change only affects the argument vector passed to spawned interpreters; it
adds no dependencies and changes no public API. The `cmd.exe` `/D` flag and the
PowerShell `-NoProfile` flag are the two halves of the same fix, so they are
submitted together.
