### PR TITLE
Feat: Workflow graph, chain syntax and validation (Part 2/3)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -293,12 +293,15 @@ export type {
   FunctionNodeConfig,
   NodeFunction,
 } from './workflow/function_node.js';
+export {Graph} from './workflow/graph.js';
+export type {ChainElement, Edge, EdgeItem} from './workflow/graph.js';
 export {JoinNode} from './workflow/join_node.js';
 export {node} from './workflow/node.js';
 export type {NodeLike, NodeOptions} from './workflow/node.js';
 export {NodeContext} from './workflow/node_context.js';
 export type {NodeContextConfig} from './workflow/node_context.js';
 export type {RetryConfig} from './workflow/retry_config.js';
+export {DEFAULT_ROUTE} from './workflow/route.js';
 export type {RouteValue} from './workflow/route.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -286,6 +286,20 @@ export {Task} from './utils/task.js';
 export type {TaskExecutable} from './utils/task.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
+export {BaseNode, START} from './workflow/base_node.js';
+export type {BaseNodeConfig} from './workflow/base_node.js';
+export {FunctionNode} from './workflow/function_node.js';
+export type {
+  FunctionNodeConfig,
+  NodeFunction,
+} from './workflow/function_node.js';
+export {JoinNode} from './workflow/join_node.js';
+export {node} from './workflow/node.js';
+export type {NodeLike, NodeOptions} from './workflow/node.js';
+export {NodeContext} from './workflow/node_context.js';
+export type {NodeContextConfig} from './workflow/node_context.js';
+export type {RetryConfig} from './workflow/retry_config.js';
+export type {RouteValue} from './workflow/route.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
 export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+
+import {NodeContext} from './node_context.js';
+import {RetryConfig} from './retry_config.js';
+
+/** Node names must be valid JavaScript identifiers. */
+const NODE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * The parameters shared by every workflow node.
+ */
+export interface BaseNodeConfig {
+  /** The node's name, unique within a graph and a valid JS identifier. */
+  name: string;
+
+  /**
+   * If true, the node completes only once it produces an output or a route.
+   *
+   * Until then it stays pending and its downstream nodes are not triggered,
+   * so its predecessors can run it again — once per queued input, one input
+   * at a time — until it decides. This is the general form of a barrier;
+   * JoinNode covers the common "wait for every predecessor" case
+   * declaratively.
+   *
+   * A node that declares this and never produces an output or a route
+   * deadlocks its branch; that is a configuration error.
+   */
+  waitForOutput?: boolean;
+
+  /** How to retry this node when it throws. No retries when omitted. */
+  retryConfig?: RetryConfig;
+
+  /** Maximum time for one run of this node, in milliseconds. */
+  timeoutMs?: number;
+}
+
+/**
+ * The contract every node in a workflow graph implements.
+ *
+ * Subclass it and implement {@link BaseNode.run} to add a node type; wrap a
+ * plain function with `node(fn)` for the common case.
+ *
+ * The class is generic over its config type so {@link BaseNode.clone} stays
+ * typed per subclass, matching `BaseAgent`.
+ *
+ * The whole `workflow` module is experimental. The `@experimental` decorator
+ * is applied only to the classes a caller names that the framework does not
+ * also build on its own: decorating `BaseNode` would warn on merely importing
+ * `@google/adk`, because the {@link START} sentinel is built at module load,
+ * and decorating `Graph` or `NodeContext` would warn on every workflow run.
+ */
+export abstract class BaseNode<
+  TConfig extends BaseNodeConfig = BaseNodeConfig,
+> {
+  /**
+   * The config this node was constructed from.
+   *
+   * Stored so {@link clone} can rebuild the node by re-running the concrete
+   * constructor with overrides applied, which re-derives all state instead of
+   * copying an already-built instance.
+   */
+  protected readonly config: TConfig;
+
+  /** The node's name, unique within a graph. */
+  readonly name: string;
+
+  /** See {@link BaseNodeConfig.waitForOutput}. */
+  readonly waitForOutput: boolean;
+
+  /** See {@link BaseNodeConfig.retryConfig}. */
+  readonly retryConfig?: RetryConfig;
+
+  /** See {@link BaseNodeConfig.timeoutMs}. */
+  readonly timeoutMs?: number;
+
+  constructor(config: TConfig) {
+    if (!NODE_NAME_PATTERN.test(config.name)) {
+      throw new Error(`Node name '${config.name}' must be a valid identifier.`);
+    }
+    // Copied so later mutation of the caller's object cannot leak into clones.
+    this.config = {...config};
+    this.name = config.name;
+    this.waitForOutput = config.waitForOutput ?? false;
+    this.retryConfig = config.retryConfig;
+    this.timeoutMs = config.timeoutMs;
+  }
+
+  /**
+   * Runs the node.
+   *
+   * @param ctx The context of this node run. The node reports its result by
+   *     assigning `ctx.output` and/or `ctx.route`.
+   * @param nodeInput The output of the upstream node, or the workflow's own
+   *     input for a node wired directly to `START`.
+   * @yields The events the node emits while it runs.
+   */
+  abstract run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void>;
+
+  /**
+   * If true, the node runs only once every predecessor has completed, and
+   * receives a record of their outputs keyed by predecessor name.
+   */
+  get requiresAllPredecessors(): boolean {
+    return false;
+  }
+
+  /**
+   * Creates a copy of this node with the given config fields overridden.
+   *
+   * @param overrides Config fields to override on the copy.
+   * @returns A new node of the same concrete class.
+   */
+  clone(overrides?: Partial<TConfig>): this {
+    const ctor = this.constructor as new (config: TConfig) => this;
+    return new ctor({...this.config, ...overrides});
+  }
+}
+
+/** The node behind {@link START}: a marker that refuses to run. */
+class StartNode extends BaseNode {
+  // Deliberately not a generator: START is never executed, so it rejects the
+  // call itself instead of waiting to be iterated.
+  run(): AsyncGenerator<Event, void, void> {
+    throw new Error('START marks a graph entry point and is never executed.');
+  }
+}
+
+/**
+ * The sentinel node marking the entry point of a workflow graph.
+ *
+ * Edges out of `START` carry no route and fire with the workflow's own input;
+ * `START` itself has no incoming edges and is never executed.
+ */
+export const START: BaseNode = new StartNode({name: '__START__'});

