### PR TITLE
fix(runner): persist events returned by onEventCallback

### DIFF
--- a/core/src/plugins/base_plugin.ts
+++ b/core/src/plugins/base_plugin.ts
@@ -168,8 +168,10 @@ export abstract class BasePlugin {
    * @param params.invocationContext The context for the entire invocation.
    * @param params.event The event raised by the runner.
    * @returns An optional value. A non-`undefined` return may be used by the
-   *     framework to modify or replace the response. Returning `undefined`
-   *     allows the original response to be used.
+   *     framework to modify or replace the response. Copy `params.event` when
+   *     constructing a replacement to preserve fields that are not being
+   *     modified, such as event actions. Returning `undefined` allows the
+   *     original response to be used.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async onEventCallback(params: {

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -412,24 +412,24 @@ export class Runner {
                   return;
                 }
 
-                if (!event.partial) {
-                  await this.sessionService.appendEvent({session, event});
-                }
                 // Step 3: Run the on_event callbacks to optionally modify the event.
                 const modifiedEvent =
                   await this.pluginManager.runOnEventCallback({
                     invocationContext,
                     event,
                   });
+                const outputEvent = modifiedEvent ?? event;
+                if (!event.partial) {
+                  await this.sessionService.appendEvent({
+                    session,
+                    event: outputEvent,
+                  });
+                }
                 if (params.abortSignal?.aborted) {
                   return;
                 }
 
-                if (modifiedEvent) {
-                  yield modifiedEvent;
-                } else {
-                  yield event;
-                }
+                yield outputEvent;
               }
               // Step 4: Run the after_run callbacks to optionally modify the context.
               await this.pluginManager.runAfterRunCallback({invocationContext});

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -412,13 +412,23 @@ export class Runner {
                   return;
                 }
 
-                // Step 3: Run the on_event callbacks to optionally modify the event.
+                // Step 3: Run the on_event callbacks before persisting so callback
+                // changes are stored in the session and match the streamed event.
                 const modifiedEvent =
                   await this.pluginManager.runOnEventCallback({
                     invocationContext,
                     event,
                   });
-                const outputEvent = modifiedEvent ?? event;
+                const outputEvent = modifiedEvent
+                  ? {
+                      ...modifiedEvent,
+                      id: event.id,
+                      invocationId: event.invocationId,
+                      timestamp: event.timestamp,
+                      author: modifiedEvent.author || event.author,
+                      branch: modifiedEvent.branch ?? event.branch,
+                    }
+                  : event;
                 if (!event.partial) {
                   await this.sessionService.appendEvent({
                     session,

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -570,6 +570,16 @@ describe('Runner with plugins', () => {
     const modifiedEventMessage = generatedEvent.content!.parts![0].text;
 
     expect(modifiedEventMessage).toEqual(MockPlugin.ON_EVENT_CALLBACK_MSG);
+
+    const session = await sessionService.getSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+    });
+    const persistedEvent = session!.events[1];
+    expect(persistedEvent.content!.parts![0].text).toEqual(
+      MockPlugin.ON_EVENT_CALLBACK_MSG,
+    );
   });
 
   it('should call beforeRunCallback and stop execution', async () => {

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -580,6 +580,7 @@ describe('Runner with plugins', () => {
     expect(persistedEvent.content!.parts![0].text).toEqual(
       MockPlugin.ON_EVENT_CALLBACK_MSG,
     );
+    expect(persistedEvent.author).toEqual('test_agent');
   });
 
   it('should call beforeRunCallback and stop execution', async () => {


### PR DESCRIPTION
## Summary

Run `onEventCallback` before persisting non-partial agent events and store the resolved callback output.

Previously, callers received the replacement event while session history retained the original event. This could make reloaded history differ from the streamed response and feed the original content into later invocations.

The persistence decision still uses the original event partial flag, so a plugin cannot change whether an agent-produced event is stored.

## Tests

- Added regression coverage that reloads the session and verifies the callback replacement was persisted
- `npx vitest run --project unit:core`
- Prettier and ESLint checks for changed files
- Workspace build

Fixes #573