### PR TITLE
Fix: reject zip-slip entries and non-bare skill names when loading zipped skills (adk-python parity)

### DIFF
--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -176,13 +176,10 @@ export function parseSkillMdContent(content: string): {
 }
 
 /**
- * Checks whether a zip member name attempts to escape the extraction root
- * (zip slip). Mirrors the guard in adk-python's `_load_skill_from_zip_bytes`
- * (`src/google/adk/skills/_utils.py`).
- *
- * This is a name-shape check on the archive metadata, not a sandbox: it rejects
- * traversal spellings, and says nothing about symlinks or what a caller
- * subsequently does with the extracted names.
+ * Checks whether a zip member name attempts to escape the extraction root (zip
+ * slip), mirroring adk-python's `_load_skill_from_zip_bytes`. This is a
+ * name-shape check on archive metadata, not a sandbox: it says nothing about
+ * symlinks.
  */
 function isDangerousZipEntryName(entryName: string): boolean {
   return (
@@ -193,12 +190,10 @@ function isDangerousZipEntryName(entryName: string): boolean {
 }
 
 /**
- * Checks that a skill name is a single bare path segment.
- *
- * Mirrors adk-python's `pathlib.Path(name).name != name` check. Node's
- * `path.basename` differs from `pathlib` for the two relative markers -
- * `path.basename('..') === '..'` whereas `pathlib.Path('..').name === ''` - so
- * '.' and '..' are rejected explicitly to keep the two languages in agreement.
+ * Checks that a skill name is a single bare path segment, mirroring
+ * adk-python's `pathlib.Path(name).name != name`. '.' and '..' are rejected
+ * explicitly because `path.basename('..') === '..'` whereas
+ * `pathlib.Path('..').name === ''`.
  */
 function isBareSkillName(name: string): boolean {
   return name !== '.' && name !== '..' && path.basename(name) === name;
@@ -393,9 +388,8 @@ export async function loadAllSkillsInDir(
 /**
  * Loads a complete skill directly from in-memory zip file buffer.
  *
- * The archive is attacker-influenced content, so the whole archive is rejected
- * if any member name escapes the extraction root, and the skill name is
- * required to be a bare path segment.
+ * The whole archive is rejected if any member name escapes the extraction
+ * root, and the skill name must be a bare path segment.
  *
  * @param zipBuffer - The raw Buffer of the zip file containing the skill.
  * @returns A Skill object with all components loaded.

--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -104,14 +104,14 @@ async function loadDir(
 }
 
 /**
- * Parses SKILL.md from a raw content string, extracting the YAML frontmatter and the body.
+ * Splits SKILL.md into its raw, unvalidated YAML frontmatter mapping and its body.
  *
  * @param content - The raw content of the SKILL.md file.
- * @returns An object containing the parsed frontmatter and the remaining markdown body.
+ * @returns An object containing the raw frontmatter mapping and the remaining markdown body.
  * @throws {Error} If the content is not properly formatted with YAML frontmatter.
  */
-export function parseSkillMdContent(content: string): {
-  frontmatter: Frontmatter;
+function parseFrontmatterYaml(content: string): {
+  raw: Record<string, unknown>;
   body: string;
 } {
   if (!content.startsWith('---')) {
@@ -132,15 +132,76 @@ export function parseSkillMdContent(content: string): {
 
   try {
     const parsed = yaml.load(frontmatterStr);
-    if (typeof parsed !== 'object' || parsed === null) {
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       throw new Error('SKILL.md frontmatter must be a YAML mapping');
     }
-    const frontmatter = FrontmatterSchema.parse(parsed);
-
-    return {frontmatter, body};
+    return {raw: parsed as Record<string, unknown>, body};
   } catch (e: unknown) {
     throw new Error(`Invalid YAML in frontmatter: ${(e as Error).message}`);
   }
+}
+
+/**
+ * Validates a raw frontmatter mapping against {@link FrontmatterSchema}.
+ *
+ * @param raw - The raw frontmatter mapping produced by {@link parseFrontmatterYaml}.
+ * @returns The validated and normalized frontmatter.
+ * @throws {Error} If the mapping does not satisfy the schema.
+ */
+function validateFrontmatter(raw: Record<string, unknown>): Frontmatter {
+  try {
+    return FrontmatterSchema.parse(raw);
+  } catch (e: unknown) {
+    throw new Error(`Invalid YAML in frontmatter: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Parses SKILL.md from a raw content string, extracting the YAML frontmatter and the body.
+ *
+ * @param content - The raw content of the SKILL.md file.
+ * @returns An object containing the parsed frontmatter and the remaining markdown body.
+ * @throws {Error} If the content is not properly formatted with YAML frontmatter.
+ */
+export function parseSkillMdContent(content: string): {
+  frontmatter: Frontmatter;
+  body: string;
+} {
+  const {raw, body} = parseFrontmatterYaml(content);
+  return {frontmatter: validateFrontmatter(raw), body};
+}
+
+/**
+ * Checks whether a zip member name attempts to escape the extraction root
+ * (zip slip). Mirrors the guard in adk-python's `_load_skill_from_zip_bytes`
+ * (`src/google/adk/skills/_utils.py`).
+ *
+ * This is a name-shape check on the archive metadata, not a sandbox: it rejects
+ * traversal spellings, and says nothing about symlinks or what a caller
+ * subsequently does with the extracted names.
+ */
+function isDangerousZipEntryName(entryName: string): boolean {
+  return (
+    entryName.startsWith('/') ||
+    entryName.startsWith('../') ||
+    entryName.includes('/../')
+  );
+}
+
+/**
+ * Checks that a skill name is a single bare path segment.
+ *
+ * Mirrors adk-python's `pathlib.Path(name).name != name` check. Node's
+ * `path.basename` differs from `pathlib` for the two relative markers -
+ * `path.basename('..') === '..'` whereas `pathlib.Path('..').name === ''` - so
+ * '.' and '..' are rejected explicitly to keep the two languages in agreement.
+ */
+function isBareSkillName(name: string): boolean {
+  return name !== '.' && name !== '..' && path.basename(name) === name;
 }
 
 /**
@@ -332,12 +393,24 @@ export async function loadAllSkillsInDir(
 /**
  * Loads a complete skill directly from in-memory zip file buffer.
  *
+ * The archive is attacker-influenced content, so the whole archive is rejected
+ * if any member name escapes the extraction root, and the skill name is
+ * required to be a bare path segment.
+ *
  * @param zipBuffer - The raw Buffer of the zip file containing the skill.
  * @returns A Skill object with all components loaded.
+ * @throws {Error} If a member name is a traversal path, if SKILL.md is missing,
+ * or if the skill name is missing or is not a bare path segment.
  */
 export function loadSkillFromZipBuffer(zipBuffer: Buffer): Skill {
   const zip = new AdmZip(zipBuffer);
   const entries = zip.getEntries();
+
+  for (const entry of entries) {
+    if (isDangerousZipEntryName(entry.entryName)) {
+      throw new Error(`Dangerous zip entry ignored: ${entry.entryName}`);
+    }
+  }
 
   let skillMdContent = '';
   for (const entry of entries) {
@@ -352,8 +425,15 @@ export function loadSkillFromZipBuffer(zipBuffer: Buffer): Skill {
     throw new Error('SKILL.md not found in zipped filesystem.');
   }
 
-  const {frontmatter: parsed, body} = parseSkillMdContent(skillMdContent);
-  const frontmatter = FrontmatterSchema.parse(parsed);
+  const {raw, body} = parseFrontmatterYaml(skillMdContent);
+  const skillName = raw['name'];
+  if (!skillName) {
+    throw new Error("SKILL.md frontmatter must contain 'name'");
+  }
+  if (typeof skillName !== 'string' || !isBareSkillName(skillName)) {
+    throw new Error(`Invalid skill name in SKILL.md: ${String(skillName)}`);
+  }
+  const frontmatter = validateFrontmatter(raw);
 
   const references: Record<string, string | Buffer> = {};
   const assets: Record<string, string | Buffer> = {};

--- a/core/test/skills/loader_test.ts
+++ b/core/test/skills/loader_test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import AdmZip from 'adm-zip';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -11,6 +12,7 @@ import {describe, expect, it} from 'vitest';
 import {
   loadAllSkillsInDir,
   loadSkillFromDir,
+  loadSkillFromZipBuffer,
   parseSkillMdContent,
   validateSkillDir,
 } from '../../src/skills/loader.js';
@@ -506,6 +508,124 @@ Instructions`,
       expect(skills['skill-3']).toBeDefined();
 
       await fs.rm(tempDir, {recursive: true, force: true});
+    });
+  });
+
+  describe('loadSkillFromZipBuffer', () => {
+    const validSkillMd = `---
+name: test-skill
+description: A test skill
+---
+Instruction body`;
+
+    /**
+     * Builds an archive containing a member with a raw, unsanitised
+     * `entryName`. `AdmZip.addFile` canonicalises the names it is given
+     * (`'../evil.txt'` is stored as `'evil.txt'`), so the entry is added under a
+     * placeholder name and renamed afterwards.
+     */
+    function createZipWithRawEntryName(entryName: string): Buffer {
+      const zip = new AdmZip();
+      zip.addFile('SKILL.md', Buffer.from(validSkillMd, 'utf-8'));
+      zip.addFile('placeholder.txt', Buffer.from('x', 'utf-8'));
+      const placeholder = zip
+        .getEntries()
+        .find((e) => e.entryName === 'placeholder.txt');
+      if (!placeholder) {
+        expect.fail('fixture setup failed: placeholder.txt was not added');
+      }
+      placeholder.entryName = entryName;
+      return zip.toBuffer();
+    }
+
+    function createZipWithSkillMd(skillMd: string): Buffer {
+      const zip = new AdmZip();
+      zip.addFile('SKILL.md', Buffer.from(skillMd, 'utf-8'));
+      return zip.toBuffer();
+    }
+
+    function createZipWithSkillName(name: string): Buffer {
+      return createZipWithSkillMd(
+        `---\nname: ${name}\ndescription: A test skill\n---\nBody`,
+      );
+    }
+
+    it('loads a benign archive with all resource trees', () => {
+      const zip = new AdmZip();
+      zip.addFile('SKILL.md', Buffer.from(validSkillMd, 'utf-8'));
+      zip.addFile('references/ref1.md', Buffer.from('ref content', 'utf-8'));
+      zip.addFile('assets/a.txt', Buffer.from('asset content', 'utf-8'));
+      zip.addFile('scripts/run.sh', Buffer.from('echo hello', 'utf-8'));
+
+      const skill = loadSkillFromZipBuffer(zip.toBuffer());
+
+      expect(skill.frontmatter.name).toBe('test-skill');
+      expect(skill.instructions).toBe('Instruction body');
+      expect(skill.resources?.references?.['ref1.md']).toBe('ref content');
+      expect(skill.resources?.assets?.['a.txt']).toBe('asset content');
+      expect(skill.resources?.scripts?.['run.sh']?.src).toBe('echo hello');
+    });
+
+    it.each(['/etc/passwd', '../evil.txt', 'references/../../esc.txt'])(
+      'rejects the whole archive for the dangerous entry %s',
+      (entryName) => {
+        expect(() =>
+          loadSkillFromZipBuffer(createZipWithRawEntryName(entryName)),
+        ).toThrow(`Dangerous zip entry ignored: ${entryName}`);
+      },
+    );
+
+    it('reports the dangerous entry even when SKILL.md is absent', () => {
+      const zip = new AdmZip();
+      zip.addFile('placeholder.txt', Buffer.from('x', 'utf-8'));
+      const placeholder = zip.getEntries()[0];
+      placeholder.entryName = '../evil.txt';
+
+      expect(() => loadSkillFromZipBuffer(zip.toBuffer())).toThrow(
+        'Dangerous zip entry ignored: ../evil.txt',
+      );
+    });
+
+    it.each(['../evil', 'a/b', '..'])(
+      'rejects the non-bare skill name %s',
+      (name) => {
+        expect(() =>
+          loadSkillFromZipBuffer(createZipWithSkillName(name)),
+        ).toThrow(`Invalid skill name in SKILL.md: ${name}`);
+      },
+    );
+
+    it('rejects a skill name that is not a string', () => {
+      expect(() =>
+        loadSkillFromZipBuffer(createZipWithSkillName('123')),
+      ).toThrow('Invalid skill name in SKILL.md: 123');
+    });
+
+    it('rejects frontmatter with no name', () => {
+      const zipBuffer = createZipWithSkillMd(
+        '---\ndescription: A test skill\n---\nBody',
+      );
+      expect(() => loadSkillFromZipBuffer(zipBuffer)).toThrow(
+        "SKILL.md frontmatter must contain 'name'",
+      );
+    });
+
+    it('reports a YAML sequence as a non-mapping, not as a missing name', () => {
+      const zipBuffer = createZipWithSkillMd(
+        '---\n- item1\n- item2\n---\nBody',
+      );
+      expect(() => loadSkillFromZipBuffer(zipBuffer)).toThrow(
+        'Invalid YAML in frontmatter: SKILL.md frontmatter must be a YAML mapping',
+      );
+    });
+
+    it('still reports a missing SKILL.md in a benign archive', () => {
+      const zip = new AdmZip();
+      zip.addFile('references/ref1.md', Buffer.from('ref content', 'utf-8'));
+
+      expect(() => loadSkillFromZipBuffer(zip.toBuffer())).toThrow(
+        'SKILL.md not found in zipped filesystem.',
+      );
     });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`loadSkillFromZipBuffer()` (`core/src/skills/loader.ts`) is the trust boundary for Agent Skills downloaded from a remote registry — `GCPSkillRegistry.getSkill()` base64-decodes an API response and hands the raw bytes straight in, so the archive is authored by whoever published the skill, not by the user running the agent. It read `SKILL.md` and the `references/` / `assets/` / `scripts/` trees out of the archive with **no validation of member names**, and never checked that the skill `name` was a bare path segment. The adk-python counterpart, `_load_skill_from_zip_bytes` in `src/google/adk/skills/_utils.py`, has both guards, so the identical archive was rejected by adk-python and accepted by adk-js.

`entryName` is not sanitised on read — verified empirically against the pinned `adm-zip@0.5.17` (`core/package.json`): a zip written with the members `../evil.txt`, `/abs.txt`, `references/../../esc.txt` round-trips through `new AdmZip(buffer).getEntries()` with those exact strings intact. The resource maps are keyed by relative path, so `loadZipDir('references')` turns a member named `references/../../esc.txt` into the map key `../../esc.txt`, which escapes for any caller that writes `Skill.resources` to disk.

**Solution:**

Port both adk-python guards into `loadSkillFromZipBuffer`, with the error strings copied character-for-character.

| Condition (checked in this order)                             | Message                                    |
| ------------------------------------------------------------- | ------------------------------------------ |
| Any member name absolute / `../`-prefixed / containing `/../` | `Dangerous zip entry ignored: <entryName>` |
| No `SKILL.md` (unchanged)                                     | `SKILL.md not found in zipped filesystem.` |
| Frontmatter `name` missing or falsy                           | `SKILL.md frontmatter must contain 'name'` |
| `name` not a string, or not a bare path segment               | `Invalid skill name in SKILL.md: <name>`   |

Three things worth calling out explicitly:

**(a) Which strings were copied verbatim, and why one of them reads oddly.** All four messages above are taken verbatim from `src/google/adk/skills/_utils.py`, including `Dangerous zip entry ignored:` — the word "ignored" is misleading (both implementations reject the _entire archive_ rather than skipping the entry; adk-python `raise`s at `_utils.py`, it does not skip-and-warn), but parity on the observable string wins over nicer prose, so it is not reworded.

**(b) The name guard has to run before schema validation, which is why `parseSkillMdContent` was split.** `parseSkillMdContent()` validated with zod internally and wrapped every failure as `Invalid YAML in frontmatter: …`, so a name of `../evil` never reached a check placed after it — a guard added downstream would be unreachable dead code. It is now split into two module-private helpers mirroring the Python structure (`_parse_skill_md_content` returns an unvalidated dict; `Frontmatter.model_validate` runs after the name checks): `parseFrontmatterYaml()` returns the raw mapping, `validateFrontmatter()` applies `FrontmatterSchema`. `parseSkillMdContent`'s exported signature, return value and **every one of its error strings are unchanged** — the five existing tests asserting them are untouched and still pass. The only behavioural addition inside it is `Array.isArray(parsed)` in the mapping check, needed so `raw['name']` really is read off a mapping (it also matches Python's `isinstance(parsed, dict)`); it is thrown from inside the same `try`, so it still surfaces composed as `Invalid YAML in frontmatter: SKILL.md frontmatter must be a YAML mapping`.

**(c) `path.basename` needs an explicit `.`/`..` case to match `pathlib`.** `path.basename('..') === '..'` whereas `pathlib.Path('..').name === ''`, so a naive `path.basename(name) === name` check accepts `..` where adk-python rejects it. `isBareSkillName` rejects `.` and `..` explicitly. There is a test pinning exactly this (case `name: ..`), and it fails against the naive version — see the mutation log below.

**Honest scope note on the skill-name guard.** I verified against the built schema that `FrontmatterSchema` already rejects every name this guard rejects (`../evil`, `a/b`, `..`, `.`, `/etc/passwd`, `123`, missing) because `SNAKE_OR_KEBAB_NAME_PATTERN` admits only `[a-z0-9]` with single `-` or `_`. So **the name guard does not change which archives are accepted today; it changes the observable error message** from a 150-character zod dump prefixed `Invalid YAML in frontmatter:` (which blames YAML for something that is not a YAML problem) to adk-python's string. It is kept as an independent check because that regex is a _naming-style_ rule, not a traversal defence: if it is ever relaxed (dots for versioned names, uppercase, …) the traversal property would disappear silently. The zip-slip guard is not redundant — nothing else in the file rejects a traversal member name.

**Breaking change**: intentional and the point of the change. An archive whose `SKILL.md` `name` contains a path separator or is `.`/`..` previously threw `Invalid YAML in frontmatter: <zod dump>` and now throws `Invalid skill name in SKILL.md: <name>`. No test asserted the old string. Archives with traversal member names previously loaded and now throw. Exported API surface, `loadSkillFromDir`, `validateSkillDir`, `loadAllSkillsInDir` and `GCPSkillRegistry`'s signature are all unchanged; no new exports, no dependency or lockfile changes.

**Scope note.** The redundant second `FrontmatterSchema.parse(...)` in `loadSkillFromZipBuffer` disappears here as a consequence of calling `validateFrontmatter(raw)` directly. `loadSkillFile`'s identical double-parse is deliberately left alone, and `ALLOWED_FRONTMATTER_KEYS` and `validateSkillDir` are untouched, to keep this security fix's diff minimal.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

12 new cases in a `describe('loadSkillFromZipBuffer', …)` block in `core/test/skills/loader_test.ts`: benign archive loads all three resource maps; the three dangerous member names (`/etc/passwd`, `../evil.txt`, `references/../../esc.txt`); a dangerous member in an archive with **no** `SKILL.md` (pins that the zip-slip loop runs _before_ the `SKILL.md` lookup, matching `_utils.py`); the three non-bare names (`../evil`, `a/b`, `..`); a non-string name (`123`); a missing name; a YAML-sequence frontmatter; and a regression guard that a benign archive without `SKILL.md` still reports `SKILL.md not found in zipped filesystem.`.

Fixture note: `AdmZip.addFile()` canonicalises the name it is given (`'../evil.txt'` is stored as `'evil.txt'`), so a test written the obvious way builds a _benign_ archive and passes for the wrong reason. The helper adds a placeholder member and reassigns `entryName` afterwards, which round-trips through `toBuffer()` intact.

Commands run (targeted only, no full-suite run):

```
npx vitest run --project unit:core core/test/skills/loader_test.ts                     # 42 passed
npx vitest run --project unit:core core/test/tools/skills/skill_registry_test.ts       # 35 passed (untouched, still green)
npm run build                                                                          # clean
npm run docs:check                                                                     # clean (typedoc, warnings-as-errors)
npx tsc --noEmit                                                                       # no errors in either touched file
npx eslint core/src/skills/loader.ts core/test/skills/loader_test.ts                   # clean
npx prettier --check core/src/skills/loader.ts core/test/skills/loader_test.ts         # clean
```

**Coverage**: 100% line and branch coverage of the new code, measured with `--coverage.include='core/src/skills/loader.ts'` and checked per-line against the coverage JSON — every uncovered line in the file is pre-existing code the change does not touch (the `loadDir` walk, `validateSkillDir`'s catch, and the dead `catch` around `data.toString('utf-8')` in `loadZipDir`). No coverage thresholds were changed and no coverage-tool suppressions were added.

**Proof the tests can fail.** Each new guard was mutated in `core/src/skills/loader.ts` and the suite re-run; every mutation was killed:

| Mutation                                                 | Result                                                                                                                                                                                                                                                                                                                                       |
| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Delete the zip-slip loop entirely                        | **4 failed** — e.g. `rejects the whole archive for the dangerous entry ../evil.txt`: _expected [Function] to throw an error_; and `reports the dangerous entry even when SKILL.md is absent`: _expected … 'Dangerous zip entry ignored: ../evil.…' but got 'SKILL.md not found in zipped filesyst…'_ (this one also pins the guard ordering) |
| `isBareSkillName` → naive `path.basename(name) === name` | **1 failed** — `rejects the non-bare skill name ..`: _expected … 'Invalid skill name in SKILL.md: ..' but got 'Invalid YAML in frontmatter: [\n {\n…'_                                                                                                                                                                                       |
| Delete both name guards                                  | **5 failed** — all four name cases plus `rejects frontmatter with no name`: _expected … 'SKILL.md frontmatter must contain \'n…' but got 'Invalid YAML in frontmatter: [\n {\n…'_                                                                                                                                                            |
| Drop the `typeof skillName !== 'string'` disjunct        | **1 failed** — `rejects a skill name that is not a string`: _expected … 'Invalid skill name in SKILL.md: 123' but got 'Invalid YAML in frontmatter: [\n {\n…'_                                                                                                                                                                               |
| Drop `Array.isArray(parsed)` from the mapping check      | **1 failed** — `reports a YAML sequence as a non-mapping, not as a missing name`: _expected … 'Invalid YAML in frontmatter: SKILL.md…' but got 'SKILL.md frontmatter must contain \'n…'_                                                                                                                                                     |

**Manual End-to-End (E2E) Tests:**

No credentials or network needed. From the repo root, after `npm ci && npm run build`, run a scratch ESM script that imports from the public entry point:

```js
import AdmZip from 'adm-zip';
import {loadSkillFromZipBuffer} from '@google/adk';

const skillMd =
  '---\nname: test-skill\ndescription: A test skill\n---\nInstruction body';

// (1) hostile archive: entryName must be reassigned, addFile() would sanitise it
const zip = new AdmZip();
zip.addFile('SKILL.md', Buffer.from(skillMd, 'utf-8'));
zip.addFile('placeholder.txt', Buffer.from('x', 'utf-8'));
zip.getEntries().find((e) => e.entryName === 'placeholder.txt').entryName =
  '../evil.txt';
loadSkillFromZipBuffer(zip.toBuffer()); // throws: Dangerous zip entry ignored: ../evil.txt

// (2) benign archive still loads all three resource maps
const ok = new AdmZip();
ok.addFile('SKILL.md', Buffer.from(skillMd, 'utf-8'));
ok.addFile('references/ref1.md', Buffer.from('ref content', 'utf-8'));
ok.addFile('assets/asset1.txt', Buffer.from('asset content', 'utf-8'));
ok.addFile('scripts/run.sh', Buffer.from('echo hello', 'utf-8'));
console.log(loadSkillFromZipBuffer(ok.toBuffer()).resources);
```

Observed output against the built package, matching adk-python's strings exactly:

```
throws: "Dangerous zip entry ignored: ../evil.txt"
throws: "Dangerous zip entry ignored: /etc/passwd"
throws: "Dangerous zip entry ignored: references/../../esc.txt"
throws: "Invalid skill name in SKILL.md: ../evil"
throws: "Invalid skill name in SKILL.md: a/b"
throws: "Invalid skill name in SKILL.md: .."
throws: "Invalid skill name in SKILL.md: 123"
benign: test-skill {"references":{"ref1.md":"ref content"},"assets":{"asset1.txt":"asset content"},"scripts":{"run.sh":{"src":"echo hello"}}}
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