--- a/core/src/workflow/function_node.ts
+++ b/core/src/workflow/function_node.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BaseNode, BaseNodeConfig} from './base_node.js';
+import {NodeContext} from './node_context.js';
+
+/**
+ * A plain function usable as a workflow node.
+ *
+ * The function reports its result in one of two ways:
+ *
+ * - return a value — anything other than `undefined` or `null` becomes the
+ *   node's output;
+ * - be an async generator — every `Event` it yields is streamed to the caller,
+ *   and it reports its result by assigning `ctx.output`.
+ *
+ * Either form may also assign `ctx.route` to steer the graph.
+ */
+export type NodeFunction = (ctx: NodeContext, nodeInput: unknown) => unknown;
+
+/**
+ * The config of a {@link FunctionNode}.
+ *
+ * The constructor takes this with `name` optional, because a named function
+ * supplies it.
+ */
+export interface FunctionNodeConfig extends BaseNodeConfig {
+  /** The function to run when the node executes. */
+  fn: NodeFunction;
+}
+
+/**
+ * Narrows a function's return value to an event stream.
+ *
+ * An async generator function returns an object carrying
+ * `Symbol.asyncIterator`, which is how a streaming node is told apart from one
+ * that returns a plain result.
+ */
+function isEventStream(value: unknown): value is AsyncIterable<Event> {
+  return (
+    typeof value === 'object' && value !== null && Symbol.asyncIterator in value
+  );
+}
+
+/**
+ * A node that runs a plain function.
+ *
+ * Unlike adk-python's `FunctionNode`, parameters are not bound by name:
+ * TypeScript erases parameter names and types at runtime, so the contract is
+ * the explicit `(ctx, nodeInput)` signature and a function reads session state
+ * through `ctx.state`.
+ */
+@experimental
+export class FunctionNode extends BaseNode<FunctionNodeConfig> {
+  /** The wrapped function. */
+  readonly fn: NodeFunction;
+
+  constructor(config: Omit<FunctionNodeConfig, 'name'> & {name?: string}) {
+    const name = config.name ?? config.fn.name;
+    if (!name) {
+      throw new Error(
+        'FunctionNode must have a name. Provide `name` explicitly when the ' +
+          'wrapped function is anonymous.',
+      );
+    }
+    super({...config, name});
+    this.fn = config.fn;
+  }
+
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    const result = this.fn(ctx, nodeInput);
+    if (isEventStream(result)) {
+      yield* result;
+      return;
+    }
+    const value = await result;
+    if (value !== undefined && value !== null) {
+      ctx.output = value;
+    }
+  }
+}

--- a/core/src/workflow/graph.ts
+++ b/core/src/workflow/graph.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {logger} from '../utils/logger.js';
+
+import {BaseNode} from './base_node.js';
+import {parseEdgeItems} from './graph_parser.js';
+import {validateGraph} from './graph_validation.js';
+import {NodeLike} from './node.js';
+import {DEFAULT_ROUTE, RouteValue, toRouteList} from './route.js';
+
+/**
+ * A directed edge between two workflow nodes.
+ *
+ * An edge with no `route` is always followed. An edge with a `route` is
+ * followed when the source node emits a matching route, and an edge routed
+ * with {@link DEFAULT_ROUTE} is followed when no other routed edge matched.
+ */
+export interface Edge {
+  /** The node the edge starts at. */
+  fromNode: BaseNode;
+
+  /** The node the edge leads to. */
+  toNode: BaseNode;
+
+  /** The route(s) this edge is followed on. */
+  route?: RouteValue | RouteValue[];
+}
+
+/**
+ * One step of a chain: a single node, or several nodes to fan out to.
+ */
+export type ChainElement = NodeLike | NodeLike[];
+
+/**
+ * An entry in a workflow's edge list: an explicit {@link Edge}, or a chain
+ * array such as `[START, a, [b, c], d]` that expands into unrouted edges.
+ */
+export type EdgeItem = Edge | ChainElement[];
+
+/**
+ * A workflow graph: a set of edges plus the nodes they connect.
+ */
+export class Graph {
+  /**
+   * The nodes of the graph, derived from the edges: deduplicated by object
+   * identity and in first-seen order.
+   */
+  readonly nodes: readonly BaseNode[];
+
+  /** The edges of the graph. */
+  readonly edges: readonly Edge[];
+
+  /**
+   * The names of the nodes with no outgoing edge — where a branch of the
+   * workflow ends. `START` is never among them: a valid graph always has at
+   * least one edge out of it.
+   */
+  readonly terminalNodeNames: ReadonlySet<string>;
+
+  constructor(edges: readonly Edge[]) {
+    this.edges = edges;
+    const nodes = new Set<BaseNode>();
+    const sourceNames = new Set<string>();
+    for (const edge of edges) {
+      nodes.add(edge.fromNode);
+      nodes.add(edge.toNode);
+      sourceNames.add(edge.fromNode.name);
+    }
+    this.nodes = [...nodes];
+    this.terminalNodeNames = new Set(
+      this.nodes.filter((n) => !sourceNames.has(n.name)).map((n) => n.name),
+    );
+  }
+
+  /** Builds a graph from a workflow's edge list, expanding any chains. */
+  static fromEdgeItems(items: readonly EdgeItem[]): Graph {
+    return new Graph(parseEdgeItems(items));
+  }
+
+  /**
+   * Returns the nodes to run next after `nodeName` completed emitting
+   * `routesToMatch`.
+   *
+   * @param nodeName The name of the node that just completed.
+   * @param routesToMatch The route(s) it emitted, if any.
+   */
+  getNextPendingNodes(
+    nodeName: string,
+    routesToMatch?: RouteValue | RouteValue[],
+  ): BaseNode[] {
+    const emitted = toRouteList(routesToMatch);
+    const next: BaseNode[] = [];
+    let matchedSpecificRoute = false;
+    let defaultRouteNode: BaseNode | undefined;
+    let hasRoutedEdges = false;
+
+    for (const edge of this.edges) {
+      if (edge.fromNode.name !== nodeName) {
+        continue;
+      }
+      if (edge.route === undefined) {
+        next.push(edge.toNode);
+        continue;
+      }
+      hasRoutedEdges = true;
+      if (edge.route === DEFAULT_ROUTE) {
+        defaultRouteNode = edge.toNode;
+        continue;
+      }
+      const edgeRoutes = toRouteList(edge.route);
+      if (edgeRoutes.some((route) => emitted.includes(route))) {
+        next.push(edge.toNode);
+        matchedSpecificRoute = true;
+      }
+    }
+
+    if (!matchedSpecificRoute && defaultRouteNode) {
+      next.push(defaultRouteNode);
+    }
+    if (hasRoutedEdges && next.length === 0) {
+      logger.warn(
+        `Node '${nodeName}' has conditional/DEFAULT edges but none were ` +
+          `matched by the emitted route(s): ${JSON.stringify(routesToMatch)}. ` +
+          'The branch will end.',
+      );
+    }
+    return next;
+  }
+
+  /**
+   * Checks the graph is runnable.
+   *
+   * @throws If the graph violates any structural rule; the message always
+   *     starts with `Graph validation failed.`.
+   */
+  validate(): void {
+    validateGraph(this.nodes, this.edges);
+  }
+}

--- a/core/src/workflow/graph_parser.ts
+++ b/core/src/workflow/graph_parser.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseNode} from './base_node.js';
+import type {ChainElement, Edge, EdgeItem} from './graph.js';
+import {node, NodeLike} from './node.js';
+
+/** Expands one chain step into the nodes it covers. */
+function flattenElement(element: ChainElement): NodeLike[] {
+  return Array.isArray(element) ? element : [element];
+}
+
+/**
+ * Resolves a chain entry to a node, reusing the node built for a given
+ * function so the same function referenced twice becomes one graph node.
+ */
+function resolveNode(
+  nodeLike: NodeLike,
+  built: Map<NodeLike, BaseNode>,
+): BaseNode {
+  if (nodeLike instanceof BaseNode) {
+    return nodeLike;
+  }
+  const existing = built.get(nodeLike);
+  if (existing) {
+    return existing;
+  }
+  const resolved = node(nodeLike);
+  built.set(nodeLike, resolved);
+  return resolved;
+}
+
+/**
+ * Flattens a workflow's edge list into plain edges.
+ *
+ * A chain array creates an unrouted edge from every node of each step to every
+ * node of the next step, so `[START, a, [b, c]]` fans `a` out to both `b` and
+ * `c`. Explicit {@link Edge} objects pass through with their route intact.
+ */
+export function parseEdgeItems(items: readonly EdgeItem[]): Edge[] {
+  const built = new Map<NodeLike, BaseNode>();
+  const edges: Edge[] = [];
+
+  for (const item of items) {
+    if (!Array.isArray(item)) {
+      // An explicit edge already names its nodes; copy it so later mutation of
+      // the caller's object cannot reshape the graph.
+      edges.push({
+        fromNode: item.fromNode,
+        toNode: item.toNode,
+        route: item.route,
+      });
+      continue;
+    }
+    for (let i = 0; i < item.length - 1; i++) {
+      for (const from of flattenElement(item[i])) {
+        for (const to of flattenElement(item[i + 1])) {
+          edges.push({
+            fromNode: resolveNode(from, built),
+            toNode: resolveNode(to, built),
+          });
+        }
+      }
+    }
+  }
+
+  return edges;
+}

