### PR TITLE
Feat: Workflow node model — BaseNode, FunctionNode, JoinNode, NodeContext (Part 1/3)

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -286,6 +286,20 @@ export {Task} from './utils/task.js';
 export type {TaskExecutable} from './utils/task.js';
 export {GoogleLLMVariant} from './utils/variant_utils.js';
 export {version} from './version.js';
+export {BaseNode, START} from './workflow/base_node.js';
+export type {BaseNodeConfig} from './workflow/base_node.js';
+export {FunctionNode} from './workflow/function_node.js';
+export type {
+  FunctionNodeConfig,
+  NodeFunction,
+} from './workflow/function_node.js';
+export {JoinNode} from './workflow/join_node.js';
+export {node} from './workflow/node.js';
+export type {NodeLike, NodeOptions} from './workflow/node.js';
+export {NodeContext} from './workflow/node_context.js';
+export type {NodeContextConfig} from './workflow/node_context.js';
+export type {RetryConfig} from './workflow/retry_config.js';
+export type {RouteValue} from './workflow/route.js';
 
 export {GCPSkillRegistry} from './skills/gcp_skill_registry.js';
 export type {GCPSkillRegistryOptions} from './skills/gcp_skill_registry.js';

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+
+import {NodeContext} from './node_context.js';
+import {RetryConfig} from './retry_config.js';
+
+/** Node names must be valid JavaScript identifiers. */
+const NODE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * The parameters shared by every workflow node.
+ */
+export interface BaseNodeConfig {
+  /** The node's name, unique within a graph and a valid JS identifier. */
+  name: string;
+
+  /**
+   * If true, the node completes only once it produces an output or a route.
+   *
+   * Until then it stays pending and its downstream nodes are not triggered,
+   * so its predecessors can run it again — once per queued input, one input
+   * at a time — until it decides. This is the general form of a barrier;
+   * JoinNode covers the common "wait for every predecessor" case
+   * declaratively.
+   *
+   * A node that declares this and never produces an output or a route
+   * deadlocks its branch; that is a configuration error.
+   */
+  waitForOutput?: boolean;
+
+  /** How to retry this node when it throws. No retries when omitted. */
+  retryConfig?: RetryConfig;
+
+  /** Maximum time for one run of this node, in milliseconds. */
+  timeoutMs?: number;
+}
+
+/**
+ * The contract every node in a workflow graph implements.
+ *
+ * Subclass it and implement {@link BaseNode.run} to add a node type; wrap a
+ * plain function with `node(fn)` for the common case.
+ *
+ * The class is generic over its config type so {@link BaseNode.clone} stays
+ * typed per subclass, matching `BaseAgent`.
+ *
+ * The whole `workflow` module is experimental. The `@experimental` decorator
+ * is applied only to the classes a caller names that the framework does not
+ * also build on its own: decorating `BaseNode` would warn on merely importing
+ * `@google/adk`, because the {@link START} sentinel is built at module load,
+ * and decorating `Graph` or `NodeContext` would warn on every workflow run.
+ */
+export abstract class BaseNode<
+  TConfig extends BaseNodeConfig = BaseNodeConfig,
+> {
+  /**
+   * The config this node was constructed from.
+   *
+   * Stored so {@link clone} can rebuild the node by re-running the concrete
+   * constructor with overrides applied, which re-derives all state instead of
+   * copying an already-built instance.
+   */
+  protected readonly config: TConfig;
+
+  /** The node's name, unique within a graph. */
+  readonly name: string;
+
+  /** See {@link BaseNodeConfig.waitForOutput}. */
+  readonly waitForOutput: boolean;
+
+  /** See {@link BaseNodeConfig.retryConfig}. */
+  readonly retryConfig?: RetryConfig;
+
+  /** See {@link BaseNodeConfig.timeoutMs}. */
+  readonly timeoutMs?: number;
+
+  constructor(config: TConfig) {
+    if (!NODE_NAME_PATTERN.test(config.name)) {
+      throw new Error(`Node name '${config.name}' must be a valid identifier.`);
+    }
+    // Copied so later mutation of the caller's object cannot leak into clones.
+    this.config = {...config};
+    this.name = config.name;
+    this.waitForOutput = config.waitForOutput ?? false;
+    this.retryConfig = config.retryConfig;
+    this.timeoutMs = config.timeoutMs;
+  }
+
+  /**
+   * Runs the node.
+   *
+   * @param ctx The context of this node run. The node reports its result by
+   *     assigning `ctx.output` and/or `ctx.route`.
+   * @param nodeInput The output of the upstream node, or the workflow's own
+   *     input for a node wired directly to `START`.
+   * @yields The events the node emits while it runs.
+   */
+  abstract run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void>;
+
+  /**
+   * If true, the node runs only once every predecessor has completed, and
+   * receives a record of their outputs keyed by predecessor name.
+   */
+  get requiresAllPredecessors(): boolean {
+    return false;
+  }
+
+  /**
+   * Creates a copy of this node with the given config fields overridden.
+   *
+   * @param overrides Config fields to override on the copy.
+   * @returns A new node of the same concrete class.
+   */
+  clone(overrides?: Partial<TConfig>): this {
+    const ctor = this.constructor as new (config: TConfig) => this;
+    return new ctor({...this.config, ...overrides});
+  }
+}
+
+/** The node behind {@link START}: a marker that refuses to run. */
+class StartNode extends BaseNode {
+  // Deliberately not a generator: START is never executed, so it rejects the
+  // call itself instead of waiting to be iterated.
+  run(): AsyncGenerator<Event, void, void> {
+    throw new Error('START marks a graph entry point and is never executed.');
+  }
+}
+
+/**
+ * The sentinel node marking the entry point of a workflow graph.
+ *
+ * Edges out of `START` carry no route and fire with the workflow's own input;
+ * `START` itself has no incoming edges and is never executed.
+ */
+export const START: BaseNode = new StartNode({name: '__START__'});

