### PR TITLE
Fix: gate the set_model_response workaround on canUseOutputSchemaWithTools (adk-python parity)

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -788,12 +788,10 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
     // TODO - b/425992518: check if tool preprocessors can be simplified.
     // Run pre-processors for tools.
     const allTools = [...this.tools];
-    // Skipped when the model can take the output schema natively alongside
-    // tools; the basic processor then sets `config.responseSchema` instead.
     if (
       this.outputSchema &&
       allTools.length > 0 &&
-      !canUseOutputSchemaWithTools(this.canonicalModel)
+      !canUseOutputSchemaWithTools(this.canonicalModel.model)
     ) {
       const setModelResponseTool = new FunctionTool({
         name: 'set_model_response',

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -34,6 +34,7 @@ import {BaseTool, isBaseTool} from '../tools/base_tool.js';
 import {BaseToolset} from '../tools/base_toolset.js';
 
 import {logger} from '../utils/logger.js';
+import {canUseOutputSchemaWithTools} from '../utils/output_schema_utils.js';
 import {Context} from './context.js';
 
 import {
@@ -787,7 +788,13 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
     // TODO - b/425992518: check if tool preprocessors can be simplified.
     // Run pre-processors for tools.
     const allTools = [...this.tools];
-    if (this.outputSchema && allTools.length > 0) {
+    // Skipped when the model can take the output schema natively alongside
+    // tools; the basic processor then sets `config.responseSchema` instead.
+    if (
+      this.outputSchema &&
+      allTools.length > 0 &&
+      !canUseOutputSchemaWithTools(this.canonicalModel)
+    ) {
       const setModelResponseTool = new FunctionTool({
         name: 'set_model_response',
         description:

--- a/core/src/agents/processors/basic_llm_request_processor.ts
+++ b/core/src/agents/processors/basic_llm_request_processor.ts
@@ -6,6 +6,7 @@
 
 import {Event} from '../../events/event.js';
 import {LlmRequest, setOutputSchema} from '../../models/llm_request.js';
+import {canUseOutputSchemaWithTools} from '../../utils/output_schema_utils.js';
 import {InvocationContext} from '../invocation_context.js';
 import {isLlmAgent} from '../llm_agent.js';
 import {BaseLlmRequestProcessor} from './base_llm_processor.js';
@@ -37,7 +38,15 @@ export class BasicLlmRequestProcessor extends BaseLlmRequestProcessor {
     llmRequest.model = agent.canonicalModel.model;
 
     llmRequest.config = {...(agent.generateContentConfig ?? {})};
-    if (agent.outputSchema && (!agent.tools || agent.tools.length === 0)) {
+    // Models that cannot take an output schema alongside tools get the
+    // prompt-based `set_model_response` workaround instead, injected by
+    // `LlmAgent.runOneStepAsync` and the instructions processor.
+    if (
+      agent.outputSchema &&
+      (!agent.tools ||
+        agent.tools.length === 0 ||
+        canUseOutputSchemaWithTools(agent.canonicalModel))
+    ) {
       setOutputSchema(llmRequest, agent.outputSchema);
     }
 

--- a/core/src/agents/processors/basic_llm_request_processor.ts
+++ b/core/src/agents/processors/basic_llm_request_processor.ts
@@ -43,9 +43,8 @@ export class BasicLlmRequestProcessor extends BaseLlmRequestProcessor {
     // `LlmAgent.runOneStepAsync` and the instructions processor.
     if (
       agent.outputSchema &&
-      (!agent.tools ||
-        agent.tools.length === 0 ||
-        canUseOutputSchemaWithTools(agent.canonicalModel))
+      (!agent.tools?.length ||
+        canUseOutputSchemaWithTools(agent.canonicalModel.model))
     ) {
       setOutputSchema(llmRequest, agent.outputSchema);
     }

--- a/core/src/agents/processors/instructions_llm_request_processor.ts
+++ b/core/src/agents/processors/instructions_llm_request_processor.ts
@@ -6,6 +6,7 @@
 
 import {Event} from '../../events/event.js';
 import {appendInstructions, LlmRequest} from '../../models/llm_request.js';
+import {canUseOutputSchemaWithTools} from '../../utils/output_schema_utils.js';
 import {injectSessionState} from '../instructions.js';
 import {InvocationContext} from '../invocation_context.js';
 import {isLlmAgent} from '../llm_agent.js';
@@ -62,7 +63,14 @@ export class InstructionsLlmRequestProcessor extends BaseLlmRequestProcessor {
       appendInstructions(llmRequest, [instructionWithState]);
     }
 
-    if (agent.outputSchema && agent.tools && agent.tools.length > 0) {
+    // Skipped when the model can take the output schema natively alongside
+    // tools; the basic processor then sets `config.responseSchema` instead.
+    if (
+      agent.outputSchema &&
+      agent.tools &&
+      agent.tools.length > 0 &&
+      !canUseOutputSchemaWithTools(agent.canonicalModel)
+    ) {
       appendInstructions(llmRequest, [
         'To output the final result, you must call the "set_model_response" function with the appropriate values. Do not output anything else.',
       ]);

--- a/core/src/agents/processors/instructions_llm_request_processor.ts
+++ b/core/src/agents/processors/instructions_llm_request_processor.ts
@@ -65,8 +65,7 @@ export class InstructionsLlmRequestProcessor extends BaseLlmRequestProcessor {
 
     if (
       agent.outputSchema &&
-      agent.tools &&
-      agent.tools.length > 0 &&
+      agent.tools?.length &&
       !canUseOutputSchemaWithTools(agent.canonicalModel.model)
     ) {
       appendInstructions(llmRequest, [

--- a/core/src/agents/processors/instructions_llm_request_processor.ts
+++ b/core/src/agents/processors/instructions_llm_request_processor.ts
@@ -63,13 +63,11 @@ export class InstructionsLlmRequestProcessor extends BaseLlmRequestProcessor {
       appendInstructions(llmRequest, [instructionWithState]);
     }
 
-    // Skipped when the model can take the output schema natively alongside
-    // tools; the basic processor then sets `config.responseSchema` instead.
     if (
       agent.outputSchema &&
       agent.tools &&
       agent.tools.length > 0 &&
-      !canUseOutputSchemaWithTools(agent.canonicalModel)
+      !canUseOutputSchemaWithTools(agent.canonicalModel.model)
     ) {
       appendInstructions(llmRequest, [
         'To output the final result, you must call the "set_model_response" function with the appropriate values. Do not output anything else.',

--- a/core/src/utils/output_schema_utils.ts
+++ b/core/src/utils/output_schema_utils.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseLlm, isBaseLlm} from '../models/base_llm.js';
+
+import {isGemini2OrAbove} from './model_name.js';
+import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
+
+/**
+ * Returns whether the model can natively accept an output schema at the same
+ * time as tools.
+ *
+ * When it can, the request should carry the schema directly
+ * (`config.responseSchema`); native structured output is strictly more
+ * reliable than the prompt-based `set_model_response` workaround, which asks
+ * the model to route its final answer through a synthetic function call.
+ * When it cannot, callers must fall back to that workaround.
+ *
+ * Note that Gemini 2.0+ is recognised by numeric version alone, so Gemini
+ * Early Access Program model names — which encode no numeric version — return
+ * false here even on Vertex AI. That is narrower than the Python
+ * implementation and is deliberate: recognising those names belongs in the
+ * shared `isGemini2OrAbove` predicate, which several other call sites share.
+ *
+ * @param model The model name, or a resolved model instance to read it from.
+ * @return True if the model supports an output schema alongside tools.
+ */
+export function canUseOutputSchemaWithTools(model: string | BaseLlm): boolean {
+  const modelString = isBaseLlm(model) ? model.model : model;
+
+  return (
+    getGoogleLlmVariant() === GoogleLLMVariant.VERTEX_AI &&
+    isGemini2OrAbove(modelString)
+  );
+}

--- a/core/src/utils/output_schema_utils.ts
+++ b/core/src/utils/output_schema_utils.ts
@@ -9,13 +9,8 @@ import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
 
 /**
  * Returns whether the model can natively accept an output schema at the same
- * time as tools.
- *
- * When it can, the request should carry the schema directly
- * (`config.responseSchema`); native structured output is strictly more
- * reliable than the prompt-based `set_model_response` workaround, which asks
- * the model to route its final answer through a synthetic function call.
- * When it cannot, callers must fall back to that workaround.
+ * time as tools, which is strictly more reliable than the prompt-based
+ * `set_model_response` workaround.
  *
  * Early Access Program model names encode no numeric version, so
  * `isGemini2OrAbove` rejects them even on Vertex AI. The Python

--- a/core/src/utils/output_schema_utils.ts
+++ b/core/src/utils/output_schema_utils.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {BaseLlm, isBaseLlm} from '../models/base_llm.js';
-
 import {isGemini2OrAbove} from './model_name.js';
 import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
 
@@ -19,18 +17,14 @@ import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
  * the model to route its final answer through a synthetic function call.
  * When it cannot, callers must fall back to that workaround.
  *
- * Note that Gemini 2.0+ is recognised by numeric version alone, so Gemini
- * Early Access Program model names — which encode no numeric version — return
- * false here even on Vertex AI. That is narrower than the Python
- * implementation and is deliberate: recognising those names belongs in the
- * shared `isGemini2OrAbove` predicate, which several other call sites share.
+ * Early Access Program model names encode no numeric version, so
+ * `isGemini2OrAbove` rejects them even on Vertex AI. The Python
+ * implementation accepts them; that gap lives in the shared predicate.
  *
- * @param model The model name, or a resolved model instance to read it from.
+ * @param modelString A simple or path-based model name.
  * @return True if the model supports an output schema alongside tools.
  */
-export function canUseOutputSchemaWithTools(model: string | BaseLlm): boolean {
-  const modelString = isBaseLlm(model) ? model.model : model;
-
+export function canUseOutputSchemaWithTools(modelString: string): boolean {
   return (
     getGoogleLlmVariant() === GoogleLLMVariant.VERTEX_AI &&
     isGemini2OrAbove(modelString)

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -16,7 +16,9 @@ import {
   Context,
   ContextCompactorRequestProcessor,
   createEvent,
+  createSession,
   Event,
+  FunctionTool,
   InvocationContext,
   LlmAgent,
   LlmRequest,
@@ -27,7 +29,7 @@ import {
   ToolProcessLlmRequest,
 } from '@google/adk';
 import {Content, Schema, Type} from '@google/genai';
-import {beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
 
@@ -838,4 +840,141 @@ describe('LlmAgent Default Request Processors', () => {
     );
     expect(authIndex).toBeLessThan(contentIndex);
   });
+});
+
+describe('LlmAgent outputSchema with tools', () => {
+  const VERTEX_ENV_VAR = 'GOOGLE_GENAI_USE_VERTEXAI';
+
+  const OUTPUT_SCHEMA: Schema = {
+    type: Type.OBJECT,
+    properties: {answer: {type: Type.STRING}},
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  /**
+   * Records the single request the agent builds so that all three gated sites
+   * can be asserted against one run of the default processor chain.
+   */
+  class CapturingLlm extends BaseLlm {
+    capturedRequest?: LlmRequest;
+
+    async *generateContentAsync(
+      request: LlmRequest,
+    ): AsyncGenerator<LlmResponse, void, void> {
+      this.capturedRequest = request;
+      yield {content: {role: 'model', parts: [{text: '{"answer": "42"}'}]}};
+    }
+
+    async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+      return new MockLlmConnection();
+    }
+  }
+
+  async function captureRequest(options: {
+    model: string;
+    withTools: boolean;
+  }): Promise<LlmRequest> {
+    const llm = new CapturingLlm({model: options.model});
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: llm,
+      instruction: 'Base instruction',
+      outputSchema: OUTPUT_SCHEMA,
+      tools: options.withTools
+        ? [
+            new FunctionTool({
+              name: 'some_tool',
+              description: 'A test tool',
+              execute: () => 'result',
+            }),
+          ]
+        : [],
+    });
+    const invocationContext = new InvocationContext({
+      invocationId: 'inv_123',
+      session: createSession({
+        id: 'sess_123',
+        events: [],
+        appName: 'test-app',
+        userId: 'test-user',
+      }),
+      agent,
+      pluginManager: new PluginManager(),
+    });
+
+    for await (const _ of agent.runAsync(invocationContext)) {
+      // Drain the run so that the request is fully built.
+    }
+
+    const request = llm.capturedRequest;
+    if (!request) {
+      expect.fail('the agent never called the model');
+    }
+    return request;
+  }
+
+  it('uses the native response schema on Vertex AI with a Gemini 2.0+ model', async () => {
+    vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+    const request = await captureRequest({
+      model: 'gemini-2.5-flash',
+      withTools: true,
+    });
+
+    expect(request.config?.responseSchema).toBeDefined();
+    expect(request.config?.responseMimeType).toBe('application/json');
+    expect(request.toolsDict).not.toHaveProperty('set_model_response');
+    expect(request.toolsDict).toHaveProperty('some_tool');
+    expect(request.config?.systemInstruction).not.toContain(
+      'set_model_response',
+    );
+  });
+
+  it('uses the set_model_response workaround outside the Vertex AI variant', async () => {
+    vi.stubEnv(VERTEX_ENV_VAR, undefined);
+
+    const request = await captureRequest({
+      model: 'gemini-2.5-flash',
+      withTools: true,
+    });
+
+    expect(request.config?.responseSchema).toBeUndefined();
+    expect(request.toolsDict).toHaveProperty('set_model_response');
+    expect(request.toolsDict).toHaveProperty('some_tool');
+    expect(request.config?.systemInstruction).toContain('set_model_response');
+  });
+
+  it('uses the set_model_response workaround on Vertex AI with a pre-2.0 model', async () => {
+    vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+    const request = await captureRequest({
+      model: 'gemini-1.5-pro',
+      withTools: true,
+    });
+
+    expect(request.config?.responseSchema).toBeUndefined();
+    expect(request.toolsDict).toHaveProperty('set_model_response');
+    expect(request.config?.systemInstruction).toContain('set_model_response');
+  });
+
+  it.each(['true', undefined])(
+    'uses the native response schema without tools when %s',
+    async (vertexEnv) => {
+      vi.stubEnv(VERTEX_ENV_VAR, vertexEnv);
+
+      const request = await captureRequest({
+        model: 'gemini-2.5-flash',
+        withTools: false,
+      });
+
+      expect(request.config?.responseSchema).toBeDefined();
+      expect(request.toolsDict).not.toHaveProperty('set_model_response');
+      expect(request.config?.systemInstruction).not.toContain(
+        'set_model_response',
+      );
+    },
+  );
 });

--- a/core/test/agents/processors/basic_llm_request_processor_test.ts
+++ b/core/test/agents/processors/basic_llm_request_processor_test.ts
@@ -18,9 +18,22 @@ import {
   PluginManager,
   RunConfig,
 } from '@google/adk';
-import {Content, Blob as GenaiBlob, Modality} from '@google/genai';
-import {beforeAll, describe, expect, it} from 'vitest';
+import {
+  Content,
+  Blob as GenaiBlob,
+  Modality,
+  Schema,
+  Type,
+} from '@google/genai';
+import {afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
 import {BASIC_LLM_REQUEST_PROCESSOR} from '../../../src/agents/processors/basic_llm_request_processor.js';
+
+const VERTEX_ENV_VAR = 'GOOGLE_GENAI_USE_VERTEXAI';
+
+const OUTPUT_SCHEMA: Schema = {
+  type: Type.OBJECT,
+  properties: {answer: {type: Type.STRING}},
+};
 
 class TestLlmConnection implements BaseLlmConnection {
   async sendHistory(_history: Content[]): Promise<void> {}
@@ -195,6 +208,63 @@ describe('BasicLlmRequestProcessor', () => {
 
     expect(llmRequest.config?.responseSchema).toBeUndefined();
     expect(llmRequest.config?.responseMimeType).toBeUndefined();
+  });
+
+  describe('outputSchema with tools on a model that supports both', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    async function runWithOutputSchemaAndTools(
+      model: string,
+    ): Promise<LlmRequest> {
+      const agent = new LlmAgent({
+        name: 'test_agent',
+        // A model instance is used so that `canonicalModel` resolves without
+        // credentials.
+        model: new TestLlmModel({model}),
+        outputSchema: OUTPUT_SCHEMA,
+        tools: [
+          new FunctionTool({
+            name: 'some_tool',
+            description: 'A test tool',
+            execute: () => 'result',
+          }),
+        ],
+      });
+      const llmRequest = makeLlmRequest();
+
+      await runProcessor(createMockInvocationContext(agent), llmRequest);
+
+      return llmRequest;
+    }
+
+    it('should set outputSchema on Vertex AI with a Gemini 2.0+ model', async () => {
+      vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+      const llmRequest = await runWithOutputSchemaAndTools('gemini-2.5-flash');
+
+      expect(llmRequest.config?.responseSchema).toBeDefined();
+      expect(llmRequest.config?.responseMimeType).toBe('application/json');
+    });
+
+    it('should not set outputSchema on Vertex AI with a pre-2.0 model', async () => {
+      vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+      const llmRequest = await runWithOutputSchemaAndTools('gemini-1.5-pro');
+
+      expect(llmRequest.config?.responseSchema).toBeUndefined();
+      expect(llmRequest.config?.responseMimeType).toBeUndefined();
+    });
+
+    it('should not set outputSchema outside the Vertex AI variant', async () => {
+      vi.stubEnv(VERTEX_ENV_VAR, undefined);
+
+      const llmRequest = await runWithOutputSchemaAndTools('gemini-2.5-flash');
+
+      expect(llmRequest.config?.responseSchema).toBeUndefined();
+      expect(llmRequest.config?.responseMimeType).toBeUndefined();
+    });
   });
 
   it('should populate liveConnectConfig from runConfig', async () => {

--- a/core/test/agents/processors/instructions_llm_request_processor_test.ts
+++ b/core/test/agents/processors/instructions_llm_request_processor_test.ts
@@ -6,16 +6,30 @@
 
 import {
   BaseAgent,
+  BaseLlm,
+  BaseLlmConnection,
   createSession,
   FunctionTool,
   InvocationContext,
   LlmAgent,
   LlmRequest,
+  LlmResponse,
   PluginManager,
   ReadonlyContext,
 } from '@google/adk';
-import {describe, expect, it} from 'vitest';
+import {Schema, Type} from '@google/genai';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import {INSTRUCTIONS_LLM_REQUEST_PROCESSOR} from '../../../src/agents/processors/instructions_llm_request_processor.js';
+
+const VERTEX_ENV_VAR = 'GOOGLE_GENAI_USE_VERTEXAI';
+
+const OUTPUT_SCHEMA: Schema = {
+  type: Type.OBJECT,
+  properties: {answer: {type: Type.STRING}},
+};
+
+const SET_MODEL_RESPONSE_INSTRUCTION =
+  'To output the final result, you must call the "set_model_response" function with the appropriate values. Do not output anything else.';
 
 class MockRootAgent extends BaseAgent {
   constructor(name: string, subAgents: BaseAgent[] = []) {
@@ -24,6 +38,20 @@ class MockRootAgent extends BaseAgent {
 
   protected async *runAsyncImpl(_context: InvocationContext) {}
   protected async *runLiveImpl(_context: InvocationContext) {}
+}
+
+/**
+ * A model instance is used rather than a model name so that `canonicalModel`
+ * resolves without credentials.
+ */
+class MockLlm extends BaseLlm {
+  async *generateContentAsync(
+    _llmRequest: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {}
+
+  async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    throw new Error('connect is not exercised by these tests');
+  }
 }
 
 function createMockInvocationContext(agent: BaseAgent): InvocationContext {
@@ -161,43 +189,100 @@ describe('InstructionsLlmRequestProcessor', () => {
     );
   });
 
-  it('should append set_model_response instruction when outputSchema and tools are present', async () => {
-    const outputSchema = {
-      type: 'object' as const,
-      properties: {
-        answer: {type: 'string' as const},
-      },
-    };
-    const agent = new LlmAgent({
-      name: 'test_agent',
-      model: 'gemini-2.5-flash',
-      instruction: 'Base instruction',
-      outputSchema,
-      tools: [
-        new FunctionTool({
-          name: 'some_tool',
-          description: 'A test tool',
-          execute: () => 'result',
-        }),
-      ],
+  describe('set_model_response instruction', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
     });
 
-    const invocationContext = createMockInvocationContext(agent);
-    const llmRequest: LlmRequest = {
-      contents: [],
-      toolsDict: {},
-      liveConnectConfig: {},
-    };
+    async function runWithOutputSchema(options: {
+      model: string;
+      withTools: boolean;
+    }): Promise<LlmRequest> {
+      const agent = new LlmAgent({
+        name: 'test_agent',
+        model: new MockLlm({model: options.model}),
+        instruction: 'Base instruction',
+        outputSchema: OUTPUT_SCHEMA,
+        tools: options.withTools
+          ? [
+              new FunctionTool({
+                name: 'some_tool',
+                description: 'A test tool',
+                execute: () => 'result',
+              }),
+            ]
+          : [],
+      });
 
-    for await (const _ of INSTRUCTIONS_LLM_REQUEST_PROCESSOR.runAsync(
-      invocationContext,
-      llmRequest,
-    )) {
-      // intentionally empty
+      const llmRequest: LlmRequest = {
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      for await (const _ of INSTRUCTIONS_LLM_REQUEST_PROCESSOR.runAsync(
+        createMockInvocationContext(agent),
+        llmRequest,
+      )) {
+        // intentionally empty
+      }
+
+      return llmRequest;
     }
 
-    expect(llmRequest.config?.systemInstruction).toContain(
-      'To output the final result, you must call the "set_model_response" function with the appropriate values. Do not output anything else.',
-    );
+    it('should append set_model_response instruction when outputSchema and tools are present', async () => {
+      vi.stubEnv(VERTEX_ENV_VAR, undefined);
+
+      const llmRequest = await runWithOutputSchema({
+        model: 'gemini-2.5-flash',
+        withTools: true,
+      });
+
+      expect(llmRequest.config?.systemInstruction).toContain(
+        SET_MODEL_RESPONSE_INSTRUCTION,
+      );
+    });
+
+    it('should not append set_model_response instruction on Vertex AI with a Gemini 2.0+ model', async () => {
+      vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+      const llmRequest = await runWithOutputSchema({
+        model: 'gemini-2.5-flash',
+        withTools: true,
+      });
+
+      expect(llmRequest.config?.systemInstruction).not.toContain(
+        'set_model_response',
+      );
+      expect(llmRequest.config?.systemInstruction).toContain(
+        'Base instruction',
+      );
+    });
+
+    it('should append set_model_response instruction on Vertex AI with a pre-2.0 model', async () => {
+      vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+      const llmRequest = await runWithOutputSchema({
+        model: 'gemini-1.5-pro',
+        withTools: true,
+      });
+
+      expect(llmRequest.config?.systemInstruction).toContain(
+        SET_MODEL_RESPONSE_INSTRUCTION,
+      );
+    });
+
+    it('should not append set_model_response instruction when there are no tools', async () => {
+      vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+      const llmRequest = await runWithOutputSchema({
+        model: 'gemini-2.5-flash',
+        withTools: false,
+      });
+
+      expect(llmRequest.config?.systemInstruction).not.toContain(
+        'set_model_response',
+      );
+    });
   });
 });

--- a/core/test/utils/output_schema_utils_test.ts
+++ b/core/test/utils/output_schema_utils_test.ts
@@ -6,25 +6,10 @@
 
 import {afterEach, describe, expect, it, vi} from 'vitest';
 // `canUseOutputSchemaWithTools` is internal and deliberately not exported from
-// the package barrel, so its `BaseLlm` parameter type comes from the same
-// source tree rather than from `@google/adk`.
-import {BaseLlm} from '../../src/models/base_llm.js';
-import {BaseLlmConnection} from '../../src/models/base_llm_connection.js';
-import {LlmRequest} from '../../src/models/llm_request.js';
-import {LlmResponse} from '../../src/models/llm_response.js';
+// the package barrel.
 import {canUseOutputSchemaWithTools} from '../../src/utils/output_schema_utils.js';
 
 const VERTEX_ENV_VAR = 'GOOGLE_GENAI_USE_VERTEXAI';
-
-class FakeLlm extends BaseLlm {
-  async *generateContentAsync(
-    _llmRequest: LlmRequest,
-  ): AsyncGenerator<LlmResponse, void, void> {}
-
-  async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
-    throw new Error('connect is not exercised by these tests');
-  }
-}
 
 interface TestCase {
   model: string;
@@ -115,20 +100,4 @@ describe('canUseOutputSchemaWithTools', () => {
       expect(canUseOutputSchemaWithTools(model)).toBe(expected);
     });
   }
-
-  it('reads the model name off a BaseLlm instance', () => {
-    vi.stubEnv(VERTEX_ENV_VAR, 'true');
-
-    expect(
-      canUseOutputSchemaWithTools(new FakeLlm({model: 'gemini-2.5-pro'})),
-    ).toBe(true);
-  });
-
-  it('returns false for a BaseLlm instance outside the Vertex AI variant', () => {
-    vi.stubEnv(VERTEX_ENV_VAR, undefined);
-
-    expect(
-      canUseOutputSchemaWithTools(new FakeLlm({model: 'gemini-2.5-pro'})),
-    ).toBe(false);
-  });
 });

--- a/core/test/utils/output_schema_utils_test.ts
+++ b/core/test/utils/output_schema_utils_test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+// `canUseOutputSchemaWithTools` is internal and deliberately not exported from
+// the package barrel, so its `BaseLlm` parameter type comes from the same
+// source tree rather than from `@google/adk`.
+import {BaseLlm} from '../../src/models/base_llm.js';
+import {BaseLlmConnection} from '../../src/models/base_llm_connection.js';
+import {LlmRequest} from '../../src/models/llm_request.js';
+import {LlmResponse} from '../../src/models/llm_response.js';
+import {canUseOutputSchemaWithTools} from '../../src/utils/output_schema_utils.js';
+
+const VERTEX_ENV_VAR = 'GOOGLE_GENAI_USE_VERTEXAI';
+
+class FakeLlm extends BaseLlm {
+  async *generateContentAsync(
+    _llmRequest: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {}
+
+  async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    throw new Error('connect is not exercised by these tests');
+  }
+}
+
+interface TestCase {
+  model: string;
+  vertexEnv: string | undefined;
+  expected: boolean;
+  why: string;
+}
+
+const TEST_CASES: TestCase[] = [
+  {
+    model: 'gemini-2.5-pro',
+    vertexEnv: 'true',
+    expected: true,
+    why: 'the variant is Vertex AI and the model is Gemini 2.0+',
+  },
+  {
+    model: 'gemini-2.5-pro',
+    vertexEnv: '1',
+    expected: true,
+    why: '"1" also selects the Vertex AI variant',
+  },
+  {
+    model: 'gemini-2.5-pro',
+    vertexEnv: 'false',
+    expected: false,
+    why: 'the variant is not Vertex AI',
+  },
+  {
+    model: 'gemini-2.5-pro',
+    vertexEnv: undefined,
+    expected: false,
+    why: 'the Gemini API variant is the default',
+  },
+  {
+    model: 'gemini-2.5-flash',
+    vertexEnv: 'true',
+    expected: true,
+    why: 'the variant is Vertex AI and the model is Gemini 2.0+',
+  },
+  {
+    model: 'gemini-1.5-pro',
+    vertexEnv: 'true',
+    expected: false,
+    why: 'Gemini 1.x is below the 2.0 floor',
+  },
+  {
+    model: 'gemini-1.5-pro',
+    vertexEnv: undefined,
+    expected: false,
+    why: 'neither condition holds',
+  },
+  {
+    model: 'claude-3-7-sonnet',
+    vertexEnv: 'true',
+    expected: false,
+    why: 'it is not a Gemini model',
+  },
+  {
+    model: '',
+    vertexEnv: 'true',
+    expected: false,
+    why: 'an empty model name is never recognised',
+  },
+  {
+    model: 'projects/p/locations/l/publishers/google/models/gemini-2.5-flash',
+    vertexEnv: 'true',
+    expected: true,
+    why: 'the version is read out of the path-based model name',
+  },
+  {
+    model: 'gemini-flash-early-exp',
+    vertexEnv: 'true',
+    expected: false,
+    why: 'Early Access Program names encode no numeric version, unlike the Python implementation',
+  },
+];
+
+describe('canUseOutputSchemaWithTools', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  for (const {model, vertexEnv, expected, why} of TEST_CASES) {
+    const envLabel = vertexEnv === undefined ? 'unset' : `"${vertexEnv}"`;
+    it(`returns ${expected} for "${model}" with ${VERTEX_ENV_VAR} ${envLabel}: ${why}`, () => {
+      vi.stubEnv(VERTEX_ENV_VAR, vertexEnv);
+
+      expect(canUseOutputSchemaWithTools(model)).toBe(expected);
+    });
+  }
+
+  it('reads the model name off a BaseLlm instance', () => {
+    vi.stubEnv(VERTEX_ENV_VAR, 'true');
+
+    expect(
+      canUseOutputSchemaWithTools(new FakeLlm({model: 'gemini-2.5-pro'})),
+    ).toBe(true);
+  });
+
+  it('returns false for a BaseLlm instance outside the Vertex AI variant', () => {
+    vi.stubEnv(VERTEX_ENV_VAR, undefined);
+
+    expect(
+      canUseOutputSchemaWithTools(new FakeLlm({model: 'gemini-2.5-pro'})),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A — no public issue is tracking this.

**2. Or, if no issue exists, describe the change:**

**Problem:** When an `LlmAgent` declares an `outputSchema` **and** has tools, `adk-js` unconditionally falls back to a prompt-based workaround: it appends a synthetic `set_model_response` `FunctionTool`, appends an instruction telling the model to call it, and suppresses the native `responseSchema`. `adk-python` applies that workaround only when the model _cannot_ natively accept a response schema alongside tools (`src/google/adk/utils/output_schema_utils.py`, `_output_schema_processor.py`, `basic.py`). On Vertex AI with Gemini 2.0+ the native path works, and the reference implementation says it is "strictly more reliable than the `SetModelResponseTool` prompt-based workaround." `adk-js` had no equivalent of `can_use_output_schema_with_tools`.

**Solution:** Add an internal `canUseOutputSchemaWithTools(modelString)` predicate and gate all three sites on it.

New file `core/src/utils/output_schema_utils.ts`:

```ts
export function canUseOutputSchemaWithTools(modelString: string): boolean {
  return (
    getGoogleLlmVariant() === GoogleLLMVariant.VERTEX_AI &&
    isGemini2OrAbove(modelString)
  );
}
```

Three gated call sites, each keeping its existing condition and adding one term:

| File                                                               | Change                                                                    |
| ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| `core/src/agents/llm_agent.ts` (`runOneStepAsync`)                 | stop appending the `set_model_response` tool when the model supports both |
| `core/src/agents/processors/instructions_llm_request_processor.ts` | stop appending the matching instruction                                   |
| `core/src/agents/processors/basic_llm_request_processor.ts`        | **do** set the native `responseSchema` when the model supports both       |

The third site is load-bearing. Gating only the tool and the instruction would leave an affected request with **neither** the native schema **nor** the workaround — strictly worse than today. The invariant is "exactly one mechanism is active whenever an agent has an `outputSchema`; never zero, never both", and the tests below assert both polarities of it.

**Behaviour change**: confined to one configuration — `GOOGLE_GENAI_USE_VERTEXAI` truthy **and** a Gemini 2.0+ model **and** an `outputSchema` **and** at least one tool. Those users now get schema-conforming content directly instead of a synthetic tool call. Every other combination is byte-identical to `main`:

| Variant      | Model              | Native schema | `set_model_response` tool | Instruction  |
| ------------ | ------------------ | ------------- | ------------------------- | ------------ |
| `VERTEX_AI`  | `gemini-2.5-flash` | **yes (new)** | **no (new)**              | **no (new)** |
| `VERTEX_AI`  | `gemini-1.5-pro`   | no            | yes                       | yes          |
| `GEMINI_API` | any                | no            | yes                       | yes          |
| any          | any, no tools      | yes           | no                        | no           |

Downstream consumers are unaffected: `maybeSaveOutputToState` parses the final response text against `outputSchema` either way, since the workaround's `postprocess` branch already rewrites the tool call into a text part.

**Two deliberate divergences from the Python reference**, both cross-boundary-invisible (internal signature and model-name matching), so local convention applies:

1. **No Gemini Early Access Program support.** Python composes the predicate from `is_gemini_eap_or_2_or_above()`, which also matches names like `gemini-flash-early-exp`. `adk-js` has only `isGemini2OrAbove()`, with no EAP case (`core/src/utils/model_name.ts`). This helper is built on `isGemini2OrAbove()` alone. The gap is **not** specific to output schema — it is a repo-wide divergence in the shared predicate, which `url_context_tool.ts`, `built_in_code_executor.ts` and `runner.ts` also depend on. Patching EAP handling into this one helper would fix output schema and leave those three inconsistent. Teaching `isGemini2OrAbove()` about EAP names changes behaviour at four call sites and warrants its own review; it is tracked separately. **This helper is not equivalent to the Python one**, and a test row pins the difference so it fails loudly if that separate work lands without revisiting this file.
2. **Signature is `(modelString: string)`, not Python's `Union[str, BaseLlm]`.** Python needs the union to `isinstance`-check `LiteLlm`; `adk-js` has no `LiteLlm` (`grep -ri litellm` over non-`node_modules` sources returns nothing), so the `BaseLlm` branch would only have read `.model`. All three callers pass `agent.canonicalModel.model` directly, matching `isGemini2OrAbove(modelString: string)`.

Also deliberately **not** done, per the scope: no `output_schema_processor.ts` mirroring the Python file layout (the three sites are edited in place), and the helper is **not** added to `core/src/common.ts` / `core/src/index.ts` — the Python module is marked "for ADK internal use only", and `getGoogleLlmVariant` is likewise unexported. Tests import it by relative path, as `core/test/utils/variant_utils_test.ts` already does.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Every test that depends on the variant sets `GOOGLE_GENAI_USE_VERTEXAI` explicitly with `vi.stubEnv` (including `undefined` for the "unset" case, so the suite is hermetic against ambient environment) and restores it with `vi.unstubAllEnvs()` in `afterEach`.

**New — `core/test/utils/output_schema_utils_test.ts`** (11 table-driven rows): ports `adk-python/tests/unittests/utils/test_output_schema_utils.py`, dropping the LiteLLM cases. Covers `'true'` / `'1'` / `'false'` / unset, Gemini 2.5 vs 1.5, a non-Gemini name, the empty string, a path-based `projects/.../models/gemini-2.5-flash` name, and `gemini-flash-early-exp` — that last row is the executable record of divergence (1) above.

**`core/test/agents/processors/basic_llm_request_processor_test.ts`**: the two existing `outputSchema` tests use `test-basic-processor-model`, a non-Gemini name, so the predicate is `false` and both pass unchanged. Added three: Vertex + `gemini-2.5-flash` + tools → `responseSchema` **is** set and `responseMimeType === 'application/json'` (this is the assertion that catches the "neither mechanism active" regression); Vertex + `gemini-1.5-pro` + tools → stays `undefined`; variant unset + `gemini-2.5-flash` + tools → stays `undefined`.

**`core/test/agents/processors/instructions_llm_request_processor_test.ts`**: the existing `should append set_model_response instruction when outputSchema and tools are present` test was **updated, not deleted** — its name and assertion string are unchanged; it moved into a nested `describe` alongside three new complements. Two things about it changed and are worth calling out: (a) it previously passed only because `GOOGLE_GENAI_USE_VERTEXAI` happened to be unset, which is now explicit; (b) it used `model: 'gemini-2.5-flash'` as a _string_, and this processor now dereferences `agent.canonicalModel`, which for a string model constructs a real `Gemini` and throws without credentials. It now passes a `BaseLlm` instance so the test is hermetic. (No new runtime failure mode: `BASIC_LLM_REQUEST_PROCESSOR` runs first in the default chain and already dereferences `agent.canonicalModel.model`.) The three added cases cover Vertex + 2.0+ (instruction absent, agent's own instruction still present), Vertex + pre-2.0 (present), and no tools (absent).

**`core/test/agents/llm_agent_test.ts`**: five cases driving `LlmAgent.runAsync` end to end through the full default processor chain and the tool loop, with a capturing `BaseLlm` subclass recording the single `LlmRequest`, so all three sites are asserted against one object. This is the machine-checkable form of the "never zero, never both" invariant:

- Vertex + `gemini-2.5-flash` + tool → `responseSchema` defined, `responseMimeType === 'application/json'`, no `set_model_response` in `toolsDict`, the user's own tool still present, `systemInstruction` free of `set_model_response`.
- Non-Vertex + `gemini-2.5-flash` + tool → the exact inverse.
- Vertex + `gemini-1.5-pro` + tool → workaround active.
- `outputSchema` with no tools, both variants → native schema, no workaround (unchanged behaviour).

The pre-existing `MockLlm` in this file uses `model: 'mock-llm'`, which is not a Gemini name, so the predicate is `false` for every other test in the file — confirmed by running it, not assumed.

**Proof the tests can fail.** Each gate was reverted in turn and the suites re-run:

| Mutation                                                                             | Result                                                                                                             |
| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
| `basic_llm_request_processor.ts`: drop `\|\| canUseOutputSchemaWithTools(...)`       | 2 failed — `AssertionError: expected undefined to be defined` (both the processor test and the full-chain test)    |
| `instructions_llm_request_processor.ts`: drop `&& !canUseOutputSchemaWithTools(...)` | 2 failed — `AssertionError: expected 'Base instruction\n\nTo output the fin…' not to contain 'set_model_response'` |
| `llm_agent.ts`: drop `&& !canUseOutputSchemaWithTools(...)`                          | 1 failed — `AssertionError: expected { …(2) } to not have property "set_model_response"`                           |
| `output_schema_utils.ts`: drop the `GoogleLLMVariant.VERTEX_AI` term                 | 3 failed — `AssertionError: expected true to be false`                                                             |

**Coverage.** `core/src/utils/output_schema_utils.ts`: 100% statements / branches / functions / lines. Branch coverage on both touched processors went **up**, not down: `basic_llm_request_processor.ts` 87.5% → 88.88%, `instructions_llm_request_processor.ts` 88.88% → 90%. The residual uncovered branches (the `isLlmAgent` early return, and the `agent.tools` nullish arm that an `LlmAgent` never reaches because `tools` defaults to `[]`) are pre-existing and untouched by this change.

**Typecheck.** `npm run ts:check` is noisy on `main` today (a pre-existing `dist`-vs-`src` resolution duality in the test tree). Total errors went from **308 on `main` to 307** with this change — no new errors, and one pre-existing error removed by typing an `outputSchema` fixture as a real `genai.Schema` instead of an object literal. No `any`, `as any`, `@ts-expect-error`, `@ts-ignore`, or `eslint-disable` was added anywhere, tests included.

Commands run locally on the pushed commit:

```
npm run build                     # clean
npm run lint                      # clean
npm run ts:check                  # 307 errors, all pre-existing (308 on main)
npx vitest run --project unit:core \
  core/test/utils/output_schema_utils_test.ts \
  core/test/agents/llm_agent_test.ts \
  core/test/agents/processors/basic_llm_request_processor_test.ts \
  core/test/agents/processors/instructions_llm_request_processor_test.ts
# 4 files, 63 tests passed
npx vitest run --project unit:core core/test/agents/processors/
# 11 files, 108 tests passed
```

**Manual End-to-End (E2E) Tests:**

No credentialed script is added, and none is needed — the behaviour is fully observable in the request, which the full-chain tests above assert. To reproduce against live Vertex AI:

1. Set `GOOGLE_GENAI_USE_VERTEXAI=true`, plus `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`.
2. Build an `LlmAgent` with `model: 'gemini-2.5-flash'`, a non-empty `outputSchema`, and at least one tool.
3. Run one step and inspect the `LlmRequest`.

Before: `toolsDict['set_model_response']` present, `systemInstruction` mentions `set_model_response`, `config.responseSchema` undefined. After: no `set_model_response` tool, no mention in the instruction, `config.responseSchema` set with `responseMimeType === 'application/json'`. Unsetting `GOOGLE_GENAI_USE_VERTEXAI`, or switching to `gemini-1.5-pro`, restores the old behaviour exactly.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