--- a/core/src/workflow/graph_validation.ts
+++ b/core/src/workflow/graph_validation.ts
@@ -1,0 +1,218 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseNode, START} from './base_node.js';
+import type {Edge} from './graph.js';
+import {DEFAULT_ROUTE} from './route.js';
+
+const PREFIX = 'Graph validation failed.';
+
+function fail(message: string): never {
+  throw new Error(`${PREFIX} ${message}`);
+}
+
+/** Every node name must be unique, so a name identifies exactly one node. */
+function validateDuplicateNodeNames(nodes: readonly BaseNode[]): Set<string> {
+  const names = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const node of nodes) {
+    if (names.has(node.name)) {
+      duplicates.add(node.name);
+    }
+    names.add(node.name);
+  }
+  if (duplicates.size > 0) {
+    fail(
+      `Duplicate node names found: ${[...duplicates].sort().join(', ')}. This` +
+        ' means multiple distinct node objects have the same name. If you' +
+        ' intended to reuse the same node, pass the exact same object' +
+        ' instance; otherwise give them unique names.',
+    );
+  }
+  return names;
+}
+
+function validateStartNode(nodeNames: ReadonlySet<string>): void {
+  if (!nodeNames.has(START.name)) {
+    fail(`START node (name: '${START.name}') not found in graph nodes.`);
+  }
+}
+
+function validateStartEdges(edges: readonly Edge[]): void {
+  for (const edge of edges) {
+    if (edge.fromNode.name === START.name && edge.route !== undefined) {
+      fail(
+        `Edges from START must not have routes (edge to ${edge.toNode.name}` +
+          ` has route ${JSON.stringify(edge.route)}).`,
+      );
+    }
+  }
+}
+
+/**
+ * Maps each source node name to the names it has edges to.
+ *
+ * @param unroutedOnly Only follow edges that carry no route.
+ */
+function successorsOf(
+  edges: readonly Edge[],
+  unroutedOnly = false,
+): Map<string, string[]> {
+  const successors = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (unroutedOnly && edge.route !== undefined) {
+      continue;
+    }
+    const fromName = edge.fromNode.name;
+    const existing = successors.get(fromName);
+    if (existing) {
+      existing.push(edge.toNode.name);
+    } else {
+      successors.set(fromName, [edge.toNode.name]);
+    }
+  }
+  return successors;
+}
+
+/** Every node must be reachable from START, and START must be the entry. */
+function validateConnectivity(
+  edges: readonly Edge[],
+  nodeNames: ReadonlySet<string>,
+): void {
+  const successors = successorsOf(edges);
+
+  const reachable = new Set<string>();
+  const stack = [START.name];
+  while (stack.length > 0) {
+    const name = stack.pop()!;
+    if (reachable.has(name)) {
+      continue;
+    }
+    reachable.add(name);
+    stack.push(...(successors.get(name) ?? []));
+  }
+
+  const unreachable = [...nodeNames].filter((name) => !reachable.has(name));
+  if (unreachable.length > 0) {
+    fail(
+      'The following nodes are unreachable from START: ' +
+        unreachable.sort().join(', '),
+    );
+  }
+  if (edges.some((edge) => edge.toNode.name === START.name)) {
+    fail('START node must not have incoming edges.');
+  }
+}
+
+function validateDuplicateEdges(edges: readonly Edge[]): void {
+  const seen = new Set<string>();
+  for (const edge of edges) {
+    const key = `${edge.fromNode.name}\u0000${edge.toNode.name}`;
+    if (seen.has(key)) {
+      fail(
+        `Duplicate edge found: from=${edge.fromNode.name},` +
+          ` to=${edge.toNode.name}`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+/** `DEFAULT_ROUTE` is a standalone fallback: one per source, never in a list. */
+function validateDefaultRoutes(edges: readonly Edge[]): void {
+  const defaultTargets = new Map<string, string>();
+  for (const edge of edges) {
+    if (Array.isArray(edge.route) && edge.route.includes(DEFAULT_ROUTE)) {
+      fail(
+        'DEFAULT_ROUTE cannot be combined with other routes in a list (edge' +
+          ` from=${edge.fromNode.name}, to=${edge.toNode.name}). Use a` +
+          ' separate edge for DEFAULT_ROUTE.',
+      );
+    }
+    if (edge.route !== DEFAULT_ROUTE) {
+      continue;
+    }
+    const existing = defaultTargets.get(edge.fromNode.name);
+    if (existing !== undefined) {
+      fail(
+        `Multiple DEFAULT_ROUTE edges found from node ${edge.fromNode.name}` +
+          ` to ${existing} and ${edge.toNode.name}`,
+      );
+    }
+    defaultTargets.set(edge.fromNode.name, edge.toNode.name);
+  }
+}
+
+/**
+ * Walks `name`'s successors depth first, failing if the walk re-enters a node
+ * still on `path`. `done` holds the nodes already fully explored.
+ */
+function walkForCycle(
+  name: string,
+  successors: ReadonlyMap<string, string[]>,
+  done: Set<string>,
+  path: string[],
+): void {
+  path.push(name);
+  for (const next of successors.get(name) ?? []) {
+    const cycleStart = path.indexOf(next);
+    if (cycleStart !== -1) {
+      const cycle = [...path.slice(cycleStart), next];
+      fail(
+        `Unconditional cycle detected: ${cycle.join(' -> ')}. Cycles must` +
+          ' include at least one conditional (routed) edge to avoid' +
+          ' infinite loops.',
+      );
+    }
+    if (!done.has(next)) {
+      walkForCycle(next, successors, done, path);
+    }
+  }
+  path.pop();
+  done.add(name);
+}
+
+/**
+ * A cycle made only of unrouted edges can never exit, so it would loop
+ * forever. A cycle needs at least one routed edge to be able to break out.
+ */
+function detectUnconditionalCycles(
+  edges: readonly Edge[],
+  nodeNames: ReadonlySet<string>,
+): void {
+  const successors = successorsOf(edges, true);
+  const done = new Set<string>();
+  for (const name of nodeNames) {
+    if (!done.has(name)) {
+      walkForCycle(name, successors, done, []);
+    }
+  }
+}
+
+/**
+ * Checks that a graph is runnable.
+ *
+ * A graph with no nodes is trivially valid: an empty workflow runs and
+ * produces nothing.
+ *
+ * @throws If any structural rule is violated. Every message starts with
+ *     `Graph validation failed.`.
+ */
+export function validateGraph(
+  nodes: readonly BaseNode[],
+  edges: readonly Edge[],
+): void {
+  if (nodes.length === 0) {
+    return;
+  }
+  const nodeNames = validateDuplicateNodeNames(nodes);
+  validateStartNode(nodeNames);
+  validateStartEdges(edges);
+  validateConnectivity(edges, nodeNames);
+  validateDuplicateEdges(edges);
+  validateDefaultRoutes(edges);
+  detectUnconditionalCycles(edges, nodeNames);
+}

--- a/core/src/workflow/join_node.ts
+++ b/core/src/workflow/join_node.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BaseNode} from './base_node.js';
+import {NodeContext} from './node_context.js';
+
+/**
+ * A fan-in node: it runs once every predecessor has completed and outputs
+ * their outputs as a record keyed by predecessor name.
+ */
+@experimental
+export class JoinNode extends BaseNode {
+  override get requiresAllPredecessors(): boolean {
+    return true;
+  }
+
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    ctx.output = nodeInput;
+    // A join emits nothing of its own; delegating to an empty stream keeps
+    // this an async generator without suppressing the require-yield rule.
+    yield* [];
+  }
+}

--- a/core/src/workflow/node.ts
+++ b/core/src/workflow/node.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseNode, BaseNodeConfig, START} from './base_node.js';
+import {FunctionNode, NodeFunction} from './function_node.js';
+
+/**
+ * Anything that can be used where a workflow node is expected: a node, a
+ * function to wrap as a node, or the literal `'START'`.
+ */
+export type NodeLike = BaseNode | NodeFunction | 'START';
+
+/** Config fields that can be overridden when building a node. */
+export type NodeOptions = Partial<BaseNodeConfig>;
+
+/**
+ * Builds a workflow node.
+ *
+ * ```ts
+ * const classify = node(async (ctx) => {
+ *   ctx.route = ctx.state.get<number>('score', 0)! > 5 ? 'high' : 'low';
+ * });
+ * const slow = node(callApi, {name: 'callApi', timeoutMs: 5_000});
+ * ```
+ *
+ * A function becomes a {@link FunctionNode}. An existing node is returned
+ * unchanged when there is nothing to override, so a node referenced several
+ * times in an edge list stays one graph node. `'START'` resolves to the shared
+ * {@link START} sentinel and ignores `options`, which a sentinel cannot carry.
+ *
+ * adk-python's `node` doubles as a decorator; TypeScript decorators cannot be
+ * applied to plain functions, so only this factory form exists.
+ *
+ * @param nodeLike The node, function or `'START'` to build a node from.
+ * @param options Config fields to override on the built node.
+ * @returns The built node.
+ */
+export function node(nodeLike: NodeLike, options: NodeOptions = {}): BaseNode {
+  if (nodeLike === 'START') {
+    return START;
+  }
+  if (nodeLike instanceof BaseNode) {
+    return Object.keys(options).length > 0 ? nodeLike.clone(options) : nodeLike;
+  }
+  return new FunctionNode({...options, fn: nodeLike});
+}

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context} from '../agents/context.js';
+import {InvocationContext} from '../agents/invocation_context.js';
+
+import type {BaseNode} from './base_node.js';
+import type {RouteValue} from './route.js';
+
+/**
+ * The parameters for creating a {@link NodeContext}.
+ */
+export interface NodeContextConfig {
+  /** The invocation this node run belongs to. */
+  invocationContext: InvocationContext;
+
+  /** The node being run. */
+  node: BaseNode;
+
+  /** Identifier of this run of the node, unique per node per workflow run. */
+  runId: string;
+
+  /** 1-based attempt number of this run. Defaults to 1. */
+  attemptCount?: number;
+
+  /** The `nodePath` of the node that scheduled this run, when nested. */
+  parentNodePath?: string;
+}
+
+/**
+ * The context of a single node run.
+ *
+ * Extends the agent {@link Context}, so a node gets the same delta-aware
+ * `state`, `actions`, `abortSignal`, artifact and memory helpers an agent
+ * callback or a tool gets.
+ *
+ * A node reports its result by assigning {@link NodeContext.output} and
+ * {@link NodeContext.route}; `adk-js` events carry neither field, so the
+ * context is the single source of truth for both.
+ */
+export class NodeContext extends Context {
+  /** The node this context belongs to. */
+  readonly node: BaseNode;
+
+  /** Identifier of this run of the node. */
+  readonly runId: string;
+
+  /** 1-based attempt number of this run. */
+  readonly attemptCount: number;
+
+  /**
+   * The location of this run in the node tree: `<name>@<runId>` at the root,
+   * `<parentNodePath>/<name>@<runId>` inside a nested workflow.
+   */
+  readonly nodePath: string;
+
+  /**
+   * The node's result. `undefined` means the node produced no output.
+   */
+  output: unknown;
+
+  /**
+   * The route(s) the node emitted, used to select its outgoing edges.
+   */
+  route?: RouteValue | RouteValue[];
+
+  constructor(config: NodeContextConfig) {
+    super({invocationContext: config.invocationContext});
+    this.node = config.node;
+    this.runId = config.runId;
+    this.attemptCount = config.attemptCount ?? 1;
+    const segment = `${config.node.name}@${config.runId}`;
+    this.nodePath = config.parentNodePath
+      ? `${config.parentNodePath}/${segment}`
+      : segment;
+  }
+}

