### PR TITLE
Feat: Run a workflow graph with per-node retry and timeout (Part 3/3)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -288,6 +288,7 @@ export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
 export {BaseNode, START} from './workflow/base_node.js';
 export type {BaseNodeConfig} from './workflow/base_node.js';
+export {NodeTimeoutError} from './workflow/errors.js';
 export {FunctionNode} from './workflow/function_node.js';
 export type {
   FunctionNodeConfig,
@@ -300,9 +301,13 @@ export {node} from './workflow/node.js';
 export type {NodeLike, NodeOptions} from './workflow/node.js';
 export {NodeContext} from './workflow/node_context.js';
 export type {NodeContextConfig} from './workflow/node_context.js';
+export {runNode} from './workflow/node_runner.js';
+export type {RunNodeOptions} from './workflow/node_runner.js';
 export type {RetryConfig} from './workflow/retry_config.js';
 export {DEFAULT_ROUTE} from './workflow/route.js';
 export type {RouteValue} from './workflow/route.js';
+export {Workflow} from './workflow/workflow.js';
+export type {WorkflowConfig} from './workflow/workflow.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
 export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -293,12 +293,15 @@ export type {
   FunctionNodeConfig,
   NodeFunction,
 } from './workflow/function_node.js';
+export {Graph} from './workflow/graph.js';
+export type {ChainElement, Edge, EdgeItem} from './workflow/graph.js';
 export {JoinNode} from './workflow/join_node.js';
 export {node} from './workflow/node.js';
 export type {NodeLike, NodeOptions} from './workflow/node.js';
 export {NodeContext} from './workflow/node_context.js';
 export type {NodeContextConfig} from './workflow/node_context.js';
 export type {RetryConfig} from './workflow/retry_config.js';
+export {DEFAULT_ROUTE} from './workflow/route.js';
 export type {RouteValue} from './workflow/route.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -286,6 +286,20 @@ export {Task} from './utils/task.js';
 export type {TaskExecutable} from './utils/task.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
+export {BaseNode, START} from './workflow/base_node.js';
+export type {BaseNodeConfig} from './workflow/base_node.js';
+export {FunctionNode} from './workflow/function_node.js';
+export type {
+  FunctionNodeConfig,
+  NodeFunction,
+} from './workflow/function_node.js';
+export {JoinNode} from './workflow/join_node.js';
+export {node} from './workflow/node.js';
+export type {NodeLike, NodeOptions} from './workflow/node.js';
+export {NodeContext} from './workflow/node_context.js';
+export type {NodeContextConfig} from './workflow/node_context.js';
+export type {RetryConfig} from './workflow/retry_config.js';
+export type {RouteValue} from './workflow/route.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
 export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+
+import {NodeContext} from './node_context.js';
+import {RetryConfig} from './retry_config.js';
+
+/** Node names must be valid JavaScript identifiers. */
+const NODE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * The parameters shared by every workflow node.
+ */
+export interface BaseNodeConfig {
+  /** The node's name, unique within a graph and a valid JS identifier. */
+  name: string;
+
+  /**
+   * If true, the node completes only once it produces an output or a route.
+   *
+   * Until then it stays pending and its downstream nodes are not triggered,
+   * so its predecessors can run it again — once per queued input, one input
+   * at a time — until it decides. This is the general form of a barrier;
+   * JoinNode covers the common "wait for every predecessor" case
+   * declaratively.
+   *
+   * A node that declares this and never produces an output or a route
+   * deadlocks its branch; that is a configuration error.
+   */
+  waitForOutput?: boolean;
+
+  /** How to retry this node when it throws. No retries when omitted. */
+  retryConfig?: RetryConfig;
+
+  /** Maximum time for one run of this node, in milliseconds. */
+  timeoutMs?: number;
+}
+
+/**
+ * The contract every node in a workflow graph implements.
+ *
+ * Subclass it and implement {@link BaseNode.run} to add a node type; wrap a
+ * plain function with `node(fn)` for the common case.
+ *
+ * The class is generic over its config type so {@link BaseNode.clone} stays
+ * typed per subclass, matching `BaseAgent`.
+ *
+ * The whole `workflow` module is experimental. The `@experimental` decorator
+ * is applied only to the classes a caller names that the framework does not
+ * also build on its own: decorating `BaseNode` would warn on merely importing
+ * `@google/adk`, because the {@link START} sentinel is built at module load,
+ * and decorating `Graph` or `NodeContext` would warn on every workflow run.
+ */
+export abstract class BaseNode<
+  TConfig extends BaseNodeConfig = BaseNodeConfig,
+> {
+  /**
+   * The config this node was constructed from.
+   *
+   * Stored so {@link clone} can rebuild the node by re-running the concrete
+   * constructor with overrides applied, which re-derives all state instead of
+   * copying an already-built instance.
+   */
+  protected readonly config: TConfig;
+
+  /** The node's name, unique within a graph. */
+  readonly name: string;
+
+  /** See {@link BaseNodeConfig.waitForOutput}. */
+  readonly waitForOutput: boolean;
+
+  /** See {@link BaseNodeConfig.retryConfig}. */
+  readonly retryConfig?: RetryConfig;
+
+  /** See {@link BaseNodeConfig.timeoutMs}. */
+  readonly timeoutMs?: number;
+
+  constructor(config: TConfig) {
+    if (!NODE_NAME_PATTERN.test(config.name)) {
+      throw new Error(`Node name '${config.name}' must be a valid identifier.`);
+    }
+    // Copied so later mutation of the caller's object cannot leak into clones.
+    this.config = {...config};
+    this.name = config.name;
+    this.waitForOutput = config.waitForOutput ?? false;
+    this.retryConfig = config.retryConfig;
+    this.timeoutMs = config.timeoutMs;
+  }
+
+  /**
+   * Runs the node.
+   *
+   * @param ctx The context of this node run. The node reports its result by
+   *     assigning `ctx.output` and/or `ctx.route`.
+   * @param nodeInput The output of the upstream node, or the workflow's own
+   *     input for a node wired directly to `START`.
+   * @yields The events the node emits while it runs.
+   */
+  abstract run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void>;
+
+  /**
+   * If true, the node runs only once every predecessor has completed, and
+   * receives a record of their outputs keyed by predecessor name.
+   */
+  get requiresAllPredecessors(): boolean {
+    return false;
+  }
+
+  /**
+   * Creates a copy of this node with the given config fields overridden.
+   *
+   * @param overrides Config fields to override on the copy.
+   * @returns A new node of the same concrete class.
+   */
+  clone(overrides?: Partial<TConfig>): this {
+    const ctor = this.constructor as new (config: TConfig) => this;
+    return new ctor({...this.config, ...overrides});
+  }
+}
+
+/** The node behind {@link START}: a marker that refuses to run. */
+class StartNode extends BaseNode {
+  // Deliberately not a generator: START is never executed, so it rejects the
+  // call itself instead of waiting to be iterated.
+  run(): AsyncGenerator<Event, void, void> {
+    throw new Error('START marks a graph entry point and is never executed.');
+  }
+}
+
+/**
+ * The sentinel node marking the entry point of a workflow graph.
+ *
+ * Edges out of `START` carry no route and fire with the workflow's own input;
+ * `START` itself has no incoming edges and is never executed.
+ */
+export const START: BaseNode = new StartNode({name: '__START__'});

--- a/core/src/workflow/errors.ts
+++ b/core/src/workflow/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Thrown when a node runs longer than its `timeoutMs`.
+ *
+ * A plain `Error` subclass, so a timed-out node can be retried by a
+ * `RetryConfig` that lists it.
+ */
+export class NodeTimeoutError extends Error {
+  /** The name of the node that timed out. */
+  readonly nodeName: string;
+
+  /** The timeout the node exceeded, in milliseconds. */
+  readonly timeoutMs: number;
+
+  constructor(options: {nodeName: string; timeoutMs: number}) {
+    super(
+      `Node '${options.nodeName}' timed out after ${options.timeoutMs} ms.`,
+    );
+    this.name = 'NodeTimeoutError';
+    this.nodeName = options.nodeName;
+    this.timeoutMs = options.timeoutMs;
+  }
+}

--- a/core/src/workflow/function_node.ts
+++ b/core/src/workflow/function_node.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BaseNode, BaseNodeConfig} from './base_node.js';
+import {NodeContext} from './node_context.js';
+
+/**
+ * A plain function usable as a workflow node.
+ *
+ * The function reports its result in one of two ways:
+ *
+ * - return a value — anything other than `undefined` or `null` becomes the
+ *   node's output;
+ * - be an async generator — every `Event` it yields is streamed to the caller,
+ *   and it reports its result by assigning `ctx.output`.
+ *
+ * Either form may also assign `ctx.route` to steer the graph.
+ */
+export type NodeFunction = (ctx: NodeContext, nodeInput: unknown) => unknown;
+
+/**
+ * The config of a {@link FunctionNode}.
+ *
+ * The constructor takes this with `name` optional, because a named function
+ * supplies it.
+ */
+export interface FunctionNodeConfig extends BaseNodeConfig {
+  /** The function to run when the node executes. */
+  fn: NodeFunction;
+}
+
+/**
+ * Narrows a function's return value to an event stream.
+ *
+ * An async generator function returns an object carrying
+ * `Symbol.asyncIterator`, which is how a streaming node is told apart from one
+ * that returns a plain result.
+ */
+function isEventStream(value: unknown): value is AsyncIterable<Event> {
+  return (
+    typeof value === 'object' && value !== null && Symbol.asyncIterator in value
+  );
+}
+
+/**
+ * A node that runs a plain function.
+ *
+ * Unlike adk-python's `FunctionNode`, parameters are not bound by name:
+ * TypeScript erases parameter names and types at runtime, so the contract is
+ * the explicit `(ctx, nodeInput)` signature and a function reads session state
+ * through `ctx.state`.
+ */
+@experimental
+export class FunctionNode extends BaseNode<FunctionNodeConfig> {
+  /** The wrapped function. */
+  readonly fn: NodeFunction;
+
+  constructor(config: Omit<FunctionNodeConfig, 'name'> & {name?: string}) {
+    const name = config.name ?? config.fn.name;
+    if (!name) {
+      throw new Error(
+        'FunctionNode must have a name. Provide `name` explicitly when the ' +
+          'wrapped function is anonymous.',
+      );
+    }
+    super({...config, name});
+    this.fn = config.fn;
+  }
+
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    const result = this.fn(ctx, nodeInput);
+    if (isEventStream(result)) {
+      yield* result;
+      return;
+    }
+    const value = await result;
+    if (value !== undefined && value !== null) {
+      ctx.output = value;
+    }
+  }
+}

--- a/core/src/workflow/graph.ts
+++ b/core/src/workflow/graph.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {logger} from '../utils/logger.js';
+
+import {BaseNode} from './base_node.js';
+import {parseEdgeItems} from './graph_parser.js';
+import {validateGraph} from './graph_validation.js';
+import {NodeLike} from './node.js';
+import {DEFAULT_ROUTE, RouteValue, toRouteList} from './route.js';
+
+/**
+ * A directed edge between two workflow nodes.
+ *
+ * An edge with no `route` is always followed. An edge with a `route` is
+ * followed when the source node emits a matching route, and an edge routed
+ * with {@link DEFAULT_ROUTE} is followed when no other routed edge matched.
+ */
+export interface Edge {
+  /** The node the edge starts at. */
+  fromNode: BaseNode;
+
+  /** The node the edge leads to. */
+  toNode: BaseNode;
+
+  /** The route(s) this edge is followed on. */
+  route?: RouteValue | RouteValue[];
+}
+
+/**
+ * One step of a chain: a single node, or several nodes to fan out to.
+ */
+export type ChainElement = NodeLike | NodeLike[];
+
+/**
+ * An entry in a workflow's edge list: an explicit {@link Edge}, or a chain
+ * array such as `[START, a, [b, c], d]` that expands into unrouted edges.
+ */
+export type EdgeItem = Edge | ChainElement[];
+
+/**
+ * A workflow graph: a set of edges plus the nodes they connect.
+ */
+export class Graph {
+  /**
+   * The nodes of the graph, derived from the edges: deduplicated by object
+   * identity and in first-seen order.
+   */
+  readonly nodes: readonly BaseNode[];
+
+  /** The edges of the graph. */
+  readonly edges: readonly Edge[];
+
+  /**
+   * The names of the nodes with no outgoing edge — where a branch of the
+   * workflow ends. `START` is never among them: a valid graph always has at
+   * least one edge out of it.
+   */
+  readonly terminalNodeNames: ReadonlySet<string>;
+
+  constructor(edges: readonly Edge[]) {
+    this.edges = edges;
+    const nodes = new Set<BaseNode>();
+    const sourceNames = new Set<string>();
+    for (const edge of edges) {
+      nodes.add(edge.fromNode);
+      nodes.add(edge.toNode);
+      sourceNames.add(edge.fromNode.name);
+    }
+    this.nodes = [...nodes];
+    this.terminalNodeNames = new Set(
+      this.nodes.filter((n) => !sourceNames.has(n.name)).map((n) => n.name),
+    );
+  }
+
+  /** Builds a graph from a workflow's edge list, expanding any chains. */
+  static fromEdgeItems(items: readonly EdgeItem[]): Graph {
+    return new Graph(parseEdgeItems(items));
+  }
+
+  /**
+   * Returns the nodes to run next after `nodeName` completed emitting
+   * `routesToMatch`.
+   *
+   * @param nodeName The name of the node that just completed.
+   * @param routesToMatch The route(s) it emitted, if any.
+   */
+  getNextPendingNodes(
+    nodeName: string,
+    routesToMatch?: RouteValue | RouteValue[],
+  ): BaseNode[] {
+    const emitted = toRouteList(routesToMatch);
+    const next: BaseNode[] = [];
+    let matchedSpecificRoute = false;
+    let defaultRouteNode: BaseNode | undefined;
+    let hasRoutedEdges = false;
+
+    for (const edge of this.edges) {
+      if (edge.fromNode.name !== nodeName) {
+        continue;
+      }
+      if (edge.route === undefined) {
+        next.push(edge.toNode);
+        continue;
+      }
+      hasRoutedEdges = true;
+      if (edge.route === DEFAULT_ROUTE) {
+        defaultRouteNode = edge.toNode;
+        continue;
+      }
+      const edgeRoutes = toRouteList(edge.route);
+      if (edgeRoutes.some((route) => emitted.includes(route))) {
+        next.push(edge.toNode);
+        matchedSpecificRoute = true;
+      }
+    }
+
+    if (!matchedSpecificRoute && defaultRouteNode) {
+      next.push(defaultRouteNode);
+    }
+    if (hasRoutedEdges && next.length === 0) {
+      logger.warn(
+        `Node '${nodeName}' has conditional/DEFAULT edges but none were ` +
+          `matched by the emitted route(s): ${JSON.stringify(routesToMatch)}. ` +
+          'The branch will end.',
+      );
+    }
+    return next;
+  }
+
+  /**
+   * Checks the graph is runnable.
+   *
+   * @throws If the graph violates any structural rule; the message always
+   *     starts with `Graph validation failed.`.
+   */
+  validate(): void {
+    validateGraph(this.nodes, this.edges);
+  }
+}