--- a/core/src/workflow/function_node.ts
+++ b/core/src/workflow/function_node.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BaseNode, BaseNodeConfig} from './base_node.js';
+import {NodeContext} from './node_context.js';
+
+/**
+ * A plain function usable as a workflow node.
+ *
+ * The function reports its result in one of two ways:
+ *
+ * - return a value — anything other than `undefined` or `null` becomes the
+ *   node's output;
+ * - be an async generator — every `Event` it yields is streamed to the caller,
+ *   and it reports its result by assigning `ctx.output`.
+ *
+ * Either form may also assign `ctx.route` to steer the graph.
+ */
+export type NodeFunction = (ctx: NodeContext, nodeInput: unknown) => unknown;
+
+/**
+ * The config of a {@link FunctionNode}.
+ *
+ * The constructor takes this with `name` optional, because a named function
+ * supplies it.
+ */
+export interface FunctionNodeConfig extends BaseNodeConfig {
+  /** The function to run when the node executes. */
+  fn: NodeFunction;
+}
+
+/**
+ * Narrows a function's return value to an event stream.
+ *
+ * An async generator function returns an object carrying
+ * `Symbol.asyncIterator`, which is how a streaming node is told apart from one
+ * that returns a plain result.
+ */
+function isEventStream(value: unknown): value is AsyncIterable<Event> {
+  return (
+    typeof value === 'object' && value !== null && Symbol.asyncIterator in value
+  );
+}
+
+/**
+ * A node that runs a plain function.
+ *
+ * Unlike adk-python's `FunctionNode`, parameters are not bound by name:
+ * TypeScript erases parameter names and types at runtime, so the contract is
+ * the explicit `(ctx, nodeInput)` signature and a function reads session state
+ * through `ctx.state`.
+ */
+@experimental
+export class FunctionNode extends BaseNode<FunctionNodeConfig> {
+  /** The wrapped function. */
+  readonly fn: NodeFunction;
+
+  constructor(config: Omit<FunctionNodeConfig, 'name'> & {name?: string}) {
+    const name = config.name ?? config.fn.name;
+    if (!name) {
+      throw new Error(
+        'FunctionNode must have a name. Provide `name` explicitly when the ' +
+          'wrapped function is anonymous.',
+      );
+    }
+    super({...config, name});
+    this.fn = config.fn;
+  }
+
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    const result = this.fn(ctx, nodeInput);
+    if (isEventStream(result)) {
+      yield* result;
+      return;
+    }
+    const value = await result;
+    if (value !== undefined && value !== null) {
+      ctx.output = value;
+    }
+  }
+}