--- a/core/src/workflow/retry_config.ts
+++ b/core/src/workflow/retry_config.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Configuration for retrying a workflow node that threw.
+ *
+ * Delays are expressed in milliseconds (adk-python's `RetryConfig` uses
+ * fractional seconds); the effective defaults are the same.
+ */
+export interface RetryConfig {
+  /**
+   * Maximum number of attempts, including the original one. `0` or `1` means
+   * no retries. Defaults to 5.
+   */
+  maxAttempts?: number;
+
+  /** Delay before the first retry, in milliseconds. Defaults to 1000. */
+  initialDelayMs?: number;
+
+  /** Maximum delay between retries, in milliseconds. Defaults to 60000. */
+  maxDelayMs?: number;
+
+  /**
+   * Multiplier applied to the delay after each attempt. Defaults to 2.
+   */
+  backoffFactor?: number;
+
+  /**
+   * Randomness factor applied to the delay. Defaults to 1; use 0 to make the
+   * delay deterministic.
+   */
+  jitter?: number;
+
+  /**
+   * The errors to retry on, given as error class names or as the error classes
+   * themselves. When omitted, every error is retried.
+   */
+  errors?: Array<string | (new (...args: never[]) => Error)>;
+}

--- a/core/src/workflow/route.ts
+++ b/core/src/workflow/route.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A value a node emits to select which of its outgoing graph edges are
+ * followed.
+ *
+ * A node emits a route by assigning `ctx.route` while it runs. Matching is by
+ * strict equality, so the emitted value and the value declared on the edge must
+ * have the same type.
+ */
+export type RouteValue = string | number | boolean;

--- a/core/src/workflow/route.ts
+++ b/core/src/workflow/route.ts
@@ -13,3 +13,21 @@
  * have the same type.
  */
 export type RouteValue = string | number | boolean;