--- a/core/src/workflow/graph_parser.ts
+++ b/core/src/workflow/graph_parser.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseNode} from './base_node.js';
+import type {ChainElement, Edge, EdgeItem} from './graph.js';
+import {node, NodeLike} from './node.js';
+
+/** Expands one chain step into the nodes it covers. */
+function flattenElement(element: ChainElement): NodeLike[] {
+  return Array.isArray(element) ? element : [element];
+}
+
+/**
+ * Resolves a chain entry to a node, reusing the node built for a given
+ * function so the same function referenced twice becomes one graph node.
+ */
+function resolveNode(
+  nodeLike: NodeLike,
+  built: Map<NodeLike, BaseNode>,
+): BaseNode {
+  if (nodeLike instanceof BaseNode) {
+    return nodeLike;
+  }
+  const existing = built.get(nodeLike);
+  if (existing) {
+    return existing;
+  }
+  const resolved = node(nodeLike);
+  built.set(nodeLike, resolved);
+  return resolved;
+}
+
+/**
+ * Flattens a workflow's edge list into plain edges.
+ *
+ * A chain array creates an unrouted edge from every node of each step to every
+ * node of the next step, so `[START, a, [b, c]]` fans `a` out to both `b` and
+ * `c`. Explicit {@link Edge} objects pass through with their route intact.
+ */
+export function parseEdgeItems(items: readonly EdgeItem[]): Edge[] {
+  const built = new Map<NodeLike, BaseNode>();
+  const edges: Edge[] = [];
+
+  for (const item of items) {
+    if (!Array.isArray(item)) {
+      // An explicit edge already names its nodes; copy it so later mutation of
+      // the caller's object cannot reshape the graph.
+      edges.push({
+        fromNode: item.fromNode,
+        toNode: item.toNode,
+        route: item.route,
+      });
+      continue;
+    }
+    for (let i = 0; i < item.length - 1; i++) {
+      for (const from of flattenElement(item[i])) {
+        for (const to of flattenElement(item[i + 1])) {
+          edges.push({
+            fromNode: resolveNode(from, built),
+            toNode: resolveNode(to, built),
+          });
+        }
+      }
+    }
+  }
+
+  return edges;
+}

--- a/core/src/workflow/graph_validation.ts
+++ b/core/src/workflow/graph_validation.ts
@@ -1,0 +1,218 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseNode, START} from './base_node.js';
+import type {Edge} from './graph.js';
+import {DEFAULT_ROUTE} from './route.js';
+
+const PREFIX = 'Graph validation failed.';
+
+function fail(message: string): never {
+  throw new Error(`${PREFIX} ${message}`);
+}
+
+/** Every node name must be unique, so a name identifies exactly one node. */
+function validateDuplicateNodeNames(nodes: readonly BaseNode[]): Set<string> {
+  const names = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const node of nodes) {
+    if (names.has(node.name)) {
+      duplicates.add(node.name);
+    }
+    names.add(node.name);
+  }
+  if (duplicates.size > 0) {
+    fail(
+      `Duplicate node names found: ${[...duplicates].sort().join(', ')}. This` +
+        ' means multiple distinct node objects have the same name. If you' +
+        ' intended to reuse the same node, pass the exact same object' +
+        ' instance; otherwise give them unique names.',
+    );
+  }
+  return names;
+}
+
+function validateStartNode(nodeNames: ReadonlySet<string>): void {
+  if (!nodeNames.has(START.name)) {
+    fail(`START node (name: '${START.name}') not found in graph nodes.`);
+  }
+}
+
+function validateStartEdges(edges: readonly Edge[]): void {
+  for (const edge of edges) {
+    if (edge.fromNode.name === START.name && edge.route !== undefined) {
+      fail(
+        `Edges from START must not have routes (edge to ${edge.toNode.name}` +
+          ` has route ${JSON.stringify(edge.route)}).`,
+      );
+    }
+  }
+}
+
+/**
+ * Maps each source node name to the names it has edges to.
+ *
+ * @param unroutedOnly Only follow edges that carry no route.
+ */
+function successorsOf(
+  edges: readonly Edge[],
+  unroutedOnly = false,
+): Map<string, string[]> {
+  const successors = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (unroutedOnly && edge.route !== undefined) {
+      continue;
+    }
+    const fromName = edge.fromNode.name;
+    const existing = successors.get(fromName);
+    if (existing) {
+      existing.push(edge.toNode.name);
+    } else {
+      successors.set(fromName, [edge.toNode.name]);
+    }
+  }
+  return successors;
+}
+
+/** Every node must be reachable from START, and START must be the entry. */
+function validateConnectivity(
+  edges: readonly Edge[],
+  nodeNames: ReadonlySet<string>,
+): void {
+  const successors = successorsOf(edges);
+
+  const reachable = new Set<string>();
+  const stack = [START.name];
+  while (stack.length > 0) {
+    const name = stack.pop()!;
+    if (reachable.has(name)) {
+      continue;
+    }
+    reachable.add(name);
+    stack.push(...(successors.get(name) ?? []));
+  }
+
+  const unreachable = [...nodeNames].filter((name) => !reachable.has(name));
+  if (unreachable.length > 0) {
+    fail(
+      'The following nodes are unreachable from START: ' +
+        unreachable.sort().join(', '),
+    );
+  }
+  if (edges.some((edge) => edge.toNode.name === START.name)) {
+    fail('START node must not have incoming edges.');
+  }
+}
+
+function validateDuplicateEdges(edges: readonly Edge[]): void {
+  const seen = new Set<string>();
+  for (const edge of edges) {
+    const key = `${edge.fromNode.name}\u0000${edge.toNode.name}`;
+    if (seen.has(key)) {
+      fail(
+        `Duplicate edge found: from=${edge.fromNode.name},` +
+          ` to=${edge.toNode.name}`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+/** `DEFAULT_ROUTE` is a standalone fallback: one per source, never in a list. */
+function validateDefaultRoutes(edges: readonly Edge[]): void {
+  const defaultTargets = new Map<string, string>();
+  for (const edge of edges) {
+    if (Array.isArray(edge.route) && edge.route.includes(DEFAULT_ROUTE)) {
+      fail(
+        'DEFAULT_ROUTE cannot be combined with other routes in a list (edge' +
+          ` from=${edge.fromNode.name}, to=${edge.toNode.name}). Use a` +
+          ' separate edge for DEFAULT_ROUTE.',
+      );
+    }
+    if (edge.route !== DEFAULT_ROUTE) {
+      continue;
+    }
+    const existing = defaultTargets.get(edge.fromNode.name);
+    if (existing !== undefined) {
+      fail(
+        `Multiple DEFAULT_ROUTE edges found from node ${edge.fromNode.name}` +
+          ` to ${existing} and ${edge.toNode.name}`,
+      );
+    }
+    defaultTargets.set(edge.fromNode.name, edge.toNode.name);
+  }
+}
+
+/**
+ * Walks `name`'s successors depth first, failing if the walk re-enters a node
+ * still on `path`. `done` holds the nodes already fully explored.
+ */
+function walkForCycle(
+  name: string,
+  successors: ReadonlyMap<string, string[]>,
+  done: Set<string>,
+  path: string[],
+): void {
+  path.push(name);
+  for (const next of successors.get(name) ?? []) {
+    const cycleStart = path.indexOf(next);
+    if (cycleStart !== -1) {
+      const cycle = [...path.slice(cycleStart), next];
+      fail(
+        `Unconditional cycle detected: ${cycle.join(' -> ')}. Cycles must` +
+          ' include at least one conditional (routed) edge to avoid' +
+          ' infinite loops.',
+      );
+    }
+    if (!done.has(next)) {
+      walkForCycle(next, successors, done, path);
+    }
+  }
+  path.pop();
+  done.add(name);
+}
+
+/**
+ * A cycle made only of unrouted edges can never exit, so it would loop
+ * forever. A cycle needs at least one routed edge to be able to break out.
+ */
+function detectUnconditionalCycles(
+  edges: readonly Edge[],
+  nodeNames: ReadonlySet<string>,
+): void {
+  const successors = successorsOf(edges, true);
+  const done = new Set<string>();
+  for (const name of nodeNames) {
+    if (!done.has(name)) {
+      walkForCycle(name, successors, done, []);
+    }
+  }
+}
+
+/**
+ * Checks that a graph is runnable.
+ *
+ * A graph with no nodes is trivially valid: an empty workflow runs and
+ * produces nothing.
+ *
+ * @throws If any structural rule is violated. Every message starts with
+ *     `Graph validation failed.`.
+ */
+export function validateGraph(
+  nodes: readonly BaseNode[],
+  edges: readonly Edge[],
+): void {
+  if (nodes.length === 0) {
+    return;
+  }
+  const nodeNames = validateDuplicateNodeNames(nodes);
+  validateStartNode(nodeNames);
+  validateStartEdges(edges);
+  validateConnectivity(edges, nodeNames);
+  validateDuplicateEdges(edges);
+  validateDefaultRoutes(edges);
+  detectUnconditionalCycles(edges, nodeNames);
+}

--- a/core/src/workflow/join_node.ts
+++ b/core/src/workflow/join_node.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BaseNode} from './base_node.js';
+import {NodeContext} from './node_context.js';
+
+/**
+ * A fan-in node: it runs once every predecessor has completed and outputs
+ * their outputs as a record keyed by predecessor name.
+ */
+@experimental
+export class JoinNode extends BaseNode {
+  override get requiresAllPredecessors(): boolean {
+    return true;
+  }
+
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    ctx.output = nodeInput;
+    // A join emits nothing of its own; delegating to an empty stream keeps
+    // this an async generator without suppressing the require-yield rule.
+    yield* [];
+  }
+}

--- a/core/src/workflow/node.ts
+++ b/core/src/workflow/node.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseNode, BaseNodeConfig, START} from './base_node.js';
+import {FunctionNode, NodeFunction} from './function_node.js';
+
+/**
+ * Anything that can be used where a workflow node is expected: a node, a
+ * function to wrap as a node, or the literal `'START'`.
+ */
+export type NodeLike = BaseNode | NodeFunction | 'START';
+
+/** Config fields that can be overridden when building a node. */
+export type NodeOptions = Partial<BaseNodeConfig>;
+
+/**
+ * Builds a workflow node.
+ *
+ * ```ts
+ * const classify = node(async (ctx) => {
+ *   ctx.route = ctx.state.get<number>('score', 0)! > 5 ? 'high' : 'low';
+ * });
+ * const slow = node(callApi, {name: 'callApi', timeoutMs: 5_000});
+ * ```
+ *
+ * A function becomes a {@link FunctionNode}. An existing node is returned
+ * unchanged when there is nothing to override, so a node referenced several
+ * times in an edge list stays one graph node. `'START'` resolves to the shared
+ * {@link START} sentinel and ignores `options`, which a sentinel cannot carry.
+ *
+ * adk-python's `node` doubles as a decorator; TypeScript decorators cannot be
+ * applied to plain functions, so only this factory form exists.
+ *
+ * @param nodeLike The node, function or `'START'` to build a node from.
+ * @param options Config fields to override on the built node.
+ * @returns The built node.
+ */
+export function node(nodeLike: NodeLike, options: NodeOptions = {}): BaseNode {
+  if (nodeLike === 'START') {
+    return START;
+  }
+  if (nodeLike instanceof BaseNode) {
+    return Object.keys(options).length > 0 ? nodeLike.clone(options) : nodeLike;
+  }
+  return new FunctionNode({...options, fn: nodeLike});
+}

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context} from '../agents/context.js';
+import {InvocationContext} from '../agents/invocation_context.js';
+
+import type {BaseNode} from './base_node.js';
+import type {RouteValue} from './route.js';
+
+/**
+ * The parameters for creating a {@link NodeContext}.
+ */
+export interface NodeContextConfig {
+  /** The invocation this node run belongs to. */
+  invocationContext: InvocationContext;
+
+  /** The node being run. */
+  node: BaseNode;
+
+  /** Identifier of this run of the node, unique per node per workflow run. */
+  runId: string;
+
+  /** 1-based attempt number of this run. Defaults to 1. */
+  attemptCount?: number;
+
+  /** The `nodePath` of the node that scheduled this run, when nested. */
+  parentNodePath?: string;
+}
+
+/**
+ * The context of a single node run.
+ *
+ * Extends the agent {@link Context}, so a node gets the same delta-aware
+ * `state`, `actions`, `abortSignal`, artifact and memory helpers an agent
+ * callback or a tool gets.
+ *
+ * A node reports its result by assigning {@link NodeContext.output} and
+ * {@link NodeContext.route}; `adk-js` events carry neither field, so the
+ * context is the single source of truth for both.
+ */
+export class NodeContext extends Context {
+  /** The node this context belongs to. */
+  readonly node: BaseNode;
+
+  /** Identifier of this run of the node. */
+  readonly runId: string;
+
+  /** 1-based attempt number of this run. */
+  readonly attemptCount: number;
+
+  /**
+   * The location of this run in the node tree: `<name>@<runId>` at the root,
+   * `<parentNodePath>/<name>@<runId>` inside a nested workflow.
+   */
+  readonly nodePath: string;
+
+  /**
+   * The node's result. `undefined` means the node produced no output.
+   */
+  output: unknown;
+
+  /**
+   * The route(s) the node emitted, used to select its outgoing edges.
+   */
+  route?: RouteValue | RouteValue[];
+
+  constructor(config: NodeContextConfig) {
+    super({invocationContext: config.invocationContext});
+    this.node = config.node;
+    this.runId = config.runId;
+    this.attemptCount = config.attemptCount ?? 1;
+    const segment = `${config.node.name}@${config.runId}`;
+    this.nodePath = config.parentNodePath
+      ? `${config.parentNodePath}/${segment}`
+      : segment;
+  }
+}

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {InvocationContext} from '../agents/invocation_context.js';
+import {createEvent, Event} from '../events/event.js';
+import {logger} from '../utils/logger.js';
+
+import {BaseNode} from './base_node.js';
+import {NodeTimeoutError} from './errors.js';
+import {NodeContext} from './node_context.js';
+import {getRetryDelayMs, shouldRetryNode} from './retry_config.js';
+
+/**
+ * The parameters for {@link runNode}.
+ */
+export interface RunNodeOptions {
+  /** The invocation this node run belongs to. */
+  invocationContext: InvocationContext;
+
+  /** The input to pass to the node. */
+  nodeInput?: unknown;
+
+  /** The `nodePath` of the node scheduling this run, when nested. */
+  parentNodePath?: string;
+
+  /** Identifier of this run of the node. Defaults to `'1'`. */
+  runId?: string;
+}
+
+/**
+ * Observes a promise that is no longer awaited so a late rejection cannot
+ * crash the process.
+ *
+ * A timed-out attempt abandons the node's in-flight `next()` and asks its
+ * generator to close. JavaScript cannot preempt the node, so both may still
+ * settle later; the run's real outcome has already been decided by then.
+ */
+function ignoreLateRejection(promise: Promise<unknown>): void {
+  promise.catch(() => undefined);
+}
+
+/** Runs one attempt of a node, enforcing `node.timeoutMs` if it is set. */
+async function* runAttempt(
+  node: BaseNode,
+  ctx: NodeContext,
+  nodeInput: unknown,
+  controller: AbortController,
+): AsyncGenerator<Event, void, void> {
+  const generator = node.run(ctx, nodeInput);
+  const timeoutMs = node.timeoutMs;
+  if (timeoutMs === undefined) {
+    yield* generator;
+    return;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new NodeTimeoutError({nodeName: node.name, timeoutMs}));
+    }, timeoutMs);
+  });
+
+  try {
+    for (;;) {
+      const step = generator.next();
+      ignoreLateRejection(step);
+      const result = await Promise.race([step, expiry]);
+      if (result.done) {
+        return;
+      }
+      yield result.value;
+    }
+  } finally {
+    clearTimeout(timer);
+    ignoreLateRejection(generator.return(undefined));
+  }
+}
+
+/**
+ * Runs a node to completion, applying its timeout and retry policy.
+ *
+ * The timeout is not cancellation: JavaScript cannot preempt a running task,
+ * so an expired node run rejects the caller and aborts `ctx.abortSignal`, and
+ * a node that does not observe that signal keeps running until its next
+ * `await`.
+ *
+ * @param node The node to run.
+ * @param options Where and how to run it.
+ * @yields The events the node emits, plus one error event per failed attempt
+ *     and one event carrying any state or artifact changes it made.
+ * @returns The finished context, carrying the node's `output` and `route`.
+ * @throws The node's error once retries are exhausted, or `NodeTimeoutError`.
+ */
+export async function* runNode(
+  node: BaseNode,
+  options: RunNodeOptions,
+): AsyncGenerator<Event, NodeContext, void> {
+  const runId = options.runId ?? '1';
+  const parentSignal = options.invocationContext.abortSignal;
+
+  for (let attemptCount = 1; ; attemptCount++) {
+    // Relayed by hand rather than with AbortSignal.any: the listener is
+    // detached in the `finally` below, so a long invocation running many nodes
+    // cannot accumulate dependents on the caller's signal.
+    const controller = new AbortController();
+    const onParentAbort = () => controller.abort();
+    if (parentSignal?.aborted) {
+      controller.abort();
+    } else {
+      parentSignal?.addEventListener('abort', onParentAbort, {once: true});
+    }
+
+    const ctx = new NodeContext({
+      invocationContext: new InvocationContext({
+        ...options.invocationContext,
+        abortSignal: controller.signal,
+      }),
+      node,
+      runId,
+      attemptCount,
+      parentNodePath: options.parentNodePath,
+    });
+
+    try {
+      yield* runAttempt(node, ctx, options.nodeInput, controller);
+      if (
+        ctx.state.hasDelta() ||
+        Object.keys(ctx.actions.artifactDelta).length > 0
+      ) {
+        yield createEvent({
+          author: node.name,
+          invocationId: ctx.invocationId,
+          actions: ctx.actions,
+        });
+      }
+      return ctx;
+    } catch (e: unknown) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      yield createEvent({
+        author: node.name,
+        invocationId: ctx.invocationId,
+        errorCode: error.name,
+        errorMessage: error.message,
+      });
+      if (!shouldRetryNode(error, node.retryConfig, attemptCount)) {
+        throw error;
+      }
+      const delayMs = getRetryDelayMs(node.retryConfig, attemptCount);
+      logger.warn(
+        `Node ${node.name} failed with ${error.name} and is being retried in ` +
+          `${delayMs} ms (attempt ${attemptCount + 1}).`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    } finally {
+      parentSignal?.removeEventListener('abort', onParentAbort);
+    }
+  }
+}