--- a/core/src/workflow/join_node.ts
+++ b/core/src/workflow/join_node.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Event} from '../events/event.js';
+import {experimental} from '../utils/experimental.js';
+
+import {BaseNode} from './base_node.js';
+import {NodeContext} from './node_context.js';
+
+/**
+ * A fan-in node: it runs once every predecessor has completed and outputs
+ * their outputs as a record keyed by predecessor name.
+ */
+@experimental
+export class JoinNode extends BaseNode {
+  override get requiresAllPredecessors(): boolean {
+    return true;
+  }
+
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    ctx.output = nodeInput;
+    // A join emits nothing of its own; delegating to an empty stream keeps
+    // this an async generator without suppressing the require-yield rule.
+    yield* [];
+  }
+}

--- a/core/src/workflow/node.ts
+++ b/core/src/workflow/node.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseNode, BaseNodeConfig, START} from './base_node.js';
+import {FunctionNode, NodeFunction} from './function_node.js';
+
+/**
+ * Anything that can be used where a workflow node is expected: a node, a
+ * function to wrap as a node, or the literal `'START'`.
+ */
+export type NodeLike = BaseNode | NodeFunction | 'START';
+
+/** Config fields that can be overridden when building a node. */
+export type NodeOptions = Partial<BaseNodeConfig>;
+
+/**
+ * Builds a workflow node.
+ *
+ * ```ts
+ * const classify = node(async (ctx) => {
+ *   ctx.route = ctx.state.get<number>('score', 0)! > 5 ? 'high' : 'low';
+ * });
+ * const slow = node(callApi, {name: 'callApi', timeoutMs: 5_000});
+ * ```
+ *
+ * A function becomes a {@link FunctionNode}. An existing node is returned
+ * unchanged when there is nothing to override, so a node referenced several
+ * times in an edge list stays one graph node. `'START'` resolves to the shared
+ * {@link START} sentinel and ignores `options`, which a sentinel cannot carry.
+ *
+ * adk-python's `node` doubles as a decorator; TypeScript decorators cannot be
+ * applied to plain functions, so only this factory form exists.
+ *
+ * @param nodeLike The node, function or `'START'` to build a node from.
+ * @param options Config fields to override on the built node.
+ * @returns The built node.
+ */
+export function node(nodeLike: NodeLike, options: NodeOptions = {}): BaseNode {
+  if (nodeLike === 'START') {
+    return START;
+  }
+  if (nodeLike instanceof BaseNode) {
+    return Object.keys(options).length > 0 ? nodeLike.clone(options) : nodeLike;
+  }
+  return new FunctionNode({...options, fn: nodeLike});
+}

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context} from '../agents/context.js';
+import {InvocationContext} from '../agents/invocation_context.js';
+
+import type {BaseNode} from './base_node.js';
+import type {RouteValue} from './route.js';
+
+/**
+ * The parameters for creating a {@link NodeContext}.
+ */
+export interface NodeContextConfig {
+  /** The invocation this node run belongs to. */
+  invocationContext: InvocationContext;
+
+  /** The node being run. */
+  node: BaseNode;
+
+  /** Identifier of this run of the node, unique per node per workflow run. */
+  runId: string;
+
+  /** 1-based attempt number of this run. Defaults to 1. */
+  attemptCount?: number;
+
+  /** The `nodePath` of the node that scheduled this run, when nested. */
+  parentNodePath?: string;
+}
+
+/**
+ * The context of a single node run.
+ *
+ * Extends the agent {@link Context}, so a node gets the same delta-aware
+ * `state`, `actions`, `abortSignal`, artifact and memory helpers an agent
+ * callback or a tool gets.
+ *
+ * A node reports its result by assigning {@link NodeContext.output} and
+ * {@link NodeContext.route}; `adk-js` events carry neither field, so the
+ * context is the single source of truth for both.
+ */
+export class NodeContext extends Context {
+  /** The node this context belongs to. */
+  readonly node: BaseNode;
+
+  /** Identifier of this run of the node. */
+  readonly runId: string;
+
+  /** 1-based attempt number of this run. */
+  readonly attemptCount: number;
+
+  /**
+   * The location of this run in the node tree: `<name>@<runId>` at the root,
+   * `<parentNodePath>/<name>@<runId>` inside a nested workflow.
+   */
+  readonly nodePath: string;
+
+  /**
+   * The node's result. `undefined` means the node produced no output.
+   */
+  output: unknown;
+
+  /**
+   * The route(s) the node emitted, used to select its outgoing edges.
+   */
+  route?: RouteValue | RouteValue[];
+
+  constructor(config: NodeContextConfig) {
+    super({invocationContext: config.invocationContext});
+    this.node = config.node;
+    this.runId = config.runId;
+    this.attemptCount = config.attemptCount ?? 1;
+    const segment = `${config.node.name}@${config.runId}`;
+    this.nodePath = config.parentNodePath
+      ? `${config.parentNodePath}/${segment}`
+      : segment;
+  }
+}