+
+/**
+ * The route of the fallback edge out of a node.
+ *
+ * An edge declaring this route is followed only when none of the node's other
+ * routed edges matched. At most one such edge per source node is allowed.
+ */
+export const DEFAULT_ROUTE = '__DEFAULT__';
+
+/** Normalizes a single route, a list of routes or nothing into a list. */
+export function toRouteList(
+  route: RouteValue | RouteValue[] | undefined,
+): RouteValue[] {
+  if (route === undefined) {
+    return [];
+  }
+  return Array.isArray(route) ? route : [route];
+}

--- a/core/test/workflow/base_node_test.ts
+++ b/core/test/workflow/base_node_test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseNode,
+  BaseNodeConfig,
+  createEvent,
+  Event,
+  NodeContext,
+  START,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode, makeNodeContext} from './workflow_test_utils.js';
+
+interface EchoNodeConfig extends BaseNodeConfig {
+  texts?: string[];
+}
+
+/** Emits one event per configured text and outputs its input. */
+class EchoNode extends BaseNode<EchoNodeConfig> {
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    for (const text of this.config.texts ?? []) {
+      yield createEvent({author: this.name, content: {parts: [{text}]}});
+    }
+    ctx.output = nodeInput;
+  }
+}
+
+describe('BaseNode', () => {
+  it('rejects a name that is not a valid identifier', () => {
+    expect(() => new EchoNode({name: 'not a name'})).toThrow(
+      "Node name 'not a name' must be a valid identifier.",
+    );
+  });
+
+  it('accepts identifier-shaped names', () => {
+    expect(new EchoNode({name: '_private$1'}).name).toBe('_private$1');
+  });
+
+  it('defaults waitForOutput and requiresAllPredecessors', () => {
+    const n = new EchoNode({name: 'plain'});
+
+    expect(n.waitForOutput).toBe(false);
+    expect(n.requiresAllPredecessors).toBe(false);
+    expect(n.retryConfig).toBeUndefined();
+    expect(n.timeoutMs).toBeUndefined();
+  });
+
+  it('keeps the configured options', () => {
+    const retryConfig = {maxAttempts: 2};
+    const n = new EchoNode({
+      name: 'configured',
+      waitForOutput: true,
+      retryConfig,
+      timeoutMs: 25,
+    });
+
+    expect(n.waitForOutput).toBe(true);
+    expect(n.retryConfig).toBe(retryConfig);
+    expect(n.timeoutMs).toBe(25);
+  });
+
+  it('streams the events it yields and exposes the result on ctx', async () => {
+    const n = new EchoNode({name: 'echo', texts: ['one', 'two']});
+
+    const {events, ctx} = await drainNode(n, 'payload');
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual([
+      'one',
+      'two',
+    ]);
+    expect(events.every((e) => e.author === 'echo')).toBe(true);
+    expect(ctx.output).toBe('payload');
+  });
+
+  it('clones into the same concrete class with overrides applied', () => {
+    const original = new EchoNode({name: 'echo', texts: ['one']});
+
+    const copy = original.clone({name: 'echo2', timeoutMs: 10});
+
+    expect(copy).toBeInstanceOf(EchoNode);
+    expect(copy).not.toBe(original);
+    expect(copy.name).toBe('echo2');
+    expect(copy.timeoutMs).toBe(10);
+    expect(original.name).toBe('echo');
+    expect(original.timeoutMs).toBeUndefined();
+  });
+
+  it('clones subclass-specific config with no overrides', async () => {
+    const original = new EchoNode({name: 'echo', texts: ['kept']});
+
+    const {events} = await drainNode(original.clone());
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['kept']);
+  });
+});
+
+describe('START', () => {
+  it('is named __START__', () => {
+    expect(START.name).toBe('__START__');
+  });
+
+  it('throws if it is ever executed', () => {
+    const ctx = makeNodeContext(START);
+
+    expect(() => START.run(ctx, undefined)).toThrow(
+      'START marks a graph entry point and is never executed.',
+    );
+  });
+});