--- a/core/src/workflow/retry_config.ts
+++ b/core/src/workflow/retry_config.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Configuration for retrying a workflow node that threw.
+ *
+ * Delays are expressed in milliseconds (adk-python's `RetryConfig` uses
+ * fractional seconds); the effective defaults are the same.
+ */
+export interface RetryConfig {
+  /**
+   * Maximum number of attempts, including the original one. `0` or `1` means
+   * no retries. Defaults to 5.
+   */
+  maxAttempts?: number;
+
+  /** Delay before the first retry, in milliseconds. Defaults to 1000. */
+  initialDelayMs?: number;
+
+  /** Maximum delay between retries, in milliseconds. Defaults to 60000. */
+  maxDelayMs?: number;
+
+  /**
+   * Multiplier applied to the delay after each attempt. Defaults to 2.
+   */
+  backoffFactor?: number;
+
+  /**
+   * Randomness factor applied to the delay. Defaults to 1; use 0 to make the
+   * delay deterministic.
+   */
+  jitter?: number;
+
+  /**
+   * The errors to retry on, given as error class names or as the error classes
+   * themselves. When omitted, every error is retried.
+   */
+  errors?: Array<string | (new (...args: never[]) => Error)>;
+}

--- a/core/src/workflow/retry_config.ts
+++ b/core/src/workflow/retry_config.ts
@@ -40,3 +40,77 @@ export interface RetryConfig {
    */
   errors?: Array<string | (new (...args: never[]) => Error)>;
 }
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_INITIAL_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 60_000;
+const DEFAULT_BACKOFF_FACTOR = 2;
+const DEFAULT_JITTER = 1;
+
+/**
+ * The names a thrown value can be matched against.
+ *
+ * A `class MyError extends Error {}` that never assigns `this.name` reports
+ * `name === 'Error'`, so the constructor name is what makes listing the class
+ * itself work. A value that is not an `Error` matches nothing.
+ */
+function matchableNames(error: unknown): string[] {
+  if (!(error instanceof Error)) {
+    return [];
+  }
+  return [error.name, error.constructor.name];
+}
+
+/**
+ * Decides whether a node that just threw should be retried.
+ *
+ * @param error The value the node threw.
+ * @param config The node's retry config; no config means no retries.
+ * @param attemptCount The 1-based number of the attempt that just failed.
+ */
+export function shouldRetryNode(
+  error: unknown,
+  config: RetryConfig | undefined,
+  attemptCount: number,
+): boolean {
+  if (!config) {
+    return false;
+  }
+  if (attemptCount >= (config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)) {
+    return false;
+  }
+  if (!config.errors) {
+    return true;
+  }
+  const names = matchableNames(error);
+  return config.errors.some((entry) =>
+    names.includes(typeof entry === 'string' ? entry : entry.name),
+  );
+}
+
+/**
+ * Returns how long to wait before the next attempt, in milliseconds.
+ *
+ * @param config The node's retry config; the defaults apply when omitted.
+ * @param attemptCount The 1-based number of the attempt that just failed.
+ */
+export function getRetryDelayMs(
+  config: RetryConfig | undefined,
+  attemptCount: number,
+): number {
+  const initialDelayMs = config?.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  const maxDelayMs = config?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const backoffFactor = config?.backoffFactor ?? DEFAULT_BACKOFF_FACTOR;
+  const jitter = config?.jitter ?? DEFAULT_JITTER;
+
+  const exponent = Math.max(0, attemptCount - 1);
+  const delayMs = Math.min(
+    initialDelayMs * backoffFactor ** exponent,
+    maxDelayMs,
+  );
+  if (jitter <= 0) {
+    return delayMs;
+  }
+  const offsetMs = (Math.random() * 2 - 1) * jitter * delayMs;
+  return Math.max(0, delayMs + offsetMs);
+}

--- a/core/src/workflow/route.ts
+++ b/core/src/workflow/route.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A value a node emits to select which of its outgoing graph edges are
+ * followed.
+ *
+ * A node emits a route by assigning `ctx.route` while it runs. Matching is by
+ * strict equality, so the emitted value and the value declared on the edge must
+ * have the same type.
+ */
+export type RouteValue = string | number | boolean;

--- a/core/src/workflow/route.ts
+++ b/core/src/workflow/route.ts
@@ -13,3 +13,21 @@
  * have the same type.
  */
 export type RouteValue = string | number | boolean;
+
+/**
+ * The route of the fallback edge out of a node.
+ *
+ * An edge declaring this route is followed only when none of the node's other
+ * routed edges matched. At most one such edge per source node is allowed.
+ */
+export const DEFAULT_ROUTE = '__DEFAULT__';
+
+/** Normalizes a single route, a list of routes or nothing into a list. */
+export function toRouteList(
+  route: RouteValue | RouteValue[] | undefined,
+): RouteValue[] {
+  if (route === undefined) {
+    return [];
+  }
+  return Array.isArray(route) ? route : [route];
+}