--- a/core/src/workflow/retry_config.ts
+++ b/core/src/workflow/retry_config.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Configuration for retrying a workflow node that threw.
+ *
+ * Delays are expressed in milliseconds (adk-python's `RetryConfig` uses
+ * fractional seconds); the effective defaults are the same.
+ */
+export interface RetryConfig {
+  /**
+   * Maximum number of attempts, including the original one. `0` or `1` means
+   * no retries. Defaults to 5.
+   */
+  maxAttempts?: number;
+
+  /** Delay before the first retry, in milliseconds. Defaults to 1000. */
+  initialDelayMs?: number;
+
+  /** Maximum delay between retries, in milliseconds. Defaults to 60000. */
+  maxDelayMs?: number;
+
+  /**
+   * Multiplier applied to the delay after each attempt. Defaults to 2.
+   */
+  backoffFactor?: number;
+
+  /**
+   * Randomness factor applied to the delay. Defaults to 1; use 0 to make the
+   * delay deterministic.
+   */
+  jitter?: number;
+
+  /**
+   * The errors to retry on, given as error class names or as the error classes
+   * themselves. When omitted, every error is retried.
+   */
+  errors?: Array<string | (new (...args: never[]) => Error)>;
+}

--- a/core/src/workflow/route.ts
+++ b/core/src/workflow/route.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A value a node emits to select which of its outgoing graph edges are
+ * followed.
+ *
+ * A node emits a route by assigning `ctx.route` while it runs. Matching is by
+ * strict equality, so the emitted value and the value declared on the edge must
+ * have the same type.
+ */
+export type RouteValue = string | number | boolean;

--- a/core/test/workflow/base_node_test.ts
+++ b/core/test/workflow/base_node_test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseNode,
+  BaseNodeConfig,
+  createEvent,
+  Event,
+  NodeContext,
+  START,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode, makeNodeContext} from './workflow_test_utils.js';
+
+interface EchoNodeConfig extends BaseNodeConfig {
+  texts?: string[];
+}
+
+/** Emits one event per configured text and outputs its input. */
+class EchoNode extends BaseNode<EchoNodeConfig> {
+  override async *run(
+    ctx: NodeContext,
+    nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    for (const text of this.config.texts ?? []) {
+      yield createEvent({author: this.name, content: {parts: [{text}]}});
+    }
+    ctx.output = nodeInput;
+  }
+}
+
+describe('BaseNode', () => {
+  it('rejects a name that is not a valid identifier', () => {
+    expect(() => new EchoNode({name: 'not a name'})).toThrow(
+      "Node name 'not a name' must be a valid identifier.",
+    );
+  });
+
+  it('accepts identifier-shaped names', () => {
+    expect(new EchoNode({name: '_private$1'}).name).toBe('_private$1');
+  });
+
+  it('defaults waitForOutput and requiresAllPredecessors', () => {
+    const n = new EchoNode({name: 'plain'});
+
+    expect(n.waitForOutput).toBe(false);
+    expect(n.requiresAllPredecessors).toBe(false);
+    expect(n.retryConfig).toBeUndefined();
+    expect(n.timeoutMs).toBeUndefined();
+  });
+
+  it('keeps the configured options', () => {
+    const retryConfig = {maxAttempts: 2};
+    const n = new EchoNode({
+      name: 'configured',
+      waitForOutput: true,
+      retryConfig,
+      timeoutMs: 25,
+    });
+
+    expect(n.waitForOutput).toBe(true);
+    expect(n.retryConfig).toBe(retryConfig);
+    expect(n.timeoutMs).toBe(25);
+  });
+
+  it('streams the events it yields and exposes the result on ctx', async () => {
+    const n = new EchoNode({name: 'echo', texts: ['one', 'two']});
+
+    const {events, ctx} = await drainNode(n, 'payload');
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual([
+      'one',
+      'two',
+    ]);
+    expect(events.every((e) => e.author === 'echo')).toBe(true);
+    expect(ctx.output).toBe('payload');
+  });
+
+  it('clones into the same concrete class with overrides applied', () => {
+    const original = new EchoNode({name: 'echo', texts: ['one']});
+
+    const copy = original.clone({name: 'echo2', timeoutMs: 10});
+
+    expect(copy).toBeInstanceOf(EchoNode);
+    expect(copy).not.toBe(original);
+    expect(copy.name).toBe('echo2');
+    expect(copy.timeoutMs).toBe(10);
+    expect(original.name).toBe('echo');
+    expect(original.timeoutMs).toBeUndefined();
+  });
+
+  it('clones subclass-specific config with no overrides', async () => {
+    const original = new EchoNode({name: 'echo', texts: ['kept']});
+
+    const {events} = await drainNode(original.clone());
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['kept']);
+  });
+});
+
+describe('START', () => {
+  it('is named __START__', () => {
+    expect(START.name).toBe('__START__');
+  });
+
+  it('throws if it is ever executed', () => {
+    const ctx = makeNodeContext(START);
+
+    expect(() => START.run(ctx, undefined)).toThrow(
+      'START marks a graph entry point and is never executed.',
+    );
+  });
+});

