### PR TITLE
Fix: check isCancel before coercing the project prompt in adk create

### DIFF
--- a/dev/src/cli/cli_create.ts
+++ b/dev/src/cli/cli_create.ts
@@ -257,14 +257,12 @@ export async function createAgent(options: AgentCreationOptions) {
       const defaultProject = await getGcpProject();
       const defaultRegion = await getGcpRegion();
 
-      const projectResponse: string = options.forceYes
+      const projectResponse: symbol | string = options.forceYes
         ? defaultProject
-        : (
-            await text({
-              message: 'Enter the Google Cloud Project ID',
-              initialValue: defaultProject,
-            })
-          ).toString();
+        : await text({
+            message: 'Enter the Google Cloud Project ID',
+            initialValue: defaultProject,
+          });
 
       if (isCancel(projectResponse)) {
         process.exit(0);

--- a/dev/test/cli/cli_create_test.ts
+++ b/dev/test/cli/cli_create_test.ts
@@ -221,6 +221,23 @@ describe('createAgent', () => {
         expect.stringContaining('GOOGLE_CLOUD_PROJECT=gcloud-project'),
       );
     });
+
+    it('should exit without writing files if project prompt is cancelled', async () => {
+      // Mirror clack's contract: only the raw cancel symbol counts as a cancel.
+      (isCancel as unknown as Mock).mockImplementation(
+        (value: unknown) => typeof value === 'symbol',
+      );
+      (select as Mock).mockResolvedValueOnce('gemini-2.5-flash'); // Model
+      (select as Mock).mockResolvedValueOnce('ts'); // Language
+      (select as Mock).mockResolvedValueOnce('vertex'); // Backend
+      (text as Mock).mockResolvedValueOnce(Symbol('clack:cancel')); // Project
+
+      await expect(createAgent(getFreshOptions())).rejects.toThrow(
+        /process\.exit/,
+      );
+
+      expect(saveToFile).not.toHaveBeenCalled();
+    });
   });
 
   describe('Folder Handling', () => {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue.

**2. Or, if no issue exists, describe the change:**

**Problem:**

Pressing `Ctrl+C` at the _"Enter the Google Cloud Project ID"_ prompt of `adk create` did not abort the wizard. It was the only prompt in `dev/src/cli/cli_create.ts` that coerced the awaited prompt result to a string before testing it:

```ts
const projectResponse: string = options.forceYes
  ? defaultProject
  : (await text({...})).toString();   // coercion

if (isCancel(projectResponse)) {      // always false: operand is a string
  process.exit(0);
}
```

`@clack/prompts` (`^0.11.0`, via `@clack/core@0.5.0`) signals cancellation by resolving the prompt with a module-private sentinel, `const S = Symbol('clack:cancel')`, and `isCancel` is a type guard that compares by identity (`value === S`). `.toString()` turns that symbol into the ordinary string `'Symbol(clack:cancel)'`, destroying identity, so `isCancel()` could never return `true` here. Execution fell through, the sentinel string was adopted as the project id, and the wizard ran to completion — scaffolding `agent.ts` / `package.json` / `tsconfig.json`, writing an `.env` containing `GOOGLE_CLOUD_PROJECT=Symbol(clack:cancel)` and `GOOGLE_GENAI_USE_VERTEXAI=1`, and then running `npm install` in the new directory. Cancelling at any sibling prompt (model, language, backend, region, API key, folder-overwrite) exited cleanly, because those pass the raw awaited value to `isCancel()`.

**Solution:**

Pass the raw prompt result to `isCancel()` and drop the coercion, giving the project prompt the same shape as the region prompt directly below it:

```ts
const projectResponse: symbol | string = options.forceYes
  ? defaultProject
  : await text({...});

if (isCancel(projectResponse)) {
  process.exit(0);
}
options.project = projectResponse;
```

This is a five-line, single-site edit — no new helper, error type, or shared `promptOrExit()` wrapper — chosen so the file has exactly one way of handling cancellation at all seven `isCancel()` call sites, which is what keeps this class of bug from recurring. Because `isCancel()` narrows to `symbol` and `process.exit()` returns `never`, TypeScript narrows `projectResponse` to `string` after the guard, so the assignment typechecks with no cast and no `!`. Removing `.toString()` also removes a latent `TypeError` for the case where `text()` resolves `undefined`. `forceYes` (`-y`) is unchanged and remains fully non-interactive; no exported signature, CLI flag, prompt text, generated-file content, or dependency changes.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added one regression test to `dev/test/cli/cli_create_test.ts`: `'should exit without writing files if project prompt is cancelled'`. The existing suite mocks `@clack/prompts` wholesale and sets `isCancel` to `mockReturnValue(false)`, a mock that ignores its argument — under it a symbol and the string `'Symbol(clack:cancel)'` are indistinguishable, so a test written the usual way would pass against the broken source and prove nothing. The new test therefore makes the mock argument-sensitive (`(value) => typeof value === 'symbol'`), mirroring clack's identity contract, so the coercion is exactly what the assertion detects.

```
npx vitest run --project unit:dev dev/test/cli/cli_create_test.ts
  Test Files  1 passed (1)
       Tests  11 passed (11)
```

Red/green verified: with the new test in place and `cli_create.ts` reverted to the `.toString()` version, the new test fails (`promise resolved "undefined" instead of rejecting`) while the other 10 tests pass; re-applying the fix turns all 11 green. Coverage of the changed code is complete — the cancel branch by the new test, the fall-through branch by the pre-existing `'should handle Vertex AI selection with gcloud defaults'` test.

Also run locally on the pushed commit, all clean:

```
npm run build            # core + dev + integrations
npm run lint             # eslint "**/*.ts"
npm run format:check     # prettier "**/*.ts" --check
```

**Manual End-to-End (E2E) Tests:**

1. `npm install && npm run build`
2. From an empty scratch directory, run the built CLI: `node <repo>/dev/dist/esm/cli_entrypoint.js create demo-agent`
3. Accept the default model, accept the default language, choose **Vertex AI** as the backend.
4. At `Enter the Google Cloud Project ID`, press `Ctrl+C`.
5. Expected: the process exits with status 0 immediately. `demo-agent/` contains no `.env`, no `agent.ts`, no `package.json`, no `tsconfig.json`, and no `npm install` runs. (An empty `demo-agent/` directory is left behind — `generateAgentFolder()` creates it before any prompt is shown, which is pre-existing behavior shared by every other cancel path and out of scope here.)

I ran this end-to-end with no mocks, driving the real built CLI through a scripted stdin that sends the keystrokes above and `0x03` at the project prompt:

- **With this fix**: exit code 0, the region prompt is never reached, and `demo-agent/` is empty.
- **Before this fix** (same driver against a build of the previous `cli_create.ts`): cancellation is ignored, the wizard advances to `Enter the Google Cloud Region`, and completing it produces `demo-agent/.env` containing `GOOGLE_CLOUD_PROJECT=Symbol(clack:cancel)` plus `agent.ts`, `package.json`, `tsconfig.json` and an installed `node_modules/`.

Environment used for the runs above: Node.js v22.22.2 on Linux, `vitest` 3.2.6, `@clack/prompts` 0.11.0.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

No dependent changes: this touches one file in the `dev` CLI package (`dev/src/cli/cli_create.ts`) plus its test, with no public API, dependency, or generated-output changes.