--- a/core/src/workflow/workflow.ts
+++ b/core/src/workflow/workflow.ts
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BaseNode, BaseNodeConfig, START} from './base_node.js';
+import {Edge, EdgeItem, Graph} from './graph.js';
+import {NodeContext} from './node_context.js';
+import {runNode} from './node_runner.js';
+
+/**
+ * The parameters for creating a {@link Workflow}.
+ */
+export interface WorkflowConfig extends BaseNodeConfig {
+  /** The graph to run, as explicit edges and/or chains. */
+  edges: readonly EdgeItem[];
+
+  /**
+   * Maximum number of node runs before the workflow gives up. Unbounded by
+   * default, mirroring `LoopAgent.maxIterations`; set it when the graph has a
+   * routed cycle that could keep looping.
+   */
+  maxSteps?: number;
+}
+
+/** The inputs queued for a node that is waiting to run. */
+interface PendingRuns {
+  node: BaseNode;
+  inputs: unknown[];
+}
+
+/**
+ * The mutable state of one workflow run.
+ *
+ * Every collection is keyed by node name, so all of them are bounded by the
+ * size of the graph however long a routed cycle keeps running. Keep it that
+ * way: do not accumulate per-run history here.
+ */
+interface RunState {
+  /** Nodes with queued inputs, in the order their first input arrived. */
+  pending: Map<string, PendingRuns>;
+
+  /** Nodes that have finished a run without staying pending for output. */
+  completed: Set<string>;
+
+  /** The latest output of each node that produced one. */
+  outputs: Map<string, unknown>;
+
+  /** How many times each node has run, which gives each run its id. */
+  runCounts: Map<string, number>;
+}
+
+/**
+ * Queues an input for a node, keeping the node's place in the run order.
+ */
+function enqueue(state: RunState, node: BaseNode, input: unknown): void {
+  const existing = state.pending.get(node.name);
+  if (existing) {
+    existing.inputs.push(input);
+    return;
+  }
+  state.pending.set(node.name, {node, inputs: [input]});
+}
+
+/** The names of the nodes with an edge into `targetName`. */
+function predecessorNames(
+  edges: readonly Edge[],
+  targetName: string,
+): string[] {
+  const names = new Set<string>();
+  for (const edge of edges) {
+    if (edge.toNode.name === targetName) {
+      names.add(edge.fromNode.name);
+    }
+  }
+  return [...names];
+}
+
+/**
+ * A node that runs a graph of other nodes.
+ *
+ * The graph is built and validated eagerly, so a malformed one throws at
+ * construction. Nodes run one at a time, in the order their inputs arrived.
+ * Because a workflow is itself a node, it can appear in another workflow's
+ * edges and gets that node's retry and timeout handling.
+ *
+ * ```ts
+ * const wf = new Workflow({
+ *   name: 'triage',
+ *   edges: [
+ *     [START, classify],
+ *     {fromNode: classify, toNode: handleHigh, route: 'high'},
+ *     {fromNode: classify, toNode: handleLow, route: DEFAULT_ROUTE},
+ *   ],
+ * });
+ * ```
+ */
+@experimental
+export class Workflow extends BaseNode<WorkflowConfig> {
+  /** The validated graph this workflow runs. */
+  readonly graph: Graph;
+
+  /** See {@link WorkflowConfig.maxSteps}. */
+  readonly maxSteps: number;
+
+  constructor(config: WorkflowConfig) {
+    super(config);
+    this.maxSteps = config.maxSteps ?? Number.MAX_SAFE_INTEGER;
+    this.graph = Graph.fromEdgeItems(config.edges);
+    this.graph.validate();
+  }
+
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    const state: RunState = {
+      pending: new Map(),
+      completed: new Set(),
+      outputs: new Map(),
+      runCounts: new Map(),
+    };
+
+    for (const edge of this.graph.edges) {
+      if (edge.fromNode.name === START.name) {
+        enqueue(state, edge.toNode, nodeInput);
+      }
+    }
+
+    let steps = 0;
+    for (;;) {
+      if (ctx.abortSignal?.aborted) {
+        return;
+      }
+      const next = state.pending.entries().next();
+      if (next.done) {
+        break;
+      }
+      const [nodeName, runs] = next.value;
+      const input = runs.inputs.shift();
+      if (runs.inputs.length === 0) {
+        state.pending.delete(nodeName);
+      }
+
+      if (++steps > this.maxSteps) {
+        throw new Error(
+          `Workflow ${this.name}: exceeded maxSteps (${this.maxSteps}).`,
+        );
+      }
+
+      const runCount = (state.runCounts.get(nodeName) ?? 0) + 1;
+      state.runCounts.set(nodeName, runCount);
+      const childCtx = yield* runNode(runs.node, {
+        invocationContext: ctx.invocationContext,
+        nodeInput: input,
+        parentNodePath: ctx.nodePath,
+        runId: String(runCount),
+      });
+
+      if (
+        runs.node.waitForOutput &&
+        childCtx.output === undefined &&
+        childCtx.route === undefined
+      ) {
+        // The node is a barrier that has not opened yet: leave it incomplete
+        // so its predecessors can trigger it again.
+        continue;
+      }
+
+      state.completed.add(nodeName);
+      if (childCtx.output !== undefined) {
+        state.outputs.set(nodeName, childCtx.output);
+      }
+      this.triggerDownstream(state, nodeName, childCtx.output, childCtx.route);
+    }
+
+    const terminalOutputs = [...this.graph.terminalNodeNames]
+      .filter((name) => state.outputs.has(name))
+      .map((name) => state.outputs.get(name));
+    if (terminalOutputs.length > 1) {
+      throw new Error(
+        `Workflow ${this.name}: multiple terminal nodes produced output ` +
+          `(${terminalOutputs.length}). A workflow must have at most one ` +
+          'terminal output.',
+      );
+    }
+    if (terminalOutputs.length === 1) {
+      ctx.output = terminalOutputs[0];
+    }
+  }
+
+  /** Queues the nodes reached by the edges the completed node opened. */
+  private triggerDownstream(
+    state: RunState,
+    nodeName: string,
+    output: unknown,
+    route: NodeContext['route'],
+  ): void {
+    for (const target of this.graph.getNextPendingNodes(nodeName, route)) {
+      if (!target.requiresAllPredecessors) {
+        enqueue(state, target, output);
+        continue;
+      }
+      const predecessors = predecessorNames(this.graph.edges, target.name);
+      if (!predecessors.every((name) => state.completed.has(name))) {
+        continue;
+      }
+      const aggregated: Record<string, unknown> = {};
+      for (const name of predecessors) {
+        aggregated[name] = state.outputs.get(name);
+      }
+      enqueue(state, target, aggregated);
+    }
+  }
+}

--- a/core/test/workflow/base_node_test.ts
+++ b/core/test/workflow/base_node_test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseNode,
+  BaseNodeConfig,
+  createEvent,
+  Event,
+  NodeContext,
+  START,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode, makeNodeContext} from './workflow_test_utils.js';
+
+interface EchoNodeConfig extends BaseNodeConfig {
+  texts?: string[];
+}
+
+/** Emits one event per configured text and outputs its input. */
+class EchoNode extends BaseNode<EchoNodeConfig> {
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    for (const text of this.config.texts ?? []) {
+      yield createEvent({author: this.name, content: {parts: [{text}]}});
+    }
+    ctx.output = nodeInput;
+  }
+}
+
+describe('BaseNode', () => {
+  it('rejects a name that is not a valid identifier', () => {
+    expect(() => new EchoNode({name: 'not a name'})).toThrow(
+      "Node name 'not a name' must be a valid identifier.",
+    );
+  });
+
+  it('accepts identifier-shaped names', () => {
+    expect(new EchoNode({name: '_private$1'}).name).toBe('_private$1');
+  });
+
+  it('defaults waitForOutput and requiresAllPredecessors', () => {
+    const n = new EchoNode({name: 'plain'});
+
+    expect(n.waitForOutput).toBe(false);
+    expect(n.requiresAllPredecessors).toBe(false);
+    expect(n.retryConfig).toBeUndefined();
+    expect(n.timeoutMs).toBeUndefined();
+  });
+
+  it('keeps the configured options', () => {
+    const retryConfig = {maxAttempts: 2};
+    const n = new EchoNode({
+      name: 'configured',
+      waitForOutput: true,
+      retryConfig,
+      timeoutMs: 25,
+    });
+
+    expect(n.waitForOutput).toBe(true);
+    expect(n.retryConfig).toBe(retryConfig);
+    expect(n.timeoutMs).toBe(25);
+  });
+
+  it('streams the events it yields and exposes the result on ctx', async () => {
+    const n = new EchoNode({name: 'echo', texts: ['one', 'two']});
+
+    const {events, ctx} = await drainNode(n, 'payload');
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual([
+      'one',
+      'two',
+    ]);
+    expect(events.every((e) => e.author === 'echo')).toBe(true);
+    expect(ctx.output).toBe('payload');
+  });
+
+  it('clones into the same concrete class with overrides applied', () => {
+    const original = new EchoNode({name: 'echo', texts: ['one']});
+
+    const copy = original.clone({name: 'echo2', timeoutMs: 10});
+
+    expect(copy).toBeInstanceOf(EchoNode);
+    expect(copy).not.toBe(original);
+    expect(copy.name).toBe('echo2');
+    expect(copy.timeoutMs).toBe(10);
+    expect(original.name).toBe('echo');
+    expect(original.timeoutMs).toBeUndefined();
+  });
+
+  it('clones subclass-specific config with no overrides', async () => {
+    const original = new EchoNode({name: 'echo', texts: ['kept']});
+
+    const {events} = await drainNode(original.clone());
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['kept']);
+  });
+});
+
+describe('START', () => {
+  it('is named __START__', () => {
+    expect(START.name).toBe('__START__');
+  });
+
+  it('throws if it is ever executed', () => {
+    const ctx = makeNodeContext(START);
+
+    expect(() => START.run(ctx, undefined)).toThrow(
+      'START marks a graph entry point and is never executed.',
+    );
+  });
+});

--- a/core/test/workflow/function_node_test.ts
+++ b/core/test/workflow/function_node_test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {createEvent, Event, FunctionNode, NodeContext} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('FunctionNode', () => {
+  it('infers its name from the wrapped function', () => {
+    function analyse() {
+      return 'ok';
+    }
+
+    expect(new FunctionNode({fn: analyse}).name).toBe('analyse');
+  });
+
+  it('prefers an explicit name over the function name', () => {
+    function analyse() {
+      return 'ok';
+    }
+
+    expect(new FunctionNode({fn: analyse, name: 'custom'}).name).toBe('custom');
+  });
+
+  it('rejects an anonymous function with no name', () => {
+    const anonymous: (ctx: NodeContext, nodeInput: unknown) => unknown =
+      function () {
+        return 'ok';
+      };
+    Object.defineProperty(anonymous, 'name', {value: ''});
+
+    expect(() => new FunctionNode({fn: anonymous})).toThrow(
+      'FunctionNode must have a name.',
+    );
+  });
+
+  it('turns a synchronous return value into the node output', async () => {
+    const n = new FunctionNode({fn: () => 42, name: 'sync'});
+
+    const {events, ctx} = await drainNode(n);
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBe(42);
+  });
+
+  it('turns an awaited return value into the node output', async () => {
+    const n = new FunctionNode({fn: async () => 'later', name: 'async'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBe('later');
+  });
+
+  it('treats undefined as no output', async () => {
+    const n = new FunctionNode({fn: () => undefined, name: 'nothing'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('treats null as no output', async () => {
+    const n = new FunctionNode({fn: () => null, name: 'nullish'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('streams the events an async generator function yields', async () => {
+    async function* streamer(
+      ctx: NodeContext,
+    ): AsyncGenerator<Event, void, void> {
+      yield createEvent({author: 'streamer', content: {parts: [{text: 'a'}]}});
+      yield createEvent({author: 'streamer', content: {parts: [{text: 'b'}]}});
+      ctx.output = 'streamed';
+    }
+    const n = new FunctionNode({fn: streamer});
+
+    const {events, ctx} = await drainNode(n);
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['a', 'b']);
+    expect(ctx.output).toBe('streamed');
+  });
+
+  it('passes the node input to the wrapped function', async () => {
+    const seen: unknown[] = [];
+    const n = new FunctionNode({
+      fn: (_ctx, nodeInput) => {
+        seen.push(nodeInput);
+        return undefined;
+      },
+      name: 'recorder',
+    });
+
+    await drainNode(n, {from: 'upstream'});
+
+    expect(seen).toEqual([{from: 'upstream'}]);
+  });
+
+  it('lets the wrapped function emit a route', async () => {
+    const n = new FunctionNode({
+      fn: (ctx) => {
+        ctx.route = 'high';
+      },
+      name: 'router',
+    });
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.route).toBe('high');
+  });
+
+  it('records state writes on the context delta', async () => {
+    const n = new FunctionNode({
+      fn: (ctx) => {
+        ctx.state.set('visited', true);
+      },
+      name: 'writer',
+    });
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.actions.stateDelta).toEqual({visited: true});
+  });
+
+  it('carries the wrapped function through clone', async () => {
+    const original = new FunctionNode({fn: () => 'value', name: 'origin'});
+
+    const copy = original.clone({name: 'copy', timeoutMs: 5});
+    const {ctx} = await drainNode(copy);
+
+    expect(copy).toBeInstanceOf(FunctionNode);
+    expect(copy.name).toBe('copy');
+    expect(copy.timeoutMs).toBe(5);
+    expect(ctx.output).toBe('value');
+  });
+});

--- a/core/test/workflow/graph_parser_test.ts
+++ b/core/test/workflow/graph_parser_test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `parseEdgeItems` is internal, so this suite imports everything relatively:
+// mixing it with `@google/adk` imports would pull in a second copy of the
+// node classes and TypeScript would treat the two as unrelated.
+import {describe, expect, it} from 'vitest';
+
+import {START} from '../../src/workflow/base_node.js';
+import {FunctionNode} from '../../src/workflow/function_node.js';
+import {Edge} from '../../src/workflow/graph.js';
+import {parseEdgeItems} from '../../src/workflow/graph_parser.js';
+import {JoinNode} from '../../src/workflow/join_node.js';
+import {DEFAULT_ROUTE} from '../../src/workflow/route.js';
+
+const a = new JoinNode({name: 'a'});
+const b = new JoinNode({name: 'b'});
+const c = new JoinNode({name: 'c'});
+
+function names(edges: Edge[]): string[][] {
+  return edges.map((e) => [e.fromNode.name, e.toNode.name]);
+}
+
+describe('parseEdgeItems', () => {
+  it('expands a chain into one edge per consecutive pair', () => {
+    const edges = parseEdgeItems([[START, a, b]]);
+
+    expect(names(edges)).toEqual([
+      ['__START__', 'a'],
+      ['a', 'b'],
+    ]);
+    expect(edges.every((e) => e.route === undefined)).toBe(true);
+  });
+
+  it('fans out to every node of an array step', () => {
+    expect(names(parseEdgeItems([[START, [a, b]]]))).toEqual([
+      ['__START__', 'a'],
+      ['__START__', 'b'],
+    ]);
+  });
+
+  it('fans in from every node of an array step', () => {
+    expect(names(parseEdgeItems([[[a, b], c]]))).toEqual([
+      ['a', 'c'],
+      ['b', 'c'],
+    ]);
+  });
+
+  it("resolves the literal 'START' to the START sentinel", () => {
+    const edges = parseEdgeItems([['START', a]]);
+
+    expect(edges[0].fromNode).toBe(START);
+  });
+
+  it('produces no edges for a chain with fewer than two steps', () => {
+    expect(parseEdgeItems([[a]])).toEqual([]);
+  });
+
+  it('wraps a bare function once and reuses it by identity', () => {
+    function step() {
+      return 'done';
+    }
+    const edges = parseEdgeItems([
+      [START, step],
+      [step, a],
+    ]);
+
+    expect(edges[0].toNode).toBeInstanceOf(FunctionNode);
+    expect(edges[0].toNode).toBe(edges[1].fromNode);
+  });
+
+  it('keeps distinct functions as distinct nodes', () => {
+    const first = () => 'first';
+    const second = () => 'second';
+
+    const edges = parseEdgeItems([
+      [START, first],
+      [START, second],
+    ]);
+
+    expect(edges[0].toNode).not.toBe(edges[1].toNode);
+  });
+
+  it('mixes explicit edges and chains in one list, keeping routes', () => {
+    const edges = parseEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'yes'},
+      {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(names(edges)).toEqual([
+      ['__START__', 'a'],
+      ['a', 'b'],
+      ['a', 'c'],
+    ]);
+    expect(edges[1].route).toBe('yes');
+    expect(edges[2].route).toBe(DEFAULT_ROUTE);
+  });
+
+  it('copies an explicit edge so the caller cannot reshape the graph', () => {
+    const spec = {fromNode: START, toNode: a};
+
+    const edges = parseEdgeItems([spec]);
+    spec.toNode = b;
+
+    expect(edges[0].toNode).toBe(a);
+  });
+});

--- a/core/test/workflow/graph_test.ts
+++ b/core/test/workflow/graph_test.ts
@@ -1,0 +1,293 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DEFAULT_ROUTE,
+  getLogger,
+  Graph,
+  JoinNode,
+  LogLevel,
+  setLogger,
+  START,
+} from '@google/adk';
+import {afterEach, describe, expect, it} from 'vitest';
+
+const a = new JoinNode({name: 'a'});
+const b = new JoinNode({name: 'b'});
+const c = new JoinNode({name: 'c'});
+const d = new JoinNode({name: 'd'});
+
+const realLogger = getLogger();
+
+/** Installs a logger that records `warn` calls, and returns the recording. */
+function captureWarnings(): string[] {
+  const warnings: string[] = [];
+  setLogger({
+    log: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => warnings.push(args.join(' ')),
+    error: () => {},
+    setLogLevel: (_level: LogLevel) => {},
+  });
+  return warnings;
+}
+
+afterEach(() => {
+  setLogger(realLogger);
+});
+
+describe('Graph', () => {
+  it('derives its nodes from its edges, deduplicated and in first-seen order', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a, b],
+      [a, c],
+    ]);
+
+    expect(graph.nodes.map((n) => n.name)).toEqual([
+      '__START__',
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('reports the nodes with no outgoing edge as terminal', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a, b],
+      [a, c],
+    ]);
+
+    expect([...graph.terminalNodeNames].sort()).toEqual(['b', 'c']);
+  });
+
+  it('accepts a valid graph', () => {
+    const graph = Graph.fromEdgeItems([[START, a, b]]);
+
+    expect(() => graph.validate()).not.toThrow();
+  });
+
+  it('accepts an empty graph', () => {
+    const graph = Graph.fromEdgeItems([]);
+
+    expect(() => graph.validate()).not.toThrow();
+    expect(graph.nodes).toEqual([]);
+    expect(graph.terminalNodeNames.size).toBe(0);
+  });
+});
+
+describe('Graph.getNextPendingNodes', () => {
+  it('always follows unrouted edges', () => {
+    const graph = Graph.fromEdgeItems([[START, a, [b, c]]]);
+
+    expect(graph.getNextPendingNodes('a').map((n) => n.name)).toEqual([
+      'b',
+      'c',
+    ]);
+  });
+
+  it('follows only the edge matching the emitted route', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: 'right'},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'right').map((n) => n.name)).toEqual([
+      'c',
+    ]);
+  });
+
+  it('falls back to the DEFAULT_ROUTE edge when nothing matched', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'nope').map((n) => n.name)).toEqual([
+      'c',
+    ]);
+  });
+
+  it('skips the DEFAULT_ROUTE edge when a specific route matched', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'left').map((n) => n.name)).toEqual([
+      'b',
+    ]);
+  });
+
+  it('matches an edge declaring several routes', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: ['left', 'up']},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'up').map((n) => n.name)).toEqual([
+      'b',
+    ]);
+  });
+
+  it('matches when the node emits several routes', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+      {fromNode: a, toNode: c, route: 'right'},
+      {fromNode: a, toNode: d, route: 'down'},
+    ]);
+
+    expect(
+      graph.getNextPendingNodes('a', ['left', 'down']).map((n) => n.name),
+    ).toEqual(['b', 'd']);
+  });
+
+  it('follows unrouted edges alongside a matched routed edge', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      [a, b],
+      {fromNode: a, toNode: c, route: 'go'},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'go').map((n) => n.name)).toEqual([
+      'b',
+      'c',
+    ]);
+  });
+
+  it('warns and ends the branch when no routed edge matched', () => {
+    const warnings = captureWarnings();
+    const graph = Graph.fromEdgeItems([
+      [START, a],
+      {fromNode: a, toNode: b, route: 'left'},
+    ]);
+
+    expect(graph.getNextPendingNodes('a', 'right')).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(
+      'has conditional/DEFAULT edges but none were matched',
+    );
+  });
+
+  it('does not warn when the node has no routed edges at all', () => {
+    const warnings = captureWarnings();
+    const graph = Graph.fromEdgeItems([[START, a, b]]);
+
+    expect(graph.getNextPendingNodes('b')).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('Graph.validate', () => {
+  it('rejects duplicate node names', () => {
+    const duplicate = new JoinNode({name: 'a'});
+
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [START, duplicate],
+      ]).validate(),
+    ).toThrow('Graph validation failed. Duplicate node names found: a');
+  });
+
+  it('rejects a graph without START', () => {
+    expect(() => Graph.fromEdgeItems([[a, b]]).validate()).toThrow(
+      "Graph validation failed. START node (name: '__START__') not found",
+    );
+  });
+
+  it('rejects a routed edge out of START', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        {fromNode: START, toNode: a, route: 'go'},
+      ]).validate(),
+    ).toThrow('Graph validation failed. Edges from START must not have routes');
+  });
+
+  it('rejects nodes unreachable from START', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [b, c],
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. The following nodes are unreachable from ' +
+        'START: b, c',
+    );
+  });
+
+  it('rejects an incoming edge into START', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [a, START],
+      ]).validate(),
+    ).toThrow('Graph validation failed. START node must not have incoming');
+  });
+
+  it('rejects a duplicated edge', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        [START, a],
+      ]).validate(),
+    ).toThrow('Graph validation failed. Duplicate edge found: from=__START__');
+  });
+
+  it('rejects DEFAULT_ROUTE combined with other routes in a list', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        {fromNode: a, toNode: b, route: ['left', DEFAULT_ROUTE]},
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. DEFAULT_ROUTE cannot be combined with other',
+    );
+  });
+
+  it('rejects two DEFAULT_ROUTE edges out of the same node', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a],
+        {fromNode: a, toNode: b, route: DEFAULT_ROUTE},
+        {fromNode: a, toNode: c, route: DEFAULT_ROUTE},
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. Multiple DEFAULT_ROUTE edges found from node a',
+    );
+  });
+
+  it('rejects a cycle made only of unrouted edges', () => {
+    expect(() =>
+      Graph.fromEdgeItems([
+        [START, a, b],
+        [b, a],
+      ]).validate(),
+    ).toThrow(
+      'Graph validation failed. Unconditional cycle detected: a -> b -> a.',
+    );
+  });
+
+  it('accepts a cycle that includes a routed edge', () => {
+    const graph = Graph.fromEdgeItems([
+      [START, a, b],
+      {fromNode: b, toNode: a, route: 'again'},
+      {fromNode: b, toNode: c, route: DEFAULT_ROUTE},
+    ]);
+
+    expect(() => graph.validate()).not.toThrow();
+  });
+
+  it('accepts a diamond, which revisits a node without cycling', () => {
+    const graph = Graph.fromEdgeItems([[START, a, [b, c], d]]);
+
+    expect(() => graph.validate()).not.toThrow();
+  });
+});