--- a/core/test/workflow/function_node_test.ts
+++ b/core/test/workflow/function_node_test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {createEvent, Event, FunctionNode, NodeContext} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('FunctionNode', () => {
+  it('infers its name from the wrapped function', () => {
+    function analyse() {
+      return 'ok';
+    }
+
+    expect(new FunctionNode({fn: analyse}).name).toBe('analyse');
+  });
+
+  it('prefers an explicit name over the function name', () => {
+    function analyse() {
+      return 'ok';
+    }
+
+    expect(new FunctionNode({fn: analyse, name: 'custom'}).name).toBe('custom');
+  });
+
+  it('rejects an anonymous function with no name', () => {
+    const anonymous: (ctx: NodeContext, nodeInput: unknown) => unknown =
+      function () {
+        return 'ok';
+      };
+    Object.defineProperty(anonymous, 'name', {value: ''});
+
+    expect(() => new FunctionNode({fn: anonymous})).toThrow(
+      'FunctionNode must have a name.',
+    );
+  });
+
+  it('turns a synchronous return value into the node output', async () => {
+    const n = new FunctionNode({fn: () => 42, name: 'sync'});
+
+    const {events, ctx} = await drainNode(n);
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBe(42);
+  });
+
+  it('turns an awaited return value into the node output', async () => {
+    const n = new FunctionNode({fn: async () => 'later', name: 'async'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBe('later');
+  });
+
+  it('treats undefined as no output', async () => {
+    const n = new FunctionNode({fn: () => undefined, name: 'nothing'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('treats null as no output', async () => {
+    const n = new FunctionNode({fn: () => null, name: 'nullish'});
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.output).toBeUndefined();
+  });
+
+  it('streams the events an async generator function yields', async () => {
+    async function* streamer(
+      ctx: NodeContext,
+    ): AsyncGenerator<Event, void, void> {
+      yield createEvent({author: 'streamer', content: {parts: [{text: 'a'}]}});
+      yield createEvent({author: 'streamer', content: {parts: [{text: 'b'}]}});
+      ctx.output = 'streamed';
+    }
+    const n = new FunctionNode({fn: streamer});
+
+    const {events, ctx} = await drainNode(n);
+
+    expect(events.map((e) => e.content?.parts?.[0].text)).toEqual(['a', 'b']);
+    expect(ctx.output).toBe('streamed');
+  });
+
+  it('passes the node input to the wrapped function', async () => {
+    const seen: unknown[] = [];
+    const n = new FunctionNode({
+      fn: (_ctx, nodeInput) => {
+        seen.push(nodeInput);
+        return undefined;
+      },
+      name: 'recorder',
+    });
+
+    await drainNode(n, {from: 'upstream'});
+
+    expect(seen).toEqual([{from: 'upstream'}]);
+  });
+
+  it('lets the wrapped function emit a route', async () => {
+    const n = new FunctionNode({
+      fn: (ctx) => {
+        ctx.route = 'high';
+      },
+      name: 'router',
+    });
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.route).toBe('high');
+  });
+
+  it('records state writes on the context delta', async () => {
+    const n = new FunctionNode({
+      fn: (ctx) => {
+        ctx.state.set('visited', true);
+      },
+      name: 'writer',
+    });
+
+    const {ctx} = await drainNode(n);
+
+    expect(ctx.actions.stateDelta).toEqual({visited: true});
+  });
+
+  it('carries the wrapped function through clone', async () => {
+    const original = new FunctionNode({fn: () => 'value', name: 'origin'});
+
+    const copy = original.clone({name: 'copy', timeoutMs: 5});
+    const {ctx} = await drainNode(copy);
+
+    expect(copy).toBeInstanceOf(FunctionNode);
+    expect(copy.name).toBe('copy');
+    expect(copy.timeoutMs).toBe(5);
+    expect(ctx.output).toBe('value');
+  });
+});

--- a/core/test/workflow/join_node_test.ts
+++ b/core/test/workflow/join_node_test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {JoinNode} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('JoinNode', () => {
+  it('waits for all of its predecessors', () => {
+    expect(new JoinNode({name: 'join'}).requiresAllPredecessors).toBe(true);
+  });
+
+  it('passes the aggregated predecessor outputs through as its output', async () => {
+    const aggregated = {NodeA: 'a', NodeB: 'b'};
+
+    const {events, ctx} = await drainNode(
+      new JoinNode({name: 'join'}),
+      aggregated,
+    );
+
+    expect(events).toEqual([]);
+    expect(ctx.output).toBe(aggregated);
+  });
+});

--- a/core/test/workflow/node_context_test.ts
+++ b/core/test/workflow/node_context_test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {NodeContext, node} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {makeInvocationContext} from './workflow_test_utils.js';
+
+const noop = node(() => undefined, {name: 'noop'});
+
+describe('NodeContext', () => {
+  it('builds a root node path from the node name and run id', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '3',
+    });
+
+    expect(ctx.nodePath).toBe('noop@3');
+    expect(ctx.attemptCount).toBe(1);
+    expect(ctx.node).toBe(noop);
+    expect(ctx.runId).toBe('3');
+  });
+
+  it('nests the node path under the parent node path', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '1',
+      parentNodePath: 'outer@2',
+      attemptCount: 4,
+    });
+
+    expect(ctx.nodePath).toBe('outer@2/noop@1');
+    expect(ctx.attemptCount).toBe(4);
+  });
+
+  it('exposes delta-aware session state', () => {
+    const invocationContext = makeInvocationContext();
+    invocationContext.session.state['seed'] = 1;
+    const ctx = new NodeContext({invocationContext, node: noop, runId: '1'});
+
+    ctx.state.set('added', 2);
+
+    expect(ctx.state.get('seed')).toBe(1);
+    expect(ctx.actions.stateDelta).toEqual({added: 2});
+  });
+
+  it('starts with no output and no route', () => {
+    const ctx = new NodeContext({
+      invocationContext: makeInvocationContext(),
+      node: noop,
+      runId: '1',
+    });
+
+    expect(ctx.output).toBeUndefined();
+    expect(ctx.route).toBeUndefined();
+  });
+});

