### PR TITLE
feat: Port the typed-errors module (errors/) from adk-python

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -146,6 +146,14 @@ export {TruncatingContextCompactor} from './context/truncating_context_compactor
 export type {TruncatingContextCompactorOptions} from './context/truncating_context_compactor.js';
 export {BaseEnvironment} from './environment/base_environment.js';
 export type {ExecutionResult} from './environment/base_environment.js';
+export {AlreadyExistsError} from './errors/already_exists_error.js';
+export {InputValidationError} from './errors/input_validation_error.js';
+export {NotFoundError} from './errors/not_found_error.js';
+export {SessionNotFoundError} from './errors/session_not_found_error.js';
+export {
+  ToolErrorType,
+  ToolExecutionError,
+} from './errors/tool_execution_error.js';
 export {isCompactedEvent, isScratchpadEvent} from './events/compacted_event.js';
 export type {CompactedEvent} from './events/compacted_event.js';
 export {

--- a/core/src/errors/already_exists_error.ts
+++ b/core/src/errors/already_exists_error.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Represents an error that occurs when an entity already exists.
+ */
+export class AlreadyExistsError extends Error {
+  /**
+   * @param message An optional custom message to describe the error.
+   */
+  constructor(message = 'The resource already exists.') {
+    super(message);
+    this.name = 'AlreadyExistsError';
+  }
+}

--- a/core/src/errors/input_validation_error.ts
+++ b/core/src/errors/input_validation_error.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Represents an error raised when user input fails validation.
+ */
+export class InputValidationError extends Error {
+  /**
+   * @param message A message describing why the input is invalid.
+   */
+  constructor(message = 'Invalid input.') {
+    super(message);
+    this.name = 'InputValidationError';
+  }
+}

--- a/core/src/errors/not_found_error.ts
+++ b/core/src/errors/not_found_error.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Represents an error that occurs when an entity is not found.
+ */
+export class NotFoundError extends Error {
+  /**
+   * @param message An optional custom message to describe the error.
+   */
+  constructor(message = 'The requested item was not found.') {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}

--- a/core/src/errors/session_not_found_error.ts
+++ b/core/src/errors/session_not_found_error.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Raised when a session cannot be found.
+ */
+export class SessionNotFoundError extends Error {
+  /**
+   * @param message An optional custom message to describe the error.
+   */
+  constructor(message = 'Session not found.') {
+    super(message);
+    this.name = 'SessionNotFoundError';
+  }
+}

--- a/core/src/errors/tool_execution_error.ts
+++ b/core/src/errors/tool_execution_error.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * HTTP error types conforming to OpenTelemetry semantics.
+ *
+ * The string values populate the `error.type` span attribute, so they are
+ * observable outside the process and must stay identical to the adk-python
+ * `ToolErrorType` members.
+ */
+export enum ToolErrorType {
+  BAD_REQUEST = 'BAD_REQUEST',
+  UNAUTHORIZED = 'UNAUTHORIZED',
+  FORBIDDEN = 'FORBIDDEN',
+  NOT_FOUND = 'NOT_FOUND',
+  REQUEST_TIMEOUT = 'REQUEST_TIMEOUT',
+  INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR',
+  BAD_GATEWAY = 'BAD_GATEWAY',
+  SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE',
+  GATEWAY_TIMEOUT = 'GATEWAY_TIMEOUT',
+}
+
+/**
+ * Represents an error that occurs during the execution of a tool.
+ */
+export class ToolExecutionError extends Error {
+  /**
+   * @param message A message describing the error.
+   * @param errorType The semantic error type (e.g.
+   *   {@link ToolErrorType.REQUEST_TIMEOUT} or `'500'`). Used to populate the
+   *   `error.type` span attribute in OpenTelemetry traces.
+   */
+  constructor(
+    message: string,
+    readonly errorType?: ToolErrorType | string,
+  ) {
+    super(message);
+    this.name = 'ToolExecutionError';
+  }
+}

--- a/core/test/errors/already_exists_error_test.ts
+++ b/core/test/errors/already_exists_error_test.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {AlreadyExistsError, NotFoundError} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('AlreadyExistsError', () => {
+  it('defaults the message when none is supplied', () => {
+    expect(new AlreadyExistsError().message).toBe(
+      'The resource already exists.',
+    );
+    expect(new AlreadyExistsError(undefined).message).toBe(
+      'The resource already exists.',
+    );
+  });
+
+  it('stores a supplied message verbatim', () => {
+    expect(new AlreadyExistsError('Session 42 already exists.').message).toBe(
+      'Session 42 already exists.',
+    );
+    expect(new AlreadyExistsError('').message).toBe('');
+  });
+
+  it('sets name', () => {
+    expect(new AlreadyExistsError().name).toBe('AlreadyExistsError');
+  });
+
+  it('is an instance of itself and of Error', () => {
+    const error = new AlreadyExistsError();
+    expect(error).toBeInstanceOf(AlreadyExistsError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('is not an instance of a sibling error class', () => {
+    expect(new AlreadyExistsError()).not.toBeInstanceOf(NotFoundError);
+  });
+
+  it('can be thrown and caught by type', () => {
+    expect(() => {
+      throw new AlreadyExistsError('boom');
+    }).toThrow(AlreadyExistsError);
+  });
+});

--- a/core/test/errors/input_validation_error_test.ts
+++ b/core/test/errors/input_validation_error_test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {InputValidationError, NotFoundError} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('InputValidationError', () => {
+  it('defaults the message when none is supplied', () => {
+    expect(new InputValidationError().message).toBe('Invalid input.');
+    expect(new InputValidationError(undefined).message).toBe('Invalid input.');
+  });
+
+  it('stores a supplied message verbatim', () => {
+    expect(new InputValidationError('appName is required.').message).toBe(
+      'appName is required.',
+    );
+    expect(new InputValidationError('').message).toBe('');
+  });
+
+  it('sets name', () => {
+    expect(new InputValidationError().name).toBe('InputValidationError');
+  });
+
+  it('is an instance of itself and of Error', () => {
+    const error = new InputValidationError();
+    expect(error).toBeInstanceOf(InputValidationError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('is not an instance of a sibling error class', () => {
+    expect(new InputValidationError()).not.toBeInstanceOf(NotFoundError);
+  });
+
+  it('can be thrown and caught by type', () => {
+    expect(() => {
+      throw new InputValidationError('boom');
+    }).toThrow(InputValidationError);
+  });
+});

--- a/core/test/errors/not_found_error_test.ts
+++ b/core/test/errors/not_found_error_test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {NotFoundError, SessionNotFoundError} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('NotFoundError', () => {
+  it('defaults the message when none is supplied', () => {
+    expect(new NotFoundError().message).toBe(
+      'The requested item was not found.',
+    );
+    expect(new NotFoundError(undefined).message).toBe(
+      'The requested item was not found.',
+    );
+  });
+
+  it('stores a supplied message verbatim', () => {
+    expect(new NotFoundError('No eval set foo.').message).toBe(
+      'No eval set foo.',
+    );
+    // An empty string is a supplied argument, so it must not fall back to the
+    // default: only `undefined` triggers a default parameter.
+    expect(new NotFoundError('').message).toBe('');
+    // No sanitisation: `$` replacement patterns are stored as written.
+    expect(new NotFoundError("a $& b $' c").message).toBe("a $& b $' c");
+  });
+
+  it('sets name', () => {
+    expect(new NotFoundError().name).toBe('NotFoundError');
+  });
+
+  it('is an instance of itself and of Error', () => {
+    const error = new NotFoundError();
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('is not an instance of a sibling error class', () => {
+    expect(new NotFoundError()).not.toBeInstanceOf(SessionNotFoundError);
+  });
+
+  it('can be thrown and caught by type', () => {
+    expect(() => {
+      throw new NotFoundError('boom');
+    }).toThrow(NotFoundError);
+  });
+});

--- a/core/test/errors/session_not_found_error_test.ts
+++ b/core/test/errors/session_not_found_error_test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {NotFoundError, SessionNotFoundError} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('SessionNotFoundError', () => {
+  it('defaults the message when none is supplied', () => {
+    expect(new SessionNotFoundError().message).toBe('Session not found.');
+    expect(new SessionNotFoundError(undefined).message).toBe(
+      'Session not found.',
+    );
+  });
+
+  it('stores a supplied message verbatim', () => {
+    expect(new SessionNotFoundError('No session 42.').message).toBe(
+      'No session 42.',
+    );
+    expect(new SessionNotFoundError('').message).toBe('');
+  });
+
+  it('sets name', () => {
+    expect(new SessionNotFoundError().name).toBe('SessionNotFoundError');
+  });
+
+  it('is an instance of itself and of Error', () => {
+    const error = new SessionNotFoundError();
+    expect(error).toBeInstanceOf(SessionNotFoundError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('is not an instance of a sibling error class', () => {
+    // The hierarchy is flat: SessionNotFoundError must not extend
+    // NotFoundError, or `catch (e) { if (e instanceof NotFoundError) }` would
+    // start swallowing session lookups it does not swallow in adk-python.
+    expect(new SessionNotFoundError()).not.toBeInstanceOf(NotFoundError);
+  });
+
+  it('can be thrown and caught by type', () => {
+    expect(() => {
+      throw new SessionNotFoundError('boom');
+    }).toThrow(SessionNotFoundError);
+  });
+});

--- a/core/test/errors/tool_execution_error_test.ts
+++ b/core/test/errors/tool_execution_error_test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {NotFoundError, ToolErrorType, ToolExecutionError} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+
+describe('ToolErrorType', () => {
+  it('matches the adk-python members, in declaration order', () => {
+    expect(Object.values(ToolErrorType)).toEqual([
+      'BAD_REQUEST',
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'NOT_FOUND',
+      'REQUEST_TIMEOUT',
+      'INTERNAL_SERVER_ERROR',
+      'BAD_GATEWAY',
+      'SERVICE_UNAVAILABLE',
+      'GATEWAY_TIMEOUT',
+    ]);
+    // Pins the count independently, so an added member fails even if the
+    // expected list above is ever loosened.
+    expect(Object.values(ToolErrorType)).toHaveLength(9);
+  });
+
+  it('gives every member a value identical to its name', () => {
+    for (const [name, value] of Object.entries(ToolErrorType)) {
+      expect(value).toBe(name);
+    }
+  });
+});
+
+describe('ToolExecutionError', () => {
+  it('stores the message and leaves errorType undefined when not supplied', () => {
+    const error = new ToolExecutionError('Tool blew up.');
+    expect(error.message).toBe('Tool blew up.');
+    expect(error.errorType).toBeUndefined();
+  });
+
+  it('stores a ToolErrorType member', () => {
+    expect(
+      new ToolExecutionError('boom', ToolErrorType.BAD_REQUEST).errorType,
+    ).toBe(ToolErrorType.BAD_REQUEST);
+  });
+
+  it('stores a member as its own string value, needing no normalisation', () => {
+    // adk-python unwraps `error_type.value`; a TypeScript string-enum member
+    // already *is* that string, so direct assignment is equivalent.
+    expect(
+      new ToolExecutionError('boom', ToolErrorType.NOT_FOUND).errorType,
+    ).toBe('NOT_FOUND');
+  });
+
+  it('stores a raw string errorType verbatim', () => {
+    expect(new ToolExecutionError('boom', '500').errorType).toBe('500');
+  });
+
+  it('sets name', () => {
+    expect(new ToolExecutionError('boom').name).toBe('ToolExecutionError');
+  });
+
+  it('is an instance of itself and of Error', () => {
+    const error = new ToolExecutionError('boom');
+    expect(error).toBeInstanceOf(ToolExecutionError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('is not an instance of a sibling error class', () => {
+    expect(new ToolExecutionError('boom')).not.toBeInstanceOf(NotFoundError);
+  });
+
+  it('can be thrown and caught by type', () => {
+    expect(() => {
+      throw new ToolExecutionError('boom', ToolErrorType.GATEWAY_TIMEOUT);
+    }).toThrow(ToolExecutionError);
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue.

**2. Or, if no issue exists, describe the change:**

**Problem:**
adk-js has no typed errors. Services signal "the thing you asked for does not exist", "the thing you are creating already exists" and "something genuinely broke" all with a bare `Error` (or by returning `undefined`), so the only way for a caller to branch on the failure mode is to string-match `error.message` — which breaks the moment a message is reworded. adk-python solved this with a small `errors/` module; adk-js has no equivalent, so each in-flight port (session services, the evaluation framework) would otherwise invent its own incompatible error classes.

**Solution:**
Port `adk-python/src/google/adk/errors/` to `core/src/errors/`, one TypeScript file per Python file, and export the six symbols from `core/src/common.ts`. The change is purely additive: 5 new source files, 5 new test files, and 8 added lines in `common.ts`. No existing `throw` site is touched, no dependency is added, and `git diff main --stat` is 387 insertions / 0 deletions.

| New file (`core/src/errors/`) | Exported symbols                      | Parity source                |
| ----------------------------- | ------------------------------------- | ---------------------------- |
| `not_found_error.ts`          | `NotFoundError`                       | `not_found_error.py`         |
| `already_exists_error.ts`     | `AlreadyExistsError`                  | `already_exists_error.py`    |
| `session_not_found_error.ts`  | `SessionNotFoundError`                | `session_not_found_error.py` |
| `input_validation_error.ts`   | `InputValidationError`                | `input_validation_error.py`  |
| `tool_execution_error.ts`     | `ToolErrorType`, `ToolExecutionError` | `tool_execution_error.py`    |

```ts
import {NotFoundError} from '@google/adk';

try {
  await evalSetManager.getEvalSet(appName, evalSetId);
} catch (e: unknown) {
  if (e instanceof NotFoundError) return undefined; // benign miss
  throw e; // real failure, propagate
}
```

**Parity decisions, and which rule won each one.** Every default message, member name and member value was diffed field-by-field against the Python source; local TS convention was only allowed to win where nothing crosses a process boundary.

1. **Flat hierarchy — parity wins.** In Python `NotFoundError`/`AlreadyExistsError` extend `Exception` while `SessionNotFoundError`/`InputValidationError` extend `ValueError` ("for backward compatibility" with callers already catching `ValueError`). TypeScript has no `ValueError` analogue, so all five extend `Error` **directly**. Deliberately _not_ done: making `SessionNotFoundError extend NotFoundError`, or introducing an `AdkError` base. Either would invent a catch relationship that does not exist upstream and would silently change which `catch` block wins. A test in each file pins this by asserting an instance is **not** an instance of a sibling.
2. **`error_type` → `errorType` — local convention wins.** The property name never leaves the process. The enum **values** are unchanged, because those do cross the boundary: they populate the OpenTelemetry `error.type` span attribute. All nine member names/values are byte-identical to `tool_execution_error.py`, and a test asserts the exact list, its order, and a length of exactly 9 (so an _added_ member also fails).
3. **No enum→string normalisation.** Python needs `error_type.value if isinstance(error_type, ToolErrorType) else error_type` because an enum member is not its value. A TypeScript string-enum member **is** its string value at runtime, so direct assignment is already equivalent and the branch would be dead code. Pinned by a test asserting `new ToolExecutionError('x', ToolErrorType.NOT_FOUND).errorType === 'NOT_FOUND'`.
4. **No separate `message` field.** Python sets `self.message` because `Exception` does not expose one; JS `Error` already has `.message` from `super(message)`. A redundant field would shadow the built-in.
5. **No `Object.setPrototypeOf(this, X.prototype)`.** That shim is only needed when `class` is downlevelled to an ES5 constructor function, and this repo never does that: `tsconfig.json` sets `"target": "ES2020"`, and `core/build.js:9-12` sets esbuild targets `node10.4` for the Node build and `chrome58`/`firefox57`/`safari11` for the browser build — all emit native classes. Verified on the actual build output: `core/dist/web/errors/not_found_error.js` (the most aggressive target) contains a literal `class NotFoundError extends Error`, and importing it under Node gives `instanceof NotFoundError: true | instanceof Error: true | not sibling: true | name: NotFoundError`. There are also zero occurrences of `setPrototypeOf` anywhere in `core/src`, `dev/src` or `integrations/src`, so adding it to five classes would be unexplained ceremony.
6. **`errorType` is written but not yet read inside this repo — intentional.** `core/src/telemetry/tracing.ts` has no `error.type` span-attribute handling today; porting adk-python's `resolve_error_type` is separate follow-up work. This is a public API property being ported for parity, not dead internal config, so please don't read it as an unwired knob. Refactoring existing bare-`Error` throws (e.g. `core/src/sessions/database_session_service.ts`) is likewise deliberately out of scope — it would collide with the in-flight session/evaluation work.

**Barrel placement.** `core/src` has no per-directory `index.ts`; `core/src/common.ts` is the real barrel and is re-exported wholesale by both `index.ts` (Node) and `index_web.ts` (browser). These classes are platform-neutral, so they go in `common.ts` **only** — adding them to `index.ts` as well would be redundant. Exported as values (`export {…}`, not `export type {…}`), since they are runtime classes plus a runtime enum.

**Collision check.** No path containing `errors` is touched by any other open PR. The only shared file is `core/src/common.ts`, where a handful of open PRs add unrelated export lines; this PR is branched from `main` rather than stacked on any of them, so expect at most a trivial add/add conflict in `common.ts` depending on merge order.

### Testing Plan

_Please describe the tests that you ran to verify your changes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

5 new files under `core/test/errors/`, 34 tests, all passing:

```
$ npx vitest run --project unit:core core/test/errors
 ✓ |unit:core| core/test/errors/session_not_found_error_test.ts (6 tests)
 ✓ |unit:core| core/test/errors/not_found_error_test.ts (6 tests)
 ✓ |unit:core| core/test/errors/already_exists_error_test.ts (6 tests)
 ✓ |unit:core| core/test/errors/input_validation_error_test.ts (6 tests)
 ✓ |unit:core| core/test/errors/tool_execution_error_test.ts (10 tests)
 Test Files  5 passed (5)
      Tests  34 passed (34)
```

Every test imports from `@google/adk` rather than a relative path, so a missing or misspelt barrel export fails the suite at import time.

**Coverage: 100% statements / branches / functions / lines on `core/src/errors/`**, measured with:

```bash
npx vitest run --project unit:core core/test/errors --coverage --coverage.include='core/src/errors/**'
```

No coverage-ignore pragmas, and no structure was compromised to reach the number.

**Coverage is not proof, so each test file was mutation-tested** — the source was broken and the suite confirmed red, then reverted:

| #   | Mutation                                                                                                     | Result                                                                                                                                         |
| --- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | `not_found_error.ts`: default message `…not found.` → `…not found!`                                          | ✗ `defaults the message when none is supplied` — `expected 'The requested item was not found!' to be 'The requested item was not found.'`      |
| 2   | `already_exists_error.ts`: delete the `this.name = 'AlreadyExistsError';` line                               | ✗ `sets name` — `expected 'Error' to be 'AlreadyExistsError'`                                                                                  |
| 3   | `session_not_found_error.ts`: `extends Error` → `extends NotFoundError` (invent a hierarchy)                 | ✗ `is not an instance of a sibling error class` — `expected SessionNotFoundError: Session not found. to not be an instance of NotFoundError`   |
| 4   | `input_validation_error.ts`: drop the default parameter (`message = 'Invalid input.'` → `message: string`)   | ✗ `defaults the message when none is supplied` — `expected '' to be 'Invalid input.'`                                                          |
| 5   | `tool_execution_error.ts`: remove the `GATEWAY_TIMEOUT` member                                               | ✗ `matches the adk-python members, in declaration order` — `expected [ … …(6) ] to deeply equal [ … …(7) ]`                                    |
| 6   | `tool_execution_error.ts`: drop the `readonly` parameter property so `errorType` is never stored             | ✗ 3 tests — `expected undefined to be 'BAD_REQUEST'`, `… 'NOT_FOUND'`, `… '500'`                                                               |
| 7   | `tool_execution_error.ts`: `BAD_GATEWAY = 'BAD_GATEWAY'` → `'BadGateway'`                                    | ✗ 2 tests — `expected 'BadGateway' to be 'BAD_GATEWAY'` and the member-table assertion                                                         |
| 8   | `common.ts`: delete the `NotFoundError` barrel export line                                                   | ✗ whole suite at import — `TypeError: NotFoundError is not a constructor`                                                                      |

Edge cases covered explicitly: `new X('')` yields `''` and **not** the default (only `undefined` triggers a TS default parameter), `new X(undefined)` yields the default, and a message containing `$` replacement metacharacters (`"a $& b $' c"`) is stored verbatim with no sanitisation.

No integration tests were added, and that is deliberate: nothing in the repo throws or catches these types yet, so an "integration" test could only re-assert the unit behaviour through more indirection. The real integration surface arrives with the follow-up ports.

**No new suppressions anywhere in the diff** — no `any`, `as any`, `@ts-expect-error`, `@ts-ignore`, `eslint-disable`, or coverage-ignore pragma, in source or in tests (verified by grepping `git diff main -U0` for all of them: zero hits).

**Manual End-to-End (E2E) Tests:**

From the repo root, run the checks CI runs:

```bash
npm install && npm run build
npx vitest run --project unit:core core/test/errors   # 34 passed
npm run lint                                          # clean
npm run format:check                                  # clean
npm run docs:check                                    # TypeDoc, warnings-as-errors: clean
bash scripts/check_license.sh                         # all headers valid
```

Then confirm the symbols really are public, against the **built** package rather than the source alias:

```bash
node --input-type=module -e "
import {ToolErrorType, ToolExecutionError} from '@google/adk';
const e = new ToolExecutionError('boom', ToolErrorType.GATEWAY_TIMEOUT);
console.log(e.name, e.message, e.errorType, e instanceof Error);
"
# ToolExecutionError boom GATEWAY_TIMEOUT true
```

Constructing each of the four no-arg errors from the built package prints its parity default: `The requested item was not found.`, `The resource already exists.`, `Session not found.`, `Invalid input.`

One honest note on `npm run ts:check`: it is **not** part of `validation.yaml` and is currently red (366 errors across 67 files). Every one of those 67 files is a file this PR does not touch, and there are zero errors in `core/src/errors/` or `core/test/errors/`. This PR neither adds to nor fixes that backlog.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