--- a/core/test/workflow/join_node_test.ts
+++ b/core/test/workflow/join_node_test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {JoinNode} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('JoinNode', () => {
+  it('waits for all of its predecessors', () => {
+    expect(new JoinNode({name: 'join'}).requiresAllPredecessors).toBe(true);
+  });
+
+  it('passes the aggregated predecessor outputs through as its output', async () => {
+    const aggregated = {NodeA: 'a', NodeB: 'b'};
+
+    const {events, ctx} = await drainNode(
+      new JoinNode({name: 'join'}),
+      aggregated,
+    );
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBe(aggregated);
+  });
+});

--- a/core/test/workflow/node_context_test.ts
+++ b/core/test/workflow/node_context_test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {NodeContext, node} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {makeInvocationContext} from './workflow_test_utils.js';
+
+const noop = node(() => undefined, {name: 'noop'});
+
+describe('NodeContext', () => {
+  it('builds a root node path from the node name and run id', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '3',
+    });
+
+    expect(ctx.nodePath).toBe('noop@3');
+    expect(ctx.attemptCount).toBe(1);
+    expect(ctx.node).toBe(noop);
+    expect(ctx.runId).toBe('3');
+  });
+
+  it('nests the node path under the parent node path', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '1',
+      parentNodePath: 'outer@2',
+      attemptCount: 4,
+    });
+
+    expect(ctx.nodePath).toBe('outer@2/noop@1');
+    expect(ctx.attemptCount).toBe(4);
+  });
+
+  it('exposes delta-aware session state', () => {
+    const invocationContext = makeInvocationContext();
+    invocationContext.session.state['seed'] = 1;
+    const ctx = new NodeContext({invocationContext, node: noop, runId: '1'});
+
+    ctx.state.set('added', 2);
+
+    expect(ctx.state.get('seed')).toBe(1);
+    expect(ctx.actions.stateDelta).toEqual({added: 2});
+  });
+
+  it('starts with no output and no route', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '1',
+    });
+
+    expect(ctx.output).toBeUndefined();
+    expect(ctx.route).toBeUndefined();
+  });
+});

--- a/core/test/workflow/node_runner_test.ts
+++ b/core/test/workflow/node_runner_test.ts
@@ -1,0 +1,298 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createEvent,
+  Event,
+  InMemoryArtifactService,
+  node,
+  NodeContext,
+  runNode,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+// Not part of the public barrel, so it is imported by path.
+import {ScopedArtifactService} from '../../src/artifacts/scoped_artifact_service.js';
+
+import {makeInvocationContext, runToCompletion} from './workflow_test_utils.js';
+
+const NO_RETRY_DELAY = {initialDelayMs: 0, jitter: 0};
+
+/** A function node that throws on its first `failures` attempts. */
+function flaky(
+  name: string,
+  failures: number,
+  error: () => Error = () => new Error('boom'),
+) {
+  const attempts: number[] = [];
+  const built = node(
+    (ctx: NodeContext) => {
+      attempts.push(ctx.attemptCount);
+      if (attempts.length <= failures) {
+        throw error();
+      }
+      return 'recovered';
+    },
+    {name, retryConfig: {maxAttempts: 4, ...NO_RETRY_DELAY}},
+  );
+  return {node: built, attempts};
+}
+
+describe('runNode', () => {
+  it('returns the finished context with the node output', async () => {
+    const {events, ctx} = await runToCompletion(
+      node(() => 'done', {name: 'done'}),
+    );
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBe('done');
+    expect(ctx.nodePath).toBe('done@1');
+    expect(ctx.attemptCount).toBe(1);
+  });
+
+  it('uses the given run id and parent node path', async () => {
+    const run = runNode(
+      node(() => 'x', {name: 'child'}),
+      {
+        invocationContext: makeInvocationContext(),
+        runId: '7',
+        parentNodePath: 'outer@1',
+      },
+    );
+
+    const step = await run.next();
+    expect(step.done).toBe(true);
+    if (step.done) {
+      expect(step.value.nodePath).toBe('outer@1/child@7');
+    }
+  });
+
+  it('streams the events the node emits', async () => {
+    const streaming = node(
+      async function* (ctx: NodeContext): AsyncGenerator<Event, void, void> {
+        yield createEvent({
+          author: 'streaming',
+          content: {parts: [{text: 'a'}]},
+        });
+        ctx.output = 'end';
+      },
+      {name: 'streaming'},
+    );
+
+    const {events, ctx} = await runToCompletion(streaming);
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['a']);
+    expect(ctx.output).toBe('end');
+  });
+
+  it('emits one event carrying the state the node wrote', async () => {
+    const writer = node(
+      (ctx: NodeContext) => {
+        ctx.state.set('seen', true);
+      },
+      {name: 'writer'},
+    );
+
+    const {events} = await runToCompletion(writer);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].author).toBe('writer');
+    expect(events[0].actions.stateDelta).toEqual({seen: true});
+  });
+
+  it('emits one event carrying the artifacts the node saved', async () => {
+    const invocationContext = makeInvocationContext({
+      artifactService: new ScopedArtifactService(
+        new InMemoryArtifactService(),
+        'test-app',
+        'test-user',
+        'test-session',
+      ),
+    });
+    const saver = node(
+      async (ctx: NodeContext) => {
+        await ctx.saveArtifact('report.txt', {text: 'hello'});
+      },
+      {name: 'saver'},
+    );
+
+    const {events} = await runToCompletion(saver, undefined, invocationContext);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].actions.artifactDelta).toEqual({'report.txt': 0});
+  });
+
+  it('emits no extra event when the node changed nothing', async () => {
+    const {events} = await runToCompletion(node(() => 'x', {name: 'quiet'}));
+
+    expect(events).toEqual([]);
+  });
+
+  it('fails immediately when the node has no retry config', async () => {
+    const failing = node(
+      () => {
+        throw new Error('nope');
+      },
+      {name: 'failing'},
+    );
+
+    await expect(runToCompletion(failing)).rejects.toThrow('nope');
+  });
+
+  it('emits an error event for every failed attempt', async () => {
+    const {node: unstable} = flaky('unstable', 2);
+
+    const {events, ctx} = await runToCompletion(unstable);
+
+    expect(events.map((e) => [e.author, e.errorCode, e.errorMessage])).toEqual([
+      ['unstable', 'Error', 'boom'],
+      ['unstable', 'Error', 'boom'],
+    ]);
+    expect(ctx.output).toBe('recovered');
+  });
+
+  it('increments the attempt count on the context', async () => {
+    const {node: unstable, attempts} = flaky('unstable', 2);
+
+    await runToCompletion(unstable);
+
+    expect(attempts).toEqual([1, 2, 3]);
+  });
+
+  it('rethrows once maxAttempts is exhausted', async () => {
+    const exhausted = node(
+      () => {
+        throw new Error('always');
+      },
+      {name: 'exhausted', retryConfig: {maxAttempts: 2, ...NO_RETRY_DELAY}},
+    );
+
+    await expect(runToCompletion(exhausted)).rejects.toThrow('always');
+  });
+
+  it('retries with the defaults for an empty retry config', async () => {
+    let calls = 0;
+    const unstable = node(
+      () => {
+        calls++;
+        if (calls === 1) {
+          throw new Error('once');
+        }
+        return 'ok';
+      },
+      // maxAttempts defaults to 5; the delay is kept at 0 so the test is fast.
+      {name: 'unstable', retryConfig: NO_RETRY_DELAY},
+    );
+
+    const {ctx} = await runToCompletion(unstable);
+
+    expect(calls).toBe(2);
+    expect(ctx.output).toBe('ok');
+  });
+
+  it('does not retry an error outside the configured list', async () => {
+    let calls = 0;
+    const wrongError = node(
+      () => {
+        calls++;
+        throw new TypeError('wrong kind');
+      },
+      {
+        name: 'wrongError',
+        retryConfig: {errors: ['RangeError'], ...NO_RETRY_DELAY},
+      },
+    );
+
+    await expect(runToCompletion(wrongError)).rejects.toThrow('wrong kind');
+    expect(calls).toBe(1);
+  });
+
+  it('retries an error listed in the retry config', async () => {
+    const {node: unstable, attempts} = flaky(
+      'unstable',
+      1,
+      () => new RangeError('out of range'),
+    );
+
+    const {ctx} = await runToCompletion(unstable);
+
+    expect(attempts).toHaveLength(2);
+    expect(ctx.output).toBe('recovered');
+  });
+
+  it('wraps a thrown non-Error value', async () => {
+    const throwsString = node(
+      () => {
+        throw 'plain string';
+      },
+      {name: 'throwsString'},
+    );
+
+    await expect(runToCompletion(throwsString)).rejects.toThrow('plain string');
+  });
+
+  it('aborts the node signal when the parent invocation is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let seenAborted: boolean | undefined;
+    const observer = node(
+      (ctx: NodeContext) => {
+        seenAborted = ctx.abortSignal?.aborted;
+      },
+      {name: 'observer'},
+    );
+
+    await runToCompletion(
+      observer,
+      undefined,
+      makeInvocationContext({abortSignal: controller.signal}),
+    );
+
+    expect(seenAborted).toBe(true);
+  });
+
+  it('aborts the node signal when the parent invocation aborts mid-run', async () => {
+    const controller = new AbortController();
+    let seenAborted: boolean | undefined;
+    const observer = node(
+      async (ctx: NodeContext) => {
+        controller.abort();
+        await Promise.resolve();
+        seenAborted = ctx.abortSignal?.aborted;
+      },
+      {name: 'observer'},
+    );
+
+    await runToCompletion(
+      observer,
+      undefined,
+      makeInvocationContext({abortSignal: controller.signal}),
+    );
+
+    expect(seenAborted).toBe(true);
+  });
+
+  it('leaves no abort listener behind on the parent signal', async () => {
+    const controller = new AbortController();
+    const invocationContext = makeInvocationContext({
+      abortSignal: controller.signal,
+    });
+    let observed: AbortSignal | undefined;
+    const observer = node(
+      (ctx: NodeContext) => {
+        observed = ctx.abortSignal;
+      },
+      {name: 'observer'},
+    );
+
+    await runToCompletion(observer, undefined, invocationContext);
+    controller.abort();
+
+    // The listener installed for the run was removed, so aborting afterwards
+    // no longer reaches the finished run's signal.
+    expect(observed?.aborted).toBe(false);
+  });
+});