--- a/core/test/workflow/node_test.ts
+++ b/core/test/workflow/node_test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionNode, JoinNode, node, START} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+import {drainNode} from './workflow_test_utils.js';
+
+describe('node()', () => {
+  it('wraps a function in a FunctionNode named after it', () => {
+    function classify() {
+      return 'high';
+    }
+
+    const built = node(classify);
+
+    expect(built).toBeInstanceOf(FunctionNode);
+    expect(built.name).toBe('classify');
+  });
+
+  it('applies option overrides when wrapping a function', () => {
+    const built = node(() => undefined, {name: 'named', timeoutMs: 7});
+
+    expect(built.name).toBe('named');
+    expect(built.timeoutMs).toBe(7);
+  });
+
+  it('returns an existing node unchanged when there is nothing to override', () => {
+    const existing = new JoinNode({name: 'join'});
+
+    expect(node(existing)).toBe(existing);
+    expect(node(existing, {})).toBe(existing);
+  });
+
+  it('copies an existing node when options are given', () => {
+    const existing = new JoinNode({name: 'join'});
+
+    const copy = node(existing, {timeoutMs: 12});
+
+    expect(copy).not.toBe(existing);
+    expect(copy).toBeInstanceOf(JoinNode);
+    expect(copy.name).toBe('join');
+    expect(copy.timeoutMs).toBe(12);
+    expect(existing.timeoutMs).toBeUndefined();
+  });
+
+  it("resolves the literal 'START' to the START sentinel", () => {
+    expect(node('START')).toBe(START);
+    expect(node('START', {name: 'ignored'})).toBe(START);
+  });
+
+  it('produces a node that runs the wrapped function', async () => {
+    const built = node((_ctx, nodeInput) => `saw ${String(nodeInput)}`, {
+      name: 'runner',
+    });
+
+    const {ctx} = await drainNode(built, 'input');
+
+    expect(ctx.output).toBe('saw input');
+  });
+});