--- a/core/test/workflow/function_node_test.ts
+++ b/core/test/workflow/function_node_test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {createEvent, Event, FunctionNode, NodeContext} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('FunctionNode', () => {
+  it('infers its name from the wrapped function', () => {
+    function analyse() {
+      return 'ok';
+    }
+
+    expect(new FunctionNode({fn: analyse}).name).toBe('analyse');
+  });
+
+  it('prefers an explicit name over the function name', () => {
+    function analyse() {
+      return 'ok';
+    }
+
+    expect(new FunctionNode({fn: analyse, name: 'custom'}).name).toBe('custom');
+  });
+
+  it('rejects an anonymous function with no name', () => {
+    const anonymous: (ctx: NodeContext, nodeInput: unknown) => unknown =
+      function () {
+        return 'ok';
+      };
+    Object.defineProperty(anonymous, 'name', {value: ''});
+
+    expect(() => new FunctionNode({fn: anonymous})).toThrow(
+      'FunctionNode must have a name.',
+    );
+  });
+
+  it('turns a synchronous return value into the node output', async () => {
+    const n = new FunctionNode({fn: () => 42, name: 'sync'});
+
+    const {events, ctx} = await drainNode(n);
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBe(42);
+  });
+
+  it('turns an awaited return value into the node output', async () => {
+    const n = new FunctionNode({fn: async () => 'later', name: 'async'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBe('later');
+  });
+
+  it('treats undefined as no output', async () => {
+    const n = new FunctionNode({fn: () => undefined, name: 'nothing'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('treats null as no output', async () => {
+    const n = new FunctionNode({fn: () => null, name: 'nullish'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('streams the events an async generator function yields', async () => {
+    async function* streamer(
+      ctx: NodeContext,
+    ): AsyncGenerator<Event, void, void> {
+      yield createEvent({author: 'streamer', content: {parts: [{text: 'a'}]}});
+      yield createEvent({author: 'streamer', content: {parts: [{text: 'b'}]}});
+      ctx.output = 'streamed';
+    }
+    const n = new FunctionNode({fn: streamer});
+
+    const {events, ctx} = await drainNode(n);
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['a', 'b']);
+    expect(ctx.output).toBe('streamed');
+  });
+
+  it('passes the node input to the wrapped function', async () => {
+    const seen: unknown[] = [];
+    const n = new FunctionNode({
+      fn: (_ctx, nodeInput) => {
+        seen.push(nodeInput);
+        return undefined;
+      },
+      name: 'recorder',
+    });
+
+    await drainNode(n, {from: 'upstream'});
+
+    expect(seen).toEqual([{from: 'upstream'}]);
+  });
+
+  it('lets the wrapped function emit a route', async () => {
+    const n = new FunctionNode({
+      fn: (ctx) => {
+        ctx.route = 'high';
+      },
+      name: 'router',
+    });
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.route).toBe('high');
+  });
+
+  it('records state writes on the context delta', async () => {
+    const n = new FunctionNode({
+      fn: (ctx) => {
+        ctx.state.set('visited', true);
+      },
+      name: 'writer',
+    });
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.actions.stateDelta).toEqual({visited: true});
+  });
+
+  it('carries the wrapped function through clone', async () => {
+    const original = new FunctionNode({fn: () => 'value', name: 'origin'});
+
+    const copy = original.clone({name: 'copy', timeoutMs: 5});
+    const {ctx} = await drainNode(copy);
+
+    expect(copy).toBeInstanceOf(FunctionNode);
+    expect(copy.name).toBe('copy');
+    expect(copy.timeoutMs).toBe(5);
+    expect(ctx.output).toBe('value');
+  });
+});

--- a/core/test/workflow/graph_parser_test.ts
+++ b/core/test/workflow/graph_parser_test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `parseEdgeItems` is internal, so this suite imports everything relatively:
+// mixing it with `@google/adk` imports would pull in a second copy of the
+// node classes and TypeScript would treat the two as unrelated.
+import {describe, expect, it} from 'vitest';
+
+import {START} from '../../src/workflow/base_node.js';
+import {FunctionNode} from '../../src/workflow/function_node.js';
+import {Edge} from '../../src/workflow/graph.js';
+import {parseEdgeItems} from '../../src/workflow/graph_parser.js';
+import {JoinNode} from '../../src/workflow/join_node.js';
+import {DEFAULT_ROUTE} from '../../src/workflow/route.js';
+
+const a = new JoinNode({name: 'a'});
+const b = new JoinNode({name: 'b'});
+const c = new JoinNode({name: 'c'});
+
+function names(edges: Edge[]): string[][] {
+  return edges.map((e) => [e.fromNode.name, e.toNode.name]);
+}
+
+describe('parseEdgeItems', () => {
+  it('expands a chain into one edge per consecutive pair', () => {
+    const edges = parseEdgeItems([[START, a, b]]);
+
+    expect(names(edges)).toEqual([
+      ['__START__', 'a'],
+      ['a', 'b'],
+    ]);
+    expect(edges.every((e) => e.route === undefined)).toBe(true);
+  });
+
+  it('fans out to every node of an array step', () => {
+    expect(names(parseEdgeItems([[START, [a, b]]]))).toEqual([
+      ['__START__', 'a'],
+      ['__START__', 'b'],
+    ]);
+  });
+
+  it('fans in from every node of an array step', () => {
+    expect(names(parseEdgeItems([[[a, b], c]]))).toEqual([
+      ['a', 'c'],
+      ['b', 'c'],
+    ]);
+  });
+
+  it("resolves the literal 'START' to the START sentinel", () => {
+    const edges = parseEdgeItems([['START', a]]);
+
+    expect(edges[0].fromNode).toBe(START);
+  });
+
+  it('produces no edges for a chain with fewer than two steps', () => {
+    expect(parseEdgeItems([[a]])).toEqual([]);
+  });
+
+  it('wraps a bare function once and reuses it by identity', () => {
+    function step() {
+      return 'done';
+    }
+    const edges = parseEdgeItems([
+      [START, step],
+      [step, a],
+    ]);
+
+    expect(edges[0].toNode).toBeInstanceOf(FunctionNode);
+    expect(edges[0].toNode).toBe(edges[1].fromNode);
+  });
+
+  it('keeps distinct functions as distinct nodes', () => {
+    const first = () => 'first';
+    const second = () => 'second';
+
+    const edges = parseEdgeItems([
+      [START, first],
+      [START, second],
+    ]);
+
+    expect(edges[0].toNode).not.toBe(edges[1].toNode);
+  });
+
+  it('mixes explicit edges and chains in one list, keeping routes', () => {
+    const edges = parseEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'yes'},
+      {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(names(edges)).toEqual([
+      ['__START__', 'a'],
+      ['a', 'b'],
+      ['a', 'c'],
+    ]);
+    expect(edges[1].route).toBe('yes');
+    expect(edges[2].route).toBe(DEFAULT_ROUTE);
+  });
+
+  it('copies an explicit edge so the caller cannot reshape the graph', () => {
+    const spec = {fromNode: START, toNode: a};
+
+    const edges = parseEdgeItems([spec]);
+    spec.toNode = b;
+
+    expect(edges[0].toNode).toBe(a);
+  });
+});

--- a/core/test/workflow/graph_test.ts
+++ b/core/test/workflow/graph_test.ts
@@ -1,0 +1,293 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DEFAULT_ROUTE,
+  getLogger,
+  Graph,
+  JoinNode,
+  LogLevel,
+  setLogger,
+  START,
+} from '@google/adk';
+import {afterEach, describe, expect, it} from 'vitest';
+
+const a = new JoinNode({name: 'a'});
+const b = new JoinNode({name: 'b'});
+const c = new JoinNode({name: 'c'});
+const d = new JoinNode({name: 'd'});
+
+const realLogger = getLogger();
+
+/** Installs a logger that records `warn` calls, and returns the recording. */
+function captureWarnings(): string[] {
+  const warnings: string[] = [];
+  setLogger({
+    log: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => warnings.push(args.join(' ')),
+    error: () => {},
+    setLogLevel: (_level: LogLevel) => {},
+  });
+  return warnings;
+}
+
+afterEach(() => {
+  setLogger(realLogger);
+});
+
+describe('Graph', () => {
+  it('derives its nodes from its edges, deduplicated and in first-seen order', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a, b],
+      [a, c],
+    ]);
+
+    expect(graph.nodes.map((n) => n.name)).toEqual([
+      '__START__',
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('reports the nodes with no outgoing edge as terminal', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a, b],
+      [a, c],
+    ]);
+
+    expect([...graph.terminalNodeNames].sort()).toEqual(['b', 'c']);
+  });
+
+  it('accepts a valid graph', () => {
+    const graph = Graph.fromEdgeItems([[START, a, b]]);
+
+    expect(() => graph.validate()).not.toThrow();
+  });
+
+  it('accepts an empty graph', () => {
+    const graph = Graph.fromEdgeItems([]);
+
+    expect(() => graph.validate()).not.toThrow();
+    expect(graph.nodes).toEqual([]);
+    expect(graph.terminalNodeNames.size).toBe(0);
+  });
+});
+
+describe('Graph.getNextPendingNodes', () => {
+  it('always follows unrouted edges', () => {
+    const graph = Graph.fromEdgeItems([[START, a, [b, c]]]);
+
+    expect(graph.getNextPendingNodes('a').map((n) => n.name)).toEqual([
+      'b',
+      'c',
+    ]);
+  });
+
+  it('follows only the edge matching the emitted route', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: 'right'},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'right').map((n) => n.name)).toEqual([
+      'c',
+    ]);
+  });
+
+  it('falls back to the DEFAULT_ROUTE edge when nothing matched', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'nope').map((n) => n.name)).toEqual([
+      'c',
+    ]);
+  });
+
+  it('skips the DEFAULT_ROUTE edge when a specific route matched', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'left').map((n) => n.name)).toEqual([
+      'b',
+    ]);
+  });
+
+  it('matches an edge declaring several routes', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: ['left', 'up']},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'up').map((n) => n.name)).toEqual([
+      'b',
+    ]);
+  });
+
+  it('matches when the node emits several routes', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: 'right'},
+      {fromNode: a, toNode: d, route: 'down'},
+    ]);
+
+    expect(
+      graph.getNextPendingNodes('a', ['left', 'down']).map((n) => n.name),
+    ).toEqual(['b', 'd']);
+  });
+
+  it('follows unrouted edges alongside a matched routed edge', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      [a, b],
+      {fromNode: a, toNode: c, route: 'go'},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'go').map((n) => n.name)).toEqual([
+      'b',
+      'c',
+    ]);
+  });
+
+  it('warns and ends the branch when no routed edge matched', () => {
+    const warnings = captureWarnings();
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'right')).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(
+      'has conditional/DEFAULT edges but none were matched',
+    );
+  });
+
+  it('does not warn when the node has no routed edges at all', () => {
+    const warnings = captureWarnings();
+    const graph = Graph.fromEdgeItems([[START, a, b]]);
+
+    expect(graph.getNextPendingNodes('b')).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('Graph.validate', () => {
+  it('rejects duplicate node names', () => {
+    const duplicate = new JoinNode({name: 'a'});
+
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [START, duplicate],
+      ]).validate(),
+    ).toThrow('Graph validation failed. Duplicate node names found: a');
+  });
+
+  it('rejects a graph without START', () => {
+    expect(() => Graph.fromEdgeItems([[a, b]]).validate()).toThrow(
+      "Graph validation failed. START node (name: '__START__') not found",
+    );
+  });
+
+  it('rejects a routed edge out of START', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        {fromNode: START, toNode: a, route: 'go'},
+      ]).validate(),
+    ).toThrow('Graph validation failed. Edges from START must not have routes');
+  });
+
+  it('rejects nodes unreachable from START', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [b, c],
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. The following nodes are unreachable from ' +
+        'START: b, c',
+    );
+  });
+
+  it('rejects an incoming edge into START', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [a, START],
+      ]).validate(),
+    ).toThrow('Graph validation failed. START node must not have incoming');
+  });
+
+  it('rejects a duplicated edge', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [START, a],
+      ]).validate(),
+    ).toThrow('Graph validation failed. Duplicate edge found: from=__START__');
+  });
+
+  it('rejects DEFAULT_ROUTE combined with other routes in a list', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        {fromNode: a, toNode: b, route: ['left', DEFAULT_ROUTE]},
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. DEFAULT_ROUTE cannot be combined with other',
+    );
+  });
+
+  it('rejects two DEFAULT_ROUTE edges out of the same node', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        {fromNode: a, toNode: b, route: DEFAULT_ROUTE},
+        {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. Multiple DEFAULT_ROUTE edges found from node a',
+    );
+  });
+
+  it('rejects a cycle made only of unrouted edges', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a, b],
+        [b, a],
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. Unconditional cycle detected: a -> b -> a.',
+    );
+  });
+
+  it('accepts a cycle that includes a routed edge', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a, b],
+      {fromNode: b, toNode: a, route: 'again'},
+      {fromNode: b, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(() => graph.validate()).not.toThrow();
+  });
+
+  it('accepts a diamond, which revisits a node without cycling', () => {
+    const graph = Graph.fromEdgeItems([[START, a, [b, c], d]]);
+
+    expect(() => graph.validate()).not.toThrow();
+  });
+});