--- a/core/test/workflow/node_test.ts
+++ b/core/test/workflow/node_test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionNode, JoinNode, node, START} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('node()', () => {
+  it('wraps a function in a FunctionNode named after it', () => {
+    function classify() {
+      return 'high';
+    }
+
+    const built = node(classify);
+
+    expect(built).toBeInstanceOf(FunctionNode);
+    expect(built.name).toBe('classify');
+  });
+
+  it('applies option overrides when wrapping a function', () => {
+    const built = node(() => undefined, {name: 'named', timeoutMs: 7});
+
+    expect(built.name).toBe('named');
+    expect(built.timeoutMs).toBe(7);
+  });
+
+  it('returns an existing node unchanged when there is nothing to override', () => {
+    const existing = new JoinNode({name: 'join'});
+
+    expect(node(existing)).toBe(existing);
+    expect(node(existing, {})).toBe(existing);
+  });
+
+  it('copies an existing node when options are given', () => {
+    const existing = new JoinNode({name: 'join'});
+
+    const copy = node(existing, {timeoutMs: 12});
+
+    expect(copy).not.toBe(existing);
+    expect(copy).toBeInstanceOf(JoinNode);
+    expect(copy.name).toBe('join');
+    expect(copy.timeoutMs).toBe(12);
+    expect(existing.timeoutMs).toBeUndefined();
+  });
+
+  it("resolves the literal 'START' to the START sentinel", () => {
+    expect(node('START')).toBe(START);
+    expect(node('START', {name: 'ignored'})).toBe(START);
+  });
+
+  it('produces a node that runs the wrapped function', async () => {
+    const built = node((_ctx, nodeInput) => `saw ${String(nodeInput)}`, {
+      name: 'runner',
+    });
+
+    const {ctx} = await drainNode(built, 'input');
+
+    expect(ctx.output).toBe('saw input');
+  });
+});

--- a/core/test/workflow/node_timeout_test.ts
+++ b/core/test/workflow/node_timeout_test.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createEvent,
+  Event,
+  node,
+  NodeContext,
+  NodeTimeoutError,
+  START,
+  Workflow,
+} from '@google/adk';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {runToCompletion} from './workflow_test_utils.js';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('node timeouts', () => {
+  it('lets a node that finishes in time complete', async () => {
+    const quick = node(
+      async () => {
+        await sleep(1);
+        return 'in time';
+      },
+      {name: 'quick', timeoutMs: 1000},
+    );
+
+    const {ctx} = await runToCompletion(quick);
+
+    expect(ctx.output).toBe('in time');
+  });
+
+  it('throws NodeTimeoutError naming the node that ran too long', async () => {
+    const slow = node(() => sleep(1000), {name: 'slow', timeoutMs: 10});
+
+    const error = await runToCompletion(slow).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NodeTimeoutError);
+    expect(error).toMatchObject({
+      nodeName: 'slow',
+      timeoutMs: 10,
+      message: "Node 'slow' timed out after 10 ms.",
+    });
+  });
+
+  it('streams the events of a node that has a timeout', async () => {
+    const streaming = node(
+      async function* (ctx: NodeContext): AsyncGenerator<Event, void, void> {
+        yield createEvent({
+          author: 'streaming',
+          content: {parts: [{text: 'progress'}]},
+        });
+        await sleep(1);
+        ctx.output = 'streamed';
+      },
+      {name: 'streaming', timeoutMs: 1000},
+    );
+
+    const {events, ctx} = await runToCompletion(streaming);
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['progress']);
+    expect(ctx.output).toBe('streamed');
+  });
+
+  it('applies no limit when timeoutMs is not set', async () => {
+    const slow = node(
+      async () => {
+        await sleep(30);
+        return 'eventually';
+      },
+      {name: 'slow'},
+    );
+
+    const {ctx} = await runToCompletion(slow);
+
+    expect(ctx.output).toBe('eventually');
+  });
+
+  it('aborts the node context signal when the timeout fires', async () => {
+    let observed: AbortSignal | undefined;
+    const slow = node(
+      async (ctx: NodeContext) => {
+        observed = ctx.abortSignal;
+        await sleep(1000);
+      },
+      {name: 'slow', timeoutMs: 10},
+    );
+
+    await expect(runToCompletion(slow)).rejects.toThrow(NodeTimeoutError);
+
+    expect(observed?.aborted).toBe(true);
+  });
+
+  it('retries a timed-out node and succeeds on the next attempt', async () => {
+    let calls = 0;
+    const slowThenFast = node(
+      async () => {
+        calls++;
+        if (calls === 1) {
+          await sleep(1000);
+        }
+        return 'second time';
+      },
+      {
+        name: 'slowThenFast',
+        timeoutMs: 20,
+        retryConfig: {maxAttempts: 2, initialDelayMs: 0, jitter: 0},
+      },
+    );
+
+    const {ctx} = await runToCompletion(slowThenFast);
+
+    expect(calls).toBe(2);
+    expect(ctx.output).toBe('second time');
+  });
+
+  it('leaves no pending timer behind after a completed run', async () => {
+    vi.useFakeTimers();
+    const quick = node(() => 'done', {name: 'quick', timeoutMs: 1000});
+
+    await runToCompletion(quick);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('surfaces the timeout even when the abandoned node later rejects', async () => {
+    const lateFailure = node(
+      async () => {
+        await sleep(20);
+        throw new Error('too late to matter');
+      },
+      {name: 'lateFailure', timeoutMs: 5},
+    );
+
+    await expect(runToCompletion(lateFailure)).rejects.toThrow(
+      NodeTimeoutError,
+    );
+    // Give the abandoned attempt time to reject; an unobserved rejection here
+    // would fail the run.
+    await sleep(40);
+  });
+
+  it('reports the inner workflow when a nested workflow times out', async () => {
+    const inner = new Workflow({
+      name: 'inner',
+      edges: [[START, node(() => sleep(1000), {name: 'slow'})]],
+      timeoutMs: 10,
+    });
+    const outer = new Workflow({name: 'outer', edges: [[START, inner]]});
+
+    const error = await runToCompletion(outer).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NodeTimeoutError);
+    expect(error).toMatchObject({nodeName: 'inner'});
+  });
+});

--- a/core/test/workflow/retry_config_test.ts
+++ b/core/test/workflow/retry_config_test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The retry helpers are internal, so this suite imports them relatively.
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  getRetryDelayMs,
+  shouldRetryNode,
+} from '../../src/workflow/retry_config.js';
+
+/** An error class that never assigns `this.name`, so `name` stays 'Error'. */
+class UnnamedError extends Error {}
+
+class NamedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NamedError';
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('shouldRetryNode', () => {
+  it('never retries without a retry config', () => {
+    expect(shouldRetryNode(new Error('boom'), undefined, 1)).toBe(false);
+  });
+
+  it('retries any error when no error filter is given', () => {
+    expect(shouldRetryNode(new TypeError('boom'), {}, 1)).toBe(true);
+  });
+
+  it('stops once the attempt count reaches maxAttempts', () => {
+    expect(shouldRetryNode(new Error('boom'), {maxAttempts: 3}, 2)).toBe(true);
+    expect(shouldRetryNode(new Error('boom'), {maxAttempts: 3}, 3)).toBe(false);
+  });
+
+  it('defaults maxAttempts to 5', () => {
+    expect(shouldRetryNode(new Error('boom'), {}, 4)).toBe(true);
+    expect(shouldRetryNode(new Error('boom'), {}, 5)).toBe(false);
+  });
+
+  it('matches an error by name', () => {
+    const config = {errors: ['NamedError']};
+
+    expect(shouldRetryNode(new NamedError('boom'), config, 1)).toBe(true);
+    expect(shouldRetryNode(new TypeError('boom'), config, 1)).toBe(false);
+  });
+
+  it('matches an error by class', () => {
+    expect(
+      shouldRetryNode(new TypeError('boom'), {errors: [TypeError]}, 1),
+    ).toBe(true);
+  });
+
+  it('matches a class that never sets this.name, by constructor name', () => {
+    const failure = new UnnamedError('boom');
+
+    expect(failure.name).toBe('Error');
+    expect(shouldRetryNode(failure, {errors: [UnnamedError]}, 1)).toBe(true);
+    expect(shouldRetryNode(failure, {errors: ['UnnamedError']}, 1)).toBe(true);
+  });
+
+  it('accepts a mix of names and classes', () => {
+    const config = {errors: ['NamedError', TypeError]};
+
+    expect(shouldRetryNode(new NamedError('boom'), config, 1)).toBe(true);
+    expect(shouldRetryNode(new TypeError('boom'), config, 1)).toBe(true);
+    expect(shouldRetryNode(new RangeError('boom'), config, 1)).toBe(false);
+  });
+
+  it('does not match a thrown value that is not an Error', () => {
+    expect(shouldRetryNode('boom', {errors: ['String']}, 1)).toBe(false);
+    expect(shouldRetryNode('boom', {}, 1)).toBe(true);
+  });
+});
+
+describe('getRetryDelayMs', () => {
+  it('grows exponentially from the initial delay', () => {
+    const config = {jitter: 0};
+
+    expect(getRetryDelayMs(config, 1)).toBe(1000);
+    expect(getRetryDelayMs(config, 2)).toBe(2000);
+    expect(getRetryDelayMs(config, 3)).toBe(4000);
+  });
+
+  it('honours a custom initial delay and backoff factor', () => {
+    const config = {initialDelayMs: 50, backoffFactor: 3, jitter: 0};
+
+    expect(getRetryDelayMs(config, 1)).toBe(50);
+    expect(getRetryDelayMs(config, 2)).toBe(150);
+  });
+
+  it('caps the delay at maxDelayMs', () => {
+    expect(getRetryDelayMs({jitter: 0, maxDelayMs: 2500}, 5)).toBe(2500);
+    expect(getRetryDelayMs({jitter: 0}, 20)).toBe(60_000);
+  });
+
+  it('treats an attempt count below one as the first attempt', () => {
+    expect(getRetryDelayMs({jitter: 0}, 0)).toBe(1000);
+  });
+
+  it('offsets the delay by the jitter fraction', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+
+    // random() === 1 puts the offset at +jitter * delay.
+    expect(getRetryDelayMs({jitter: 0.5}, 1)).toBe(1500);
+  });
+
+  it('never returns a negative delay', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    // random() === 0 puts the offset at -jitter * delay, twice the delay here.
+    expect(getRetryDelayMs({jitter: 2}, 1)).toBe(0);
+  });
+
+  it('applies the default jitter of one', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+
+    expect(getRetryDelayMs({}, 1)).toBe(2000);
+  });
+});