--- a/core/test/workflow/workflow_test_utils.ts
+++ b/core/test/workflow/workflow_test_utils.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseNode,
+  createSession,
+  Event,
+  InvocationContext,
+  NodeContext,
+  PluginManager,
+} from '@google/adk';
+
+/** A minimal agent, used only to satisfy `InvocationContext.agent`. */
+export class StubAgent extends BaseAgent {
+  protected async *runAsyncImpl(): AsyncGenerator<Event, void, void> {}
+
+  protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {}
+}
+
+/** Builds an invocation context backed by an in-memory session. */
+export function makeInvocationContext(
+  overrides: Partial<ConstructorParameters<typeof InvocationContext>[0]> = {},
+): InvocationContext {
+  return new InvocationContext({
+    invocationId: 'test-invocation',
+    agent: new StubAgent({name: 'host'}),
+    session: createSession({id: 'test-session', appName: 'test-app'}),
+    pluginManager: new PluginManager(),
+    ...overrides,
+  });
+}
+
+/** Builds a node context for a single node run. */
+export function makeNodeContext(
+  node: BaseNode,
+  invocationContext = makeInvocationContext(),
+): NodeContext {
+  return new NodeContext({invocationContext, node, runId: '1'});
+}
+
+/**
+ * Runs a node directly through {@link BaseNode.run}, collecting its events.
+ *
+ * This deliberately bypasses the node runner so node semantics can be tested
+ * without retry or timeout handling in the way.
+ */
+export async function drainNode(
+  node: BaseNode,
+  nodeInput?: unknown,
+  ctx: NodeContext = makeNodeContext(node),
+): Promise<{events: Event[]; ctx: NodeContext}> {
+  const events: Event[] = [];
+  for await (const event of node.run(ctx, nodeInput)) {
+    events.push(event);
+  }
+  return {events, ctx};
+}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: google/adk-js#366

**2. Or, if no issue exists, describe the change:**

**Problem:**
`adk-js` can only compose agents in the three fixed shapes `SequentialAgent`, `ParallelAgent` and `LoopAgent` provide. There is no way to express an arbitrary directed graph of steps with conditional routing, fan-out/fan-in, per-step retry or per-step timeout. `adk-python` ships that as `src/google/adk/workflow/`; `adk-js` has no `core/src/workflow/` at all.

**Solution:**
Port the static graph core of that module to TypeScript as a new, self-contained `core/src/workflow/`. Split into a stack of three PRs so each is reviewable:

- **Part 1/3 (this PR)** — branch `feat/workflow-graph-core-part1`: the node model: `BaseNode` + the `START` sentinel, `FunctionNode`, `JoinNode`, `NodeContext`, the `node()` factory, and the `RetryConfig` / `RouteValue` types the later parts consume.
- **Part 2/3** — branch `feat/workflow-graph-core-part2`: `Graph`, `Edge`, the chain syntax and graph validation.
- **Part 3/3** — branch `feat/workflow-graph-core-part3`: `runNode` and the executable `Workflow`.

Nothing existing changes: `core/src/events/*`, `core/src/runner/*` and `core/src/agents/*` are untouched, and the only edit outside the new directory is a block of named exports appended to `core/src/common.ts`.

**Design notes and deliberate deviations from adk-python**

