### PR TITLE
fix(artifacts): isolate in-memory composite keys

### DIFF
--- a/core/src/artifacts/in_memory_artifact_service.ts
+++ b/core/src/artifacts/in_memory_artifact_service.ts
@@ -101,17 +101,19 @@ export class InMemoryArtifactService implements BaseArtifactService {
     userId,
     sessionId,
   }: ListArtifactKeysRequest): Promise<string[]> {
-    const sessionPrefix = `${appName}/${userId}/${sessionId}/`;
-    const usernamespacePrefix = `${appName}/${userId}/user/`;
     const filenames: string[] = [];
 
     for (const path in this.artifacts) {
-      if (path.startsWith(sessionPrefix)) {
-        const filename = path.replace(sessionPrefix, '');
-        filenames.push(filename);
-      } else if (path.startsWith(usernamespacePrefix)) {
-        const filename = path.replace(usernamespacePrefix, '');
-        filenames.push(filename);
+      const key = JSON.parse(path) as ArtifactStorageKey;
+      if (
+        key[0] === 'session' &&
+        key[1] === appName &&
+        key[2] === userId &&
+        key[3] === sessionId
+      ) {
+        filenames.push(key[4]);
+      } else if (key[0] === 'user' && key[1] === appName && key[2] === userId) {
+        filenames.push(key[3]);
       }
     }
 
@@ -212,11 +214,15 @@ function artifactPath(
   filename: string,
 ): string {
   if (fileHasUserNamespace(filename)) {
-    return `${appName}/${userId}/user/${filename}`;
+    return JSON.stringify(['user', appName, userId, filename]);
   }
 
-  return `${appName}/${userId}/${sessionId}/${filename}`;
+  return JSON.stringify(['session', appName, userId, sessionId, filename]);
 }
+
+type ArtifactStorageKey =
+  | ['session', string, string, string, string]
+  | ['user', string, string, string];
 
 /**
  * Checks if the filename has a user namespace prefix.

--- a/core/src/artifacts/in_memory_artifact_service.ts
+++ b/core/src/artifacts/in_memory_artifact_service.ts
@@ -199,13 +199,13 @@ export class InMemoryArtifactService implements BaseArtifactService {
 }
 
 /**
- * Constructs the path to the artifact.
+ * Constructs the storage key for the artifact.
  *
  * @param appName The app name.
  * @param userId The user ID.
  * @param sessionId The session ID.
  * @param filename The filename.
- * @return The path to the artifact.
+ * @return The encoded storage key for the artifact.
  */
 function artifactPath(
   appName: string,
@@ -221,8 +221,14 @@ function artifactPath(
 }
 
 type ArtifactStorageKey =
-  | ['session', string, string, string, string]
-  | ['user', string, string, string];
+  | [
+      'session',
+      appName: string,
+      userId: string,
+      sessionId: string,
+      filename: string,
+    ]
+  | ['user', appName: string, userId: string, filename: string];
 
 /**
  * Checks if the filename has a user namespace prefix.

--- a/core/src/artifacts/in_memory_artifact_service.ts
+++ b/core/src/artifacts/in_memory_artifact_service.ts
@@ -101,19 +101,15 @@ export class InMemoryArtifactService implements BaseArtifactService {
     userId,
     sessionId,
   }: ListArtifactKeysRequest): Promise<string[]> {
+    const sessionPrefix = artifactPrefix('session', appName, userId, sessionId);
+    const userPrefix = artifactPrefix('user', appName, userId);
     const filenames: string[] = [];
 
     for (const path in this.artifacts) {
-      const key = JSON.parse(path) as ArtifactStorageKey;
-      if (
-        key[0] === 'session' &&
-        key[1] === appName &&
-        key[2] === userId &&
-        key[3] === sessionId
-      ) {
-        filenames.push(key[4]);
-      } else if (key[0] === 'user' && key[1] === appName && key[2] === userId) {
-        filenames.push(key[3]);
+      if (path.startsWith(sessionPrefix)) {
+        filenames.push(decodeURIComponent(path.slice(sessionPrefix.length)));
+      } else if (path.startsWith(userPrefix)) {
+        filenames.push(decodeURIComponent(path.slice(userPrefix.length)));
       }
     }
 
@@ -214,21 +210,15 @@ function artifactPath(
   filename: string,
 ): string {
   if (fileHasUserNamespace(filename)) {
-    return JSON.stringify(['user', appName, userId, filename]);
+    return `${artifactPrefix('user', appName, userId)}${encodeURIComponent(filename)}`;
   }
 
-  return JSON.stringify(['session', appName, userId, sessionId, filename]);
+  return `${artifactPrefix('session', appName, userId, sessionId)}${encodeURIComponent(filename)}`;
 }
 
-type ArtifactStorageKey =
-  | [
-      'session',
-      appName: string,
-      userId: string,
-      sessionId: string,
-      filename: string,
-    ]
-  | ['user', appName: string, userId: string, filename: string];
+function artifactPrefix(scope: string, ...parts: string[]): string {
+  return `${[scope, ...parts].map(encodeURIComponent).join('/')}/`;
+}
 
 /**
  * Checks if the filename has a user namespace prefix.

--- a/core/test/artifacts/in_memory_artifact_service_test.ts
+++ b/core/test/artifacts/in_memory_artifact_service_test.ts
@@ -32,13 +32,40 @@ describe('InMemoryArtifactService', () => {
       artifact: {text: 'artifact-b'},
     });
 
-    const artifact = await service.loadArtifact({
+    const artifactA = await service.loadArtifact({
       appName: 'app',
       userId: 'user',
       sessionId: 'session',
       filename: 'nested/report.txt',
     });
+    const artifactB = await service.loadArtifact({
+      appName: 'app',
+      userId: 'user',
+      sessionId: 'session/nested',
+      filename: 'report.txt',
+    });
 
-    expect(artifact?.text).toBe('artifact-a');
+    expect(artifactA?.text).toBe('artifact-a');
+    expect(artifactB?.text).toBe('artifact-b');
+  });
+
+  it('does not leak a session named user into other sessions', async () => {
+    const service = new InMemoryArtifactService();
+
+    await service.saveArtifact({
+      appName: 'app',
+      userId: 'user',
+      sessionId: 'user',
+      filename: 'foo.txt',
+      artifact: {text: 'session-scoped'},
+    });
+
+    const keys = await service.listArtifactKeys({
+      appName: 'app',
+      userId: 'user',
+      sessionId: 'other',
+    });
+
+    expect(keys).toEqual([]);
   });
 });

--- a/core/test/artifacts/in_memory_artifact_service_test.ts
+++ b/core/test/artifacts/in_memory_artifact_service_test.ts
@@ -49,6 +49,41 @@ describe('InMemoryArtifactService', () => {
     expect(artifactB?.text).toBe('artifact-b');
   });
 
+  it('keeps artifacts with ambiguous app and user components isolated', async () => {
+    const service = new InMemoryArtifactService();
+
+    await service.saveArtifact({
+      appName: 'app',
+      userId: 'nested/user',
+      sessionId: 'session',
+      filename: 'report.txt',
+      artifact: {text: 'artifact-a'},
+    });
+    await service.saveArtifact({
+      appName: 'app/nested',
+      userId: 'user',
+      sessionId: 'session',
+      filename: 'report.txt',
+      artifact: {text: 'artifact-b'},
+    });
+
+    const artifactA = await service.loadArtifact({
+      appName: 'app',
+      userId: 'nested/user',
+      sessionId: 'session',
+      filename: 'report.txt',
+    });
+    const artifactB = await service.loadArtifact({
+      appName: 'app/nested',
+      userId: 'user',
+      sessionId: 'session',
+      filename: 'report.txt',
+    });
+
+    expect(artifactA?.text).toBe('artifact-a');
+    expect(artifactB?.text).toBe('artifact-b');
+  });
+
   it('does not leak a session named user into other sessions', async () => {
     const service = new InMemoryArtifactService();
 

--- a/core/test/artifacts/in_memory_artifact_service_test.ts
+++ b/core/test/artifacts/in_memory_artifact_service_test.ts
@@ -5,7 +5,7 @@
  */
 
 import {InMemoryArtifactService} from '@google/adk';
-import {describe} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {runArtifactServiceTests} from './artifact_service_test_utils.js';
 
 describe('InMemoryArtifactService', () => {
@@ -13,4 +13,32 @@ describe('InMemoryArtifactService', () => {
     async () => new InMemoryArtifactService(),
     async () => {},
   );
+
+  it('keeps artifacts with ambiguous path components isolated', async () => {
+    const service = new InMemoryArtifactService();
+
+    await service.saveArtifact({
+      appName: 'app',
+      userId: 'user',
+      sessionId: 'session',
+      filename: 'nested/report.txt',
+      artifact: {text: 'artifact-a'},
+    });
+    await service.saveArtifact({
+      appName: 'app',
+      userId: 'user',
+      sessionId: 'session/nested',
+      filename: 'report.txt',
+      artifact: {text: 'artifact-b'},
+    });
+
+    const artifact = await service.loadArtifact({
+      appName: 'app',
+      userId: 'user',
+      sessionId: 'session',
+      filename: 'nested/report.txt',
+    });
+
+    expect(artifact?.text).toBe('artifact-a');
+  });
 });


### PR DESCRIPTION
## Summary

Encode in-memory artifact keys as scoped tuples instead of joining components with slashes.

The previous key format could map distinct artifacts to the same array when a nested filename overlapped with a separator in another key component. That combined version histories and allowed loads or deletes through one logical key to affect another.

The explicit scope marker also keeps user-scoped artifacts separate while preserving existing listing behavior.

## Tests

- Added regression coverage for a nested filename and overlapping session ID
- `npx vitest run --project unit:core`
- Prettier and ESLint checks for changed files
- Workspace build

Fixes #574