--- a/core/test/workflow/workflow_integration_test.ts
+++ b/core/test/workflow/workflow_integration_test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DEFAULT_ROUTE,
+  JoinNode,
+  node,
+  NodeContext,
+  START,
+  Workflow,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {runToCompletion} from './workflow_test_utils.js';
+
+/**
+ * Exercises the whole module end to end on one realistic graph: START fans out
+ * to two nodes, a JoinNode gathers them, a routing node picks a branch through
+ * DEFAULT_ROUTE, the chosen branch fails twice before succeeding under its
+ * retry policy, and a terminal node produces the workflow's output.
+ */
+describe('workflow end to end', () => {
+  it('runs a fan-out, join, route, retry and terminal-output graph', async () => {
+    const executed: string[] = [];
+    const track = (name: string) => executed.push(name);
+
+    const fetchOrders = node(
+      (ctx: NodeContext) => {
+        track('fetchOrders');
+        ctx.state.set('orderCount', 12);
+        return 12;
+      },
+      {name: 'fetchOrders'},
+    );
+
+    const fetchReturns = node(
+      async () => {
+        track('fetchReturns');
+        return 9;
+      },
+      {name: 'fetchReturns'},
+    );
+
+    const collect = new JoinNode({name: 'collect'});
+
+    let joined: unknown;
+    const classify = node(
+      (ctx: NodeContext, nodeInput) => {
+        track('classify');
+        joined = nodeInput;
+        const {fetchOrders: orders, fetchReturns: returns} = nodeInput as {
+          fetchOrders: number;
+          fetchReturns: number;
+        };
+        // Reads state written by an earlier node in the same run.
+        expect(ctx.state.get<number>('orderCount')).toBe(orders);
+        ctx.route = returns / orders > 0.9 ? 'alarming' : 'normal';
+        return returns;
+      },
+      {name: 'classify'},
+    );
+
+    let escalateAttempts = 0;
+    const escalate = node(
+      (ctx: NodeContext, nodeInput) => {
+        track(`escalate#${ctx.attemptCount}`);
+        escalateAttempts++;
+        if (escalateAttempts < 3) {
+          throw new RangeError('pager unavailable');
+        }
+        return `escalated ${String(nodeInput)} returns`;
+      },
+      {
+        name: 'escalate',
+        retryConfig: {
+          maxAttempts: 3,
+          initialDelayMs: 0,
+          jitter: 0,
+          errors: [RangeError],
+        },
+      },
+    );
+
+    const alarm = node(
+      () => {
+        track('alarm');
+        return 'alarm raised';
+      },
+      {name: 'alarm'},
+    );
+
+    const report = node(
+      (_ctx, nodeInput) => {
+        track('report');
+        return `report: ${String(nodeInput)}`;
+      },
+      {name: 'report'},
+    );
+
+    const workflow = new Workflow({
+      name: 'returnsTriage',
+      maxSteps: 20,
+      edges: [
+        [START, [fetchOrders, fetchReturns]],
+        [fetchOrders, collect],
+        [fetchReturns, collect],
+        [collect, classify],
+        {fromNode: classify, toNode: alarm, route: 'alarming'},
+        {fromNode: classify, toNode: escalate, route: DEFAULT_ROUTE},
+        [escalate, report],
+      ],
+    });
+
+    const {events, ctx} = await runToCompletion(workflow, 'nightly');
+
+    expect(executed).toEqual([
+      'fetchOrders',
+      'fetchReturns',
+      'classify',
+      'escalate#1',
+      'escalate#2',
+      'escalate#3',
+      'report',
+    ]);
+    // The join gathered both branches before classify ran.
+    expect(joined).toEqual({fetchOrders: 12, fetchReturns: 9});
+    expect(escalateAttempts).toBe(3);
+    expect(ctx.output).toBe('report: escalated 9 returns');
+
+    // Two failed attempts produced one error event each, and the state write
+    // produced one event carrying the delta.
+    expect(
+      events.filter((e) => e.errorCode === 'RangeError').map((e) => e.author),
+    ).toEqual(['escalate', 'escalate']);
+    expect(
+      events.filter((e) => Object.keys(e.actions.stateDelta).length > 0),
+    ).toHaveLength(1);
+  });
+});

