### PR TITLE
fix(core): use a cryptographically secure source for randomUUID

### DIFF
--- a/core/src/utils/env_aware_utils.ts
+++ b/core/src/utils/env_aware_utils.ts
@@ -30,25 +30,22 @@ export function randomUUID(): string {
   }
 
   if (globalThis.crypto?.getRandomValues) {
-    const bytes = new Uint8Array(16);
-    globalThis.crypto.getRandomValues(bytes);
+    const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
     // RFC 4122 section 4.4: version 4 in the high nibble of octet 6, variant
     // 10xx in the two high bits of octet 8.
     bytes[6] = (bytes[6] & 0x0f) | 0x40;
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
 
-    const hex: string[] = [];
-    for (let i = 0; i < bytes.length; i++) {
-      hex.push(bytes[i].toString(16).padStart(2, '0'));
-    }
-
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
     return [
-      hex.slice(0, 4).join(''),
-      hex.slice(4, 6).join(''),
-      hex.slice(6, 8).join(''),
-      hex.slice(8, 10).join(''),
-      hex.slice(10, 16).join(''),
-    ].join('-');
+      hex.slice(0, 4),
+      hex.slice(4, 6),
+      hex.slice(6, 8),
+      hex.slice(8, 10),
+      hex.slice(10, 16),
+    ]
+      .map((group) => group.join(''))
+      .join('-');
   }
 
   throw new Error(

--- a/core/src/utils/env_aware_utils.ts
+++ b/core/src/utils/env_aware_utils.ts
@@ -12,29 +12,50 @@ export function isBrowser() {
 }
 
 /**
- * Generates a random UUID.
+ * Generates a random UUID from a cryptographically secure source.
+ *
+ * `crypto.randomUUID()` is only exposed in secure contexts, so it is absent on
+ * plain-HTTP origins even though `crypto` itself is present.
+ * `crypto.getRandomValues()` carries no such restriction, so it is used as the
+ * fallback rather than `Math.random()`.
+ *
+ * Some callers use this value to make security decisions — the OAuth2 `state`
+ * parameter in `AuthHandler` and the session identifiers minted by the session
+ * services — so this function must not silently degrade to a non-cryptographic
+ * generator.
  */
-const UUID_MASK = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
 export function randomUUID(): string {
   if (globalThis.crypto?.randomUUID) {
     return globalThis.crypto.randomUUID();
   }
 
-  let uuid = '';
+  if (globalThis.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    // RFC 4122 section 4.4: version 4 in the high nibble of octet 6, variant
+    // 10xx in the two high bits of octet 8.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
 
-  for (let i = 0; i < UUID_MASK.length; i++) {
-    const randomValue = (Math.random() * 16) | 0;
-
-    if (UUID_MASK[i] === 'x') {
-      uuid += randomValue.toString(16);
-    } else if (UUID_MASK[i] === 'y') {
-      uuid += ((randomValue & 0x3) | 0x8).toString(16);
-    } else {
-      uuid += UUID_MASK[i];
+    const hex: string[] = [];
+    for (let i = 0; i < bytes.length; i++) {
+      hex.push(bytes[i].toString(16).padStart(2, '0'));
     }
+
+    return [
+      hex.slice(0, 4).join(''),
+      hex.slice(4, 6).join(''),
+      hex.slice(6, 8).join(''),
+      hex.slice(8, 10).join(''),
+      hex.slice(10, 16).join(''),
+    ].join('-');
   }
 
-  return uuid;
+  throw new Error(
+    'randomUUID: no cryptographically secure source of randomness is ' +
+      'available. Neither crypto.randomUUID() nor crypto.getRandomValues() is ' +
+      'present in this environment.',
+  );
 }
 
 /**

--- a/core/test/utils/env_aware_utils_test.ts
+++ b/core/test/utils/env_aware_utils_test.ts
@@ -5,7 +5,7 @@
  */
 
 import {afterEach, describe, expect, it} from 'vitest';
-import {getBooleanEnvVar} from '../../src/utils/env_aware_utils.js';
+import {getBooleanEnvVar, randomUUID} from '../../src/utils/env_aware_utils.js';
 
 describe('env_aware_utils', () => {
   describe('getBooleanEnvVar', () => {
@@ -48,6 +48,62 @@ describe('env_aware_utils', () => {
 
     it('should return false for undefined', () => {
       expect(getBooleanEnvVar('NON_EXISTENT_VAR')).toBe(false);
+    });
+  });
+
+  describe('randomUUID', () => {
+    const originalCrypto = globalThis.crypto;
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    const setCrypto = (value: unknown) => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value,
+        configurable: true,
+        writable: true,
+      });
+    };
+
+    const UUID_V4 =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+    it('uses crypto.randomUUID when it is available', () => {
+      expect(randomUUID()).toMatch(UUID_V4);
+    });
+
+    // crypto.randomUUID is a secure-context-only API, so it is absent on
+    // plain-HTTP origins while crypto.getRandomValues remains available.
+    it('falls back to crypto.getRandomValues when randomUUID is absent', () => {
+      const getRandomValues =
+        originalCrypto.getRandomValues.bind(originalCrypto);
+      setCrypto({getRandomValues});
+
+      expect(randomUUID()).toMatch(UUID_V4);
+    });
+
+    it('draws every byte from getRandomValues, not Math.random', () => {
+      const getRandomValues = (array: Uint8Array) => {
+        array.fill(0xab);
+        return array;
+      };
+      setCrypto({getRandomValues});
+
+      // 0xab in every byte, with the RFC 4122 version and variant bits applied.
+      expect(randomUUID()).toBe('abababab-abab-4bab-abab-abababababab');
+    });
+
+    it('throws instead of degrading when no secure source exists', () => {
+      setCrypto(undefined);
+
+      expect(() => randomUUID()).toThrow(
+        /no cryptographically secure source of randomness/,
+      );
     });
   });
 });

--- a/core/test/utils/env_aware_utils_test.ts
+++ b/core/test/utils/env_aware_utils_test.ts
@@ -74,6 +74,17 @@ describe('env_aware_utils', () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
     it('uses crypto.randomUUID when it is available', () => {
+      setCrypto({
+        randomUUID: () => '00000000-0000-4000-8000-000000000000',
+        getRandomValues: () => {
+          throw new Error('getRandomValues must not be called');
+        },
+      });
+
+      expect(randomUUID()).toBe('00000000-0000-4000-8000-000000000000');
+    });
+
+    it('returns a valid v4 UUID on this runtime', () => {
       expect(randomUUID()).toMatch(UUID_V4);
     });
 


### PR DESCRIPTION
`randomUUID()` prefers `crypto.randomUUID()` and otherwise builds the UUID from
`Math.random()`:

```ts
export function randomUUID(): string {
  if (globalThis.crypto?.randomUUID) {
    return globalThis.crypto.randomUUID();
  }
  ...
  const randomValue = (Math.random() * 16) | 0;   // not a CSPRNG
```

`crypto.randomUUID()` is a **secure-context-only** API. On a plain-HTTP origin
`globalThis.crypto` is still present but `crypto.randomUUID` is `undefined`, so the optional
chain short-circuits and every byte of the UUID comes from `Math.random()`, which is not a
cryptographically secure generator. The degradation is silent — the output has the same
shape and length either way. The same happens on runtimes with no `globalThis.crypto`
at all (Node 16 and earlier).

This matters because some callers use the result to make security decisions:

- `core/src/auth/auth_handler.ts:141` — the OAuth2 `state` parameter, which
  `core/src/auth/oauth2/oauth2_credential_exchanger.ts:167-171` later compares against the
  value returned by the provider. `core/src/auth/auth_credential.ts:44` describes this as
  the client being able to "verify the state", so its unpredictability is the property being
  relied on.
- `core/src/sessions/in_memory_session_service.ts:63` and
  `core/src/sessions/database_session_service.ts:112` — session identifiers.

`AuthHandler` is reachable from the browser bundle, which is the environment where the
secure-context restriction applies: `core/package.json:21` points `browser` at
`dist/web/index_web.js`, `core/src/index_web.ts:2` re-exports `./common.js`, and
`core/src/common.ts:90` exports `AuthHandler`.

### Change

Insert `crypto.getRandomValues()` as the fallback ahead of `Math.random()`, and throw if
neither is available.

`getRandomValues()` is deliberately the right fallback here: unlike `randomUUID()`, it is
**not** restricted to secure contexts, so it is available in exactly the environments where
`randomUUID()` is missing. In practice this preserves every environment that works today —
all browsers and Node 18+ expose it — while removing the non-cryptographic path. The UUID is
assembled per RFC 4122 §4.4 (version 4, variant `10xx`).

The `throw` is a last resort for a runtime that offers no CSPRNG at all. Failing closed
seemed better than silently returning a predictable value, but I am happy to change it if
you would rather keep a fallback for such environments — one option is a separate,
explicitly-named non-cryptographic helper for the IDs that do not gate anything (A2A message
and artifact IDs, for example), leaving this function strictly secure.

### Tests

Adds coverage for `randomUUID()` in `core/test/utils/env_aware_utils_test.ts`, which had
none:

- returns a valid v4 UUID when `crypto.randomUUID()` exists;
- still returns a valid v4 UUID when `randomUUID` is absent but `getRandomValues` is present
  (the plain-HTTP browser case);
- with a stubbed `getRandomValues` returning fixed bytes, the output is exactly the expected
  UUID — proving the bytes come from `getRandomValues` and not from `Math.random()`;
- throws when neither API is available.

### Context

Prior to #433 the `Math.random()` construction ran unconditionally, so this is not a
regression from that change — #433 narrowed when the weak path is taken. This PR removes it.
