### PR TITLE
Fix: treat @google/genai ApiError 404 as session not found in VertexAiSessionService

### DIFF
--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -247,8 +247,17 @@ export class VertexAiSessionService extends BaseSessionService {
 
       return session;
     } catch (error: unknown) {
-      const err = error as {code?: number; message?: string};
-      if (err.code === GRPC_NOT_FOUND || err.code === HTTP_NOT_FOUND) {
+      const err = error as {code?: number; status?: number; message?: string};
+      // gRPC transports report NOT_FOUND as a numeric `code`; the
+      // `@google/genai` `ApiClient` behind the Sessions client throws an
+      // `ApiError` carrying a numeric `status` instead. Matched structurally,
+      // not with `instanceof`: `@google-cloud/vertexai` resolves its own copy
+      // of `@google/genai`, so its `ApiError` is a different class object.
+      if (
+        err.code === GRPC_NOT_FOUND ||
+        err.code === HTTP_NOT_FOUND ||
+        err.status === HTTP_NOT_FOUND
+      ) {
         return undefined;
       }
       logger.error(`Error getting session from Vertex AI: ${err.message}`);

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -7,6 +7,7 @@
 import {Sessions} from '@google-cloud/vertexai/build/src/genai/sessions.js';
 import {createEvent, State, VertexAiSessionService} from '@google/adk';
 import {Session} from '@google/adk/sessions/session.js';
+import {ApiError} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 // Mock the unreleased nodejs-vertexai package so the import resolves
@@ -425,6 +426,54 @@ describe('VertexAiSessionService', () => {
       });
 
       expect(session).toBeUndefined();
+    });
+
+    it('returns undefined when sessions.get rejects with an ApiError 404', async () => {
+      const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+      mockClient.get.mockRejectedValueOnce(
+        new ApiError({message: 'Session not found', status: 404}),
+      );
+
+      const session = await service.getSession({
+        appName: '12345',
+        userId: 'testUser',
+        sessionId: 'my-session-id',
+      });
+
+      expect(session).toBeUndefined();
+      expect(loggerSpy).not.toHaveBeenCalled();
+      loggerSpy.mockRestore();
+    });
+
+    it('returns undefined when events.listInternal rejects with an ApiError 404', async () => {
+      mockClient.events.listInternal.mockRejectedValueOnce(
+        new ApiError({message: 'Session not found', status: 404}),
+      );
+
+      const session = await service.getSession({
+        appName: '12345',
+        userId: 'testUser',
+        sessionId: 'my-session-id',
+      });
+
+      expect(session).toBeUndefined();
+    });
+
+    it('throws an ApiError 403 instead of reporting the session as missing', async () => {
+      const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+      mockClient.get.mockRejectedValueOnce(
+        new ApiError({message: 'Permission denied', status: 403}),
+      );
+
+      await expect(
+        service.getSession({
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'my-session-id',
+        }),
+      ).rejects.toThrow('Permission denied');
+      expect(loggerSpy).toHaveBeenCalled();
+      loggerSpy.mockRestore();
     });
 
     it('falls back to empty array if sessionEvents is missing in getSession', async () => {

--- a/tests/integration/sessions/vertex_ai_session_service_test.ts
+++ b/tests/integration/sessions/vertex_ai_session_service_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Sessions} from '@google-cloud/vertexai/build/src/genai/sessions.js';
+import {VertexAiSessionService} from '@google/adk';
+import {
+  ApiClient,
+  NodeAuth,
+  NodeDownloader,
+  NodeUploader,
+} from '@google/genai/vertex_internal';
+import http from 'node:http';
+import {AddressInfo} from 'node:net';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+
+const AGENT_ENGINE_ID = '12345';
+
+/**
+ * Exercises `getSession`'s NOT_FOUND handling against an error the SDK builds
+ * itself: a loopback HTTP server answers 404 in place of the Agent Engine
+ * Sessions API, and the response travels back through the real
+ * `@google-cloud/vertexai` Sessions client and the real `@google/genai`
+ * `ApiClient`.
+ *
+ * The unit tests construct an `ApiError` directly, so they pin its shape but
+ * not the translation of an HTTP response into it -- and misreading that
+ * translation is what caused the bug this covers. Authentication is out of
+ * scope: the client is wired with an API key so no credentials are needed.
+ */
+describe('VertexAiSessionService over the real Sessions HTTP client', () => {
+  let server: http.Server;
+  let service: VertexAiSessionService;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(404, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({error: {code: 404, message: 'not found'}}));
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+
+    const {port} = server.address() as AddressInfo;
+    const apiClient = new ApiClient({
+      auth: new NodeAuth({apiKey: 'not-a-real-key'}),
+      uploader: new NodeUploader(),
+      downloader: new NodeDownloader(),
+      vertexai: true,
+      apiKey: 'not-a-real-key',
+      httpOptions: {baseUrl: `http://127.0.0.1:${port}`},
+    });
+    service = new VertexAiSessionService({
+      agentEngineId: AGENT_ENGINE_ID,
+      sessions: new Sessions(apiClient),
+    });
+  });
+
+  afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  it('resolves undefined when the backend reports the session is gone', async () => {
+    const session = await service.getSession({
+      appName: AGENT_ENGINE_ID,
+      userId: 'testUser',
+      sessionId: 'missing-session',
+    });
+
+    expect(session).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue; the change is described below.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`BaseSessionService.getSession()` documents its contract as "a promise that resolves to the session instance or `undefined` if not found", and callers depend on it: `getOrCreateSession()` creates a session when `getSession()` resolves falsy, and the dev API server branches on it to return `404 Session not found`.

`VertexAiSessionService.getSession()` classified NOT_FOUND by reading a numeric `code` off the caught error (`code === 5 || code === 404`). The errors that actually reach that `catch` never carry `code`. The Agent Engine Sessions client reaches the API over plain HTTP through `@google/genai`'s `ApiClient`, which throws an `ApiError` built from the HTTP response, carrying `{name: 'ApiError', status: <number>}` and no `code`. So against a live backend a genuine 404 fell through the guard and was rethrown, and `getSession()` never resolved to `undefined`. Only the hand-rolled test mocks — which rejected with `{code: 5}` / `{code: 404}` — ever reached that branch, which is why the tests passed while the production path was dead.

`deleteSession()` delegates to `getSession()` for its existence and ownership check, so it inherited the same defect: deleting an already-deleted session rejected instead of being a no-op.

**Solution:**

Also treat a numeric `status === 404` as NOT_FOUND in the shared `catch`. Both legs of the `Promise.all` (`sessions.get` and `sessions.events.listInternal`) go through the same `ApiClient` and the same `catch`, so both are covered, and `deleteSession()` inherits the fix with no source change.

Detection is structural rather than `instanceof`, and the comment in the source records why: `core` declares `@google/genai ^2.9.0` while `@google-cloud/vertexai@1.12.0` resolves its own copy via `^1.45.0`. Both are installed, so the `ApiError` thrown by the Sessions client is a different class object from the one this package would import, and a cross-copy `instanceof` evaluates to `false` — which would silently reintroduce this exact bug.

Only `code` is compared against the gRPC constant; `status` is HTTP-only, so `status === 5` is not treated as NOT_FOUND. Every other error (403, 500, gRPC `code: 9`, a bare `Error`) is still logged via `logger.error` and rethrown by identity, and the ownership check (`Session <id> does not belong to user <userId>.`) is unaffected.

Behavioural reference: `adk-python`'s `src/google/adk/sessions/vertex_ai_session_service.py` does the same thing in `get_session` and `delete_session`. Note the naming trap that likely caused this port to drift — the Python SDK exposes the HTTP status as `ClientError.code`, the TypeScript SDK as `ApiError.status`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added to `core/test/sessions/vertex_ai_session_service_test.ts` (all three fail on the pre-fix code except the 403 fence, which passes before and after):

- `sessions.get` rejecting with an `ApiError` 404 resolves `undefined`, and `logger.error` is not called — the NOT_FOUND path stays silent.
- `events.listInternal` rejecting with an `ApiError` 404 resolves `undefined`, covering the second leg of the `Promise.all`.
- An `ApiError` 403 still rejects and still logs, so the widened check did not start swallowing real failures. The pre-existing `{code: 9}` test does not cover this: its error has no `status` field at all, so only this case pins that the new check is exact rather than a range.

These construct the SDK's real exported `ApiError` rather than a hand-built look-alike, so they fail loudly if its shape changes. The four pre-existing error-path tests (`code: 5`, `code: 404`, `code: 9`, and `deleteSession` with `code: 5`) are unmodified and still pass.

Added `tests/integration/sessions/vertex_ai_session_service_test.ts`. The unit tests pin the shape of `ApiError` but not the translation of an HTTP response into one — and misreading that translation is what caused this bug. This test drives `VertexAiSessionService` through the real `@google-cloud/vertexai` `Sessions` client and the real `@google/genai` `ApiClient` against a loopback HTTP server answering 404, so the error being classified is the one the SDK itself builds from a real response. It is hermetic: the client is wired with an API key, so no credentials are needed.

New lines and branches in the changed code are fully covered: `code === 5`, `code === 404`, and `status === 404` are each exercised true, and the all-false path is covered by the `code: 9` and 403 tests.

Commands run locally on the pushed commit:

```
npx vitest run --project unit:core core/test/sessions/vertex_ai_session_service_test.ts
npx vitest run --project integration tests/integration/sessions/vertex_ai_session_service_test.ts
npm run build
npm run lint
npm run format:check
npm run docs:check
```

**Manual End-to-End (E2E) Tests:**

With a real Agent Engine (`projectId`, `location`, `agentEngineId` set and ADC available):

1. `const svc = new VertexAiSessionService({projectId, location, agentEngineId});`
2. `await svc.getSession({appName: agentEngineId, userId: 'u', sessionId: 'no-such-session'})` resolves `undefined` (before the fix: rejects with an `ApiError` 404).
3. `await svc.deleteSession({appName: agentEngineId, userId: 'u', sessionId: 'no-such-session'})` resolves (before the fix: rejects).
4. `await svc.getOrCreateSession({appName: agentEngineId, userId: 'u', sessionId: 'brand-new-id'})` creates and returns a session (before the fix: rejects).
5. Create a session, then `getSession` it with a different `userId` — still throws `Session <id> does not belong to user <userId>.` (unchanged).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The fix is three lines of condition plus a comment; the rest of the diff is tests. The added integration test is hermetic and needs no cloud credentials, so it runs in CI alongside the unit tests.
