### PR TITLE
Fix: make streaming and stateDelta optional on RunAgentRequest

### DIFF
--- a/dev/src/server/adk_api_client.ts
+++ b/dev/src/server/adk_api_client.ts
@@ -25,8 +25,11 @@ export interface RunAgentRequest {
   appName: string;
   userId: string;
   sessionId: string;
-  /** New turn content. Omit to run without adding a message to the session. */
-  newMessage?: Content | string;
+  /**
+   * New turn content. Required: the server runs the agent only when a new
+   * message is present, so a request without one returns an empty stream.
+   */
+  newMessage: Content | string;
   /** Whether to stream partial events. Defaults to non-streaming server-side. */
   streaming?: boolean;
   /** State delta to apply before the run. Omit to apply none. */

--- a/dev/src/server/adk_api_client.ts
+++ b/dev/src/server/adk_api_client.ts
@@ -17,14 +17,23 @@ export interface AdkApiClientConfig {
 
 /**
  * Run agent request interface.
+ *
+ * Mirrors the body accepted by the ADK API server's `POST /run` and
+ * `POST /run_sse` endpoints. Fields the server treats as optional are optional
+ * here too; when omitted they are left out of the JSON body entirely and the
+ * server applies its own default (no new turn content, no state delta,
+ * non-streaming).
  */
 export interface RunAgentRequest {
   appName: string;
   userId: string;
   sessionId: string;
-  newMessage: Content | string;
-  streaming: boolean;
-  stateDelta: Record<string, unknown>;
+  /** New turn content. Omit to run without adding a message to the session. */
+  newMessage?: Content | string;
+  /** Whether to stream partial events. Defaults to non-streaming server-side. */
+  streaming?: boolean;
+  /** State delta to apply before the run. Omit to apply none. */
+  stateDelta?: Record<string, unknown>;
 }
 
 /**

--- a/dev/src/server/adk_api_client.ts
+++ b/dev/src/server/adk_api_client.ts
@@ -19,10 +19,7 @@ export interface AdkApiClientConfig {
  * Run agent request interface.
  *
  * Mirrors the body accepted by the ADK API server's `POST /run` and
- * `POST /run_sse` endpoints. Fields the server treats as optional are optional
- * here too; when omitted they are left out of the JSON body entirely and the
- * server applies its own default (no new turn content, no state delta,
- * non-streaming).
+ * `POST /run_sse`; omitted optional fields are dropped from the JSON body.
  */
 export interface RunAgentRequest {
   appName: string;

--- a/dev/test/server/adk_api_client_test.ts
+++ b/dev/test/server/adk_api_client_test.ts
@@ -346,11 +346,16 @@ describe('AdkApiClient', () => {
       }).rejects.toThrow(errorMsg);
     });
 
-    it('should omit optional fields from the request body when they are omitted', async () => {
+    it('should omit streaming and stateDelta from the request body when they are omitted', async () => {
       mockEmptyStream(fetchMock);
 
       await client
-        .runAsync({appName: 'app1', userId: 'user1', sessionId: 'session1'})
+        .runAsync({
+          appName: 'app1',
+          userId: 'user1',
+          sessionId: 'session1',
+          newMessage: {role: 'user', parts: [{text: 'hello'}]},
+        })
         .next();
 
       expect(global.fetch).toHaveBeenCalledWith(`${mockBackendUrl}/run_sse`, {
@@ -360,6 +365,7 @@ describe('AdkApiClient', () => {
           appName: 'app1',
           userId: 'user1',
           sessionId: 'session1',
+          newMessage: {role: 'user', parts: [{text: 'hello'}]},
         }),
       });
     });
@@ -372,6 +378,7 @@ describe('AdkApiClient', () => {
           appName: 'app1',
           userId: 'user1',
           sessionId: 'session1',
+          newMessage: {role: 'user', parts: [{text: 'hello'}]},
           stateDelta: {counter: 1},
         })
         .next();
@@ -384,6 +391,7 @@ describe('AdkApiClient', () => {
           userId: 'user1',
           sessionId: 'session1',
           stateDelta: {counter: 1},
+          newMessage: {role: 'user', parts: [{text: 'hello'}]},
         }),
       });
     });