--- a/core/test/workflow/workflow_test.ts
+++ b/core/test/workflow/workflow_test.ts
@@ -1,0 +1,489 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createEvent,
+  Event,
+  JoinNode,
+  node,
+  NodeContext,
+  START,
+  Workflow,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {makeInvocationContext, runToCompletion} from './workflow_test_utils.js';
+
+/** A node that appends its name to `log` and outputs `output`. */
+function recording(log: string[], name: string, output?: unknown) {
+  return node(
+    () => {
+      log.push(name);
+      return output;
+    },
+    {name},
+  );
+}
+
+describe('Workflow', () => {
+  it('validates its graph eagerly', () => {
+    expect(
+      () =>
+        new Workflow({
+          name: 'invalid',
+          edges: [[node(() => 'a', {name: 'a'}), node(() => 'b', {name: 'b'})]],
+        }),
+    ).toThrow('Graph validation failed. START node');
+  });
+
+  it('runs two nodes in sequence and returns the terminal output', async () => {
+    const log: string[] = [];
+    const wf = new Workflow({
+      name: 'sequence',
+      edges: [
+        [
+          START,
+          recording(log, 'first', 'one'),
+          recording(log, 'second', 'two'),
+        ],
+      ],
+    });
+
+    const {ctx} = await runToCompletion(wf, 'start');
+
+    expect(log).toEqual(['first', 'second']);
+    expect(ctx.output).toBe('two');
+  });
+
+  it('passes each node output on as the next node input', async () => {
+    const seen: unknown[] = [];
+    const wf = new Workflow({
+      name: 'propagation',
+      edges: [
+        [
+          START,
+          node(
+            (_ctx, nodeInput) => {
+              seen.push(nodeInput);
+              return 'from first';
+            },
+            {name: 'first'},
+          ),
+          node(
+            (_ctx, nodeInput) => {
+              seen.push(nodeInput);
+              return 'done';
+            },
+            {name: 'second'},
+          ),
+        ],
+      ],
+    });
+
+    await runToCompletion(wf, 'workflow input');
+
+    expect(seen).toEqual(['workflow input', 'from first']);
+  });
+
+  it('streams node events before producing the output', async () => {
+    const wf = new Workflow({
+      name: 'streaming',
+      edges: [
+        [
+          START,
+          node(
+            async function* (
+              ctx: NodeContext,
+            ): AsyncGenerator<Event, void, void> {
+              yield createEvent({
+                author: 'talker',
+                content: {parts: [{text: 'thinking'}]},
+              });
+              ctx.output = 'answer';
+            },
+            {name: 'talker'},
+          ),
+        ],
+      ],
+    });
+
+    const {events, ctx} = await runToCompletion(wf);
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['thinking']);
+    expect(ctx.output).toBe('answer');
+  });
+
+  it('accepts an empty graph and produces nothing', async () => {
+    const {events, ctx} = await runToCompletion(
+      new Workflow({name: 'empty', edges: []}),
+    );
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('auto-wraps a bare function used in the edge list', async () => {
+    function greet() {
+      return 'hello';
+    }
+    const wf = new Workflow({name: 'autoWrap', edges: [[START, greet]]});
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(wf.graph.nodes.map((n) => n.name)).toEqual(['__START__', 'greet']);
+    expect(ctx.output).toBe('hello');
+  });
+
+  it('gives every START successor the workflow input', async () => {
+    const seen: unknown[] = [];
+    const record = (name: string) =>
+      node(
+        (_ctx, nodeInput) => {
+          seen.push([name, nodeInput]);
+        },
+        {name},
+      );
+    const wf = new Workflow({
+      name: 'fanOut',
+      edges: [[START, [record('a'), record('b')]]],
+    });
+
+    await runToCompletion(wf, 'shared');
+
+    expect(seen).toEqual([
+      ['a', 'shared'],
+      ['b', 'shared'],
+    ]);
+  });
+
+  it('fans in through a JoinNode once every predecessor completed', async () => {
+    const log: string[] = [];
+    const join = new JoinNode({name: 'join'});
+    const summarize = node(
+      (_ctx, nodeInput) => {
+        log.push('summarize');
+        return nodeInput;
+      },
+      {name: 'summarize'},
+    );
+    const a = recording(log, 'a', 'outA');
+    const b = recording(log, 'b', 'outB');
+    const wf = new Workflow({
+      name: 'fanIn',
+      edges: [
+        [START, [a, b]],
+        [a, join],
+        [b, join],
+        [join, summarize],
+      ],
+    });
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(log).toEqual(['a', 'b', 'summarize']);
+    expect(ctx.output).toEqual({a: 'outA', b: 'outB'});
+  });
+
+  it('delivers undefined for predecessors that produced no output', async () => {
+    const a = node(() => undefined, {name: 'a'});
+    const b = node(() => undefined, {name: 'b'});
+    const join = new JoinNode({name: 'join'});
+    const wf = new Workflow({
+      name: 'fanInEmpty',
+      edges: [
+        [START, [a, b]],
+        [a, join],
+        [b, join],
+      ],
+    });
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(ctx.output).toEqual({a: undefined, b: undefined});
+  });
+
+  it('does not run a fan-in node until every predecessor completed', async () => {
+    const log: string[] = [];
+    const gate = node(() => 'go', {name: 'gate'});
+    const slowBranch = node(() => 'slow', {name: 'slowBranch'});
+    const join = new JoinNode({name: 'join'});
+    const after = node(
+      () => {
+        log.push('after');
+        return 'end';
+      },
+      {name: 'after'},
+    );
+    const wf = new Workflow({
+      name: 'barrier',
+      edges: [
+        [START, gate, slowBranch],
+        [gate, join],
+        [slowBranch, join],
+        [join, after],
+      ],
+    });
+
+    await runToCompletion(wf);
+
+    expect(log).toEqual(['after']);
+  });
+
+  it('loops through a routed cycle until the break route is taken', async () => {
+    let count = 0;
+    const step = node(
+      (ctx: NodeContext) => {
+        count++;
+        ctx.route = count < 3 ? 'again' : 'done';
+        return count;
+      },
+      {name: 'step'},
+    );
+    const finish = node((_ctx, nodeInput) => `ran ${String(nodeInput)} times`, {
+      name: 'finish',
+    });
+    const wf = new Workflow({
+      name: 'loop',
+      edges: [
+        [START, step],
+        {fromNode: step, toNode: step, route: 'again'},
+        {fromNode: step, toNode: finish, route: 'done'},
+      ],
+    });
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(count).toBe(3);
+    expect(ctx.output).toBe('ran 3 times');
+  });
+
+  it('gives each run of a node a sequential run id', async () => {
+    const paths: string[] = [];
+    let count = 0;
+    const step = node(
+      (ctx: NodeContext) => {
+        paths.push(ctx.nodePath);
+        count++;
+        ctx.route = count < 3 ? 'again' : 'done';
+      },
+      {name: 'step'},
+    );
+    const wf = new Workflow({
+      name: 'runIds',
+      edges: [
+        [START, step],
+        {fromNode: step, toNode: step, route: 'again'},
+        {
+          fromNode: step,
+          toNode: node(() => 'end', {name: 'end'}),
+          route: 'done',
+        },
+      ],
+    });
+
+    await runToCompletion(wf);
+
+    expect(paths).toEqual([
+      'runIds@1/step@1',
+      'runIds@1/step@2',
+      'runIds@1/step@3',
+    ]);
+  });
+
+  it('nests node paths through a nested workflow', async () => {
+    let innerPath = '';
+    const inner = new Workflow({
+      name: 'inner',
+      edges: [
+        [
+          START,
+          node(
+            (ctx: NodeContext) => {
+              innerPath = ctx.nodePath;
+              return 'inner output';
+            },
+            {name: 'leaf'},
+          ),
+        ],
+      ],
+    });
+    const outer = new Workflow({name: 'outer', edges: [[START, inner]]});
+
+    const {ctx} = await runToCompletion(outer);
+
+    expect(innerPath).toBe('outer@1/inner@1/leaf@1');
+    expect(ctx.output).toBe('inner output');
+  });
+
+  it('keeps a waitForOutput node pending until it produces something', async () => {
+    const log: string[] = [];
+    let triggers = 0;
+    const gate = node(
+      () => {
+        triggers++;
+        return triggers < 2 ? undefined : 'open';
+      },
+      {name: 'gate', waitForOutput: true},
+    );
+    const a = recording(log, 'a', 'outA');
+    const b = recording(log, 'b', 'outB');
+    const wf = new Workflow({
+      name: 'gated',
+      edges: [
+        [START, [a, b]],
+        [a, gate],
+        [b, gate],
+        [gate, recording(log, 'downstream', 'end')],
+      ],
+    });
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(triggers).toBe(2);
+    expect(log).toEqual(['a', 'b', 'downstream']);
+    expect(ctx.output).toBe('end');
+  });
+
+  it('suppresses downstream nodes while a waitForOutput node stays pending', async () => {
+    const log: string[] = [];
+    const gate = node(() => undefined, {name: 'gate', waitForOutput: true});
+    const wf = new Workflow({
+      name: 'stuck',
+      edges: [
+        [START, gate],
+        [gate, recording(log, 'downstream', 'end')],
+      ],
+    });
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(log).toEqual([]);
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('rejects two terminal nodes producing output', async () => {
+    const wf = new Workflow({
+      name: 'twoOutputs',
+      edges: [
+        [
+          START,
+          [node(() => 'one', {name: 'a'}), node(() => 'two', {name: 'b'})],
+        ],
+      ],
+    });
+
+    await expect(runToCompletion(wf)).rejects.toThrow(
+      'Workflow twoOutputs: multiple terminal nodes produced output (2).',
+    );
+  });
+
+  it('leaves the output unset when no terminal node produced one', async () => {
+    const wf = new Workflow({
+      name: 'silent',
+      edges: [[START, node(() => undefined, {name: 'quiet'})]],
+    });
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('stops with the first error and does not schedule later nodes', async () => {
+    const log: string[] = [];
+    const wf = new Workflow({
+      name: 'failing',
+      edges: [
+        [
+          START,
+          node(
+            () => {
+              throw new Error('Fail');
+            },
+            {name: 'boom'},
+          ),
+          recording(log, 'never', 'x'),
+        ],
+      ],
+    });
+
+    await expect(runToCompletion(wf)).rejects.toThrow('Fail');
+    expect(log).toEqual([]);
+  });
+
+  it('is unbounded by default', async () => {
+    const wf = new Workflow({
+      name: 'unbounded',
+      edges: [[START, node(() => 'x', {name: 'only'})]],
+    });
+
+    expect(wf.maxSteps).toBe(Number.MAX_SAFE_INTEGER);
+    await expect(runToCompletion(wf)).resolves.toBeDefined();
+  });
+
+  it('gives up once maxSteps node runs have happened', async () => {
+    const step = node(
+      (ctx: NodeContext) => {
+        ctx.route = 'again';
+      },
+      {name: 'step'},
+    );
+    const wf = new Workflow({
+      name: 'runaway',
+      maxSteps: 3,
+      edges: [[START, step], {fromNode: step, toNode: step, route: 'again'}],
+    });
+
+    await expect(runToCompletion(wf)).rejects.toThrow(
+      'Workflow runaway: exceeded maxSteps (3).',
+    );
+  });
+
+  it('stops scheduling when the invocation is aborted', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    const first = node(
+      () => {
+        log.push('first');
+        controller.abort();
+        return 'stop here';
+      },
+      {name: 'first'},
+    );
+    const wf = new Workflow({
+      name: 'aborted',
+      edges: [[START, first, recording(log, 'second', 'end')]],
+    });
+
+    const {ctx} = await runToCompletion(
+      wf,
+      undefined,
+      makeInvocationContext({abortSignal: controller.signal}),
+    );
+
+    expect(log).toEqual(['first']);
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('shares session state between nodes', async () => {
+    const writer = node(
+      (ctx: NodeContext) => {
+        ctx.state.set('token', 'abc');
+      },
+      {name: 'writer'},
+    );
+    const reader = node((ctx: NodeContext) => ctx.state.get<string>('token'), {
+      name: 'reader',
+    });
+    const wf = new Workflow({
+      name: 'shareState',
+      edges: [[START, writer, reader]],
+    });
+
+    const {ctx} = await runToCompletion(wf);
+
+    expect(ctx.output).toBe('abc');
+  });
+});

--- a/core/test/workflow/workflow_test_utils.ts
+++ b/core/test/workflow/workflow_test_utils.ts
@@ -12,6 +12,7 @@ import {
   InvocationContext,
   NodeContext,
   PluginManager,
+  runNode,
 } from '@google/adk';
 
 /** A minimal agent, used only to satisfy `InvocationContext.agent`. */
@@ -58,4 +59,23 @@ export async function drainNode(
     events.push(event);
   }
   return {events, ctx};
+}
+
+/**
+ * Runs a node through the node runner, collecting its events and its finished
+ * context — the way a caller drives a workflow.
+ */
+export async function runToCompletion(
+  node: BaseNode,
+  nodeInput?: unknown,
+  invocationContext = makeInvocationContext(),
+): Promise<{events: Event[]; ctx: NodeContext}> {
+  const events: Event[] = [];
+  const run = runNode(node, {invocationContext, nodeInput});
+  let step = await run.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await run.next();
+  }
+  return {events, ctx: step.value};
 }

--- a/core/test/workflow/workflow_test_utils.ts
+++ b/core/test/workflow/workflow_test_utils.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseNode,
+  createSession,
+  Event,
+  InvocationContext,
+  NodeContext,
+  PluginManager,
+} from '@google/adk';
+
+/** A minimal agent, used only to satisfy `InvocationContext.agent`. */
+export class StubAgent extends BaseAgent {
+  protected async *runAsyncImpl(): AsyncGenerator<Event, void, void> {}
+
+  protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {}
+}
+
+/** Builds an invocation context backed by an in-memory session. */
+export function makeInvocationContext(
+  overrides: Partial<ConstructorParameters<typeof InvocationContext>[0]> = {},
+): InvocationContext {
+  return new InvocationContext({
+    invocationId: 'test-invocation',
+    agent: new StubAgent({name: 'host'}),
+    session: createSession({id: 'test-session', appName: 'test-app'}),
+    pluginManager: new PluginManager(),
+    ...overrides,
+  });
+}
+
+/** Builds a node context for a single node run. */
+export function makeNodeContext(
+  node: BaseNode,
+  invocationContext = makeInvocationContext(),
+): NodeContext {
+  return new NodeContext({invocationContext, node, runId: '1'});
+}
+
+/**
+ * Runs a node directly through {@link BaseNode.run}, collecting its events.
+ *
+ * This deliberately bypasses the node runner so node semantics can be tested
+ * without retry or timeout handling in the way.
+ */
+export async function drainNode(
+  node: BaseNode,
+  nodeInput?: unknown,
+  ctx: NodeContext = makeNodeContext(node),
+): Promise<{events: Event[]; ctx: NodeContext}> {
+  const events: Event[] = [];
+  for await (const event of node.run(ctx, nodeInput)) {
+    events.push(event);
+  }
+  return {events, ctx};
+}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: google/adk-js#366

**2. Or, if no issue exists, describe the change:**

**Problem:** Parts 1 and 2 describe a workflow — nodes and the graph that connects them — but nothing runs it. There is still no executor, no per-node retry, and no per-node timeout.

**Solution:** Add the two pieces that make a graph executable, ported from `adk-python`'s `workflow/_node_runner.py`, `_workflow.py` and `utils/_retry_utils.py`.

**`runNode(node, options)`** — the per-node executor and the public entry point for driving a workflow. It is an async generator of `Event` whose *return* value is the finished `NodeContext`, so a caller reads `ctx.output` / `ctx.route` from it and a nesting workflow simply uses `yield*`. Per attempt it:

- builds a per-attempt `AbortController`, relayed from the caller's signal (including the already-aborted case) and detached again in a `finally`, so a long invocation running many nodes cannot accumulate listeners on the caller's signal;
- races the node against its `timeoutMs`, if set, clearing the timer on every exit path;
- on failure emits one error event, then consults `shouldRetryNode` and sleeps `getRetryDelayMs` before the next attempt, or rethrows;
- on success flushes any state or artifact changes the node made as one event, so a session service can persist them.

**`Workflow`** — a `BaseNode` that runs a graph to completion. It builds and validates the graph eagerly, so a malformed one throws at construction. The loop is a single `while`, not a scheduler: seed `START`'s successors, then repeatedly take the first node with a queued input, run it, record its output, and queue whatever its outgoing edges open — honouring `waitForOutput` barriers and `requiresAllPredecessors` fan-in. At the end, the single terminal node's output becomes `ctx.output`; two terminal outputs is an error. Because a `Workflow` is itself a node, nesting comes for free, with the nested workflow getting its own retry and timeout.

```ts
const wf = new Workflow({
  name: 'triage',
  edges: [
    [START, classify],
    {fromNode: classify, toNode: handleHigh, route: 'high'},
    {fromNode: classify, toNode: handleLow, route: DEFAULT_ROUTE},
  ],
});

const gen = runNode(wf, {invocationContext, nodeInput: 'start'});
let step = await gen.next();
while (!step.done) {
  handleEvent(step.value);
  step = await gen.next();
}
console.log(step.value.output); // 'escalated' | 'auto-resolved'
```

**Stacked series — this is Part 3/3.** This is Part 3/3 of a three-PR stack. A cross-fork PR must target `main`, so this branch is rebased onto `main` and its diff also contains Parts 1 and 2 (branches `feat/workflow-graph-core-part1` and `feat/workflow-graph-core-part2`, each filed as its own PR); review the commits after Part 2's.

**Deliberate deviations from adk-python**

- **Retry delays are milliseconds.** `adk-python`'s `RetryConfig` uses fractional seconds (`initial_delay=1.0`); this port uses `Ms`-suffixed names to match JS timer semantics and existing `adk-js` naming. The effective defaults are unchanged: 5 attempts, 1000 ms initial, 60000 ms max, factor 2, jitter 1. The field is `errors` rather than `exceptions`, since TypeScript has no exceptions distinct from errors.
- **Retry matching also checks the constructor name.** Python matches `type(exception).__name__`. In JS, `class MyError extends Error {}` without an explicit `this.name` reports `name === 'Error'`, so a config listing `MyError` would never match. Both `err.name` and `err.constructor.name` are checked; there is a test for the class that never sets `this.name`.
- **The timeout is not cancellation, and the TSDoc says so.** JavaScript cannot preempt a running task. On expiry the run rejects the caller and aborts `ctx.abortSignal`; a node that ignores that signal keeps running until its next `await`. The abandoned attempt's promise is observed so a late rejection cannot crash the process, which is covered by a test.
- **`AbortSignal.any` is deliberately not used.** It would leave a dependent signal attached to the caller's signal for every node run, whereas the hand-rolled relay detaches in a `finally`. The repo also declares no minimum Node version anywhere (`engines`, `.nvmrc`, or a CI `node-version` pin), so `AbortSignal.any` (Node 20+) is not something this change can assume.
- **Execution is sequential.** `maxConcurrency` and `asyncio`-style task scheduling are out of scope, so there are no sibling tasks to cancel on failure: the first error stops scheduling and propagates unchanged (a `NodeTimeoutError` stays a `NodeTimeoutError`).
- **`maxSteps` bounds the loop.** A graph may legitimately contain a routed cycle, and `adk-python` has no guard. This follows the local `LoopAgent.maxIterations` convention instead: unbounded by default (`Number.MAX_SAFE_INTEGER`), throwing once exceeded. Both paths are tested.
- **`NodeStatus` and `NodeState` are not ported.** They are private in `adk-python` too (not in its `__all__`), and a sequential engine only ever distinguishes "completed" from "not completed" — a five-member status enum would be write-only state. They return with concurrency (`RUNNING`) and human-in-the-loop (`WAITING` + interrupts).
- **Accumulators are bounded by design.** `pending`, `completed`, `outputs` and `runCounts` are all keyed by node name, so a long-running routed cycle cannot grow them. A comment on `RunState` says so, so a future change does not silently make them unbounded.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npx vitest run --project unit:core core/test/workflow` — 12 files, 131 tests, all passing (65 new here, on top of the 66 from Parts 1 and 2).

New suites: `node_runner_test.ts` (17 cases: retry behaviour, attempt counting, error events, delta flushing including a real artifact save through `InMemoryArtifactService`, and abort-signal relay and teardown), `node_timeout_test.ts` (9 cases: within/exceeded/no limit, streaming under a timeout, retry after a timeout, signal abort, timer cleanup, a late-rejecting abandoned attempt, and a nested workflow's own timeout), `retry_config_test.ts` (17 cases for `shouldRetryNode` and `getRetryDelayMs` including the jitter maths under `vi.spyOn(Math, 'random')`), `workflow_test.ts` (22 cases), and `workflow_integration_test.ts`.

**Coverage.** Measured with
`npx vitest run --project unit:core --coverage --coverage.include='core/src/workflow/**' core/test/workflow`:
all 13 files of `core/src/workflow/` are at **100% statements, 100% branches, 100% functions, 100% lines**. No coverage suppressions were used, and no resource handling was weakened to reach it — every `finally` that clears a timer or detaches a listener is still there and is what the mutation table below pins.

**Proof the new tests can fail.** Each was run against mutated source and confirmed to fail:

| Mutation | Failing test | Message |
| --- | --- | --- |
| `retry_config.ts`: `attemptCount >= maxAttempts` → `>` | `shouldRetryNode > stops once the attempt count reaches maxAttempts` (and `> defaults maxAttempts to 5`) | `expected true to be false` |
| `retry_config.ts`: match only `err.name`, not `err.constructor.name` | `shouldRetryNode > matches a class that never sets this.name, by constructor name` | `expected false to be true` |
| `workflow.ts`: join barrier `every` → `some` predecessor completed | `Workflow > does not run a fan-in node until every predecessor completed`, `Workflow > fans in through a JoinNode once every predecessor completed`, and the integration test | `expected [ 'after', 'after' ] to deeply equal [ 'after' ]` |
| `node_runner.ts`: remove `clearTimeout` from the timeout `finally` | `node timeouts > leaves no pending timer behind after a completed run` | `expected 1 to be +0` |
| `node_runner.ts`: remove `removeEventListener` from the `finally` | `runNode > leaves no abort listener behind on the parent signal` | `expected true to be false` |
| `node_runner.ts`: ignore an already-aborted parent signal | `runNode > aborts the node signal when the parent invocation is already aborted` | `expected false to be true` |
| `node_runner.ts`: skip the state/artifact delta flush | `runNode > emits one event carrying the state the node wrote` | `expected [] to have a length of 1 but got +0` |

No suppressions were added anywhere: no `any`, `as any`, `as never`, `@ts-expect-error`, `@ts-ignore`, `eslint-disable` or coverage ignores, in `src/` or in the tests.

**Manual End-to-End (E2E) Tests:**

No network, credentials or model access are needed.

1. `npm install`
2. `npm run build`
3. `npx vitest run --project unit:core core/test/workflow`
4. `npm run lint && npm run format:check`
5. `npm run docs:check` — confirms every new public type is exported and documented.

`core/test/workflow/workflow_integration_test.ts` is the automated end-to-end check, and it uses no mocks or stubs: it drives one graph that combines every in-scope feature at once — `START` fans out to two nodes, a `JoinNode` gathers them, a routing node picks a branch through `DEFAULT_ROUTE`, that branch fails twice with a `RangeError` and succeeds on its third attempt under `retryConfig`, and a terminal node produces the output. It asserts the exact ordered list of executed nodes, the aggregated join input, the attempt count, that state written by an early node is visible to a later one through `ctx.state`, and that the terminal output reaches the caller's `NodeContext.output`.

For a hands-on check, the routing example from the module docs was run against a real session and printed the expected results:

```
score=1 -> auto-resolved
score=9 -> escalated
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