--- a/core/test/workflow/join_node_test.ts
+++ b/core/test/workflow/join_node_test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {JoinNode} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('JoinNode', () => {
+  it('waits for all of its predecessors', () => {
+    expect(new JoinNode({name: 'join'}).requiresAllPredecessors).toBe(true);
+  });
+
+  it('passes the aggregated predecessor outputs through as its output', async () => {
+    const aggregated = {NodeA: 'a', NodeB: 'b'};
+
+    const {events, ctx} = await drainNode(
+      new JoinNode({name: 'join'}),
+      aggregated,
+    );
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBe(aggregated);
+  });
+});

--- a/core/test/workflow/node_context_test.ts
+++ b/core/test/workflow/node_context_test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {NodeContext, node} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {makeInvocationContext} from './workflow_test_utils.js';
+
+const noop = node(() => undefined, {name: 'noop'});
+
+describe('NodeContext', () => {
+  it('builds a root node path from the node name and run id', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '3',
+    });
+
+    expect(ctx.nodePath).toBe('noop@3');
+    expect(ctx.attemptCount).toBe(1);
+    expect(ctx.node).toBe(noop);
+    expect(ctx.runId).toBe('3');
+  });
+
+  it('nests the node path under the parent node path', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '1',
+      parentNodePath: 'outer@2',
+      attemptCount: 4,
+    });
+
+    expect(ctx.nodePath).toBe('outer@2/noop@1');
+    expect(ctx.attemptCount).toBe(4);
+  });
+
+  it('exposes delta-aware session state', () => {
+    const invocationContext = makeInvocationContext();
+    invocationContext.session.state['seed'] = 1;
+    const ctx = new NodeContext({invocationContext, node: noop, runId: '1'});
+
+    ctx.state.set('added', 2);
+
+    expect(ctx.state.get('seed')).toBe(1);
+    expect(ctx.actions.stateDelta).toEqual({added: 2});
+  });
+
+  it('starts with no output and no route', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '1',
+    });
+
+    expect(ctx.output).toBeUndefined();
+    expect(ctx.route).toBeUndefined();
+  });
+});

--- a/core/test/workflow/node_test.ts
+++ b/core/test/workflow/node_test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionNode, JoinNode, node, START} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('node()', () => {
+  it('wraps a function in a FunctionNode named after it', () => {
+    function classify() {
+      return 'high';
+    }
+
+    const built = node(classify);
+
+    expect(built).toBeInstanceOf(FunctionNode);
+    expect(built.name).toBe('classify');
+  });
+
+  it('applies option overrides when wrapping a function', () => {
+    const built = node(() => undefined, {name: 'named', timeoutMs: 7});
+
+    expect(built.name).toBe('named');
+    expect(built.timeoutMs).toBe(7);
+  });
+
+  it('returns an existing node unchanged when there is nothing to override', () => {
+    const existing = new JoinNode({name: 'join'});
+
+    expect(node(existing)).toBe(existing);
+    expect(node(existing, {})).toBe(existing);
+  });
+
+  it('copies an existing node when options are given', () => {
+    const existing = new JoinNode({name: 'join'});
+
+    const copy = node(existing, {timeoutMs: 12});
+
+    expect(copy).not.toBe(existing);
+    expect(copy).toBeInstanceOf(JoinNode);
+    expect(copy.name).toBe('join');
+    expect(copy.timeoutMs).toBe(12);
+    expect(existing.timeoutMs).toBeUndefined();
+  });
+
+  it("resolves the literal 'START' to the START sentinel", () => {
+    expect(node('START')).toBe(START);
+    expect(node('START', {name: 'ignored'})).toBe(START);
+  });
+
+  it('produces a node that runs the wrapped function', async () => {
+    const built = node((_ctx, nodeInput) => `saw ${String(nodeInput)}`, {
+      name: 'runner',
+    });
+
+    const {ctx} = await drainNode(built, 'input');
+
+    expect(ctx.output).toBe('saw input');
+  });
+});

--- a/core/test/workflow/workflow_test_utils.ts
+++ b/core/test/workflow/workflow_test_utils.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseNode,
+  createSession,
+  Event,
+  InvocationContext,
+  NodeContext,
+  PluginManager,
+} from '@google/adk';
+
+/** A minimal agent, used only to satisfy `InvocationContext.agent`. */
+export class StubAgent extends BaseAgent {
+  protected async *runAsyncImpl(): AsyncGenerator<Event, void, void> {}
+
+  protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {}
+}
+
+/** Builds an invocation context backed by an in-memory session. */
+export function makeInvocationContext(
+  overrides: Partial<ConstructorParameters<typeof InvocationContext>[0]> = {},
+): InvocationContext {
+  return new InvocationContext({
+    invocationId: 'test-invocation',
+    agent: new StubAgent({name: 'host'}),
+    session: createSession({id: 'test-session', appName: 'test-app'}),
+    pluginManager: new PluginManager(),
+    ...overrides,
+  });
+}
+
+/** Builds a node context for a single node run. */
+export function makeNodeContext(
+  node: BaseNode,
+  invocationContext = makeInvocationContext(),
+): NodeContext {
+  return new NodeContext({invocationContext, node, runId: '1'});
+}
+
+/**
+ * Runs a node directly through {@link BaseNode.run}, collecting its events.
+ *
+ * This deliberately bypasses the node runner so node semantics can be tested
+ * without retry or timeout handling in the way.
+ */
+export async function drainNode(
+  node: BaseNode,
+  nodeInput?: unknown,
+  ctx: NodeContext = makeNodeContext(node),
+): Promise<{events: Event[]; ctx: NodeContext}> {
+  const events: Event[] = [];
+  for await (const event of node.run(ctx, nodeInput)) {
+    events.push(event);
+  }
+  return {events, ctx};
+}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: google/adk-js#366

