### PR TITLE
Feat: Port the environment abstraction (BaseEnvironment, ExecutionResult, LocalEnvironment) from adk-python

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -129,6 +129,8 @@ export {TrajectoryThoughtPruningCompactor} from './context/trajectory_thought_pr
 export type {TrajectoryThoughtPruningCompactorOptions} from './context/trajectory_thought_pruning_compactor.js';
 export {TruncatingContextCompactor} from './context/truncating_context_compactor.js';
 export type {TruncatingContextCompactorOptions} from './context/truncating_context_compactor.js';
+export {BaseEnvironment} from './environment/base_environment.js';
+export type {ExecutionResult} from './environment/base_environment.js';
 export {isCompactedEvent, isScratchpadEvent} from './events/compacted_event.js';
 export type {CompactedEvent} from './events/compacted_event.js';
 export {

--- a/core/src/environment/base_environment.ts
+++ b/core/src/environment/base_environment.ts
@@ -14,7 +14,7 @@ import {experimental} from '../utils/experimental.js';
  * produced, whereas an environment runs a *shell command* inside a working
  * directory and reports its process exit status.
  *
- * Every field is required. A command that succeeds with no output yields
+ * A command that succeeds with no output yields
  * `{exitCode: 0, stdout: '', stderr: '', timedOut: false}`.
  */
 export interface ExecutionResult {

--- a/core/src/environment/base_environment.ts
+++ b/core/src/environment/base_environment.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {experimental} from '../utils/experimental.js';
+
+/**
+ * Result of a shell command executed in a {@link BaseEnvironment}.
+ *
+ * This is distinct from `CodeExecutionResult`, which is produced by the code
+ * executors: a code executor runs a code *snippet* and reports the files it
+ * produced, whereas an environment runs a *shell command* inside a working
+ * directory and reports its process exit status.
+ *
+ * Every field is required. A command that succeeds with no output yields
+ * `{exitCode: 0, stdout: '', stderr: '', timedOut: false}`.
+ */
+export interface ExecutionResult {
+  /** The exit code of the process. `0` on success. */
+  exitCode: number;
+  /** Standard output captured from the process. `''` when nothing was written. */
+  stdout: string;
+  /** Standard error captured from the process. `''` when nothing was written. */
+  stderr: string;
+  /** Whether the execution exceeded the timeout. `false` when it completed. */
+  timedOut: boolean;
+}
+
+/**
+ * Abstract base class for code execution environments.
+ *
+ * An environment provides the ability to execute shell commands, read files,
+ * and write files within a working directory. Concrete implementations include
+ * local subprocess execution, sandboxed execution, container environments, and
+ * cloud-hosted environments.
+ *
+ * Lifecycle:
+ * 1. Construct the environment.
+ * 2. Call {@link initialize} before first use.
+ * 3. Use {@link execute}, {@link readFile}, {@link writeFile}.
+ * 4. Call {@link close} when done.
+ */
+@experimental
+export abstract class BaseEnvironment {
+  /**
+   * Backing flag for {@link isInitialized}.
+   *
+   * Subclasses own this flag: set it in {@link initialize} and clear it in
+   * {@link close}.
+   */
+  protected initialized = false;
+
+  /** Whether the environment has been initialized. */
+  get isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Initializes the environment (e.g. creates the working directory).
+   *
+   * Called before first use. The default implementation is a no-op and leaves
+   * {@link isInitialized} `false`. Subclasses must be idempotent and must set
+   * {@link initialized}.
+   */
+  async initialize(): Promise<void> {}
+
+  /**
+   * Releases resources held by the environment.
+   *
+   * The default implementation is a no-op. Subclasses must be idempotent and
+   * must clear {@link initialized}.
+   */
+  async close(): Promise<void> {}
+
+  /** The absolute path to the environment's working directory. */
+  abstract get workingDir(): string;
+
+  /**
+   * Executes a shell command in the working directory.
+   *
+   * @param command The shell command string to execute.
+   * @param timeoutSeconds Maximum execution time in seconds. `undefined` means
+   *   no limit.
+   * @returns The exit code, stdout, stderr, and timeout status. A non-zero exit
+   *   code is reported in the result, not thrown.
+   */
+  abstract execute(
+    command: string,
+    timeoutSeconds?: number,
+  ): Promise<ExecutionResult>;
+
+  /**
+   * Reads a file from the environment's filesystem.
+   *
+   * @param filePath Absolute or working-dir-relative path to the file.
+   * @returns The raw file contents.
+   */
+  abstract readFile(filePath: string): Promise<Uint8Array>;
+
+  /**
+   * Writes content to a file in the environment's filesystem.
+   *
+   * Parent directories are created automatically if they do not exist.
+   *
+   * @param filePath Absolute or working-dir-relative path to the file.
+   * @param content The string or raw bytes to write.
+   */
+  abstract writeFile(
+    filePath: string,
+    content: string | Uint8Array,
+  ): Promise<void>;
+
+  /**
+   * Throws if {@link initialize} has not been called.
+   *
+   * Implementations should call this at the start of every operation that needs
+   * a live working directory.
+   */
+  protected assertInitialized(): void {
+    if (!this.initialized) {
+      throw new Error(
+        'Environment is not initialized. Call initialize() first.',
+      );
+    }
+  }
+}

--- a/core/src/environment/local_environment.ts
+++ b/core/src/environment/local_environment.ts
@@ -69,7 +69,9 @@ function resolvePathInWorkingDir(workingDir: string, filePath: string): string {
  * - The child inherits the whole of `process.env`, so any secret in the parent
  *   environment is visible to the command.
  * - A timeout sends `SIGKILL` to the spawned shell; processes it forked itself
- *   may survive, and anything they write after the kill is not captured.
+ *   may survive, and anything they write after the kill is not captured. On
+ *   Windows such a survivor also keeps the working directory locked, so a
+ *   {@link close} following a timeout can fail to remove a temporary workspace.
  * - File paths are confined to the working directory by a lexical check only
  *   (see {@link readFile} and {@link writeFile}).
  */

--- a/core/src/environment/local_environment.ts
+++ b/core/src/environment/local_environment.ts
@@ -69,7 +69,7 @@ function resolvePathInWorkingDir(workingDir: string, filePath: string): string {
  * - The child inherits the whole of `process.env`, so any secret in the parent
  *   environment is visible to the command.
  * - A timeout sends `SIGKILL` to the spawned shell; processes it forked itself
- *   may survive.
+ *   may survive, and anything they write after the kill is not captured.
  * - File paths are confined to the working directory by a lexical check only
  *   (see {@link readFile} and {@link writeFile}).
  */
@@ -137,6 +137,12 @@ export class LocalEnvironment extends BaseEnvironment {
       timer = setTimeout(() => {
         timedOut = true;
         child.kill('SIGKILL');
+        // Killing the shell does not kill a command it forked rather than
+        // exec'd, and that survivor keeps the pipes open, which would hold
+        // 'close' back until it exits on its own. Release the read ends so
+        // the timeout is actually enforced.
+        child.stdout.destroy();
+        child.stderr.destroy();
       }, timeoutSeconds * 1000);
     }
 

--- a/core/src/environment/local_environment.ts
+++ b/core/src/environment/local_environment.ts
@@ -144,9 +144,8 @@ export class LocalEnvironment extends BaseEnvironment {
       const exitCode = await new Promise<number>((resolve, reject) => {
         // 'close' rather than 'exit': the stdio streams are drained by then.
         child.on('close', (code, signal) => {
-          // Node reports either an exit code or the name of the signal that
-          // terminated the process; Python reports the negative signal number
-          // (`-9` for SIGKILL) via `proc.returncode or 0`, so map it back.
+          // Node reports either an exit code or the terminating signal; Python
+          // reports the negative signal number (`-9` for SIGKILL), so map back.
           resolve(
             signal === null ? (code ?? 0) : -os.constants.signals[signal],
           );

--- a/core/src/environment/local_environment.ts
+++ b/core/src/environment/local_environment.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {spawn} from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {experimental} from '../utils/experimental.js';
+import {logger} from '../utils/logger.js';
+import {BaseEnvironment, ExecutionResult} from './base_environment.js';
+
+/** Prefix for the temporary workspace created when no `workingDir` is given. */
+const TEMP_WORKSPACE_PREFIX = 'adk_workspace_';
+
+/** Options for {@link LocalEnvironment}. */
+export interface LocalEnvironmentOptions {
+  /**
+   * Absolute path to the workspace directory. Created by
+   * {@link LocalEnvironment.initialize} if it does not exist, and never deleted
+   * by {@link LocalEnvironment.close}. If omitted, a temporary directory is
+   * created on `initialize()` and removed on `close()`.
+   */
+  workingDir?: string;
+  /** Extra variables merged over `process.env` for every executed command. */
+  envVars?: Record<string, string>;
+}
+
+/**
+ * Resolves `filePath` against `workingDir` and rejects anything outside it.
+ *
+ * This is a **lexical** containment check on the resolved path strings, not a
+ * sandbox: it does not survive symlinks, hardlinks, bind mounts, or TOCTOU
+ * races. It is a guard against accidental traversal, not a security boundary.
+ *
+ * @throws If the resolved path is not inside `workingDir`.
+ */
+function resolvePathInWorkingDir(workingDir: string, filePath: string): string {
+  const base = path.resolve(workingDir);
+  const resolved = path.resolve(base, filePath);
+  const relative = path.relative(base, resolved);
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    // `path.relative` returns an absolute path across Windows drives.
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`Path escapes working directory: ${filePath}`);
+  }
+  return resolved;
+}
+
+/**
+ * Executes commands via local child processes, scoped to a working directory.
+ *
+ * When `workingDir` is not specified, a temporary directory is created on
+ * {@link initialize} and removed on {@link close}.
+ *
+ * WARNING: this class runs arbitrary shell strings on the host with **no
+ * sandboxing** and no sanitisation — the caller is responsible for trusting the
+ * command. It is a building block; tools built on top of it are responsible for
+ * gating execution behind an explicit user confirmation.
+ *
+ * Further limitations, all shared with the adk-python reference implementation:
+ * - stdout and stderr are buffered fully in memory with no cap, so a command
+ *   producing unbounded output will grow the heap until it fails.
+ * - The child inherits the whole of `process.env`, so any secret in the parent
+ *   environment is visible to the command.
+ * - A timeout sends `SIGKILL` to the spawned shell; processes it forked itself
+ *   may survive.
+ * - File paths are confined to the working directory by a lexical check only
+ *   (see {@link readFile} and {@link writeFile}).
+ */
+@experimental
+export class LocalEnvironment extends BaseEnvironment {
+  private currentWorkingDir?: string;
+  private readonly envVars?: Record<string, string>;
+  private autoCreated = false;
+
+  constructor(options: LocalEnvironmentOptions = {}) {
+    super();
+    this.currentWorkingDir = options.workingDir;
+    this.envVars = options.envVars;
+  }
+
+  override get workingDir(): string {
+    if (this.currentWorkingDir === undefined) {
+      throw new Error('`workingDir` is not set. Call initialize() first.');
+    }
+    return this.currentWorkingDir;
+  }
+
+  override async initialize(): Promise<void> {
+    if (this.currentWorkingDir === undefined) {
+      this.currentWorkingDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), TEMP_WORKSPACE_PREFIX),
+      );
+      this.autoCreated = true;
+      logger.debug(`Created temporary workspace: ${this.currentWorkingDir}`);
+    } else {
+      await fs.mkdir(this.currentWorkingDir, {recursive: true});
+    }
+    this.initialized = true;
+  }
+
+  override async close(): Promise<void> {
+    if (this.autoCreated && this.currentWorkingDir !== undefined) {
+      await fs.rm(this.currentWorkingDir, {recursive: true, force: true});
+      logger.debug(`Removed temporary workspace: ${this.currentWorkingDir}`);
+      this.currentWorkingDir = undefined;
+    }
+    this.initialized = false;
+  }
+
+  override async execute(
+    command: string,
+    timeoutSeconds?: number,
+  ): Promise<ExecutionResult> {
+    this.assertInitialized();
+
+    const child = spawn(command, {
+      shell: true,
+      cwd: this.workingDir,
+      env: {...process.env, ...this.envVars},
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (timeoutSeconds !== undefined) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGKILL');
+      }, timeoutSeconds * 1000);
+    }
+
+    try {
+      const exitCode = await new Promise<number>((resolve, reject) => {
+        // 'close' rather than 'exit': the stdio streams are drained by then.
+        child.on('close', (code, signal) => {
+          // Node reports either an exit code or the name of the signal that
+          // terminated the process; Python reports the negative signal number
+          // (`-9` for SIGKILL) via `proc.returncode or 0`, so map it back.
+          resolve(
+            signal === null ? (code ?? 0) : -os.constants.signals[signal],
+          );
+        });
+        child.on('error', reject);
+      });
+      return {
+        exitCode,
+        // Decode once, so a multi-byte character split across two chunks is
+        // not corrupted. Invalid bytes become U+FFFD, matching Python's
+        // `errors='replace'`.
+        stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+        timedOut,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Reads a file from the working directory.
+   *
+   * `filePath` is confined to the working directory by a lexical check on the
+   * resolved path, which is not a sandbox.
+   *
+   * @throws If the environment is not initialized, if the path escapes the
+   *   working directory, or — as `ENOENT` — if the file does not exist.
+   */
+  override async readFile(filePath: string): Promise<Uint8Array> {
+    this.assertInitialized();
+    return fs.readFile(resolvePathInWorkingDir(this.workingDir, filePath));
+  }
+
+  /**
+   * Writes a file in the working directory, creating parent directories.
+   *
+   * `filePath` is confined to the working directory by a lexical check on the
+   * resolved path, which is not a sandbox. No newline translation is applied,
+   * so explicit CRLF sequences are preserved.
+   *
+   * @throws If the environment is not initialized or the path escapes the
+   *   working directory.
+   */
+  override async writeFile(
+    filePath: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    this.assertInitialized();
+    const resolved = resolvePathInWorkingDir(this.workingDir, filePath);
+    await fs.mkdir(path.dirname(resolved), {recursive: true});
+    await fs.writeFile(resolved, content);
+  }
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -37,6 +37,8 @@ export {
   type UnsafeLocalCodeExecutorOptions,
 } from './code_executors/unsafe_local_code_executor.js';
 export * from './common.js';
+export {LocalEnvironment} from './environment/local_environment.js';
+export type {LocalEnvironmentOptions} from './environment/local_environment.js';
 export {DatabaseSessionService} from './sessions/database_session_service.js';
 export {getSessionServiceFromUri} from './sessions/registry.js';
 export {VertexAiSessionService} from './sessions/vertex_ai_session_service.js';

--- a/core/test/environment/base_environment_test.ts
+++ b/core/test/environment/base_environment_test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseEnvironment, ExecutionResult} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+const EMPTY_RESULT: ExecutionResult = {
+  exitCode: 0,
+  stdout: '',
+  stderr: '',
+  timedOut: false,
+};
+
+/** Minimal concrete environment that relies on the base lifecycle defaults. */
+class TestEnvironment extends BaseEnvironment {
+  override get workingDir(): string {
+    return '/test';
+  }
+
+  override async execute(): Promise<ExecutionResult> {
+    this.assertInitialized();
+    return EMPTY_RESULT;
+  }
+
+  override async readFile(): Promise<Uint8Array> {
+    this.assertInitialized();
+    return new Uint8Array();
+  }
+
+  override async writeFile(): Promise<void> {
+    this.assertInitialized();
+  }
+}
+
+/** An environment that owns the initialized flag, as real subclasses do. */
+class InitializingTestEnvironment extends TestEnvironment {
+  override async initialize(): Promise<void> {
+    this.initialized = true;
+  }
+}
+
+describe('BaseEnvironment', () => {
+  it('is not initialized when constructed', () => {
+    expect(new TestEnvironment().isInitialized).toBe(false);
+  });
+
+  it('leaves isInitialized false when the default initialize() runs', async () => {
+    const env = new TestEnvironment();
+
+    await env.initialize();
+
+    expect(env.isInitialized).toBe(false);
+  });
+
+  it('resolves the default close() without throwing', async () => {
+    await expect(new TestEnvironment().close()).resolves.toBeUndefined();
+  });
+
+  it('rejects operations until a subclass marks it initialized', async () => {
+    const env = new InitializingTestEnvironment();
+
+    await expect(env.execute()).rejects.toThrow(
+      'Environment is not initialized. Call initialize() first.',
+    );
+
+    await env.initialize();
+
+    expect(env.isInitialized).toBe(true);
+    await expect(env.execute()).resolves.toEqual(EMPTY_RESULT);
+  });
+});

--- a/core/test/environment/local_environment_test.ts
+++ b/core/test/environment/local_environment_test.ts
@@ -20,6 +20,15 @@ const NODE = `"${process.execPath}"`;
 /** Spawning a child process is slow on Windows CI runners. */
 const SPAWN_TIMEOUT_MS = 30_000;
 
+/**
+ * How long the commands used by the timeout tests run for. A killed shell can
+ * leave the command running, so this also bounds how long cleanup has to wait.
+ */
+const SURVIVOR_LIFETIME_MS = 5_000;
+
+/** Upper bound on a timed-out call: comfortably short of the command itself. */
+const TIMED_OUT_BY_MS = 4_000;
+
 const decoder = new TextDecoder();
 
 describe('LocalEnvironment', () => {
@@ -30,15 +39,16 @@ describe('LocalEnvironment', () => {
   });
 
   afterEach(async () => {
-    // A command killed by a timeout can outlive the test, and Windows refuses
-    // to remove a directory that is a live process's cwd; retry until it goes.
+    // A command killed by a timeout outlives the test by up to
+    // SURVIVOR_LIFETIME_MS, and Windows refuses to remove a directory that is
+    // a live process's cwd; retry until that process exits.
     await fs.rm(tmpRoot, {
       recursive: true,
       force: true,
       maxRetries: 10,
       retryDelay: 500,
     });
-  });
+  }, SPAWN_TIMEOUT_MS);
 
   describe('lifecycle', () => {
     it('reports isInitialized across initialize() and close()', async () => {
@@ -327,13 +337,13 @@ describe('LocalEnvironment', () => {
         const startedAt = Date.now();
 
         const result = await env.execute(
-          `${NODE} -e "setTimeout(() => {}, 10000)"`,
+          `${NODE} -e "setTimeout(() => {}, ${SURVIVOR_LIFETIME_MS})"`,
           0.5,
         );
 
         expect(result.timedOut).toBe(true);
         expect(result.exitCode).not.toBe(0);
-        expect(Date.now() - startedAt).toBeLessThan(9_000);
+        expect(Date.now() - startedAt).toBeLessThan(TIMED_OUT_BY_MS);
       },
       SPAWN_TIMEOUT_MS,
     );
@@ -348,10 +358,10 @@ describe('LocalEnvironment', () => {
           'spawn_survivor.cjs',
           [
             "const {spawn} = require('node:child_process');",
-            "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10000)'], {",
+            `spawn(process.execPath, ['-e', 'setTimeout(() => {}, ${SURVIVOR_LIFETIME_MS})'], {`,
             "  stdio: 'inherit',",
             '});',
-            'setTimeout(() => {}, 10000);',
+            `setTimeout(() => {}, ${SURVIVOR_LIFETIME_MS});`,
           ].join('\n'),
         );
         const startedAt = Date.now();
@@ -359,7 +369,7 @@ describe('LocalEnvironment', () => {
         const result = await env.execute(`${NODE} spawn_survivor.cjs`, 0.5);
 
         expect(result.timedOut).toBe(true);
-        expect(Date.now() - startedAt).toBeLessThan(9_000);
+        expect(Date.now() - startedAt).toBeLessThan(TIMED_OUT_BY_MS);
       },
       SPAWN_TIMEOUT_MS,
     );

--- a/core/test/environment/local_environment_test.ts
+++ b/core/test/environment/local_environment_test.ts
@@ -283,8 +283,11 @@ describe('LocalEnvironment', () => {
           `${NODE} -e "process.stdout.write(process.cwd())"`,
         );
 
-        // macOS resolves the temp dir through a symlink, so compare real paths.
-        expect(result.stdout.trim()).toBe(await fs.realpath(env.workingDir));
+        // Normalise both sides: macOS reaches the temp dir through a symlink,
+        // and Windows CI reports it as an 8.3 short path.
+        expect(await fs.realpath(result.stdout.trim())).toBe(
+          await fs.realpath(env.workingDir),
+        );
       },
       SPAWN_TIMEOUT_MS,
     );
@@ -323,6 +326,32 @@ describe('LocalEnvironment', () => {
 
         expect(result.timedOut).toBe(true);
         expect(result.exitCode).not.toBe(0);
+        expect(Date.now() - startedAt).toBeLessThan(9_000);
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'times out even when the command leaves a child holding the pipes open',
+      async () => {
+        // A shell that forks rather than exec's its command leaves a survivor
+        // that keeps stdout/stderr open after the kill. Reproduce that with a
+        // script file so no shell-specific syntax is needed.
+        await env.writeFile(
+          'spawn_survivor.cjs',
+          [
+            "const {spawn} = require('node:child_process');",
+            "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10000)'], {",
+            "  stdio: 'inherit',",
+            '});',
+            'setTimeout(() => {}, 10000);',
+          ].join('\n'),
+        );
+        const startedAt = Date.now();
+
+        const result = await env.execute(`${NODE} spawn_survivor.cjs`, 0.5);
+
+        expect(result.timedOut).toBe(true);
         expect(Date.now() - startedAt).toBeLessThan(9_000);
       },
       SPAWN_TIMEOUT_MS,

--- a/core/test/environment/local_environment_test.ts
+++ b/core/test/environment/local_environment_test.ts
@@ -30,7 +30,14 @@ describe('LocalEnvironment', () => {
   });
 
   afterEach(async () => {
-    await fs.rm(tmpRoot, {recursive: true, force: true});
+    // A command killed by a timeout can outlive the test, and Windows refuses
+    // to remove a directory that is a live process's cwd; retry until it goes.
+    await fs.rm(tmpRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 500,
+    });
   });
 
   describe('lifecycle', () => {

--- a/core/test/environment/local_environment_test.ts
+++ b/core/test/environment/local_environment_test.ts
@@ -1,0 +1,361 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LocalEnvironment} from '@google/adk';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+/**
+ * Commands are built from the Node binary running the tests so that they work
+ * under both `sh` and `cmd.exe`. The outer double quotes survive both shells;
+ * the inner JavaScript string literals stay single-quoted.
+ */
+const NODE = `"${process.execPath}"`;
+
+/** Spawning a child process is slow on Windows CI runners. */
+const SPAWN_TIMEOUT_MS = 30_000;
+
+const decoder = new TextDecoder();
+
+describe('LocalEnvironment', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-local-env-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, {recursive: true, force: true});
+  });
+
+  describe('lifecycle', () => {
+    it('reports isInitialized across initialize() and close()', async () => {
+      const env = new LocalEnvironment({workingDir: path.join(tmpRoot, 'ws')});
+      expect(env.isInitialized).toBe(false);
+
+      await env.initialize();
+      expect(env.isInitialized).toBe(true);
+
+      await env.close();
+      expect(env.isInitialized).toBe(false);
+    });
+
+    it('creates a temporary workspace and removes it on close()', async () => {
+      const env = new LocalEnvironment();
+      expect(() => env.workingDir).toThrow(
+        '`workingDir` is not set. Call initialize() first.',
+      );
+
+      await env.initialize();
+      const workingDir = env.workingDir;
+      expect(path.basename(workingDir)).toMatch(/^adk_workspace_/);
+      await expect(fs.access(workingDir)).resolves.toBeUndefined();
+
+      await env.close();
+      await expect(fs.access(workingDir)).rejects.toThrow(/ENOENT/);
+    });
+
+    it('creates a caller-supplied workspace and keeps it after close()', async () => {
+      const workingDir = path.join(tmpRoot, 'nested', 'workspace');
+      const env = new LocalEnvironment({workingDir});
+
+      await env.initialize();
+      await expect(fs.access(workingDir)).resolves.toBeUndefined();
+
+      await env.close();
+      await expect(fs.access(workingDir)).resolves.toBeUndefined();
+    });
+
+    it('tolerates close() being called twice', async () => {
+      const env = new LocalEnvironment();
+      await env.initialize();
+      await env.close();
+
+      await expect(env.close()).resolves.toBeUndefined();
+    });
+
+    it('keeps the same workspace when initialize() is called twice', async () => {
+      const env = new LocalEnvironment();
+      await env.initialize();
+      const workingDir = env.workingDir;
+
+      await env.initialize();
+
+      expect(env.workingDir).toBe(workingDir);
+      await env.close();
+    });
+
+    it('creates a fresh temporary workspace when re-initialized', async () => {
+      const env = new LocalEnvironment();
+      await env.initialize();
+      const first = env.workingDir;
+      await env.close();
+
+      await env.initialize();
+
+      expect(env.workingDir).not.toBe(first);
+      await env.close();
+    });
+
+    it('rejects execute, readFile and writeFile before initialize()', async () => {
+      const env = new LocalEnvironment({workingDir: path.join(tmpRoot, 'ws')});
+
+      await expect(env.execute(`${NODE} -e ""`)).rejects.toThrow(
+        /not initialized/,
+      );
+      await expect(env.readFile('a.txt')).rejects.toThrow(/not initialized/);
+      await expect(env.writeFile('a.txt', 'x')).rejects.toThrow(
+        /not initialized/,
+      );
+    });
+
+    it('rejects execute() after close() even for a caller-supplied workspace', async () => {
+      const env = new LocalEnvironment({workingDir: path.join(tmpRoot, 'ws')});
+      await env.initialize();
+      await env.close();
+
+      await expect(env.execute(`${NODE} -e ""`)).rejects.toThrow(
+        /not initialized/,
+      );
+    });
+  });
+
+  describe('files', () => {
+    let env: LocalEnvironment;
+    let workingDir: string;
+
+    beforeEach(async () => {
+      workingDir = path.join(tmpRoot, 'ws');
+      env = new LocalEnvironment({workingDir});
+      await env.initialize();
+    });
+
+    afterEach(async () => {
+      await env.close();
+    });
+
+    it('round-trips string content', async () => {
+      await env.writeFile('hello.txt', 'hello world');
+
+      expect(decoder.decode(await env.readFile('hello.txt'))).toBe(
+        'hello world',
+      );
+    });
+
+    it('round-trips binary content', async () => {
+      const raw = Uint8Array.from([0, 1, 2, 255]);
+
+      await env.writeFile('binary.bin', raw);
+
+      expect(Uint8Array.from(await env.readFile('binary.bin'))).toEqual(raw);
+    });
+
+    it('preserves explicit CRLF sequences', async () => {
+      await env.writeFile('crlf.txt', 'first\r\nsecond\r\n');
+
+      expect(decoder.decode(await env.readFile('crlf.txt'))).toBe(
+        'first\r\nsecond\r\n',
+      );
+    });
+
+    it('creates parent directories when writing', async () => {
+      await env.writeFile(path.join('sub', 'dir', 'file.txt'), 'nested');
+
+      expect(decoder.decode(await env.readFile('sub/dir/file.txt'))).toBe(
+        'nested',
+      );
+    });
+
+    it('accepts an absolute path inside the working directory', async () => {
+      const absolute = path.join(workingDir, 'absolute.txt');
+
+      await env.writeFile(absolute, 'absolute');
+
+      expect(decoder.decode(await env.readFile(absolute))).toBe('absolute');
+    });
+
+    it('rejects parent traversal on both read and write', async () => {
+      await fs.writeFile(path.join(tmpRoot, 'outside.txt'), 'secret');
+
+      await expect(
+        env.readFile(path.join('..', 'outside.txt')),
+      ).rejects.toThrow(/escapes working directory/);
+      await expect(
+        env.writeFile(path.join('..', 'write-outside.txt'), 'nope'),
+      ).rejects.toThrow(/escapes working directory/);
+      await expect(
+        fs.access(path.join(tmpRoot, 'write-outside.txt')),
+      ).rejects.toThrow(/ENOENT/);
+    });
+
+    it('rejects the working directory parent itself', async () => {
+      await expect(env.readFile('..')).rejects.toThrow(
+        /escapes working directory/,
+      );
+    });
+
+    it('rejects an absolute path outside the working directory', async () => {
+      const outside = path.join(tmpRoot, 'outside-absolute.txt');
+      await fs.writeFile(outside, 'secret');
+
+      await expect(env.readFile(outside)).rejects.toThrow(
+        /escapes working directory/,
+      );
+    });
+
+    it('rejects a sibling directory that merely shares the name prefix', async () => {
+      const sibling = path.join(`${workingDir}-evil`, 'x.txt');
+
+      await expect(env.readFile(sibling)).rejects.toThrow(
+        /escapes working directory/,
+      );
+    });
+
+    it('propagates ENOENT when reading a missing file', async () => {
+      await expect(env.readFile('does_not_exist.txt')).rejects.toThrow(
+        /ENOENT/,
+      );
+    });
+  });
+
+  describe('execute', () => {
+    let env: LocalEnvironment;
+
+    beforeEach(async () => {
+      env = new LocalEnvironment({workingDir: path.join(tmpRoot, 'ws')});
+      await env.initialize();
+    });
+
+    afterEach(async () => {
+      await env.close();
+    });
+
+    it(
+      'captures stdout and reports the documented zero-state result',
+      async () => {
+        const result = await env.execute(
+          `${NODE} -e "process.stdout.write('hello')"`,
+        );
+
+        expect(result).toEqual({
+          exitCode: 0,
+          stdout: 'hello',
+          stderr: '',
+          timedOut: false,
+        });
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'captures stderr',
+      async () => {
+        const result = await env.execute(
+          `${NODE} -e "process.stderr.write('boom')"`,
+        );
+
+        expect(result.stderr).toBe('boom');
+        expect(result.exitCode).toBe(0);
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'propagates a non-zero exit code',
+      async () => {
+        const result = await env.execute(`${NODE} -e "process.exit(3)"`);
+
+        expect(result.exitCode).toBe(3);
+        expect(result.timedOut).toBe(false);
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'runs the command in the working directory',
+      async () => {
+        const result = await env.execute(
+          `${NODE} -e "process.stdout.write(process.cwd())"`,
+        );
+
+        // macOS resolves the temp dir through a symlink, so compare real paths.
+        expect(result.stdout.trim()).toBe(await fs.realpath(env.workingDir));
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'merges envVars into the command environment',
+      async () => {
+        const scoped = new LocalEnvironment({
+          workingDir: path.join(tmpRoot, 'env-ws'),
+          envVars: {ADK_TEST_VAR: 'abc'},
+        });
+        await scoped.initialize();
+
+        try {
+          const result = await scoped.execute(
+            `${NODE} -e "process.stdout.write(process.env.ADK_TEST_VAR || '')"`,
+          );
+
+          expect(result.stdout.trim()).toBe('abc');
+        } finally {
+          await scoped.close();
+        }
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'kills the command and reports timedOut once the timeout elapses',
+      async () => {
+        const startedAt = Date.now();
+
+        const result = await env.execute(
+          `${NODE} -e "setTimeout(() => {}, 10000)"`,
+          0.5,
+        );
+
+        expect(result.timedOut).toBe(true);
+        expect(result.exitCode).not.toBe(0);
+        expect(Date.now() - startedAt).toBeLessThan(9_000);
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'clears the timer when the command finishes before the timeout',
+      async () => {
+        const result = await env.execute(
+          `${NODE} -e "process.stdout.write('quick')"`,
+          SPAWN_TIMEOUT_MS / 1000,
+        );
+
+        expect(result.stdout).toBe('quick');
+        expect(result.timedOut).toBe(false);
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+
+    it(
+      'rejects when the shell cannot be spawned',
+      async () => {
+        const removed = new LocalEnvironment({
+          workingDir: path.join(tmpRoot, 'gone'),
+        });
+        await removed.initialize();
+        await fs.rm(removed.workingDir, {recursive: true, force: true});
+
+        await expect(removed.execute(`${NODE} -e ""`)).rejects.toThrow();
+
+        await removed.close();
+      },
+      SPAWN_TIMEOUT_MS,
+    );
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**Problem:** adk-python has a small, self-contained abstraction for "a place where an agent can run shell commands and read/write files" (`src/google/adk/environment/`). Everything file/shell related there is written against that interface, which is what lets the same tool run against a local subprocess or a remote sandbox. adk-js has no equivalent, so any future adk-js shell/file tool has to hardcode local `child_process` access and can never be pointed at a sandbox.

**Solution:** port the interface itself first, as an independent, cleanly landable change — the abstract contract, its result type, and the one concrete local implementation, nothing else. `core/src/environment/` now exports:

| Symbol                                         | Kind           | Parity source                                  |
| ---------------------------------------------- | -------------- | ---------------------------------------------- |
| `ExecutionResult`                              | interface      | `environment/_base_environment.py` (dataclass) |
| `BaseEnvironment`                              | abstract class | `environment/_base_environment.py`             |
| `LocalEnvironment` / `LocalEnvironmentOptions` | class          | `environment/_local_environment.py`            |

All three are marked `@experimental`. `BaseEnvironment` and `ExecutionResult` import no Node built-ins, so they ship from the browser-safe barrel (`core/src/common.ts`); `LocalEnvironment` spawns child processes and is exported from the Node barrel (`core/src/index.ts`) only, matching how `UnsafeLocalCodeExecutor` is wired.

```ts
import {LocalEnvironment} from '@google/adk';

const env = new LocalEnvironment(); // temp dir created on initialize(), removed on close()
await env.initialize();
try {
  await env.writeFile('script.js', 'console.log("hi");');
  const result = await env.execute(`"${process.execPath}" script.js`, 30);
  // {exitCode: 0, stdout: 'hi\n', stderr: '', timedOut: false}
} finally {
  await env.close();
}
```

**Deliberately out of scope** (queued separately, not touched here): the `tools/environment/` toolset, any Daytona/E2B sandbox implementation, and any refactor of `core/src/code_executors/*` onto `BaseEnvironment`. Code executors are a _different_ abstraction — they run a code _snippet_ and return `CodeExecutionResult {stdout, stderr, outputFiles}`, with no working-dir scoping, no `readFile`/`writeFile` and no lifecycle — so the two result types are deliberately not unified. The `ExecutionResult` JSDoc says so explicitly to keep the two apart.

**Why one PR and not a stack.** 823 added lines, but 481 of them are the two test files and the source is a single cohesive module. The only natural split — `BaseEnvironment` in part 1, `LocalEnvironment` in part 2 — would make part 1 an exported abstract class with zero implementations and zero readers, which is worse to review, not better.

#### Parity deviations (all deliberate)

| adk-python                                       | This port                                                            | Why                                                                                                                                                                                                                                                                                                                                                                      |
| ------------------------------------------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `is_initialized` property **with a setter**      | `isInitialized` **getter only**, backed by `protected initialized`   | A public setter lets external code assert an initialized state that is false, defeating the guard. Subclasses set the protected field, which is what `LocalEnvironment` already does in Python (`self._is_initialized = True`).                                                                                                                                          |
| guards on `if self._working_dir is None`         | guards on `assertInitialized()`                                      | **The one place this port is deliberately stricter.** In Python, passing an explicit `working_dir` sets the attribute in `__init__`, so `execute`/`read_file`/`write_file` work without `initialize()` ever being called — and keep working after `close()`, which only clears `_working_dir` for auto-created dirs. Here they fail loudly instead. Pinned by two tests. |
| `working_dir -> Path`                            | `workingDir: string`                                                 | Node has no `Path` object; `string` is the adk-js convention (`FileArtifactService`, `materializeFiles`).                                                                                                                                                                                                                                                                |
| `execute(command, *, timeout)`                   | `execute(command, timeoutSeconds?)`                                  | Keyword-only maps to an optional trailing parameter. Renamed for unit clarity, matching `UnsafeLocalCodeExecutorOptions.timeoutSeconds`. No options bag for one optional parameter.                                                                                                                                                                                      |
| `read_file -> bytes`, `write_file(str \| bytes)` | `readFile -> Promise<Uint8Array>`, `writeFile(string \| Uint8Array)` | `Uint8Array` rather than `Buffer` keeps `base_environment.ts` free of Node types so it can live in the browser-safe barrel. `Buffer` is assignable to `Uint8Array`, so no cast is needed.                                                                                                                                                                                |
| dataclass field defaults                         | required fields                                                      | Same call as `CodeExecutionResult`, which makes `stdout`/`stderr`/`outputFiles` required though the Python original defaults them. Optional fields would push `\| undefined` onto every consumer. The default _values_ still hold behaviourally and are pinned by a test asserting the exact zero-state object.                                                          |
| `Path.resolve()` containment (resolves symlinks) | `path.resolve` + `path.relative` containment (lexical only)          | `fs.realpath` would fail for the not-yet-created file in `writeFile`. The JSDoc says plainly that this is a lexical check and **not** a sandbox: it does not survive symlinks, hardlinks, bind mounts or TOCTOU.                                                                                                                                                         |

Parity rule applied where the two conflict: local TS convention wins for in-process concerns (naming, `private`/`protected`, module layout); parity wins for anything observable — hence `exitCode` reproduces Python's negative signal number (`-9` for SIGKILL) rather than an invented sentinel, and the thrown message keeps Python's `Path escapes working directory:` wording.

#### Documented limitations (all stated in the JSDoc, all shared with the reference)

`LocalEnvironment` runs arbitrary shell strings on the host with no sandboxing and no sanitisation; stdout/stderr are buffered fully in memory with no cap; the child inherits the whole of `process.env`; and a timeout `SIGKILL`s the shell, so processes it forked may survive. It is a building block — gating execution behind an explicit confirmation is the job of the (out-of-scope) tools built on top of it.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npx vitest run --project unit:core core/test/environment` → **31 passed** (2 files), and green on all three CI legs (`ubuntu-latest`, `macos-latest`, `windows-latest`). Commands are built from `process.execPath` with outer double quotes so they run under both `sh` and `cmd.exe`; the cwd assertion normalises `fs.realpath` on **both** sides, because macOS reaches `os.tmpdir()` through a symlink and Windows CI reports it as an 8.3 short path.

Coverage of the new module (`--coverage.include='core/src/environment/**'`):

```
File                    | % Stmts | % Branch | % Funcs | % Lines
base_environment.ts     |     100 |      100 |     100 |     100
local_environment.ts    |     100 |    96.77 |     100 |     100
```

The single uncovered branch is the `?? 0` fallback in
`exitCode: signal === null ? (code ?? 0) : -os.constants.signals[signal]`.
It is unreachable by construction — Node guarantees exactly one of `code`/`signal` is non-null on `'close'` — but TypeScript types both as nullable. Keeping it is the honest option: the alternative is a non-null assertion, and the fallback mirrors Python's own `proc.returncode or 0`. No coverage pragma was added to hide it.

#### A real defect the cross-platform CI caught

The first CI run was green on macOS and red on `ubuntu-latest` and `windows-latest`, both with `expected 10054 to be less than 9000` — `execute(cmd, 0.5)` had blocked for the command's full 10s runtime. Root cause: `spawn(…, {shell: true})` runs the command under `/bin/sh` (bash on my workstation, **dash** on ubuntu-latest, `cmd.exe` on Windows). bash `exec`s a simple command, so the shell process _is_ the command and `SIGKILL` reaches it; dash and `cmd.exe` fork, so the kill only reaches the shell and the surviving command keeps the stdio pipes open — and `'close'` fires only once the process has exited **and** its stdio is closed. Reproduced locally by forcing the shell:

```
/bin/bash  close after 524ms    (SIGKILL)
/bin/dash  exit  after 516ms  ->  close after 10132ms
```

Fix: destroy the read ends alongside the kill, so the timeout is enforced regardless of what the shell did with the command. Output produced before the kill is still returned. The surviving process itself is the documented limitation this port shares with adk-python; the JSDoc now also records its Windows consequence (a survivor keeps the working directory locked, so a `close()` right after a timeout can fail to remove a temporary workspace). Actually killing the process tree — `detached` + a process-group kill on POSIX, `taskkill /T` on Windows — would remove the limitation entirely but goes beyond the reference implementation, so it is filed as follow-up work rather than smuggled into this port.

A regression test pins this on every platform without depending on which shell is installed: it writes a script that spawns a child inheriting stdio, so the survivor exists even under bash.

The second, Windows-only failure was in the test's own teardown — `EBUSY: resource busy or locked, rmdir` — the same survivor holding the workspace as its cwd. That was fixed in the tests only (`fs.rm` retries, shorter-lived commands, an explicit hook budget); no assertion was weakened to get CI green.

**Proof the tests can fail.** Each mutation was applied to the finished implementation, the suite re-run, then reverted:

| Mutation                                                                          | Test that failed                                                                           | Failure message                                                                                                        |
| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
| Delete `this.assertInitialized()` from `execute()`                                | `rejects execute, readFile and writeFile before initialize()` (+ the after-`close()` test) | `expected [Function] to throw error matching /not initialized/ but got 'spawn /bin/sh ENOENT'`                         |
| Replace the `path.relative` guard with `if (!resolved.startsWith(base))`          | `rejects a sibling directory that merely shares the name prefix`                           | `expected [Function] to throw error matching /escapes working directory/ but got 'ENOENT: no such file or directory…'` |
| `timedOut = false` in the timeout handler                                         | `kills the command and reports timedOut once the timeout elapses`                          | `expected false to be true`                                                                                            |
| Drop `this.autoCreated &&` from `close()`                                         | `creates a caller-supplied workspace and keeps it after close()`                           | `promise rejected "Error: ENOENT: no such file or directory…" instead of resolving`                                    |
| `if (false)` in `BaseEnvironment.assertInitialized()`                             | `rejects operations until a subclass marks it initialized`                                 | `promise resolved "{ exitCode: +0, stdout: '', …(2) }" instead of rejecting`                                           |
| Drop `child.stdout.destroy()` / `child.stderr.destroy()` from the timeout handler | `times out even when the command leaves a child holding the pipes open`                    | `expected 5296 to be less than 4000`                                                                                   |

**Manual End-to-End (E2E) Tests:**

Run against the **built** package (`npm run build --workspace core`), importing from `@google/adk` — no mocks, real child processes, real filesystem:

```ts
import {LocalEnvironment} from '@google/adk';
const env = new LocalEnvironment();
await env.initialize();
console.log(env.workingDir); // /tmp/adk_workspace_XXXXXX
await env.writeFile('script.js', 'console.log("hi");');
console.log(await env.execute(`"${process.execPath}" script.js`, 30));
console.log(
  await env.execute(
    `"${process.execPath}" -e "setTimeout(() => {}, 10000)"`,
    0.5,
  ),
);
await env.close(); // temp dir is gone
```

Observed:

```
workspace: /tmp/adk_workspace_XG45Vh
execute:   { exitCode: 0, stdout: 'hi\n', stderr: '', timedOut: false }
timeout:   { exitCode: -9, stdout: '', stderr: '', timedOut: true }
envVars:   { exitCode: 0, stdout: '1', stderr: '', timedOut: false }
```

i.e. the temp directory appears under the OS temp dir while open and is gone after `close()`, output round-trips, `-9` matches Python's SIGKILL return code, `envVars` reach the child, `readFile('../escape.txt')` rejects, and a caller-supplied `workingDir` survives `close()`.

Other CI gates run locally on the rebased commit: `npm run build` ✅, `npm run lint` ✅, `scripts/check_license.sh` ✅, `npx secretlint` ✅, `npm run docs:check` (typedoc `--treatWarningsAsErrors`) ✅, and `tsc -p core --noEmit` is clean. `npm run format:check` reports no issue in any file this PR touches (its 16 remaining warnings are pre-existing on `main`). `npm run ts:check` at the repo root fails identically before and after this change (745 pre-existing errors on a clean tree, 745 with it, none in the new files).

#### Simplicity review

An independent complexity audit returned _"Lean. Faithful, tightly scoped port with no suppressions and no unrelated hunks. Nothing blocking."_ A second pass over the final diff, asked specifically to scrutinise the late CI fixes, returned _"Lean already. Ship."_ with no findings. Two of the first pass's four nits were applied (trimmed a redundant JSDoc sentence and a comment). Three were declined, with reasons:

- **"`resolve(code ?? -1)` instead of the negative signal number."** Declined: `exitCode` is an observable output of a ported API, so parity wins. Verified: the manual run returns `-9` for SIGKILL, matching Python.
- **"Collapse the path guard to `resolved !== base && !resolved.startsWith(base + path.sep)`."** Declined — it is 4 lines shorter but wrong on Windows, which CI runs. `path.win32.relative('C:\Users\x\ws', 'c:\users\x\ws\a.txt')` returns `'a.txt'` (case-folded, correctly accepted) whereas the `startsWith` form returns `false` and would reject a legitimate in-workspace path on a case-insensitive filesystem. The `path.isAbsolute(relative)` arm is likewise load-bearing: `path.win32.relative('C:\ws', 'D:\evil.txt')` returns `'D:\evil.txt'`, which neither of the other two conditions catches. This also matches existing repo precedent in `core/src/artifacts/file_artifact_service.ts`.
- **"Let the base `initialize()` set the flag."** Declined: Python's base `initialize()` is a pure no-op that leaves `is_initialized` false, and flipping the flag by default would let a subclass that failed to set itself up report as initialized — the opposite of the strictness this port exists to add.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