--- a/dev/test/server/adk_api_client_test.ts
+++ b/dev/test/server/adk_api_client_test.ts
@@ -10,8 +10,8 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {AdkApiClient} from '../../src/server/adk_api_client.js';
 
 /** Makes the mocked `fetch` resolve to an SSE response that yields no events. */
-function mockEmptyStream(): void {
-  (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+function mockEmptyStream(fetchMock: ReturnType<typeof vi.fn>): void {
+  fetchMock.mockResolvedValue({
     ok: true,
     body: {
       getReader: () => ({read: async () => ({done: true, value: undefined})}),
@@ -22,10 +22,12 @@ function mockEmptyStream(): void {
 describe('AdkApiClient', () => {
   const mockBackendUrl = 'http://localhost:3000';
   let client: AdkApiClient;
+  let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     client = new AdkApiClient({backendUrl: mockBackendUrl});
-    global.fetch = vi.fn();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
   });
 
   afterEach(() => {
@@ -345,7 +347,7 @@ describe('AdkApiClient', () => {
     });
 
     it('should omit optional fields from the request body when they are omitted', async () => {
-      mockEmptyStream();
+      mockEmptyStream(fetchMock);
 
       await client
         .runAsync({appName: 'app1', userId: 'user1', sessionId: 'session1'})
@@ -363,7 +365,7 @@ describe('AdkApiClient', () => {
     });
 
     it('should include only the optional fields that are provided', async () => {
-      mockEmptyStream();
+      mockEmptyStream(fetchMock);
 
       await client
         .runAsync({
@@ -387,7 +389,7 @@ describe('AdkApiClient', () => {
     });
 
     it('should send explicit false for streaming when provided', async () => {
-      mockEmptyStream();
+      mockEmptyStream(fetchMock);
 
       await client
         .runAsync({

--- a/dev/test/server/adk_api_client_test.ts
+++ b/dev/test/server/adk_api_client_test.ts
@@ -9,6 +9,16 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {AdkApiClient} from '../../src/server/adk_api_client.js';
 
+/** Makes the mocked `fetch` resolve to an SSE response that yields no events. */
+function mockEmptyStream(): void {
+  (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: true,
+    body: {
+      getReader: () => ({read: async () => ({done: true, value: undefined})}),
+    },
+  });
+}
+
 describe('AdkApiClient', () => {
   const mockBackendUrl = 'http://localhost:3000';
   let client: AdkApiClient;
@@ -332,6 +342,76 @@ describe('AdkApiClient', () => {
           // do nothing
         }
       }).rejects.toThrow(errorMsg);
+    });
+
+    it('should omit optional fields from the request body when they are omitted', async () => {
+      mockEmptyStream();
+
+      await client
+        .runAsync({appName: 'app1', userId: 'user1', sessionId: 'session1'})
+        .next();
+
+      expect(global.fetch).toHaveBeenCalledWith(`${mockBackendUrl}/run_sse`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          appName: 'app1',
+          userId: 'user1',
+          sessionId: 'session1',
+        }),
+      });
+    });
+
+    it('should include only the optional fields that are provided', async () => {
+      mockEmptyStream();
+
+      await client
+        .runAsync({
+          appName: 'app1',
+          userId: 'user1',
+          sessionId: 'session1',
+          stateDelta: {counter: 1},
+        })
+        .next();
+
+      expect(global.fetch).toHaveBeenCalledWith(`${mockBackendUrl}/run_sse`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          appName: 'app1',
+          userId: 'user1',
+          sessionId: 'session1',
+          stateDelta: {counter: 1},
+        }),
+      });
+    });
+
+    it('should send explicit false for streaming when provided', async () => {
+      mockEmptyStream();
+
+      await client
+        .runAsync({
+          appName: 'app1',
+          userId: 'user1',
+          sessionId: 'session1',
+          newMessage: {role: 'user', parts: [{text: 'hello'}]},
+          streaming: false,
+          stateDelta: {},
+        })
+        .next();
+
+      expect(global.fetch).toHaveBeenCalledWith(`${mockBackendUrl}/run_sse`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          appName: 'app1',
+          userId: 'user1',
+          sessionId: 'session1',
+          streaming: false,
+          stateDelta: {},
+          newMessage: {role: 'user', parts: [{text: 'hello'}]},
+        }),
+      });
     });
   });
 


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change

1. Link to an existing issue (if applicable):

_No existing issue._

2. Or, if no issue exists, describe the change:

**Problem**: `RunAgentRequest` in `dev/src/server/adk_api_client.ts` marks `streaming` and `stateDelta` as **required**, but the ADK API server treats both as optional and applies its own defaults. The typed client therefore cannot express a request the server already serves — a caller who does not care about streaming or state has to pass placeholder values.

Verified against the actual handlers:

- `/run_sse` (`dev/src/server/adk_api_server.ts:858-859`) destructures `{appName, userId, sessionId, newMessage, streaming, stateDelta}` off `req.body`; a body missing either field forwards `undefined`. `streaming` is consumed as `streaming ? StreamingMode.SSE : StreamingMode.NONE` (`adk_api_server.ts:900`), so an absent `streaming` already means non-streaming. `/run` (`adk_api_server.ts:734`) does not read `streaming` at all.
- `stateDelta` is optional all the way down: `executeAgentRun` declares `stateDelta?: Record<string, unknown>` (`adk_api_server.ts:1012`) and `Runner.runAsync` declares `stateDelta?: Record<string, unknown>` (`core/src/runner/runner.ts:231`), which becomes `actions: stateDelta ? createEventActions({stateDelta}) : undefined`.

**Solution**: Make `streaming` and `stateDelta` optional. **No change to the body construction** (`adk_api_client.ts:145-155`): `JSON.stringify` already omits properties whose value is `undefined`, so an omitted field produces no wire key and a fully-populated request serializes byte-identically to before. The three new tests assert the exact serialized body, which is what pins that.

Rejected alternatives, each of which would emit a key the caller did not ask for: `params.streaming ?? false`, `params.stateDelta ?? {}`, a `JSON.stringify` replacer, and conditional spreads (unnecessary — `JSON.stringify` already provides the behaviour).

#### Why `newMessage` stays required

An earlier revision of this PR also made `newMessage` optional, on the grounds that adk-python declares `new_message: Optional[types.Content] = None`. **That was wrong and has been reverted.** Thanks to @kalenkevich for catching it. Three independent reasons, all checked by running the code rather than reading types:

1. **The adk-js server cannot serve such a request.** `Runner.runAsync` wraps the _entire_ agent execution in `if (newMessage)` (`core/src/runner/runner.ts:376`) with **no `else` branch** — the same guard also gates appending the user event (`runner.ts:328`). Driving the real `Runner` with a real `InMemorySessionService` and a recording agent:

   |                      | agent invocations | events yielded | session events written |
   | -------------------- | ----------------- | -------------- | ---------------------- |
   | with `newMessage`    | 1                 | 1              | 2                      |
   | without `newMessage` | **0**             | **0**          | **0**                  |

   Driving the real `AdkApiServer` over HTTP confirms it end to end. `POST /run_sse` without `newMessage`:

   ```
   status: 200, content-type: text/event-stream, body length: 0, agent invocations: 0
   ```

   versus the same request with `newMessage`: `status 200, body length 329, agent invocations: 1`. So the server does not reject the request — it returns a **successful, completely empty stream having done nothing**. That is worse than an error, because the caller gets a 200 with no signal that the run never happened.

2. **This is exactly the rule this PR already applies to `appName`.** `app_name` is `Optional` in Python only because that server has a `default_app_name` fallback (`api_server.py:1630-1635`, which 400s when unset); adk-js has no such fallback, so widening `appName` would let the client express a request this server cannot serve. Applying the same test to `newMessage` fails it. Keeping `newMessage` optional would have made this PR internally inconsistent.

3. **Python's `Optional` is a one-of constraint, not optionality.** `adk-python` `runners.py:1148-1153` raises:

   ```python
   if not invocation_id and not new_message:
     raise ValueError(
         'Running an agent requires either a new_message or an '
         'invocation_id to resume a previous invocation. ...')
   ```

   `new_message` may be `None` **only** when `invocation_id` is supplied, for the resume-a-previous-invocation flow. adk-js has no `invocationId` on `RunAgentRequest` and no resume-by-invocation path — `functionCallEventId`/`invocationId` have zero occurrences in `core/src` and `dev/src`. The "resume/replay a session" use case cited in the earlier revision **does not exist in this codebase**. So the only valid form here is `newMessage` required, and "Python declares it Optional" was a partial-parity argument that does not survive contact with what Python actually does.

**Cross-language parity: which rule was applied where.** Wire-observable behaviour follows adk-python for `streaming` and `stateDelta` (optional, same server-side defaults). Two fields deliberately **diverge** from Python's `Optional`, both for the same reason — Python's optionality is enabled by a fallback (`default_app_name`) or a sibling field (`invocation_id`) that adk-js does not have: `appName` and `newMessage` stay required. Adding `invocationId`/`customMetadata`/`functionCallEventId` for fuller parity is out of scope: they have no reader in the TypeScript server today, so adding them client-side would ship dead config; that needs the server plumbing in the same change.

**Breaking-change analysis** — widening a required field to optional is source-breaking for **readers** of a `RunAgentRequest` value (`req.streaming.toString()` stops compiling, since the type is now `boolean | undefined`) and non-breaking for **writers** (an object literal supplying all fields still satisfies the type). Against this checkout:

- **Readers**: exactly one. `grep -rn "RunAgentRequest"` over the repo (excluding `node_modules`) returns two hits total — the declaration and the parameter annotation of `runAsync`, both in `adk_api_client.ts`. No `Required<RunAgentRequest>`, no `implements`, no re-declaration. The single reader is `runAsync` itself, which already tolerates `undefined` for both fields.
- **Writers**: all in `dev/test/server/adk_api_client_test.ts`, all passing every field — unaffected. `tests/integration/test_api_server.ts` constructs an `AdkApiClient` but never calls `runAsync`.
- **External consumers**: `RunAgentRequest` is not re-exported from `dev/src/index.ts` (which exports only `AdkApiClient` and `AdkApiServer`) and `dev/package.json`'s `exports` map exposes only `"."`, so a consumer of `@google/adk-devtools` cannot name the type through the public entry point.
- **Wire compatibility**: unchanged in both directions. A fully-populated request serializes byte-identically to before (key order in the object literal is untouched: `appName`, `userId`, `sessionId`, `streaming`, `stateDelta`, `newMessage`).

Classified as a `fix`, not `feat!`.

**Note on typing**: zero `any`, zero `@ts-expect-error`, zero `eslint-disable`, zero `as any`/`as never`, zero coverage-tool suppressions were added — in `src/` or in tests. `git diff main -U0 | grep -E '^\+.*(@ts-expect-error|@ts-ignore|eslint-disable|v8 ignore|istanbul ignore|: *any\b|as any|as never|as unknown as)'` returns no hits. The new `mockEmptyStream` test helper takes the `vi.fn()` mock as a typed parameter rather than casting it back off `global.fetch`, so it needs no cast (the pre-existing casts elsewhere in that file are left untouched — out of scope).

### Testing Plan

Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
[x] I have added or updated unit tests for my change.
[x] All unit tests pass locally.

Three cases added inside the existing `describe('run', ...)` block in `dev/test/server/adk_api_client_test.ts`. Each asserts the **exact** serialized body via `toHaveBeenCalledWith` (not `objectContaining`/`stringContaining`), which pins both "the key is absent" and "no `undefined`/`null` was serialized":

1. `should omit streaming and stateDelta from the request body when they are omitted` — both omitted; body carries only `appName`, `userId`, `sessionId`, `newMessage`.
2. `should include only the optional fields that are provided` — only `stateDelta` supplied; guards the mixed path so a future "default everything" regression cannot hide behind case 1.
3. `should send explicit false for streaming when provided` — pins that `streaming: false` and _omitted_ must not collapse into each other.

```
$ npx vitest run --project unit:dev dev/test/server/adk_api_client_test.ts
 ✓ |unit:dev| dev/test/server/adk_api_client_test.ts (20 tests)
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

(17 pre-existing + 3 new; no existing test was modified, skipped, weakened or deleted.)

#### Proof each test can fail

**Type-level proofs.** Vitest does not type-check (esbuild transpile only), so `tsc` is what demonstrates an optionality change.

Reverting the two `?` and re-running `npm run ts:check`:

```
dev/test/server/adk_api_client_test.ts:353:19 - error TS2345: ... is missing the
  following properties from type 'RunAgentRequest': streaming, stateDelta
dev/test/server/adk_api_client_test.ts:377:19 - error TS2345: Property 'streaming'
  is missing in type '...' but required in type 'RunAgentRequest'.
```

And confirming `newMessage` really is still enforced — dropping it from a call site must not compile:

```
dev/test/server/adk_api_client_test.ts:353:19 - error TS2345: Argument of type
'{ appName: string; userId: string; sessionId: string; }' is not assignable to
parameter of type 'RunAgentRequest'.
  Property 'newMessage' is missing in type '{ appName: string; userId: string;
  sessionId: string; }' but required in type 'RunAgentRequest'.
```

**Runtime proofs.** Three source mutations, each reverted afterwards. Every new test is killed by at least one:

| Mutation in `adk_api_client.ts`              | Result           |
| -------------------------------------------- | ---------------- |
| `streaming: params.streaming ?? false`       | cases 1 + 2 FAIL |
| `stateDelta: params.stateDelta ?? {}`        | case 1 FAILS     |
| `streaming: params.streaming \|\| undefined` | case 3 FAILS     |

Failure message for mutation 1 (case 1):

```
AssertionError: expected "spy" to be called with arguments: [ …(2) ]
-  "body": "{\"appName\":\"app1\",...,\"newMessage\":{...}}",
+  "body": "{\"appName\":\"app1\",...,\"streaming\":false,\"newMessage\":{...}}",
```

#### Coverage

This change adds **zero executable lines** — `interface` members are erased at compile time and are not counted by the coverage provider — so there is no new code to cover, and no `/* v8 ignore */` or `istanbul ignore` was added. Measured on `dev/src/server/adk_api_client.ts`, line coverage is unchanged at 95.72%; the residual uncovered lines are pre-existing and untouched by this PR (the `!response.ok` throw and `!response.body` early return in `runAsync`, and the status-fallback string in the private `fetch<T>` helper).

#### Local validation

```
$ npm ci                                                           # lockfile unchanged
$ npm run build                                                    # exit 0
$ npm run lint                                                     # exit 0
$ npm run format:check                                             # All matched files use Prettier code style!
$ npx vitest run --project unit:dev dev/test/server/adk_api_client_test.ts
                                                                   # 20 passed (20)
$ npx tsc --noEmit  (errors under dev/)                            # 0
```

`npm run ts:check` reports pre-existing errors repo-wide (all under `core/test/**` and `tests/**`, which several other PRs are addressing). That count is **identical on `main` and on this branch — 320 both ways — and `dev/` has 0 on both**, so this change introduces no new type errors.

Manual End-to-End (E2E) Tests:

Please provide instructions on how to manually test your changes, including any necessary setup or configuration.

No automated integration test was added: the behaviour under test is the serialized request body, fully observable at the unit level with a mocked `fetch`. A live-server test would add a spawned process and CI time for no additional signal.

To sanity-check by hand that the request the type now permits is the request the server already accepted:

1. Start the dev API server: `npx adk api-server <agents-dir>`
2. Create a session: `POST /apps/<app>/users/u/sessions/<sid>`
3. `POST /run_sse` with body `{"appName":"<app>","userId":"u","sessionId":"<sid>","newMessage":{"role":"user","parts":[{"text":"hi"}]}}` — no `streaming`, no `stateDelta`.
4. Expect a populated SSE stream (`Content-Type: text/event-stream`), not a 4xx.

(For contrast, the same request with `newMessage` removed returns `200` with a zero-length body and never runs the agent — which is why `newMessage` is required.)

### Checklist

[x] I have read the CONTRIBUTING.md document.
[x] I have performed a self-review of my own code.
[x] I have commented my code, particularly in hard-to-understand areas.
[x] I have added tests that prove my fix is effective or that my feature works.
[x] New and existing unit tests pass locally with my changes.