**2. Or, if no issue exists, describe the change:**

**Problem:** With the node model from Part 1 in place, there is still no way to describe how nodes connect: no edges, no conditional routing, and no validation to catch a graph that cannot run (a missing entry point, an unreachable node, a cycle with no way out).

**Solution:** Add `Graph`, `Edge` and the chain syntax, plus the structural validators, ported from `adk-python`'s `workflow/_graph.py`, `utils/_graph_parser.py` and `utils/_graph_validation.py`.

- **`Graph`** derives its nodes from its edges — deduplicated by object identity, in first-seen order — and computes its terminal nodes (those with no outgoing edge).
- **`getNextPendingNodes(name, routes)`** selects the edges to follow: unrouted edges always fire; a routed edge fires when the emitted route matches any of its declared routes; the `DEFAULT_ROUTE` edge fires only when nothing else matched; and if a node has routed edges but nothing matched at all, it logs a warning and ends that branch.
- **Chain syntax**: `[START, a, [b, c], d]` expands to unrouted edges from every node of one step to every node of the next, so fan-out and fan-in are one array. A bare function in a chain is wrapped once and memoised by identity, so referencing it twice yields one graph node.
- **`validate()`** rejects, in order: duplicate node names, a missing `START`, routed edges out of `START`, nodes unreachable from `START`, incoming edges into `START`, duplicate edges, `DEFAULT_ROUTE` misuse (in a list, or twice from one node), and cycles made only of unrouted edges. Every message starts with `Graph validation failed.` so callers can match on it. An empty graph is trivially valid, which is what makes an empty workflow run and produce nothing.

**This is Part 2/3 of a three-PR stack.** A cross-fork PR must target `main`, so this branch is rebased onto `main` and its diff also contains Part 1's commits (branch `feat/workflow-graph-core-part1`, filed as its own PR); review the commits after Part 1's. Part 3/3 is filed separately from `feat/workflow-graph-core-part3` and adds `runNode` and the executable `Workflow`.

**Deliberate deviations from `adk-python`**

- **`getNextPendingNodes` returns `BaseNode[]`, not names.** The caller always needs the node itself; returning names forced a reverse lookup whose "node not found" arm was unreachable and therefore untestable. This is internal to the process, so local convention wins over wire-shape parity.
- **`RoutingMap` chain sugar (`{route: node}` inside a chain) is not ported.** A JS object literal coerces numeric and boolean keys to strings, which would silently break strict-equality route matching. Routed edges are written as explicit `Edge` objects, which covers every routing behaviour the reference tests exercise. Queued as a follow-up.
- **An explicit `Edge` takes nodes, not `NodeLike`.** Matching `adk-python`, where pydantic validates `from_node`/`to_node` as `BaseNode`. Wrap a function with `node(fn)` first. Chains still accept bare functions.
- **`_validate_static_schemas` and `_validate_chat_agent_wiring` are not ported** — schema validation and `LlmAgent`-as-node are out of scope for this port.
- **Terminal nodes are computed in the constructor**, not as a side effect of `validate()` as in `adk-python`, so `validate()` is a pure check and `terminalNodeNames` is always populated.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npx vitest run --project unit:core core/test/workflow` — 7 files, 66 tests, all passing (33 new here, on top of Part 1's 33).

New suites: `graph_test.ts` (24 cases: node derivation and ordering, terminal nodes, all seven route-selection behaviours including the unmatched-route warning captured through `setLogger`, and each of the eight validation failures asserted on its message) and `graph_parser_test.ts` (9 cases: chain expansion, fan-out, fan-in, the `'START'` literal, function memoisation by identity, mixing explicit edges with chains, and edge copying).

**Coverage.** Measured with `npx vitest run --project unit:core --coverage --coverage.include='core/src/workflow/**' core/test/workflow`: `graph.ts`, `graph_parser.ts`, `graph_validation.ts` and `route.ts` are at **100% statements / branches / functions / lines**, as is everything from Part 1. `retry_config.ts` still reports 0% at this point in the stack because it contains only type declarations, which v8 erases before it can count them; it reaches 100% in Part 3.

**Proof the new tests can fail.** Each was run against mutated source and confirmed to fail:

| Mutation | Failing test | Message |
| --- | --- | --- |
| `graph.ts`: drop the `!matchedSpecificRoute` guard so `DEFAULT_ROUTE` always fires | `Graph.getNextPendingNodes > skips the DEFAULT_ROUTE edge when a specific route matched` | `expected [ 'b', 'c' ] to deeply equal [ 'b' ]` |
| `graph_validation.ts`: skip `detectUnconditionalCycles` | `Graph.validate > rejects a cycle made only of unrouted edges` | `expected [Function] to throw an error` |
| `graph_validation.ts`: make the cycle walk's `path.indexOf` always return `-1` | `Graph.validate > rejects a cycle made only of unrouted edges` | `expected [Function] to throw error including 'Graph validation failed. Unconditiona…' but got 'Maximum call stack size exceeded'` |

One mutation deliberately **survived** and led to a code change rather than a new test: excluding `START` from the terminal-node computation turned out to be unreachable, because a graph that passes validation always has at least one edge out of `START`. The guard was removed instead of pinning dead code with a test.

No suppressions were added: no `any`, `as any`, `as never`, `@ts-expect-error`, `@ts-ignore`, `eslint-disable` or coverage ignores, in `src/` or in the tests. `graph_parser_test.ts` imports everything relatively, with a comment explaining why: `parseEdgeItems` is internal, and mixing a relative import with `@google/adk` would load a second copy of the node classes that TypeScript treats as unrelated.

**Manual End-to-End (E2E) Tests:**

No network, credentials or model access are needed.

1. `npm install`
2. `npm run build`
3. `npx vitest run --project unit:core core/test/workflow`
4. `npm run lint && npm run format:check`
5. `npm run docs:check` — confirms every new public type is exported and documented.

Graph construction can be inspected directly in a REPL:

```ts
import {Graph, JoinNode, START} from '@google/adk';

const a = new JoinNode({name: 'a'});
const b = new JoinNode({name: 'b'});
const g = Graph.fromEdgeItems([[START, a, b]]);
g.validate();
console.log(g.nodes.map((n) => n.name));                    // [ '__START__', 'a', 'b' ]
console.log([...g.terminalNodeNames]);                      // [ 'b' ]
console.log(g.getNextPendingNodes('a').map((n) => n.name)); // [ 'b' ]
```

The graph is exercised end to end by the executable `Workflow` in Part 3 of this stack.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