- **Output and route travel on the context, not on events.** `adk-python`'s `Event` has `output` and `EventActions.route`; `adk-js`'s has neither. Rather than widen `Event` (which would mean auditing every session-service serialization path), a node reports its result by assigning `ctx.output` / `ctx.route`. That is already `adk-python`'s source of truth — its `NodeRunner` copies `event.output` into `ctx.output` and the workflow reads the context, never the events.
- **Parameter binding is not ported.** `adk-python`'s `FunctionNode` binds function parameters by name using `inspect.signature` and `typing.get_type_hints`. TypeScript erases both at runtime, so this cannot be reproduced and is not faked: the contract is the explicit `(ctx, nodeInput)` signature, and a function reads session state through `ctx.state`.
- **`node()` is a factory only.** `adk-python`'s `node` doubles as a decorator; TypeScript decorators cannot be applied to plain functions.
- **`Node` is not ported.** In `adk-python` it exists purely as the `parallel_worker` seam, which is out of scope here — a subclass that only renames `runImpl` would be an empty abstraction. Subclass `BaseNode` directly; `Node` returns with the concurrency follow-up.
- **`description` is not ported.** It is only read by `adk-python`'s agent-as-node path, which is out of scope, so it would ship as write-only config.
- **`@experimental` placement.** It is applied to the concrete classes a caller constructs, not to `BaseNode`: `START` is built at module load, so decorating the base class would print an experimental warning on merely importing `@google/adk`. This is stated in `BaseNode`'s TSDoc.
- **Out of scope, deliberately not stubbed:** dynamic nodes, concurrent execution / `maxConcurrency`, replay and rehydration, human-in-the-loop and interrupts, agent-as-node and tool-as-node, live/bidi, and Pydantic-style schema validation.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npx vitest run --project unit:core core/test/workflow` — 5 files, 33 tests, all passing.

New suites: `base_node_test.ts`, `function_node_test.ts`, `join_node_test.ts`, `node_test.ts`, `node_context_test.ts`, plus the shared `workflow_test_utils.ts` fixtures.

**Coverage.** Measured with
`npx vitest run --project unit:core --coverage --coverage.include='core/src/workflow/**' core/test/workflow`:
`base_node.ts`, `function_node.ts`, `join_node.ts`, `node.ts` and `node_context.ts` are at **100% statements / branches / functions / lines**. `retry_config.ts` and `route.ts` report 0% in this PR only because at this point in the stack they contain nothing but type declarations, which v8 erases before it can count them; both reach 100% in Part 3, where their runtime helpers land.

**Proof the new tests can fail.** Each test was run against mutated source and confirmed to fail:

| Mutation | Failing test | Message |
| --- | --- | --- |
| `base_node.ts`: delete the `NODE_NAME_PATTERN` check | `BaseNode > rejects a name that is not a valid identifier` | `expected [Function] to throw an error` |
| `base_node.ts`: `clone()` drops `...overrides` | `BaseNode > clones into the same concrete class with overrides applied` | `expected 'echo' to be 'echo2'` |
| `function_node.ts`: `value !== undefined && value !== null` → `value !== undefined` | `FunctionNode > treats null as no output` | `expected null to be undefined` |
| `node.ts`: always clone instead of returning the node as-is | `node() > returns an existing node unchanged when there is nothing to override` | `expected {…} to be {…} // Object.is equality` |
| `node_context.ts`: ignore `parentNodePath` | `NodeContext > nests the node path under the parent node path` | `expected 'noop@1' to be 'outer@2/noop@1'` |

No suppressions were added anywhere: no `any`, `as any`, `as never`, `@ts-expect-error`, `@ts-ignore`, `eslint-disable` or coverage ignores, in `src/` or in the tests. `require-yield` is satisfied by construction (`yield* []` in `JoinNode`; the `START` sentinel's `run` is not a generator at all, so it rejects the call eagerly).

**Manual End-to-End (E2E) Tests:**

No network, credentials or model access are needed.

1. `npm install`
2. `npm run build`
3. `npx vitest run --project unit:core core/test/workflow`
4. `npm run lint && npm run format:check`
5. `npm run docs:check` — confirms every new public type is exported and documented.

The end-to-end behaviour of these primitives is exercised by the executable `Workflow` in Part 3 of this stack, which drives a full graph through `runNode` with no mocks.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
