### PR TITLE
fix: resolve the exit_loop built-in tool in YAML agent configs

### DIFF
--- a/dev/src/integration/agent_registry.ts
+++ b/dev/src/integration/agent_registry.ts
@@ -7,6 +7,8 @@
 import {
   AgentTool,
   BaseAgent,
+  BaseTool,
+  EXIT_LOOP,
   LlmAgent,
   LoopAgent,
   MCPToolset,
@@ -22,8 +24,19 @@ import {
 } from './agent_types.js';
 import {AnyFunctionTool, IntegrationRegistry} from './integration_registry.js';
 
-const BUILTIN_TOOLS = [
-  'exit_loop',
+/**
+ * Built-in tools that a YAML config can name directly, mirroring adk-python's
+ * `LlmAgent._resolve_tools`, which resolves a bare built-in name to the real
+ * tool object.
+ */
+const BUILTIN_TOOLS = new Map<string, BaseTool>([['exit_loop', EXIT_LOOP]]);
+
+/**
+ * Server-side built-ins that are dropped instead of resolved: they are executed
+ * by the Gemini backend and their `processLlmRequest` throws for the replay
+ * harness' `DummyLlm` model name.
+ */
+const SKIPPED_BUILTIN_TOOLS = [
   'google_search',
   'url_context',
   'google_maps_grounding',
@@ -135,8 +148,12 @@ export class AgentRegistry {
 
       const tools = config.tools
         ?.map((toolConfig) => {
-          // Built in tools are skipped
-          if (BUILTIN_TOOLS.includes(toolConfig.name)) {
+          const builtinTool = BUILTIN_TOOLS.get(toolConfig.name);
+          if (builtinTool) {
+            return builtinTool;
+          }
+
+          if (SKIPPED_BUILTIN_TOOLS.includes(toolConfig.name)) {
             return undefined;
           }
 
@@ -174,7 +191,7 @@ export class AgentRegistry {
 
           return this.findToolOrThrow(toolConfig.name);
         })
-        // remove entries for built-in tools
+        // remove entries for the server-side built-in tools
         .filter((tool) => tool !== undefined);
 
       const options = {

--- a/dev/src/integration/agent_registry.ts
+++ b/dev/src/integration/agent_registry.ts
@@ -27,9 +27,10 @@ import {AnyFunctionTool, IntegrationRegistry} from './integration_registry.js';
 /**
  * Built-in tools that a YAML config can name directly, mirroring adk-python's
  * `LlmAgent._resolve_tools`, which resolves a bare built-in name to the real
- * tool object.
+ * tool object. Looked up with `Object.hasOwn` so that a YAML string naming an
+ * inherited member such as `constructor` does not resolve to one.
  */
-const BUILTIN_TOOLS = new Map<string, BaseTool>([['exit_loop', EXIT_LOOP]]);
+const BUILTIN_TOOLS: Record<string, BaseTool> = {exit_loop: EXIT_LOOP};
 
 /**
  * Server-side built-ins that are dropped instead of resolved: they are executed
@@ -148,9 +149,8 @@ export class AgentRegistry {
 
       const tools = config.tools
         ?.map((toolConfig) => {
-          const builtinTool = BUILTIN_TOOLS.get(toolConfig.name);
-          if (builtinTool) {
-            return builtinTool;
+          if (Object.hasOwn(BUILTIN_TOOLS, toolConfig.name)) {
+            return BUILTIN_TOOLS[toolConfig.name];
           }
 
           if (SKIPPED_BUILTIN_TOOLS.includes(toolConfig.name)) {

--- a/dev/src/integration/replay_plugin.ts
+++ b/dev/src/integration/replay_plugin.ts
@@ -74,11 +74,20 @@ export class ReplayPlugin extends BasePlugin {
     const rec = this.recordings[index];
     (rec as unknown as {_consumed: boolean})._consumed = true;
 
-    // Handle side effects for built-in tools that modify EventActions
-    if (toolName === 'transfer_to_agent') {
-      params.toolContext.actions.transferToAgent = params.toolArgs[
-        'agentName'
-      ] as string;
+    // Returning the recorded response short-circuits the real tool call, so
+    // built-in tools whose only observable effect is on EventActions must have
+    // that effect replicated here. (adk-python instead runs the real tool in
+    // its replay plugin before returning the recording.)
+    switch (toolName) {
+      case 'transfer_to_agent':
+        params.toolContext.actions.transferToAgent = params.toolArgs[
+          'agentName'
+        ] as string;
+        break;
+      case 'exit_loop':
+        params.toolContext.actions.escalate = true;
+        params.toolContext.actions.skipSummarization = true;
+        break;
     }
 
     // The response from a tool call is a plain object.

--- a/dev/src/integration/replay_plugin.ts
+++ b/dev/src/integration/replay_plugin.ts
@@ -74,14 +74,24 @@ export class ReplayPlugin extends BasePlugin {
     const rec = this.recordings[index];
     (rec as unknown as {_consumed: boolean})._consumed = true;
 
-    // Handle side effects for built-in tools that modify EventActions
-    if (toolName === 'transfer_to_agent') {
-      // `agent_name` is the wire spelling, matching adk-python. Recordings
-      // captured before the rename still carry `agentName`, so both are read
-      // here rather than invalidating every recording on disk.
-      const args = params.toolArgs;
-      params.toolContext.actions.transferToAgent = (args['agent_name'] ??
-        args['agentName']) as string;
+    // Returning the recorded response short-circuits the real tool call, so
+    // built-in tools whose only observable effect is on EventActions must have
+    // that effect replicated here. (adk-python instead runs the real tool in
+    // its replay plugin before returning the recording.)
+    switch (toolName) {
+      case 'transfer_to_agent': {
+        // `agent_name` is the wire spelling, matching adk-python. Recordings
+        // captured before the rename still carry `agentName`, so both are read
+        // here rather than invalidating every recording on disk.
+        const args = params.toolArgs;
+        params.toolContext.actions.transferToAgent = (args['agent_name'] ??
+          args['agentName']) as string;
+        break;
+      }
+      case 'exit_loop':
+        params.toolContext.actions.escalate = true;
+        params.toolContext.actions.skipSummarization = true;
+        break;
     }
 
     // The response from a tool call is a plain object.

--- a/dev/src/integration/test_runner.ts
+++ b/dev/src/integration/test_runner.ts
@@ -30,7 +30,6 @@ const SKIPPED_TESTS = [
     name: 'tool/example_tool_001',
     reason: 'ExampleTool is not implemented yet.',
   },
-  {name: 'workflow/loop_001', reason: 'ExitLoopTool is not implemented yet.'},
   {
     name: 'core/multi_005',
     reason: 'Suspected broken test. Need to re-evaluate.',

--- a/dev/test/integration/agent_registry_test.ts
+++ b/dev/test/integration/agent_registry_test.ts
@@ -6,6 +6,7 @@
 
 import {
   AgentTool,
+  EXIT_LOOP,
   FunctionTool,
   LlmAgent,
   MCPToolset,
@@ -257,7 +258,7 @@ describe('AgentRegistry', () => {
     expect(retrieved.tools[0]).toBe(tool);
   });
 
-  it('should skip built-in tools', () => {
+  it('should resolve exit_loop to the EXIT_LOOP built-in tool', () => {
     const config = {
       name: 'builtin_agent',
       model: 'model',
@@ -270,7 +271,26 @@ describe('AgentRegistry', () => {
     agentRegistry.registerAgentConfig('builtin_agent', config);
     const retrieved = agentRegistry.getAgent('builtin_agent') as LlmAgent;
 
-    expect(retrieved).toBeDefined();
+    expect(retrieved.tools).toEqual([EXIT_LOOP]);
+  });
+
+  it('should skip server-side built-in tools', () => {
+    const config = {
+      name: 'builtin_agent',
+      model: 'model',
+      description: 'desc',
+      instruction: 'inst',
+      agentClass: 'LlmAgent',
+      tools: [
+        {name: 'google_search'},
+        {name: 'url_context'},
+        {name: 'google_maps_grounding'},
+      ],
+    } as unknown as YamlAgentConfig;
+
+    agentRegistry.registerAgentConfig('builtin_agent', config);
+    const retrieved = agentRegistry.getAgent('builtin_agent') as LlmAgent;
+
     expect(retrieved.tools.length).toBe(0);
   });
 });

--- a/dev/test/integration/agent_registry_test.ts
+++ b/dev/test/integration/agent_registry_test.ts
@@ -293,4 +293,20 @@ describe('AgentRegistry', () => {
 
     expect(retrieved.tools.length).toBe(0);
   });
+
+  it('should not resolve an inherited Object member as a built-in tool', () => {
+    const config = {
+      name: 'bad_agent',
+      model: 'model',
+      description: 'desc',
+      instruction: 'inst',
+      agentClass: 'LlmAgent',
+      tools: [{name: 'constructor'}],
+    } as unknown as YamlAgentConfig;
+
+    agentRegistry.registerAgentConfig('bad_agent', config);
+    expect(() => agentRegistry.getAgent('bad_agent')).toThrow(
+      'Tool constructor not found in registry',
+    );
+  });
 });

--- a/dev/test/integration/replay_plugin_test.ts
+++ b/dev/test/integration/replay_plugin_test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  createEventActions,
+  EventActions,
+  EXIT_LOOP,
+  FunctionTool,
+} from '@google/adk';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {ReplayPlugin} from '../../src/integration/replay_plugin.js';
+import {Recording} from '../../src/integration/test_types.js';
+
+const AGENT_NAME = 'refiner_agent';
+
+const TRANSFER_TO_AGENT = new FunctionTool({
+  name: 'transfer_to_agent',
+  description: 'Transfers to another agent.',
+  execute: async () => ({}),
+});
+
+const GREET = new FunctionTool({
+  name: 'greet',
+  description: 'Greets the user.',
+  execute: async () => ({}),
+});
+
+function toolRecording(
+  name: string,
+  response: Record<string, unknown>,
+): Recording {
+  return {
+    userMessageIndex: 0,
+    agentName: AGENT_NAME,
+    toolRecording: {toolCall: {name}, toolResponse: {response}},
+  };
+}
+
+describe('ReplayPlugin', () => {
+  let actions: EventActions;
+  let toolContext: Context;
+
+  beforeEach(() => {
+    actions = createEventActions();
+    toolContext = {
+      actions,
+      invocationContext: {agent: {name: AGENT_NAME}},
+    } as unknown as Context;
+  });
+
+  it('replays the recorded response and escalates for exit_loop', async () => {
+    const plugin = new ReplayPlugin(
+      [toolRecording('exit_loop', {result: null})],
+      {
+        userMessageIndex: 0,
+      },
+    );
+
+    const response = await plugin.beforeToolCallback({
+      tool: EXIT_LOOP,
+      toolArgs: {},
+      toolContext,
+    });
+
+    expect(response).toEqual({result: null});
+    expect(actions.escalate).toBe(true);
+    expect(actions.skipSummarization).toBe(true);
+  });
+
+  it('replays transfer_to_agent by setting transferToAgent', async () => {
+    const plugin = new ReplayPlugin(
+      [toolRecording('transfer_to_agent', {result: null})],
+      {userMessageIndex: 0},
+    );
+
+    await plugin.beforeToolCallback({
+      tool: TRANSFER_TO_AGENT,
+      toolArgs: {agentName: 'writer_agent'},
+      toolContext,
+    });
+
+    expect(actions.transferToAgent).toBe('writer_agent');
+    expect(actions.escalate).toBeUndefined();
+  });
+
+  it('replays a plain tool without touching the actions', async () => {
+    const plugin = new ReplayPlugin(
+      [toolRecording('greet', {greeting: 'hi'})],
+      {
+        userMessageIndex: 0,
+      },
+    );
+
+    const response = await plugin.beforeToolCallback({
+      tool: GREET,
+      toolArgs: {},
+      toolContext,
+    });
+
+    expect(response).toEqual({greeting: 'hi'});
+    expect(actions).toEqual(createEventActions());
+  });
+
+  it('throws when no recording matches the tool call', async () => {
+    const plugin = new ReplayPlugin([], {userMessageIndex: 0});
+
+    await expect(
+      plugin.beforeToolCallback({tool: GREET, toolArgs: {}, toolContext}),
+    ).rejects.toThrow(
+      `No tool recording found for agent ${AGENT_NAME}, tool greet at turn 0`,
+    );
+  });
+
+  it('consumes each recording only once', async () => {
+    const plugin = new ReplayPlugin(
+      [toolRecording('greet', {greeting: 'hi'})],
+      {
+        userMessageIndex: 0,
+      },
+    );
+    const call = () =>
+      plugin.beforeToolCallback({tool: GREET, toolArgs: {}, toolContext});
+
+    await call();
+
+    await expect(call()).rejects.toThrow(
+      `No tool recording found for agent ${AGENT_NAME}, tool greet at turn 0`,
+    );
+  });
+});

--- a/dev/test/integration/test_runner_test.ts
+++ b/dev/test/integration/test_runner_test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {createEvent, createEventActions, createSession} from '@google/adk';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {AgentRegistry} from '../../src/integration/agent_registry.js';
+import {YamlAgentConfig} from '../../src/integration/agent_types.js';
+import {IntegrationRegistry} from '../../src/integration/integration_registry.js';
+import {TestRunner} from '../../src/integration/test_runner.js';
+import {TestInfo} from '../../src/integration/test_types.js';
+
+const ROOT_AGENT = 'loop_root_agent';
+const SUB_AGENT = 'refiner_agent';
+const USER_MESSAGE = 'Refine the poem.';
+
+/**
+ * Registers the in-memory equivalent of the `workflow/loop_001` conformance
+ * corpus: a LoopAgent whose only sub-agent calls `exit_loop`.
+ */
+function registerLoopAgents(registry: AgentRegistry) {
+  registry.registerAgentConfig('loop_test/refiner_agent', {
+    name: SUB_AGENT,
+    model: 'gemini-2.5-flash',
+    description: 'Refines a poem.',
+    instruction: 'Refine the poem, then call exit_loop.',
+    agentClass: 'LlmAgent',
+    tools: [{name: 'exit_loop'}],
+  } as unknown as YamlAgentConfig);
+
+  registry.registerAgentConfig('loop_test/root_agent', {
+    name: ROOT_AGENT,
+    model: 'gemini-2.5-flash',
+    description: 'Loops until the refiner exits.',
+    instruction: '',
+    agentClass: 'LoopAgent',
+    maxIterations: '3',
+    isRootAgent: true,
+    subAgents: [{configPath: 'loop_test/refiner_agent'}],
+  } as unknown as YamlAgentConfig);
+}
+
+/**
+ * The session the harness must reproduce: the refiner agent calls `exit_loop`
+ * once and the LoopAgent stops, so there is exactly one iteration. The final
+ * function-response event carries `escalate` / `skipSummarization`, which only
+ * happens when the `exit_loop` tool is resolved and its side effects replayed.
+ *
+ * The fixture keeps the shape of a recorded `generated-session.yaml`, but note
+ * that `filterPartFields` strips `functionCall` / `functionResponse` from every
+ * part before the comparison, so those payloads are documentation rather than
+ * assertions.
+ */
+function expectedSession() {
+  return createSession({
+    id: 'expected-session',
+    appName: 'test-runner',
+    events: [
+      createEvent({
+        author: 'user',
+        content: {role: 'user', parts: [{text: USER_MESSAGE}]},
+      }),
+      createEvent({
+        author: SUB_AGENT,
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'exit_loop', args: {}}}],
+        },
+      }),
+      createEvent({
+        author: SUB_AGENT,
+        content: {
+          role: 'user',
+          parts: [
+            {functionResponse: {name: 'exit_loop', response: {result: null}}},
+          ],
+        },
+        actions: {
+          ...createEventActions(),
+          escalate: true,
+          skipSummarization: true,
+        },
+      }),
+    ],
+  });
+}
+
+function loopTestInfo(): TestInfo {
+  return {
+    name: 'workflow/loop_001',
+    spec: {
+      description: 'The refiner agent exits the loop on the first iteration.',
+      agent: 'loop_test',
+      userMessages: [{text: USER_MESSAGE}],
+    },
+    recordings: {
+      recordings: [
+        {
+          userMessageIndex: 0,
+          agentName: SUB_AGENT,
+          llmRecording: {
+            llmResponse: {
+              content: {
+                role: 'model',
+                parts: [{functionCall: {name: 'exit_loop', args: {}}}],
+              },
+            },
+          },
+        },
+        {
+          userMessageIndex: 0,
+          agentName: SUB_AGENT,
+          toolRecording: {
+            toolCall: {name: 'exit_loop'},
+            toolResponse: {response: {result: null}},
+          },
+        },
+      ],
+    },
+    session: expectedSession(),
+  };
+}
+
+describe('TestRunner', () => {
+  let registry: AgentRegistry;
+  let testRunner: TestRunner;
+
+  beforeEach(() => {
+    registry = new AgentRegistry(new IntegrationRegistry());
+    testRunner = new TestRunner(registry);
+  });
+
+  it('replays a loop agent that exits via the exit_loop built-in tool', async () => {
+    registerLoopAgents(registry);
+
+    await expect(testRunner.run(loopTestInfo(), false)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A — no existing issue.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`ExitLoopTool` and the `EXIT_LOOP` singleton already exist in core and are exported from `@google/adk`, but the conformance harness in the `dev` package still behaves as if they did not.

`dev/src/integration/agent_registry.ts` listed `exit_loop` in a `BUILTIN_TOOLS` array whose every entry was mapped to `undefined` and filtered out, so a YAML agent declaring:

```yaml
tools:
  - name: exit_loop
```

was instantiated with **zero** tools. During a conformance replay the recorded `exit_loop` function call then fails with `Function exit_loop is not found in the toolsDict.`, which is why `workflow/loop_001` was permanently listed in `SKIPPED_TESTS` with the (now false) reason `ExitLoopTool is not implemented yet.`

**Solution:**

Two changes are required, and both are needed for the case to actually pass.

1. **Registry resolution** (`dev/src/integration/agent_registry.ts`). `BUILTIN_TOOLS` becomes a `Record<string, BaseTool>` of built-ins that resolve to a real tool object — currently just `exit_loop -> EXIT_LOOP` — mirroring `adk-python`'s `LlmAgent._resolve_tools`, which resolves a bare, dot-less built-in name to the real tool object. The three purely server-side built-ins (`google_search`, `url_context`, `google_maps_grounding`) move to a separate `SKIPPED_BUILTIN_TOOLS` list and keep being dropped on purpose: they are executed by the Gemini backend and their `processLlmRequest` throws for a non-Gemini model name, and the replay harness injects `DummyLlm` (model name `dummy-llm`). The table is read through `Object.hasOwn` so that a YAML string naming an inherited member such as `constructor` falls through to `findToolOrThrow` instead of resolving to `Object.prototype.constructor`; `Object.hasOwn` is already the idiom used elsewhere in this package (`dev/src/integration/test_runner.ts`).

2. **Replay side effects** (`dev/src/integration/replay_plugin.ts`). This is the non-obvious half — reviewers will otherwise read it as unrelated. `ReplayPlugin.beforeToolCallback` returns the recorded tool response, and in `core/src/agents/functions.ts` a non-null plugin response short-circuits `callToolAsync`. The response recorded for a Python tool returning `None` is the dict `{result: None}` — a non-null object — so `EXIT_LOOP.runAsync` would never execute and neither `escalate` nor `skipSummarization` would be set. Without `escalate` the `LoopAgent` never stops; without `skipSummarization` the sub-agent asks the model for one more turn and the replay throws `No LLM recording found ...`. Both flags are also deep-compared by `validateSession`. The plugin already replicated this class of side effect for `transfer_to_agent`; the `if` becomes a small `switch` with an `exit_loop` arm that sets both flags. (`adk-python` solves this differently — its replay plugin runs the real tool before returning the recording — but porting that would change execution for every replayed tool, so it is deliberately out of scope here.)

With both in place, `workflow/loop_001` is removed from `SKIPPED_TESTS`; that list now holds exactly `tool/example_tool_001`, `core/multi_005` and `tool/long_running_tool_001`.

No `core/` change, no public API change, and no new dependency: `AgentRegistry` and `ReplayPlugin` are internal to the devtools conformance harness.

### Testing Plan

**Note on the conformance corpus:** the replay corpus (`spec.yaml` / `generated-recordings.yaml` / `generated-session.yaml` triplets) is not vendored in this repo and is not exercised by `.github/workflows/validation.yaml`. **The real `adk integration conformance` replay was NOT executed** — no corpus was available in the environment. `dev/test/integration/test_runner_test.ts` was added as the in-repo, CI-runnable substitute: it drives the real `TestRunner`, `AgentRegistry`, `ReplayPlugin`, `LoopAgent` and `LlmAgent` with no mocks, over an in-memory equivalent of the `loop_001` case, and asserts the produced session deep-equals the expected one — including `escalate` / `skipSummarization` on the final function-response event, which is only reachable when both halves of this fix are present.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

- `dev/test/integration/agent_registry_test.ts` — `exit_loop` now resolves to the shared `EXIT_LOOP` instance; the three server-side built-ins are still dropped; an inherited member name such as `constructor` is not resolved as a built-in.
  - **Rewritten test, called out explicitly:** the old `should skip built-in tools` case asserted `expect(retrieved.tools.length).toBe(0)` for `exit_loop` — it pinned exactly the behaviour this PR fixes, so it became `should resolve exit_loop to the EXIT_LOOP built-in tool`. Its original assertion is not lost: it survives verbatim in the new `should skip server-side built-in tools` case, which applies it to `google_search` / `url_context` / `google_maps_grounding`. No other existing test was changed or removed.
- `dev/test/integration/replay_plugin_test.ts` (new) — both `switch` arms, the no-side-effect arm, the not-found rejection, and single-consumption of a recording.
- `dev/test/integration/test_runner_test.ts` (new) — the end-to-end loop replay described above.

Commands run locally on the pushed commit:

```
npx vitest run --project unit:dev dev/test/integration   # 4 files, 24 tests passed
npm run build                                            # OK
npm run lint                                             # OK
npm run format:check                                     # OK
npm run docs:check                                       # 0 errors
npx secretlint "**/*"                                    # clean
```

Each half of the fix was verified to be load-bearing by reverting it in isolation and re-running `dev/test/integration/test_runner_test.ts`:

- without the `agent_registry.ts` resolution, the run fails with `Tool exit_loop not found in registry`;
- without the `replay_plugin.ts` `exit_loop` arm, the loop never terminates and the run fails with `No LLM recording found for agent refiner_agent at turn 0`.

Pre-existing failures unrelated to this change: the `tests/integration/build_setup`, `tests/integration/app_loader`, `tests/integration/agent_loader` and `e2e` suites fail in this sandbox because they shell out to real builds and to the live Gemini API. They fail on the base commit too, and repeated runs on an unchanged tree produce a different subset each time, so they are environmental rather than caused by this diff.

**Manual End-to-End (E2E) Tests:**

1. Write a YAML agent config for a refiner agent that exits a loop:

   ```yaml
   agent_class: LlmAgent
   name: refiner_agent
   model: gemini-2.5-flash
   description: Refines a poem.
   instruction: Refine the poem, then call exit_loop.
   tools:
     - name: exit_loop
   ```

2. Load it via `AgentRegistry.registerAgentConfig` + `getAgent` and confirm the resulting `LlmAgent.tools` is `[EXIT_LOOP]` (before this change it was `[]`).

3. If you have a conformance corpus available:

   ```
   npm run build
   npx adk integration conformance --agents_dir <corpus>/agents --tests_dir <corpus>/tests
   ```

   `workflow/loop_001` should now run and pass instead of being reported as skipped.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The two unchecked boxes are accurate rather than oversights: the full end-to-end path is the `adk integration conformance` replay, whose corpus is not vendored in this repo and was not available in this environment, and this change has no dependent downstream modules.

