### PR TITLE
feat(workflow): add engine core — execution model, graph, and node registry (Part 2)

### DIFF
--- a/core/src/utils/schema.ts
+++ b/core/src/utils/schema.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A single, reusable abstraction over the schema formats ADK APIs accept: a Zod
+ * v3 type, a Zod v4 type, or a genai `Schema`. Mirrors the union
+ * `FunctionTool` uses for its parameters, but at the `ZodType` level (any
+ * schema, not just an object) so it also fits value validation.
+ */
+
+import {Schema} from '@google/genai';
+import {zodToJsonSchema as toJSONSchemaV3} from 'zod-to-json-schema';
+import {z as z3} from 'zod/v3';
+import {toJSONSchema as toJSONSchemaV4, z as z4} from 'zod/v4';
+
+import {
+  isZodSchema,
+  isZodV3Schema,
+  isZodV4Schema,
+} from './simple_zod_to_json.js';
+
+/**
+ * A schema accepted by ADK APIs, expressed as a Zod v3 type, a Zod v4 type, or
+ * a genai `Schema`.
+ *
+ * Use {@link parseWithSchema} to validate a value against one, and
+ * {@link toJsonSchema} to render one as a plain JSON Schema.
+ */
+export type SchemaLike = z3.ZodType | z4.ZodType | Schema;
+
+/**
+ * Validates `value` against `schema`.
+ *
+ * - Zod v3/v4 schema: runs `schema.parse(value)` and returns the parsed value.
+ * - genai `Schema` or `undefined`: returns `value` unchanged. A genai `Schema`
+ *   is a declaration, not a runtime validator, so it is not enforced here —
+ *   matching how `FunctionTool` only `.parse()`s Zod parameters.
+ */
+export function parseWithSchema<T>(
+  schema: SchemaLike | undefined,
+  value: T,
+): T {
+  if (schema !== undefined && isZodSchema(schema)) {
+    return schema.parse(value) as T;
+  }
+  return value;
+}
+
+/**
+ * Renders a {@link SchemaLike} as a plain JSON Schema object.
+ *
+ * Zod v3 and v4 schemas are converted with their respective serializers; a
+ * genai `Schema` is already schema-shaped and is returned as-is.
+ */
+export function toJsonSchema(schema: SchemaLike): Record<string, unknown> {
+  if (isZodV4Schema(schema)) {
+    return toJSONSchemaV4(schema) as Record<string, unknown>;
+  }
+  if (isZodV3Schema(schema)) {
+    return toJSONSchemaV3(schema) as Record<string, unknown>;
+  }
+  return schema as Record<string, unknown>;
+}

--- a/core/src/utils/simple_zod_to_json.ts
+++ b/core/src/utils/simple_zod_to_json.ts
@@ -19,7 +19,8 @@ import {toJSONSchema as toJSONSchemaV4, z as z4} from 'zod/v4';
 
 type ZodSchema<T = unknown> = z3.ZodType<T> | z4.ZodType<T>;
 
-function isZodSchema(obj: unknown): obj is ZodSchema {
+/** Returns true if the value is a Zod schema (v3 or v4). */
+export function isZodSchema(obj: unknown): obj is ZodSchema {
   return (
     obj !== null &&
     typeof obj === 'object' &&
@@ -30,11 +31,13 @@ function isZodSchema(obj: unknown): obj is ZodSchema {
   );
 }
 
-function isZodV3Schema(obj: unknown): obj is z3.ZodTypeAny {
+/** Returns true if the value is a Zod v3 schema. */
+export function isZodV3Schema(obj: unknown): obj is z3.ZodTypeAny {
   return isZodSchema(obj) && !('_zod' in obj);
 }
 
-function isZodV4Schema(obj: unknown): obj is z4.ZodType {
+/** Returns true if the value is a Zod v4 schema. */
+export function isZodV4Schema(obj: unknown): obj is z4.ZodType {
   return isZodSchema(obj) && '_zod' in obj;
 }
 

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Content, createModelContent} from '@google/genai';
+import {Content, createModelContent, PartListUnion} from '@google/genai';
 import {createEvent, Event, isEvent} from '../events/event.js';
 import {parseWithSchema, SchemaLike} from '../utils/schema.js';
 import type {NodeContext} from './node_context.js';
@@ -253,6 +253,10 @@ export const START: BaseNode = new StartNode({name: '__START__'});
 
 /**
  * Best-effort conversion of an arbitrary value to genai `Content` for display.
+ *
+ * Strings, `Part`s, and arrays of them are converted via `createModelContent`.
+ * Any other value (a plain object, number, boolean, …) is not a valid genai
+ * part list, so it is serialized to text rather than throwing.
  */
 export function toContent(val: unknown): Content | undefined {
   if (val === null || val === undefined) {
@@ -263,5 +267,23 @@ export function toContent(val: unknown): Content | undefined {
     return val;
   }
 
-  return createModelContent(val);
+  try {
+    return createModelContent(val as PartListUnion);
+  } catch {
+    return createModelContent(valueToText(val));
+  }
+}
+
+/** Serializes an arbitrary value to a text string for display. */
+function valueToText(val: unknown): string {
+  if (typeof val === 'string') {
+    return val;
+  }
+  try {
+    // JSON.stringify returns undefined for functions/symbols; fall back to
+    // String() there (and for non-serializable values like circular refs).
+    return JSON.stringify(val) ?? String(val);
+  } catch {
+    return String(val);
+  }
 }

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Content} from '@google/genai';
+import {Content, createModelContent} from '@google/genai';
 import {createEvent, Event, isEvent} from '../events/event.js';
 import {parseWithSchema, SchemaLike} from '../utils/schema.js';
 import type {NodeContext} from './node_context.js';
@@ -258,21 +258,10 @@ export function toContent(val: unknown): Content | undefined {
   if (val === null || val === undefined) {
     return undefined;
   }
-  // Use the same predicate as validateOutput so a value is never treated as
-  // `Content` by one and re-encoded as text by the other.
+
   if (isContent(val)) {
     return val;
   }
-  if (typeof val === 'string') {
-    return {role: 'model', parts: [{text: val}]};
-  }
-  try {
-    // JSON.stringify returns `undefined` (rather than throwing) for a function
-    // or a symbol, so fall back to String() in that case too.
-    const json = JSON.stringify(val);
-    return {role: 'model', parts: [{text: json ?? String(val)}]};
-  } catch {
-    // Reached for values JSON cannot serialize at all (e.g. circular refs).
-    return {role: 'model', parts: [{text: String(val)}]};
-  }
+
+  return createModelContent(val);
 }

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -1,0 +1,235 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Content} from '@google/genai';
+import type {ZodType} from 'zod';
+import {createEvent, Event, isEvent} from '../events/event.js';
+import type {NodeContext} from './node_context.js';
+import {isRequestInput} from './request_input.js';
+import {
+  PreparedRetryConfig,
+  prepareRetryConfig,
+  RetryConfig,
+} from './retry_config.js';
+import {createRequestInputEvent} from './utils/hitl_utils.js';
+
+/**
+ * Configuration shared by all workflow nodes.
+ *
+ * Mirrors the fields of `google/adk-python` `workflow/_base_node.py::BaseNode`.
+ */
+export interface BaseNodeConfig {
+  /** Canonical, unique-within-a-graph node name. */
+  name: string;
+
+  /** Human-readable description (used when a node is exposed as a tool). */
+  description?: string;
+
+  /**
+   * If true, the node re-executes when a workflow resumes even if it already
+   * completed in a prior turn. Default false.
+   */
+  rerunOnResume?: boolean;
+
+  /**
+   * If true, the node only produces its output once all of its predecessors
+   * have triggered it (fan-in / join semantics). Default false.
+   */
+  waitForOutput?: boolean;
+
+  /** Optional retry configuration for transient failures. */
+  retryConfig?: RetryConfig;
+
+  /** Maximum time, in seconds, for this node to complete. */
+  timeout?: number;
+
+  /** Optional zod schema validating the node input. */
+  inputSchema?: ZodType;
+
+  /** Optional zod schema validating the node output. */
+  outputSchema?: ZodType;
+
+  /** Optional zod schema validating relevant session state. */
+  stateSchema?: ZodType;
+}
+
+/**
+ * Abstract base class for all nodes in an ADK workflow.
+ *
+ * A node is a discrete unit of execution. Subclasses implement {@link runImpl},
+ * which may yield {@link Event}s, raw values (boxed into an event), or
+ * `null`/`undefined` (skipped). {@link run} normalizes those into a stream of
+ * {@link Event}s consumed by the engine.
+ */
+export abstract class BaseNode<TInput = unknown, TOutput = unknown> {
+  readonly name: string;
+  readonly description: string;
+  readonly rerunOnResume: boolean;
+  readonly waitForOutput: boolean;
+  readonly retryConfig?: RetryConfig;
+  /**
+   * The retry config with its exception filter normalized once, up front (see
+   * {@link prepareRetryConfig}). Used by the node runner so the retry hot path
+   * never re-normalizes or throws on a malformed config mid-retry.
+   */
+  readonly preparedRetryConfig?: PreparedRetryConfig;
+  readonly timeout?: number;
+  readonly inputSchema?: ZodType;
+  readonly outputSchema?: ZodType;
+  readonly stateSchema?: ZodType;
+
+  constructor(config: BaseNodeConfig) {
+    if (
+      !config.name ||
+      typeof config.name !== 'string' ||
+      config.name.trim().length === 0
+    ) {
+      throw new Error('Node name must be a non-empty string.');
+    }
+    this.name = config.name.trim();
+    this.description = config.description ?? '';
+    this.rerunOnResume = config.rerunOnResume ?? false;
+    this.waitForOutput = config.waitForOutput ?? false;
+    this.retryConfig = config.retryConfig;
+    this.preparedRetryConfig = config.retryConfig
+      ? prepareRetryConfig(config.retryConfig)
+      : undefined;
+    this.timeout = config.timeout;
+    this.inputSchema = config.inputSchema;
+    this.outputSchema = config.outputSchema;
+    this.stateSchema = config.stateSchema;
+  }
+
+  /**
+   * Whether this node must wait for ALL of its predecessors to trigger before
+   * it runs (fan-in barrier). Overridden by `JoinNode`.
+   */
+  get requiresAllPredecessors(): boolean {
+    return false;
+  }
+
+  /**
+   * Core execution contract. Subclasses yield one of:
+   *  - an {@link Event} (emitted as-is),
+   *  - a raw value (boxed into an event whose `output` is that value),
+   *  - `null`/`undefined` (skipped).
+   */
+  protected abstract runImpl(
+    ctx: NodeContext,
+    input: TInput,
+  ): AsyncGenerator<Event | TOutput | unknown, void, void>;
+
+  /**
+   * Runs the node, normalizing every yielded item into an {@link Event}. This
+   * is what the engine (and `ctx.runNode()`) consumes. Validates the input
+   * against `inputSchema` once, up front (skipping genai `Content`, which nodes
+   * coerce themselves).
+   */
+  async *run(
+    ctx: NodeContext,
+    input: TInput,
+  ): AsyncGenerator<Event, void, void> {
+    const validatedInput = this.validateInput(input);
+    for await (const item of this.runImpl(ctx, validatedInput)) {
+      if (isRequestInput(item)) {
+        // HITL: convert a request-for-input into an interrupt event.
+        yield createRequestInputEvent(item);
+        continue;
+      }
+      const event = this.toEvent(ctx, item);
+      if (event) {
+        yield event;
+      }
+    }
+  }
+
+  /** Validates node input against `inputSchema` (Content passes through). */
+  protected validateInput(input: TInput): TInput {
+    if (!this.inputSchema || isContent(input)) {
+      return input;
+    }
+    return this.inputSchema.parse(input) as TInput;
+  }
+
+  /** Validates node output against `outputSchema` (Content passes through). */
+  protected validateOutput(output: unknown): unknown {
+    if (!this.outputSchema || isContent(output)) {
+      return output;
+    }
+    return this.outputSchema.parse(output);
+  }
+
+  /**
+   * Normalizes a single yielded item into an {@link Event} (or `null` to skip).
+   * Subclasses may override for richer coercion (e.g. `FunctionNode`).
+   */
+  protected toEvent(ctx: NodeContext, data: unknown): Event | null {
+    if (data === null || data === undefined) {
+      return null;
+    }
+    if (isEvent(data)) {
+      const event = data as Event;
+      if (event.output !== undefined) {
+        event.output = this.validateOutput(event.output);
+      }
+      return event;
+    }
+    const output = this.validateOutput(data);
+    return createEvent({
+      author: this.name,
+      invocationId: ctx.invocationContext.invocationId,
+      branch: ctx.branch,
+      content: toContent(output),
+      output,
+    });
+  }
+}
+
+/** Returns whether a value looks like a genai `Content` object. */
+export function isContent(value: unknown): value is Content {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'parts' in value &&
+    Array.isArray((value as {parts?: unknown}).parts)
+  );
+}
+
+/**
+ * The sentinel node marking the entry point of a workflow graph. It is never
+ * executed — the orchestrator seeds triggers for its successors directly.
+ *
+ * Mirrors `google/adk-python` `START = BaseNode(name='__START__')`.
+ */
+class StartNode extends BaseNode {
+  // eslint-disable-next-line require-yield
+  protected async *runImpl(): AsyncGenerator<Event, void, void> {
+    throw new Error('START node is never executed.');
+  }
+}
+
+/** The workflow entry-point sentinel node (name `__START__`). */
+export const START: BaseNode = new StartNode({name: '__START__'});
+
+/**
+ * Best-effort conversion of an arbitrary value to genai `Content` for display.
+ */
+export function toContent(val: unknown): Content | undefined {
+  if (val === null || val === undefined) {
+    return undefined;
+  }
+  if (typeof val === 'object' && 'role' in val && 'parts' in val) {
+    return val as Content;
+  }
+  if (typeof val === 'string') {
+    return {role: 'model', parts: [{text: val}]};
+  }
+  try {
+    return {role: 'model', parts: [{text: JSON.stringify(val)}]};
+  } catch {
+    return {role: 'model', parts: [{text: String(val)}]};
+  }
+}

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -5,8 +5,8 @@
  */
 
 import {Content} from '@google/genai';
-import type {ZodType} from 'zod';
 import {createEvent, Event, isEvent} from '../events/event.js';
+import {parseWithSchema, SchemaLike} from '../utils/schema.js';
 import type {NodeContext} from './node_context.js';
 import {isRequestInput} from './request_input.js';
 import {
@@ -15,6 +15,17 @@ import {
   RetryConfig,
 } from './retry_config.js';
 import {createRequestInputEvent} from './utils/hitl_utils.js';
+
+/**
+ * A unique symbol branding {@link BaseNode} instances.
+ *
+ * Guards match on this brand rather than `instanceof` so a node stays
+ * recognisable when it crosses a package boundary (two copies of adk-js in one
+ * runtime would fail an `instanceof` check between them) — mirroring the
+ * `Symbol.for('google.adk.*')` brands used across ADK (`isBaseAgent`,
+ * `isBaseTool`, `isEvent`).
+ */
+const BASE_NODE_SIGNATURE_SYMBOL = Symbol.for('google.adk.workflow.baseNode');
 
 /**
  * Configuration shared by all workflow nodes.
@@ -46,14 +57,14 @@ export interface BaseNodeConfig {
   /** Maximum time, in seconds, for this node to complete. */
   timeout?: number;
 
-  /** Optional zod schema validating the node input. */
-  inputSchema?: ZodType;
+  /** Optional schema validating the node input (Zod v3/v4 or genai `Schema`). */
+  inputSchema?: SchemaLike;
 
-  /** Optional zod schema validating the node output. */
-  outputSchema?: ZodType;
+  /** Optional schema validating the node output (Zod v3/v4 or genai `Schema`). */
+  outputSchema?: SchemaLike;
 
-  /** Optional zod schema validating relevant session state. */
-  stateSchema?: ZodType;
+  /** Optional schema validating relevant session state (Zod v3/v4 or genai `Schema`). */
+  stateSchema?: SchemaLike;
 }
 
 /**
@@ -65,6 +76,9 @@ export interface BaseNodeConfig {
  * {@link Event}s consumed by the engine.
  */
 export abstract class BaseNode<TInput = unknown, TOutput = unknown> {
+  /** Brand identifying this object as a {@link BaseNode} (see {@link isBaseNode}). */
+  readonly [BASE_NODE_SIGNATURE_SYMBOL] = true;
+
   readonly name: string;
   readonly description: string;
   readonly rerunOnResume: boolean;
@@ -77,9 +91,9 @@ export abstract class BaseNode<TInput = unknown, TOutput = unknown> {
    */
   readonly preparedRetryConfig?: PreparedRetryConfig;
   readonly timeout?: number;
-  readonly inputSchema?: ZodType;
-  readonly outputSchema?: ZodType;
-  readonly stateSchema?: ZodType;
+  readonly inputSchema?: SchemaLike;
+  readonly outputSchema?: SchemaLike;
+  readonly stateSchema?: SchemaLike;
 
   constructor(config: BaseNodeConfig) {
     if (
@@ -146,20 +160,28 @@ export abstract class BaseNode<TInput = unknown, TOutput = unknown> {
     }
   }
 
-  /** Validates node input against `inputSchema` (Content passes through). */
+  /**
+   * Validates node input against `inputSchema` (Content passes through). Only
+   * enforced for Zod schemas; a genai `Schema` is left unvalidated (see
+   * {@link parseWithSchema}).
+   */
   protected validateInput(input: TInput): TInput {
-    if (!this.inputSchema || isContent(input)) {
+    if (isContent(input)) {
       return input;
     }
-    return this.inputSchema.parse(input) as TInput;
+    return parseWithSchema(this.inputSchema, input);
   }
 
-  /** Validates node output against `outputSchema` (Content passes through). */
+  /**
+   * Validates node output against `outputSchema` (Content passes through). Only
+   * enforced for Zod schemas; a genai `Schema` is left unvalidated (see
+   * {@link parseWithSchema}).
+   */
   protected validateOutput(output: unknown): unknown {
-    if (!this.outputSchema || isContent(output)) {
+    if (isContent(output)) {
       return output;
     }
-    return this.outputSchema.parse(output);
+    return parseWithSchema(this.outputSchema, output);
   }
 
   /**
@@ -186,6 +208,21 @@ export abstract class BaseNode<TInput = unknown, TOutput = unknown> {
       output,
     });
   }
+}
+
+/**
+ * Type guard for {@link BaseNode}.
+ *
+ * Matches on the {@link BASE_NODE_SIGNATURE_SYMBOL} brand rather than
+ * `instanceof` so it stays correct across package copies (see the brand's doc).
+ */
+export function isBaseNode(value: unknown): value is BaseNode {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    BASE_NODE_SIGNATURE_SYMBOL in value &&
+    value[BASE_NODE_SIGNATURE_SYMBOL] === true
+  );
 }
 
 /** Returns whether a value looks like a genai `Content` object. */
@@ -221,15 +258,21 @@ export function toContent(val: unknown): Content | undefined {
   if (val === null || val === undefined) {
     return undefined;
   }
-  if (typeof val === 'object' && 'role' in val && 'parts' in val) {
-    return val as Content;
+  // Use the same predicate as validateOutput so a value is never treated as
+  // `Content` by one and re-encoded as text by the other.
+  if (isContent(val)) {
+    return val;
   }
   if (typeof val === 'string') {
     return {role: 'model', parts: [{text: val}]};
   }
   try {
-    return {role: 'model', parts: [{text: JSON.stringify(val)}]};
+    // JSON.stringify returns `undefined` (rather than throwing) for a function
+    // or a symbol, so fall back to String() in that case too.
+    const json = JSON.stringify(val);
+    return {role: 'model', parts: [{text: json ?? String(val)}]};
   } catch {
+    // Reached for values JSON cannot serialize at all (e.g. circular refs).
     return {role: 'model', parts: [{text: String(val)}]};
   }
 }

--- a/core/src/workflow/errors.ts
+++ b/core/src/workflow/errors.ts
@@ -8,27 +8,7 @@
  * Errors raised by the workflow framework.
  *
  * Ported from `google/adk-python` `workflow/_errors.py`.
- *
- * Each error carries a `Symbol.for('google.adk.*')` brand and its type guard
- * matches on that brand rather than `instanceof` — mirroring the signature
- * symbols used across ADK (`isBaseLlm`, `isBaseAgent`, `isEvent`). Registered
- * symbols are shared across realms, so the brand stays correct even when two
- * copies of adk-js are loaded in one runtime (an `instanceof` check between
- * them would fail).
  */
-
-const NODE_INTERRUPTED_ERROR_SYMBOL = Symbol.for(
-  'google.adk.workflow.nodeInterruptedError',
-);
-const NODE_TIMEOUT_ERROR_SYMBOL = Symbol.for(
-  'google.adk.workflow.nodeTimeoutError',
-);
-const DYNAMIC_NODE_FAIL_ERROR_SYMBOL = Symbol.for(
-  'google.adk.workflow.dynamicNodeFailError',
-);
-const INVOCATION_ABORTED_ERROR_SYMBOL = Symbol.for(
-  'google.adk.workflow.invocationAbortedError',
-);
 
 /**
  * Internal: raised when a dynamic node interrupts (HITL).
@@ -40,14 +20,10 @@ const INVOCATION_ABORTED_ERROR_SYMBOL = Symbol.for(
  * Internal to the framework — not part of the public API.
  */
 export class NodeInterruptedError extends Error {
-  /** Brand identifying this error (see {@link isNodeInterruptedError}). */
-  readonly [NODE_INTERRUPTED_ERROR_SYMBOL] = true;
-
   constructor(message = 'Node interrupted (awaiting resume input).') {
     super(message);
     this.name = 'NodeInterruptedError';
-    // Restore prototype chain so `instanceof Error` stays true across
-    // transpilation targets.
+    // Restore prototype chain for `instanceof` across transpilation targets.
     Object.setPrototypeOf(this, NodeInterruptedError.prototype);
   }
 }
@@ -55,15 +31,12 @@ export class NodeInterruptedError extends Error {
 /**
  * Type guard for {@link NodeInterruptedError}.
  *
- * Matches on the {@link NODE_INTERRUPTED_ERROR_SYMBOL} brand (see the file doc).
+ * Matches on `name` rather than `instanceof <subclass>` so it stays correct when
+ * errors cross a package boundary (two copies of adk-js in one runtime would
+ * fail an `instanceof` check between them).
  */
 export function isNodeInterruptedError(e: unknown): e is NodeInterruptedError {
-  return (
-    typeof e === 'object' &&
-    e !== null &&
-    NODE_INTERRUPTED_ERROR_SYMBOL in e &&
-    e[NODE_INTERRUPTED_ERROR_SYMBOL] === true
-  );
+  return e instanceof Error && e.name === 'NodeInterruptedError';
 }
 
 /**
@@ -73,9 +46,6 @@ export function isNodeInterruptedError(e: unknown): e is NodeInterruptedError {
  * `retryConfig`.
  */
 export class NodeTimeoutError extends Error {
-  /** Brand identifying this error (see {@link isNodeTimeoutError}). */
-  readonly [NODE_TIMEOUT_ERROR_SYMBOL] = true;
-
   readonly nodeName: string;
   readonly timeout: number;
 
@@ -94,14 +64,9 @@ export class NodeTimeoutError extends Error {
   }
 }
 
-/** Type guard for {@link NodeTimeoutError} (brand-based; see the file doc). */
+/** Type guard for {@link NodeTimeoutError} (name-based; see above). */
 export function isNodeTimeoutError(e: unknown): e is NodeTimeoutError {
-  return (
-    typeof e === 'object' &&
-    e !== null &&
-    NODE_TIMEOUT_ERROR_SYMBOL in e &&
-    e[NODE_TIMEOUT_ERROR_SYMBOL] === true
-  );
+  return e instanceof Error && e.name === 'NodeTimeoutError';
 }
 
 /**
@@ -111,9 +76,6 @@ export function isNodeTimeoutError(e: unknown): e is NodeTimeoutError {
  * Internal to the framework — not part of the public API.
  */
 export class DynamicNodeFailError extends Error {
-  /** Brand identifying this error (see {@link isDynamicNodeFailError}). */
-  readonly [DYNAMIC_NODE_FAIL_ERROR_SYMBOL] = true;
-
   readonly error: Error;
   readonly errorNodePath: string;
 
@@ -131,14 +93,9 @@ export class DynamicNodeFailError extends Error {
   }
 }
 
-/** Type guard for {@link DynamicNodeFailError} (brand-based; see the file doc). */
+/** Type guard for {@link DynamicNodeFailError} (name-based; see above). */
 export function isDynamicNodeFailError(e: unknown): e is DynamicNodeFailError {
-  return (
-    typeof e === 'object' &&
-    e !== null &&
-    DYNAMIC_NODE_FAIL_ERROR_SYMBOL in e &&
-    e[DYNAMIC_NODE_FAIL_ERROR_SYMBOL] === true
-  );
+  return e instanceof Error && e.name === 'DynamicNodeFailError';
 }
 
 /**
@@ -149,9 +106,6 @@ export function isDynamicNodeFailError(e: unknown): e is DynamicNodeFailError {
  * cancelled" apart from "the node threw".
  */
 export class InvocationAbortedError extends Error {
-  /** Brand identifying this error (see {@link isInvocationAbortedError}). */
-  readonly [INVOCATION_ABORTED_ERROR_SYMBOL] = true;
-
   constructor(message = 'Invocation aborted.') {
     super(message);
     this.name = 'InvocationAbortedError';
@@ -159,14 +113,9 @@ export class InvocationAbortedError extends Error {
   }
 }
 
-/** Type guard for {@link InvocationAbortedError} (brand-based; see the file doc). */
+/** Type guard for {@link InvocationAbortedError} (name-based; see above). */
 export function isInvocationAbortedError(
   e: unknown,
 ): e is InvocationAbortedError {
-  return (
-    typeof e === 'object' &&
-    e !== null &&
-    INVOCATION_ABORTED_ERROR_SYMBOL in e &&
-    e[INVOCATION_ABORTED_ERROR_SYMBOL] === true
-  );
+  return e instanceof Error && e.name === 'InvocationAbortedError';
 }

--- a/core/src/workflow/errors.ts
+++ b/core/src/workflow/errors.ts
@@ -8,7 +8,27 @@
  * Errors raised by the workflow framework.
  *
  * Ported from `google/adk-python` `workflow/_errors.py`.
+ *
+ * Each error carries a `Symbol.for('google.adk.*')` brand and its type guard
+ * matches on that brand rather than `instanceof` — mirroring the signature
+ * symbols used across ADK (`isBaseLlm`, `isBaseAgent`, `isEvent`). Registered
+ * symbols are shared across realms, so the brand stays correct even when two
+ * copies of adk-js are loaded in one runtime (an `instanceof` check between
+ * them would fail).
  */
+
+const NODE_INTERRUPTED_ERROR_SYMBOL = Symbol.for(
+  'google.adk.workflow.nodeInterruptedError',
+);
+const NODE_TIMEOUT_ERROR_SYMBOL = Symbol.for(
+  'google.adk.workflow.nodeTimeoutError',
+);
+const DYNAMIC_NODE_FAIL_ERROR_SYMBOL = Symbol.for(
+  'google.adk.workflow.dynamicNodeFailError',
+);
+const INVOCATION_ABORTED_ERROR_SYMBOL = Symbol.for(
+  'google.adk.workflow.invocationAbortedError',
+);
 
 /**
  * Internal: raised when a dynamic node interrupts (HITL).
@@ -20,10 +40,14 @@
  * Internal to the framework — not part of the public API.
  */
 export class NodeInterruptedError extends Error {
+  /** Brand identifying this error (see {@link isNodeInterruptedError}). */
+  readonly [NODE_INTERRUPTED_ERROR_SYMBOL] = true;
+
   constructor(message = 'Node interrupted (awaiting resume input).') {
     super(message);
     this.name = 'NodeInterruptedError';
-    // Restore prototype chain for `instanceof` across transpilation targets.
+    // Restore prototype chain so `instanceof Error` stays true across
+    // transpilation targets.
     Object.setPrototypeOf(this, NodeInterruptedError.prototype);
   }
 }
@@ -31,12 +55,15 @@ export class NodeInterruptedError extends Error {
 /**
  * Type guard for {@link NodeInterruptedError}.
  *
- * Matches on `name` rather than `instanceof` so it stays correct when errors
- * cross a package boundary (two copies of adk-js in one runtime would fail an
- * `instanceof` check between them).
+ * Matches on the {@link NODE_INTERRUPTED_ERROR_SYMBOL} brand (see the file doc).
  */
 export function isNodeInterruptedError(e: unknown): e is NodeInterruptedError {
-  return e instanceof Error && e.name === 'NodeInterruptedError';
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    NODE_INTERRUPTED_ERROR_SYMBOL in e &&
+    e[NODE_INTERRUPTED_ERROR_SYMBOL] === true
+  );
 }
 
 /**
@@ -46,6 +73,9 @@ export function isNodeInterruptedError(e: unknown): e is NodeInterruptedError {
  * `retryConfig`.
  */
 export class NodeTimeoutError extends Error {
+  /** Brand identifying this error (see {@link isNodeTimeoutError}). */
+  readonly [NODE_TIMEOUT_ERROR_SYMBOL] = true;
+
   readonly nodeName: string;
   readonly timeout: number;
 
@@ -64,9 +94,14 @@ export class NodeTimeoutError extends Error {
   }
 }
 
-/** Type guard for {@link NodeTimeoutError} (name-based; see above). */
+/** Type guard for {@link NodeTimeoutError} (brand-based; see the file doc). */
 export function isNodeTimeoutError(e: unknown): e is NodeTimeoutError {
-  return e instanceof Error && e.name === 'NodeTimeoutError';
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    NODE_TIMEOUT_ERROR_SYMBOL in e &&
+    e[NODE_TIMEOUT_ERROR_SYMBOL] === true
+  );
 }
 
 /**
@@ -76,6 +111,9 @@ export function isNodeTimeoutError(e: unknown): e is NodeTimeoutError {
  * Internal to the framework — not part of the public API.
  */
 export class DynamicNodeFailError extends Error {
+  /** Brand identifying this error (see {@link isDynamicNodeFailError}). */
+  readonly [DYNAMIC_NODE_FAIL_ERROR_SYMBOL] = true;
+
   readonly error: Error;
   readonly errorNodePath: string;
 
@@ -93,7 +131,42 @@ export class DynamicNodeFailError extends Error {
   }
 }
 
-/** Type guard for {@link DynamicNodeFailError} (name-based; see above). */
+/** Type guard for {@link DynamicNodeFailError} (brand-based; see the file doc). */
 export function isDynamicNodeFailError(e: unknown): e is DynamicNodeFailError {
-  return e instanceof Error && e.name === 'DynamicNodeFailError';
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    DYNAMIC_NODE_FAIL_ERROR_SYMBOL in e &&
+    e[DYNAMIC_NODE_FAIL_ERROR_SYMBOL] === true
+  );
+}
+
+/**
+ * Raised when the invocation is aborted (e.g. its abort signal fires) while the
+ * engine is waiting — currently during a node's retry backoff delay.
+ *
+ * Distinct from a node's own failure so a caller can tell "the invocation was
+ * cancelled" apart from "the node threw".
+ */
+export class InvocationAbortedError extends Error {
+  /** Brand identifying this error (see {@link isInvocationAbortedError}). */
+  readonly [INVOCATION_ABORTED_ERROR_SYMBOL] = true;
+
+  constructor(message = 'Invocation aborted.') {
+    super(message);
+    this.name = 'InvocationAbortedError';
+    Object.setPrototypeOf(this, InvocationAbortedError.prototype);
+  }
+}
+
+/** Type guard for {@link InvocationAbortedError} (brand-based; see the file doc). */
+export function isInvocationAbortedError(
+  e: unknown,
+): e is InvocationAbortedError {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    INVOCATION_ABORTED_ERROR_SYMBOL in e &&
+    e[INVOCATION_ABORTED_ERROR_SYMBOL] === true
+  );
 }

--- a/core/src/workflow/graph.ts
+++ b/core/src/workflow/graph.ts
@@ -10,6 +10,16 @@ import {BaseNode} from './base_node.js';
 import {parseEdgeItems} from './utils/graph_parser.js';
 import {validateGraph} from './utils/graph_validation.js';
 
+/**
+ * A unique symbol branding {@link Edge} instances.
+ *
+ * {@link isEdge} matches on this brand rather than `instanceof` so an edge built
+ * by another copy of adk-js in the same runtime is still recognised (an
+ * `instanceof` check fails across package copies) — mirroring the
+ * `Symbol.for('google.adk.*')` brands used across ADK.
+ */
+const EDGE_SIGNATURE_SYMBOL = Symbol.for('google.adk.workflow.edge');
+
 /** Valid routing values used in conditional graph edges. */
 export type RouteValue = boolean | number | string;
 
@@ -35,6 +45,17 @@ export type NodeLike =
  * @example
  *   {question: answerNode, statement: commentNode}
  *   {retry: [nodeA, nodeB]}   // fan-out: both triggered
+ *
+ * @remarks
+ * JavaScript object keys are always strings, so a numeric key (`{2: node}`) and
+ * a boolean key (`{true: node}`) are reconstructed to their typed
+ * {@link RouteValue} (`2`, `true`) when parsed — mirroring Python dict keys.
+ * Because of this, routes are matched **by string value**
+ * ({@link Graph.getNextPendingNodes} compares `String(route)` on both sides), so
+ * a node emitting `2` and one emitting `'2'` both fire a `{2: node}` edge. The
+ * flip side is that a numeric/boolean-looking route and its string spelling
+ * cannot be distinguished in a routing map; use distinct, non-ambiguous route
+ * keys when that matters.
  */
 export type RoutingMap = Record<
   string | number,
@@ -57,6 +78,9 @@ export type EdgeItem = Edge | ChainElement[];
  * Mirrors `google/adk-python` `workflow/_graph.py::Edge`.
  */
 export class Edge {
+  /** Brand identifying this object as an {@link Edge} (see {@link isEdge}). */
+  readonly [EDGE_SIGNATURE_SYMBOL] = true;
+
   constructor(
     readonly fromNode: BaseNode,
     readonly toNode: BaseNode,
@@ -67,6 +91,21 @@ export class Edge {
      */
     readonly route: RouteValue | RouteValue[] | null = null,
   ) {}
+}
+
+/**
+ * Type guard for {@link Edge}.
+ *
+ * Matches on the {@link EDGE_SIGNATURE_SYMBOL} brand rather than `instanceof` so
+ * it stays correct across package copies (see the brand's doc).
+ */
+export function isEdge(value: unknown): value is Edge {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    EDGE_SIGNATURE_SYMBOL in value &&
+    value[EDGE_SIGNATURE_SYMBOL] === true
+  );
 }
 
 /**
@@ -93,11 +132,6 @@ export class Graph {
       }
     }
     this.nodes = nodes;
-  }
-
-  /** Builds and returns a graph from a list of edge items. */
-  static fromEdgeItems(edgeItems: EdgeItem[]): Graph {
-    return new Graph(parseEdgeItems(edgeItems));
   }
 
   /** Terminal node names (no outgoing edges); populated by {@link validate}. */
@@ -132,15 +166,20 @@ export class Graph {
         continue;
       }
 
-      const edgeRoutes = new Set<RouteValue>(
-        Array.isArray(edge.route) ? edge.route : [edge.route],
+      // Match by string value: a JS routing-map key is always a string, so
+      // `{2: n}`/`{'2': n}` are indistinguishable and are both normalized to the
+      // number 2 by the parser. Comparing `String(...)` on both sides keeps a
+      // node that emits `'2'` (or `'true'`) from silently missing its edge. See
+      // the RoutingMap doc comment.
+      const edgeRoutes = new Set<string>(
+        (Array.isArray(edge.route) ? edge.route : [edge.route]).map(String),
       );
 
       let edgeMatched = false;
       if (Array.isArray(routesToMatch)) {
-        edgeMatched = routesToMatch.some((r) => edgeRoutes.has(r));
+        edgeMatched = routesToMatch.some((r) => edgeRoutes.has(String(r)));
       } else if (routesToMatch !== null && routesToMatch !== undefined) {
-        edgeMatched = edgeRoutes.has(routesToMatch);
+        edgeMatched = edgeRoutes.has(String(routesToMatch));
       }
 
       if (edgeMatched) {
@@ -160,4 +199,19 @@ export class Graph {
   validate(): void {
     this._terminalNodeNames = validateGraph(this.nodes, this.edges);
   }
+}
+
+/**
+ * Builds, validates, and returns a {@link Graph} from a list of edge items.
+ *
+ * Validation runs here (not opt-in) so structural problems a graph can only
+ * have at build time — unreachable nodes, duplicate names/edges, routed edges
+ * from START, unconditional cycles — fail loudly at construction rather than
+ * surfacing as silent mis-routing at run time. It also populates the graph's
+ * {@link Graph.terminalNodeNames}, which is otherwise empty.
+ */
+export function createGraphFromEdgeItems(edgeItems: EdgeItem[]): Graph {
+  const graph = new Graph(parseEdgeItems(edgeItems));
+  graph.validate();
+  return graph;
 }

--- a/core/src/workflow/graph.ts
+++ b/core/src/workflow/graph.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {BaseAgent} from '../agents/base_agent.js';
+import {BaseTool} from '../tools/base_tool.js';
+import {BaseNode} from './base_node.js';
+import {parseEdgeItems} from './utils/graph_parser.js';
+import {validateGraph} from './utils/graph_validation.js';
+
+/** Valid routing values used in conditional graph edges. */
+export type RouteValue = boolean | number | string;
+
+/** The fallback route key used when no specific route matches. */
+export const DEFAULT_ROUTE = '__DEFAULT__';
+
+/**
+ * Any value that can be converted to a workflow node: a node, a tool, a plain
+ * function, or the `'START'` sentinel literal. (Agent wrapping is added in
+ * Phase 3 via `build_node`.)
+ */
+export type NodeLike =
+  | BaseNode
+  | BaseAgent
+  | BaseTool
+  | ((...args: never[]) => unknown)
+  | 'START';
+
+/**
+ * A mapping from route values to destination node(s). A value may be a single
+ * node or an array of nodes (fan-out).
+ *
+ * @example
+ *   {question: answerNode, statement: commentNode}
+ *   {retry: [nodeA, nodeB]}   // fan-out: both triggered
+ */
+export type RoutingMap = Record<
+  string | number,
+  NodeLike | readonly NodeLike[]
+>;
+
+/** An element within a workflow chain. */
+export type ChainElement = NodeLike | readonly NodeLike[] | RoutingMap;
+
+/**
+ * An item that can be parsed into workflow edges: an explicit {@link Edge}, or a
+ * chain expressed as an array of {@link ChainElement}s (e.g.
+ * `['START', nodeA, nodeB]`).
+ */
+export type EdgeItem = Edge | ChainElement[];
+
+/**
+ * A directed edge in the workflow graph.
+ *
+ * Mirrors `google/adk-python` `workflow/_graph.py::Edge`.
+ */
+export class Edge {
+  constructor(
+    readonly fromNode: BaseNode,
+    readonly toNode: BaseNode,
+    /**
+     * The route(s) this edge is associated with. `null` means unconditional
+     * (always triggered). A single value or a list; the edge fires when the
+     * emitted route matches any listed value.
+     */
+    readonly route: RouteValue | RouteValue[] | null = null,
+  ) {}
+}
+
+/**
+ * A compiled workflow graph. Nodes are inferred (deduped by identity) from the
+ * edges.
+ *
+ * Mirrors `google/adk-python` `workflow/_graph.py::Graph`.
+ */
+export class Graph {
+  readonly nodes: BaseNode[];
+  readonly edges: Edge[];
+  private _terminalNodeNames: ReadonlySet<string> = new Set();
+
+  constructor(edges: Edge[]) {
+    this.edges = edges;
+    const seen = new Set<BaseNode>();
+    const nodes: BaseNode[] = [];
+    for (const edge of edges) {
+      for (const node of [edge.fromNode, edge.toNode]) {
+        if (!seen.has(node)) {
+          seen.add(node);
+          nodes.push(node);
+        }
+      }
+    }
+    this.nodes = nodes;
+  }
+
+  /** Builds and returns a graph from a list of edge items. */
+  static fromEdgeItems(edgeItems: EdgeItem[]): Graph {
+    return new Graph(parseEdgeItems(edgeItems));
+  }
+
+  /** Terminal node names (no outgoing edges); populated by {@link validate}. */
+  get terminalNodeNames(): ReadonlySet<string> {
+    return this._terminalNodeNames;
+  }
+
+  /**
+   * Determines the next nodes to transition to PENDING based on the route(s)
+   * emitted by a completed node. Ported from Python `get_next_pending_nodes`.
+   */
+  getNextPendingNodes(
+    nodeName: string,
+    routesToMatch: RouteValue | RouteValue[] | null | undefined,
+  ): string[] {
+    const nextPending: string[] = [];
+    let matchedSpecificRoute = false;
+    let defaultRouteNode: string | undefined;
+
+    for (const edge of this.edges) {
+      if (edge.fromNode.name !== nodeName) {
+        continue;
+      }
+      if (edge.route === null || edge.route === undefined) {
+        // Unconditional edges always fire.
+        nextPending.push(edge.toNode.name);
+        continue;
+      }
+
+      if (edge.route === DEFAULT_ROUTE) {
+        defaultRouteNode = edge.toNode.name;
+        continue;
+      }
+
+      const edgeRoutes = new Set<RouteValue>(
+        Array.isArray(edge.route) ? edge.route : [edge.route],
+      );
+
+      let edgeMatched = false;
+      if (Array.isArray(routesToMatch)) {
+        edgeMatched = routesToMatch.some((r) => edgeRoutes.has(r));
+      } else if (routesToMatch !== null && routesToMatch !== undefined) {
+        edgeMatched = edgeRoutes.has(routesToMatch);
+      }
+
+      if (edgeMatched) {
+        nextPending.push(edge.toNode.name);
+        matchedSpecificRoute = true;
+      }
+    }
+
+    if (!matchedSpecificRoute && defaultRouteNode) {
+      nextPending.push(defaultRouteNode);
+    }
+
+    return nextPending;
+  }
+
+  /** Validates the graph and computes terminal node names. */
+  validate(): void {
+    this._terminalNodeNames = validateGraph(this.nodes, this.edges);
+  }
+}

--- a/core/src/workflow/node_builders.ts
+++ b/core/src/workflow/node_builders.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  NodeBuilder,
+  ParallelWorkerFactory,
+} from './utils/workflow_graph_utils.js';
+
+/**
+ * The built-in node builders, consulted in order by `buildNode` / `isNodeLike`
+ * to turn a bare function / tool / agent into the right `BaseNode`.
+ *
+ * This is a single, explicit, statically-imported list — node-type modules are
+ * wired in here rather than self-registering at import time, so there is no
+ * global mutable registry and no import-order side effects. Order is the match
+ * precedence (first match wins). Each node-type part adds its builder here; the
+ * list is empty in the engine-core part.
+ */
+export const NODE_BUILDERS: readonly NodeBuilder[] = [];
+
+/**
+ * Wraps an already-built node in a parallel worker. Wired in by the
+ * parallel-worker node part; `undefined` until then, so requesting
+ * `parallelWorker` before that part is present throws.
+ */
+export const PARALLEL_WORKER_FACTORY: ParallelWorkerFactory | undefined =
+  undefined;

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {InvocationContext} from '../agents/invocation_context.js';
+import {Event} from '../events/event.js';
+import {createEventActions, EventActions} from '../events/event_actions.js';
+import {State} from '../sessions/state.js';
+import {AsyncQueue} from '../utils/async_queue.js';
+import type {BaseNode} from './base_node.js';
+import type {RouteValue} from './graph.js';
+import {executeChildNode, RunNodeOptions} from './node_runner.js';
+import type {ScheduleDynamicNode} from './schedule_dynamic_node.js';
+
+/**
+ * Options for constructing a {@link NodeContext}.
+ */
+export interface NodeContextOptions {
+  invocationContext: InvocationContext;
+  channel: AsyncQueue<Event>;
+  /** Dotted node path of the owning node (empty string for the root). */
+  nodePath: string;
+  /** Deterministic run id of the owning node. */
+  runId: string;
+  /** Responses for resuming interrupted child nodes, keyed by interrupt id. */
+  resumeInputs?: Record<string, unknown>;
+  /** Scope tag isolating this node's events from peer scopes. */
+  isolationScope?: string;
+  /** Accumulator for event actions (state delta, etc). */
+  actions?: EventActions;
+}
+
+/**
+ * The execution context for a workflow node — the TypeScript analogue of
+ * `google/adk-python` `agents/context.py::Context` (the workflow flavour).
+ *
+ * It exposes `ctx.runNode(...)` for programmatic child execution, `ctx.state`
+ * for delta-aware session state, `ctx.emit(...)` to stream an event, and the
+ * mutable `output`/`route`/`interruptIds` a node sets while running.
+ */
+export class NodeContext {
+  readonly invocationContext: InvocationContext;
+  readonly channel: AsyncQueue<Event>;
+  readonly nodePath: string;
+  readonly runId: string;
+  readonly actions: EventActions;
+  resumeInputs: Record<string, unknown>;
+  isolationScope?: string;
+
+  /** The structured output produced by the node during its run. */
+  output: unknown = undefined;
+
+  /** The route key(s) emitted by the node, if any (array = multi-route). */
+  route?: RouteValue | RouteValue[];
+
+  /** Interrupt ids the node is currently blocked on (HITL). */
+  interruptIds: string[] = [];
+
+  /**
+   * Abort signal for the current node run, set by the engine while a node that
+   * declares a `timeout` is executing. It fires when the timeout elapses (or the
+   * invocation itself is aborted). Cooperative node bodies can observe
+   * `ctx.abortSignal` to cancel their own in-flight work (e.g. pass it to a
+   * model/tool call); the engine also stops consuming the node's events once it
+   * fires, so nothing is pushed past the deadline.
+   */
+  abortSignal?: AbortSignal;
+
+  /**
+   * The dynamic-node scheduler for this subtree. When set, `ctx.runNode()`
+   * routes through it (dedup/resume/fresh); otherwise it runs the child
+   * directly. Propagated to child contexts by the node runner; a nested
+   * Workflow overrides it with its own scheduler.
+   */
+  scheduler?: ScheduleDynamicNode;
+
+  /** The current attempt number (1-based) for the running node (see retry). */
+  attemptCount = 1;
+
+  private readonly _state: State;
+  private readonly dynamicRunCounters = new Map<string, number>();
+
+  constructor(opts: NodeContextOptions) {
+    this.invocationContext = opts.invocationContext;
+    this.channel = opts.channel;
+    this.nodePath = opts.nodePath;
+    this.runId = opts.runId;
+    this.resumeInputs = opts.resumeInputs ?? {};
+    this.isolationScope = opts.isolationScope;
+    this.actions = opts.actions ?? createEventActions();
+    // Writes via `ctx.state` accumulate into `actions.stateDelta`, mirroring
+    // Python's `ctx.state` -> `ctx.actions.state_delta` behaviour.
+    this._state = new State(
+      opts.invocationContext.session.state,
+      this.actions.stateDelta,
+    );
+  }
+
+  /** Delta-aware session state; writes accumulate in `actions.stateDelta`. */
+  get state(): State {
+    return this._state;
+  }
+
+  /** The branch of the owning invocation context. */
+  get branch(): string | undefined {
+    return this.invocationContext.branch;
+  }
+
+  /** The current invocation id. */
+  get invocationId(): string {
+    return this.invocationContext.invocationId;
+  }
+
+  /** The current session. */
+  get session() {
+    return this.invocationContext.session;
+  }
+
+  /** Streams a single event out through the workflow's event channel. */
+  emit(event: Event): void {
+    this.channel.push(event);
+  }
+
+  /**
+   * Runs a child node programmatically, streaming its events through the same
+   * channel and resolving to the child's {@link NodeContext} (carrying its
+   * `output`, `route`, and `interruptIds`).
+   *
+   * When a dynamic-node {@link scheduler} is set (inside a Workflow subtree),
+   * the call routes through it for dedup/resume; otherwise the child runs
+   * directly.
+   */
+  runNode(
+    node: BaseNode,
+    input?: unknown,
+    options?: RunNodeOptions,
+  ): Promise<NodeContext> {
+    if (this.scheduler) {
+      const nodeName = options?.nodeName ?? node.name;
+      let runId = options?.runId;
+      if (!runId) {
+        const next = (this.dynamicRunCounters.get(nodeName) ?? 0) + 1;
+        this.dynamicRunCounters.set(nodeName, next);
+        runId = String(next);
+      }
+      return this.scheduler.schedule(this, node, input, {
+        ...options,
+        nodeName,
+        runId,
+      });
+    }
+    return executeChildNode(this, node, input, options);
+  }
+}

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -151,6 +151,6 @@ export class NodeContext {
         runId,
       });
     }
-    return executeChildNode(this, node, input, options);
+    return executeChildNode({parent: this, node, input, options});
   }
 }

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -82,7 +82,7 @@ export async function executeChildNode(
   const childIc =
     branch === parent.invocationContext.branch
       ? parent.invocationContext
-      : withBranch(parent.invocationContext, branch);
+      : new InvocationContext({...parent.invocationContext, branch});
 
   const child = new NodeContext({
     invocationContext: childIc,
@@ -267,26 +267,6 @@ function enrichEvent(
   if (isolationScope !== undefined && event.isolationScope === undefined) {
     event.isolationScope = isolationScope;
   }
-}
-
-/**
- * Creates a child InvocationContext with a different branch, preserving the
- * shared invocation cost manager and all services/session.
- *
- * Passes the parent context straight to the constructor (the same pattern
- * `ParallelAgent.createBranchCtxForSubAgent` uses) instead of spreading it
- * through a double cast: spreading copies only own enumerable properties, which
- * silently drops anything the class exposes via a getter or derives in its
- * constructor. The constructor already carries every field — including the
- * private cost manager — across for us.
- */
-function withBranch(
-  ic: InvocationContext,
-  branch: string | undefined,
-): InvocationContext {
-  const child = new InvocationContext(ic);
-  child.branch = branch;
-  return child;
 }
 
 /**

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -113,26 +113,26 @@ export async function executeChildNode({
     runId,
   });
 
-  for (;;) {
+  let succeeded = false;
+  while (!succeeded) {
     resetState(child);
     child.attemptCount = nodeState.attemptCount;
     try {
       await runOnce({node, child, input, nodeName, branch, isolationScope});
-      break;
+      succeeded = true;
     } catch (err) {
       // Check retry eligibility with the attempt that just failed, compute its
       // backoff delay, THEN advance the counter (matches Python semantics).
       const retryConfig = node.preparedRetryConfig;
       if (
-        retryConfig &&
-        shouldRetryNode({error: err, retryConfig, nodeState})
+        !retryConfig ||
+        !shouldRetryNode({error: err, retryConfig, nodeState})
       ) {
-        const delaySeconds = getRetryDelaySeconds({retryConfig, nodeState});
-        nodeState.attemptCount += 1;
-        await delay(delaySeconds * 1000, parent.invocationContext.abortSignal);
-        continue;
+        throw err;
       }
-      throw err;
+      const delaySeconds = getRetryDelaySeconds({retryConfig, nodeState});
+      nodeState.attemptCount += 1;
+      await delay(delaySeconds * 1000, parent.invocationContext.abortSignal);
     }
   }
 
@@ -256,12 +256,10 @@ async function runOnce({
 
   const iterator = node.run(child, input)[Symbol.asyncIterator]();
   try {
-    for (;;) {
-      const result = await Promise.race([iterator.next(), aborted]);
-      if (result.done) {
-        break;
-      }
+    let result = await Promise.race([iterator.next(), aborted]);
+    while (!result.done) {
       consume(result.value);
+      result = await Promise.race([iterator.next(), aborted]);
     }
   } finally {
     clearTimeout(timer);

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -1,0 +1,282 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  InvocationContext,
+  InvocationContextParams,
+} from '../agents/invocation_context.js';
+import {Event} from '../events/event.js';
+import {BaseNode} from './base_node.js';
+import {createSubBranch} from './branch_path.js';
+import {NodeTimeoutError} from './errors.js';
+import {NodeContext} from './node_context.js';
+import {createNodeState} from './node_state.js';
+import {NodeStatus} from './node_status.js';
+import {getRetryDelaySeconds, shouldRetryNode} from './utils/retry_utils.js';
+
+/**
+ * Options controlling a single `ctx.runNode(...)` execution.
+ */
+export interface RunNodeOptions {
+  /** Deterministic tracking name; defaults to `node.name`. */
+  nodeName?: string;
+  /** Unique id for this specific run; defaults to `nodeName`. */
+  runId?: string;
+  /** If true, the child's output replaces the caller's output. */
+  useAsOutput?: boolean;
+  /** If true, run the child in an isolated sub-branch. */
+  useSubBranch?: boolean;
+  /** Explicit branch, overriding the default/sub-branch computation. */
+  overrideBranch?: string;
+  /** Explicit isolation scope, overriding inheritance from the parent. */
+  overrideIsolationScope?: string;
+  /**
+   * Explicit node path for the child (used by the dynamic scheduler to embed
+   * the run id, e.g. `wf.node@1`, so distinct runs are distinguishable on
+   * resume). Defaults to `${parent.nodePath}.${nodeName}`.
+   */
+  overrideNodePath?: string;
+}
+
+/**
+ * Executes a child node on behalf of `parent.runNode(...)`.
+ *
+ * Responsibilities (Phase 1 scope): create the child {@link NodeContext},
+ * drive `node.run()`, enrich each emitted event (author, node path, branch,
+ * isolation scope), track the child's `output`/`route`, apply the per-node
+ * `timeout`, and retry on failure per `retryConfig`. Returns the child context.
+ */
+export async function executeChildNode(
+  parent: NodeContext,
+  node: BaseNode,
+  input: unknown,
+  options: RunNodeOptions = {},
+): Promise<NodeContext> {
+  const nodeName = options.nodeName ?? node.name;
+  const runId = options.runId ?? nodeName;
+  const nodePath =
+    options.overrideNodePath ??
+    (parent.nodePath ? `${parent.nodePath}.${nodeName}` : nodeName);
+
+  let branch = parent.branch;
+  if (options.overrideBranch !== undefined) {
+    branch = options.overrideBranch;
+  } else if (options.useSubBranch) {
+    branch = createSubBranch(parent.branch, {
+      name: nodeName,
+      runId: options.runId,
+    });
+  }
+
+  const isolationScope =
+    options.overrideIsolationScope ?? parent.isolationScope;
+
+  const childIc =
+    branch === parent.invocationContext.branch
+      ? parent.invocationContext
+      : withBranch(parent.invocationContext, branch);
+
+  const child = new NodeContext({
+    invocationContext: childIc,
+    channel: parent.channel,
+    nodePath,
+    runId,
+    resumeInputs: parent.resumeInputs,
+    isolationScope,
+  });
+  // Propagate the dynamic scheduler down; a nested Workflow overrides it.
+  child.scheduler = parent.scheduler;
+
+  const nodeState = createNodeState({
+    status: NodeStatus.RUNNING,
+    input,
+    runId,
+  });
+
+  for (;;) {
+    // Reset per-attempt output so a retry starts clean.
+    child.output = undefined;
+    child.route = undefined;
+    child.interruptIds = [];
+    child.attemptCount = nodeState.attemptCount;
+    try {
+      await runOnce(node, child, input, nodeName, branch, isolationScope);
+      break;
+    } catch (err) {
+      // Check retry eligibility with the attempt that just failed, compute its
+      // backoff delay, THEN advance the counter (matches Python semantics).
+      const retryConfig = node.preparedRetryConfig;
+      if (retryConfig && shouldRetryNode(err, retryConfig, nodeState)) {
+        const delaySeconds = getRetryDelaySeconds(retryConfig, nodeState);
+        nodeState.attemptCount += 1;
+        await delay(delaySeconds * 1000, parent.invocationContext.abortSignal);
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  if (options.useAsOutput) {
+    parent.output = child.output;
+    parent.route = child.route;
+  }
+
+  return child;
+}
+
+/**
+ * Drives one attempt of `node.run()`, enriching and pushing each event and
+ * tracking the child's output/route.
+ *
+ * When the node declares a `timeout`, execution is driven step-by-step and
+ * raced against a deadline: on timeout the engine stops consuming events (so
+ * nothing is pushed past the deadline — which would otherwise leak into a retry
+ * or the next node), closes the generator so its `finally` blocks run, and
+ * aborts `child.abortSignal` so a cooperative node body can cancel its own
+ * in-flight work. Mirrors the cancellation semantics of Python's
+ * `asyncio.wait_for`.
+ */
+async function runOnce(
+  node: BaseNode,
+  child: NodeContext,
+  input: unknown,
+  nodeName: string,
+  branch: string | undefined,
+  isolationScope: string | undefined,
+): Promise<void> {
+  const consume = (event: Event): void => {
+    enrichEvent(event, child, nodeName, branch, isolationScope);
+    if (event.output !== undefined) {
+      child.output = event.output;
+    }
+    if (event.route !== undefined) {
+      child.route = event.route;
+    }
+    // HITL: an interrupt event marks its ids as long-running tool ids.
+    if (event.longRunningToolIds && event.longRunningToolIds.length > 0) {
+      for (const id of event.longRunningToolIds) {
+        if (!child.interruptIds.includes(id)) {
+          child.interruptIds.push(id);
+        }
+      }
+      // Persist the node's input on the interrupt event so a resumed
+      // (waiting) node re-runs with its ORIGINAL input, not the resume
+      // message. Rehydrated by reconstructNodeStates on the next turn.
+      event.actions.agentState = {
+        ...(event.actions.agentState ?? {}),
+        input,
+      };
+    }
+    child.channel.push(event);
+  };
+
+  if (!(typeof node.timeout === 'number' && node.timeout > 0)) {
+    for await (const event of node.run(child, input)) {
+      consume(event);
+    }
+    return;
+  }
+
+  const timeoutSeconds = node.timeout;
+  const controller = new AbortController();
+  const parentSignal = child.invocationContext.abortSignal;
+  const onParentAbort = () => controller.abort();
+  if (parentSignal?.aborted) {
+    controller.abort();
+  } else {
+    parentSignal?.addEventListener('abort', onParentAbort, {once: true});
+  }
+  const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+  child.abortSignal = controller.signal;
+
+  // A single promise that rejects once the deadline (or external abort) fires;
+  // reused across iterations so we don't leak a listener per step.
+  const aborted = new Promise<never>((_, reject) => {
+    const fail = () =>
+      reject(new NodeTimeoutError({nodeName, timeout: timeoutSeconds}));
+    if (controller.signal.aborted) {
+      fail();
+    } else {
+      controller.signal.addEventListener('abort', fail, {once: true});
+    }
+  });
+
+  const iterator = node.run(child, input)[Symbol.asyncIterator]();
+  try {
+    for (;;) {
+      const result = await Promise.race([iterator.next(), aborted]);
+      if (result.done) {
+        break;
+      }
+      consume(result.value);
+    }
+  } finally {
+    clearTimeout(timer);
+    parentSignal?.removeEventListener('abort', onParentAbort);
+    child.abortSignal = undefined;
+    // Best-effort: close the generator so its `finally`/cleanup runs. This is
+    // queued behind any in-flight `next()`; its result is discarded.
+    void Promise.resolve(iterator.return?.(undefined)).catch(() => {});
+  }
+}
+
+/**
+ * Stamps engine-owned provenance onto an event without clobbering values the
+ * node explicitly set.
+ */
+function enrichEvent(
+  event: Event,
+  child: NodeContext,
+  nodeName: string,
+  branch: string | undefined,
+  isolationScope: string | undefined,
+): void {
+  if (!event.author) {
+    event.author = nodeName;
+  }
+  event.nodeInfo = {...(event.nodeInfo ?? {}), path: child.nodePath};
+  if (branch !== undefined && event.branch === undefined) {
+    event.branch = branch;
+  }
+  if (isolationScope !== undefined && event.isolationScope === undefined) {
+    event.isolationScope = isolationScope;
+  }
+}
+
+/**
+ * Creates a shallow child InvocationContext with a different branch, preserving
+ * the shared invocation cost manager and all services/session.
+ */
+function withBranch(
+  ic: InvocationContext,
+  branch: string | undefined,
+): InvocationContext {
+  return new InvocationContext({
+    ...(ic as unknown as InvocationContextParams),
+    branch,
+  });
+}
+
+/**
+ * Promise-based delay that rejects early if the abort signal fires.
+ */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('Aborted'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error('Aborted'));
+    };
+    signal?.addEventListener('abort', onAbort, {once: true});
+  });
+}

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -4,14 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  InvocationContext,
-  InvocationContextParams,
-} from '../agents/invocation_context.js';
+import {InvocationContext} from '../agents/invocation_context.js';
 import {Event} from '../events/event.js';
 import {BaseNode} from './base_node.js';
 import {createSubBranch} from './branch_path.js';
-import {NodeTimeoutError} from './errors.js';
+import {InvocationAbortedError, NodeTimeoutError} from './errors.js';
 import {NodeContext} from './node_context.js';
 import {createNodeState} from './node_state.js';
 import {NodeStatus} from './node_status.js';
@@ -48,6 +45,14 @@ export interface RunNodeOptions {
  * drive `node.run()`, enrich each emitted event (author, node path, branch,
  * isolation scope), track the child's `output`/`route`, apply the per-node
  * `timeout`, and retry on failure per `retryConfig`. Returns the child context.
+ *
+ * Retry semantics: each attempt starts with the child's per-attempt state
+ * cleared (output, route, interrupt ids, and `actions.stateDelta`). Events are
+ * the exception — they stream out through the shared channel as they are
+ * produced and cannot be retracted, so a node that emits some events and then
+ * fails will re-emit them when the attempt is retried. Nodes that must not
+ * duplicate observable events across retries should emit only after their
+ * fallible work has succeeded.
  */
 export async function executeChildNode(
   parent: NodeContext,
@@ -97,10 +102,23 @@ export async function executeChildNode(
   });
 
   for (;;) {
-    // Reset per-attempt output so a retry starts clean.
+    // Reset per-attempt state so a retry starts clean. This covers everything a
+    // failed attempt can leave behind on the child context: its output/route,
+    // interrupt ids, AND its state writes. A node that calls `ctx.state.set(...)`
+    // and then throws would otherwise leave the failed attempt's writes in the
+    // delta, to be committed alongside the successful attempt's. `NodeContext`
+    // builds its `State` over this exact `stateDelta` object once (in its
+    // constructor), so we clear the keys in place rather than reassigning it.
+    //
+    // Note: events already pushed through the channel on a failed attempt are
+    // downstream and cannot be retracted, so a node that emits N events and
+    // then fails re-emits those N on retry (see the note on `executeChildNode`).
     child.output = undefined;
     child.route = undefined;
     child.interruptIds = [];
+    for (const key of Object.keys(child.actions.stateDelta)) {
+      delete child.actions.stateDelta[key];
+    }
     child.attemptCount = nodeState.attemptCount;
     try {
       await runOnce(node, child, input, nodeName, branch, isolationScope);
@@ -224,8 +242,12 @@ async function runOnce(
 }
 
 /**
- * Stamps engine-owned provenance onto an event without clobbering values the
- * node explicitly set.
+ * Stamps engine-owned provenance onto an event.
+ *
+ * `author`, `branch` and `isolationScope` are only filled in when the node left
+ * them unset, so a node can override them. `path` is different: it is
+ * engine-owned and always set to the child's real node path — a node must not be
+ * able to misreport where it ran.
  */
 function enrichEvent(
   event: Event,
@@ -237,6 +259,7 @@ function enrichEvent(
   if (!event.author) {
     event.author = nodeName;
   }
+  // Engine-owned: always stamp the true node path (see doc above).
   event.nodeInfo = {...(event.nodeInfo ?? {}), path: child.nodePath};
   if (branch !== undefined && event.branch === undefined) {
     event.branch = branch;
@@ -247,26 +270,34 @@ function enrichEvent(
 }
 
 /**
- * Creates a shallow child InvocationContext with a different branch, preserving
- * the shared invocation cost manager and all services/session.
+ * Creates a child InvocationContext with a different branch, preserving the
+ * shared invocation cost manager and all services/session.
+ *
+ * Passes the parent context straight to the constructor (the same pattern
+ * `ParallelAgent.createBranchCtxForSubAgent` uses) instead of spreading it
+ * through a double cast: spreading copies only own enumerable properties, which
+ * silently drops anything the class exposes via a getter or derives in its
+ * constructor. The constructor already carries every field — including the
+ * private cost manager — across for us.
  */
 function withBranch(
   ic: InvocationContext,
   branch: string | undefined,
 ): InvocationContext {
-  return new InvocationContext({
-    ...(ic as unknown as InvocationContextParams),
-    branch,
-  });
+  const child = new InvocationContext(ic);
+  child.branch = branch;
+  return child;
 }
 
 /**
- * Promise-based delay that rejects early if the abort signal fires.
+ * Promise-based delay that rejects early (with {@link InvocationAbortedError})
+ * if the abort signal fires — so an abort during retry backoff is
+ * distinguishable from a node failure.
  */
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
-      reject(new Error('Aborted'));
+      reject(new InvocationAbortedError('Invocation aborted during retry.'));
       return;
     }
     const timer = setTimeout(() => {
@@ -275,7 +306,7 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
     }, ms);
     const onAbort = () => {
       clearTimeout(timer);
-      reject(new Error('Aborted'));
+      reject(new InvocationAbortedError('Invocation aborted during retry.'));
     };
     signal?.addEventListener('abort', onAbort, {once: true});
   });

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -38,6 +38,18 @@ export interface RunNodeOptions {
   overrideNodePath?: string;
 }
 
+/** Parameters for {@link executeChildNode}. */
+export interface ExecuteChildNodeParams {
+  /** The context requesting the child run. */
+  parent: NodeContext;
+  /** The node to execute. */
+  node: BaseNode;
+  /** The input passed to the node. */
+  input: unknown;
+  /** Options controlling this run. */
+  options?: RunNodeOptions;
+}
+
 /**
  * Executes a child node on behalf of `parent.runNode(...)`.
  *
@@ -54,12 +66,12 @@ export interface RunNodeOptions {
  * duplicate observable events across retries should emit only after their
  * fallible work has succeeded.
  */
-export async function executeChildNode(
-  parent: NodeContext,
-  node: BaseNode,
-  input: unknown,
-  options: RunNodeOptions = {},
-): Promise<NodeContext> {
+export async function executeChildNode({
+  parent,
+  node,
+  input,
+  options = {},
+}: ExecuteChildNodeParams): Promise<NodeContext> {
   const nodeName = options.nodeName ?? node.name;
   const runId = options.runId ?? nodeName;
   const nodePath =
@@ -102,33 +114,20 @@ export async function executeChildNode(
   });
 
   for (;;) {
-    // Reset per-attempt state so a retry starts clean. This covers everything a
-    // failed attempt can leave behind on the child context: its output/route,
-    // interrupt ids, AND its state writes. A node that calls `ctx.state.set(...)`
-    // and then throws would otherwise leave the failed attempt's writes in the
-    // delta, to be committed alongside the successful attempt's. `NodeContext`
-    // builds its `State` over this exact `stateDelta` object once (in its
-    // constructor), so we clear the keys in place rather than reassigning it.
-    //
-    // Note: events already pushed through the channel on a failed attempt are
-    // downstream and cannot be retracted, so a node that emits N events and
-    // then fails re-emits those N on retry (see the note on `executeChildNode`).
-    child.output = undefined;
-    child.route = undefined;
-    child.interruptIds = [];
-    for (const key of Object.keys(child.actions.stateDelta)) {
-      delete child.actions.stateDelta[key];
-    }
+    resetState(child);
     child.attemptCount = nodeState.attemptCount;
     try {
-      await runOnce(node, child, input, nodeName, branch, isolationScope);
+      await runOnce({node, child, input, nodeName, branch, isolationScope});
       break;
     } catch (err) {
       // Check retry eligibility with the attempt that just failed, compute its
       // backoff delay, THEN advance the counter (matches Python semantics).
       const retryConfig = node.preparedRetryConfig;
-      if (retryConfig && shouldRetryNode(err, retryConfig, nodeState)) {
-        const delaySeconds = getRetryDelaySeconds(retryConfig, nodeState);
+      if (
+        retryConfig &&
+        shouldRetryNode({error: err, retryConfig, nodeState})
+      ) {
+        const delaySeconds = getRetryDelaySeconds({retryConfig, nodeState});
         nodeState.attemptCount += 1;
         await delay(delaySeconds * 1000, parent.invocationContext.abortSignal);
         continue;
@@ -146,6 +145,39 @@ export async function executeChildNode(
 }
 
 /**
+ * Reset per-attempt state so a retry starts clean. This covers everything a
+ * failed attempt can leave behind on the child context: its output/route,
+ * interrupt ids, AND its state writes. A node that calls `ctx.state.set(...)`
+ * and then throws would otherwise leave the failed attempt's writes in the
+ * delta, to be committed alongside the successful attempt's. `NodeContext`
+ * builds its `State` over this exact `stateDelta` object once (in its
+ * constructor), so we clear the keys in place rather than reassigning it.
+ *
+ * Note: events already pushed through the channel on a failed attempt are
+ * downstream and cannot be retracted, so a node that emits N events and
+ * then fails re-emits those N on retry (see the note on `executeChildNode`).
+ *
+ * @param childNodeContext Node context to reset
+ */
+function resetState(childNodeContext: NodeContext): void {
+  childNodeContext.output = undefined;
+  childNodeContext.route = undefined;
+  childNodeContext.interruptIds = [];
+  for (const key of Object.keys(childNodeContext.actions.stateDelta)) {
+    delete childNodeContext.actions.stateDelta[key];
+  }
+}
+
+interface RunOnceParams {
+  node: BaseNode;
+  child: NodeContext;
+  input: unknown;
+  nodeName: string;
+  branch: string | undefined;
+  isolationScope: string | undefined;
+}
+
+/**
  * Drives one attempt of `node.run()`, enriching and pushing each event and
  * tracking the child's output/route.
  *
@@ -157,16 +189,16 @@ export async function executeChildNode(
  * in-flight work. Mirrors the cancellation semantics of Python's
  * `asyncio.wait_for`.
  */
-async function runOnce(
-  node: BaseNode,
-  child: NodeContext,
-  input: unknown,
-  nodeName: string,
-  branch: string | undefined,
-  isolationScope: string | undefined,
-): Promise<void> {
+async function runOnce({
+  node,
+  child,
+  input,
+  nodeName,
+  branch,
+  isolationScope,
+}: RunOnceParams): Promise<void> {
   const consume = (event: Event): void => {
-    enrichEvent(event, child, nodeName, branch, isolationScope);
+    enrichEvent({event, child, nodeName, branch, isolationScope});
     if (event.output !== undefined) {
       child.output = event.output;
     }
@@ -241,6 +273,14 @@ async function runOnce(
   }
 }
 
+interface EnrichEventParams {
+  event: Event;
+  child: NodeContext;
+  nodeName: string;
+  branch: string | undefined;
+  isolationScope: string | undefined;
+}
+
 /**
  * Stamps engine-owned provenance onto an event.
  *
@@ -249,13 +289,13 @@ async function runOnce(
  * engine-owned and always set to the child's real node path — a node must not be
  * able to misreport where it ran.
  */
-function enrichEvent(
-  event: Event,
-  child: NodeContext,
-  nodeName: string,
-  branch: string | undefined,
-  isolationScope: string | undefined,
-): void {
+function enrichEvent({
+  event,
+  child,
+  nodeName,
+  branch,
+  isolationScope,
+}: EnrichEventParams): void {
   if (!event.author) {
     event.author = nodeName;
   }

--- a/core/src/workflow/request_input.ts
+++ b/core/src/workflow/request_input.ts
@@ -4,8 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ZodType} from 'zod';
 import {randomUUID} from '../utils/env_aware_utils.js';
+import type {SchemaLike} from '../utils/schema.js';
+
+/**
+ * A unique symbol branding {@link RequestInput} instances.
+ *
+ * {@link isRequestInput} matches on this brand rather than `instanceof` so a
+ * request built by another copy of adk-js in the same runtime is still
+ * recognised (an `instanceof` check fails across package copies). This matters
+ * because the guard gates the HITL interrupt path in `BaseNode.run`: a missed
+ * match would silently stringify the request into a text part instead of
+ * pausing the workflow. Mirrors the `Symbol.for('google.adk.*')` brands used
+ * across ADK.
+ */
+const REQUEST_INPUT_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.workflow.requestInput',
+);
 
 /** Parameters for constructing a {@link RequestInput}. */
 export interface RequestInputParams {
@@ -15,8 +30,8 @@ export interface RequestInputParams {
   payload?: unknown;
   /** A message to display to the user when requesting input. */
   message?: string;
-  /** The expected schema of the response. */
-  responseSchema?: ZodType;
+  /** The expected schema of the response (Zod v3/v4 or genai `Schema`). */
+  responseSchema?: SchemaLike;
 }
 
 /**
@@ -28,10 +43,13 @@ export interface RequestInputParams {
  * Ported from `google/adk-python` `events/request_input.py`.
  */
 export class RequestInput {
+  /** Brand identifying this object as a {@link RequestInput} (see {@link isRequestInput}). */
+  readonly [REQUEST_INPUT_SIGNATURE_SYMBOL] = true;
+
   readonly interruptId: string;
   readonly payload?: unknown;
   readonly message?: string;
-  readonly responseSchema?: ZodType;
+  readonly responseSchema?: SchemaLike;
 
   constructor(params: RequestInputParams = {}) {
     this.interruptId = params.interruptId ?? randomUUID();
@@ -41,7 +59,17 @@ export class RequestInput {
   }
 }
 
-/** Type guard for {@link RequestInput}. */
+/**
+ * Type guard for {@link RequestInput}.
+ *
+ * Matches on the {@link REQUEST_INPUT_SIGNATURE_SYMBOL} brand rather than
+ * `instanceof` so it stays correct across package copies (see the brand's doc).
+ */
 export function isRequestInput(value: unknown): value is RequestInput {
-  return value instanceof RequestInput;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    REQUEST_INPUT_SIGNATURE_SYMBOL in value &&
+    value[REQUEST_INPUT_SIGNATURE_SYMBOL] === true
+  );
 }

--- a/core/src/workflow/request_input.ts
+++ b/core/src/workflow/request_input.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {ZodType} from 'zod';
+import {randomUUID} from '../utils/env_aware_utils.js';
+
+/** Parameters for constructing a {@link RequestInput}. */
+export interface RequestInputParams {
+  /** The interrupt id (usually a function-call id). Auto-generated if omitted. */
+  interruptId?: string;
+  /** Custom payload provided for resuming. */
+  payload?: unknown;
+  /** A message to display to the user when requesting input. */
+  message?: string;
+  /** The expected schema of the response. */
+  responseSchema?: ZodType;
+}
+
+/**
+ * A request for input from the user, yielded/returned by a node to pause a
+ * workflow (Human-in-the-Loop). The framework converts it to an interrupt
+ * event; the workflow surfaces the interrupt id to the caller, which later
+ * resumes by providing `resumeInputs[interruptId]`.
+ *
+ * Ported from `google/adk-python` `events/request_input.py`.
+ */
+export class RequestInput {
+  readonly interruptId: string;
+  readonly payload?: unknown;
+  readonly message?: string;
+  readonly responseSchema?: ZodType;
+
+  constructor(params: RequestInputParams = {}) {
+    this.interruptId = params.interruptId ?? randomUUID();
+    this.payload = params.payload;
+    this.message = params.message;
+    this.responseSchema = params.responseSchema;
+  }
+}
+
+/** Type guard for {@link RequestInput}. */
+export function isRequestInput(value: unknown): value is RequestInput {
+  return value instanceof RequestInput;
+}

--- a/core/src/workflow/schedule_dynamic_node.ts
+++ b/core/src/workflow/schedule_dynamic_node.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {BaseNode} from './base_node.js';
+import type {NodeContext} from './node_context.js';
+import {NodeState} from './node_state.js';
+
+/**
+ * Options for scheduling a dynamic node via {@link ScheduleDynamicNode}.
+ */
+export interface ScheduleDynamicNodeOptions {
+  /** Deterministic tracking name; defaults to `node.name`. */
+  nodeName?: string;
+  /** Unique id for this specific execution (used for path/dedup keys). */
+  runId: string;
+  /** If true, the child's output replaces the caller's output. */
+  useAsOutput?: boolean;
+  /** If true, run the child in an isolated sub-branch. */
+  useSubBranch?: boolean;
+  /** Explicit branch override. */
+  overrideBranch?: string;
+  /** Explicit isolation-scope override. */
+  overrideIsolationScope?: string;
+}
+
+/**
+ * Protocol for scheduling a dynamically-invoked node (via `ctx.runNode()`).
+ *
+ * Implementations handle fresh execution, deduplication of concurrent calls,
+ * and (Phase 5) resumption from session events. Ported from
+ * `google/adk-python` `workflow/_schedule_dynamic_node.py`.
+ */
+export interface ScheduleDynamicNode {
+  schedule(
+    ctx: NodeContext,
+    node: BaseNode,
+    input: unknown,
+    options: ScheduleDynamicNodeOptions,
+  ): Promise<NodeContext>;
+}
+
+/**
+ * Combines state, output, and the running task for a single dynamic node
+ * execution.
+ */
+export interface DynamicNodeRun {
+  state: NodeState;
+  output?: unknown;
+  task?: Promise<NodeContext>;
+  transferToAgent?: string;
+}
+
+/**
+ * State for tracking dynamic nodes scheduled via `ctx.runNode()`.
+ *
+ * Ported (Phase 4 subset) from `google/adk-python`
+ * `workflow/_dynamic_node_scheduler.py::DynamicNodeState`. Replay/rehydration
+ * fields are added in Phase 5.
+ */
+export class DynamicNodeState {
+  /** Dynamic node runs keyed by unique node path (e.g. `wf/node_a@1`). */
+  readonly runs = new Map<string, DynamicNodeRun>();
+
+  /** Union of unresolved interrupt ids across dynamic child nodes. */
+  readonly interruptIds = new Set<string>();
+
+  /** All in-flight dynamic node tasks. */
+  getDynamicTasks(): Array<Promise<NodeContext>> {
+    return [...this.runs.values()]
+      .map((run) => run.task)
+      .filter((task): task is Promise<NodeContext> => task !== undefined);
+  }
+}

--- a/core/src/workflow/utils/graph_parser.ts
+++ b/core/src/workflow/utils/graph_parser.ts
@@ -128,11 +128,19 @@ function getOrBuildNode(
   return buildNode(nodeLike);
 }
 
-function processExplicitEdge(
-  edge: Edge,
-  nodeMap: Map<object, BaseNode>,
-  out: Edge[],
-): void {
+/** Shared accumulator threaded through the edge-processing helpers. */
+interface ParseContext {
+  /** Cache mapping a source node-like to the {@link BaseNode} built for it. */
+  nodeMap: Map<object, BaseNode>;
+  /** Accumulator the produced edges are pushed into. */
+  out: Edge[];
+}
+
+function processExplicitEdge({
+  edge,
+  nodeMap,
+  out,
+}: ParseContext & {edge: Edge}): void {
   out.push(
     new Edge(
       getOrBuildNode(edge.fromNode, nodeMap),
@@ -142,12 +150,12 @@ function processExplicitEdge(
   );
 }
 
-function processRoutingMapEdge(
-  fromEl: ChainElement,
-  toEl: RoutingMap,
-  nodeMap: Map<object, BaseNode>,
-  out: Edge[],
-): void {
+function processRoutingMapEdge({
+  fromEl,
+  toEl,
+  nodeMap,
+  out,
+}: ParseContext & {fromEl: ChainElement; toEl: RoutingMap}): void {
   if (isPlainObject(fromEl)) {
     throw new Error(
       'Consecutive routing maps are not allowed in a chain. Split them into separate edge items.',
@@ -168,12 +176,12 @@ function processRoutingMapEdge(
   }
 }
 
-function processUnconditionalEdge(
-  fromEl: ChainElement,
-  toEl: ChainElement,
-  nodeMap: Map<object, BaseNode>,
-  out: Edge[],
-): void {
+function processUnconditionalEdge({
+  fromEl,
+  toEl,
+  nodeMap,
+  out,
+}: ParseContext & {fromEl: ChainElement; toEl: ChainElement}): void {
   for (const fromNode of flattenElement(fromEl)) {
     for (const toNode of flattenElement(toEl)) {
       out.push(
@@ -187,18 +195,18 @@ function processUnconditionalEdge(
   }
 }
 
-function processChain(
-  chain: ChainElement[],
-  nodeMap: Map<object, BaseNode>,
-  out: Edge[],
-): void {
+function processChain({
+  chain,
+  nodeMap,
+  out,
+}: ParseContext & {chain: ChainElement[]}): void {
   for (let i = 0; i < chain.length - 1; i++) {
     const fromEl = chain[i];
     const toEl = chain[i + 1];
     if (isPlainObject(toEl)) {
-      processRoutingMapEdge(fromEl, toEl as RoutingMap, nodeMap, out);
+      processRoutingMapEdge({fromEl, toEl: toEl as RoutingMap, nodeMap, out});
     } else {
-      processUnconditionalEdge(fromEl, toEl, nodeMap, out);
+      processUnconditionalEdge({fromEl, toEl, nodeMap, out});
     }
   }
 }
@@ -210,9 +218,9 @@ export function parseEdgeItems(edgeItems: EdgeItem[]): Edge[] {
 
   for (const item of edgeItems) {
     if (isEdge(item)) {
-      processExplicitEdge(item, nodeMap, out);
+      processExplicitEdge({edge: item, nodeMap, out});
     } else if (Array.isArray(item)) {
-      processChain(item, nodeMap, out);
+      processChain({chain: item, nodeMap, out});
     } else {
       throw new Error(`Invalid edge item type: ${typeof item}`);
     }

--- a/core/src/workflow/utils/graph_parser.ts
+++ b/core/src/workflow/utils/graph_parser.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Parses workflow edge items and chains into a flat list of {@link Edge}s.
+ *
+ * Ported from `google/adk-python` `workflow/utils/_graph_parser.py`.
+ */
+
+import {BaseNode} from '../base_node.js';
+import {
+  ChainElement,
+  Edge,
+  EdgeItem,
+  NodeLike,
+  RouteValue,
+  RoutingMap,
+} from '../graph.js';
+import {buildNode, isNodeLike, isPlainObject} from './workflow_graph_utils.js';
+
+function isRouteValue(value: unknown): value is RouteValue {
+  const t = typeof value;
+  return t === 'string' || t === 'number' || t === 'boolean';
+}
+
+/**
+ * Normalizes a routing-map key back to its typed {@link RouteValue}. JS object
+ * keys are always strings, so integer route keys arrive as numeric strings and
+ * boolean route keys as `'true'`/`'false'`. Reconstructing the typed value lets
+ * a node emitting `2` or `true` match `{2: ...}` / `{true: ...}` (mirroring
+ * Python dict keys `2` / `True`).
+ */
+function normalizeRouteKey(routeKey: string): RouteValue {
+  if (/^-?\d+$/.test(routeKey)) {
+    return Number(routeKey);
+  }
+  if (routeKey === 'true' || routeKey === 'false') {
+    return routeKey === 'true';
+  }
+  return routeKey;
+}
+
+/** Expands a routing map into individual (from, to, route) triples. */
+function expandRoutingMap(
+  fromElement: ChainElement,
+  routingMap: RoutingMap,
+): Array<[ChainElement, NodeLike | readonly NodeLike[], RouteValue]> {
+  const keys = Object.keys(routingMap);
+  if (keys.length === 0) {
+    throw new Error(
+      'Routing map must not be empty. Provide at least one route -> node mapping.',
+    );
+  }
+
+  const expanded: Array<
+    [ChainElement, NodeLike | readonly NodeLike[], RouteValue]
+  > = [];
+  for (const routeKey of keys) {
+    const normalizedKey: RouteValue = normalizeRouteKey(routeKey);
+    const target = routingMap[routeKey];
+    if (Array.isArray(target)) {
+      for (const node of target) {
+        if (!isNodeLike(node)) {
+          throw new Error(
+            `Invalid node in fan-out tuple for route ${String(routeKey)}.`,
+          );
+        }
+      }
+    } else if (!isNodeLike(target)) {
+      throw new Error(
+        `Invalid routing map value for route ${String(routeKey)}.`,
+      );
+    }
+    if (!isRouteValue(normalizedKey)) {
+      throw new Error(`Invalid routing map key: ${String(routeKey)}.`);
+    }
+    expanded.push([
+      fromElement,
+      target as NodeLike | readonly NodeLike[],
+      normalizedKey,
+    ]);
+  }
+  return expanded;
+}
+
+/** Extracts all target nodes from a routing map, flattening fan-out arrays. */
+function nodesFromRoutingMap(routingMap: RoutingMap): NodeLike[] {
+  const nodes: NodeLike[] = [];
+  for (const target of Object.values(routingMap)) {
+    if (Array.isArray(target)) {
+      nodes.push(...(target as NodeLike[]));
+    } else {
+      nodes.push(target as NodeLike);
+    }
+  }
+  return nodes;
+}
+
+/** Flattens a chain element into a list of individual nodes. */
+function flattenElement(element: ChainElement): NodeLike[] {
+  if (isPlainObject(element)) {
+    return nodesFromRoutingMap(element as RoutingMap);
+  }
+  if (Array.isArray(element)) {
+    return [...(element as readonly NodeLike[])];
+  }
+  return [element as NodeLike];
+}
+
+/** Gets a node from the identity map or builds (and caches) it. */
+function getOrBuildNode(
+  nodeLike: NodeLike,
+  nodeMap: Map<object, BaseNode>,
+): BaseNode {
+  if (nodeLike === 'START') {
+    return buildNode('START');
+  }
+  if (typeof nodeLike === 'object' || typeof nodeLike === 'function') {
+    const cached = nodeMap.get(nodeLike as object);
+    if (cached) {
+      return cached;
+    }
+    const built = buildNode(nodeLike);
+    // Only cache when a distinct wrapper was produced (or always, to preserve
+    // identity across repeated references within the same parse).
+    nodeMap.set(nodeLike as object, built);
+    return built;
+  }
+  return buildNode(nodeLike);
+}
+
+function processExplicitEdge(
+  edge: Edge,
+  nodeMap: Map<object, BaseNode>,
+  out: Edge[],
+): void {
+  out.push(
+    new Edge(
+      getOrBuildNode(edge.fromNode, nodeMap),
+      getOrBuildNode(edge.toNode, nodeMap),
+      edge.route,
+    ),
+  );
+}
+
+function processRoutingMapEdge(
+  fromEl: ChainElement,
+  toEl: RoutingMap,
+  nodeMap: Map<object, BaseNode>,
+  out: Edge[],
+): void {
+  if (isPlainObject(fromEl)) {
+    throw new Error(
+      'Consecutive routing maps are not allowed in a chain. Split them into separate edge items.',
+    );
+  }
+  for (const [expFrom, expTo, route] of expandRoutingMap(fromEl, toEl)) {
+    for (const fromNode of flattenElement(expFrom)) {
+      for (const toNode of flattenElement(expTo as ChainElement)) {
+        out.push(
+          new Edge(
+            getOrBuildNode(fromNode, nodeMap),
+            getOrBuildNode(toNode, nodeMap),
+            route,
+          ),
+        );
+      }
+    }
+  }
+}
+
+function processUnconditionalEdge(
+  fromEl: ChainElement,
+  toEl: ChainElement,
+  nodeMap: Map<object, BaseNode>,
+  out: Edge[],
+): void {
+  for (const fromNode of flattenElement(fromEl)) {
+    for (const toNode of flattenElement(toEl)) {
+      out.push(
+        new Edge(
+          getOrBuildNode(fromNode, nodeMap),
+          getOrBuildNode(toNode, nodeMap),
+          null,
+        ),
+      );
+    }
+  }
+}
+
+function processChain(
+  chain: ChainElement[],
+  nodeMap: Map<object, BaseNode>,
+  out: Edge[],
+): void {
+  for (let i = 0; i < chain.length - 1; i++) {
+    const fromEl = chain[i];
+    const toEl = chain[i + 1];
+    if (isPlainObject(toEl)) {
+      processRoutingMapEdge(fromEl, toEl as RoutingMap, nodeMap, out);
+    } else {
+      processUnconditionalEdge(fromEl, toEl, nodeMap, out);
+    }
+  }
+}
+
+/** Parses a list of edge items into a flat list of {@link Edge} objects. */
+export function parseEdgeItems(edgeItems: EdgeItem[]): Edge[] {
+  const nodeMap = new Map<object, BaseNode>();
+  const out: Edge[] = [];
+
+  for (const item of edgeItems) {
+    if (item instanceof Edge) {
+      processExplicitEdge(item, nodeMap, out);
+    } else if (Array.isArray(item)) {
+      processChain(item, nodeMap, out);
+    } else {
+      throw new Error(`Invalid edge item type: ${typeof item}`);
+    }
+  }
+
+  return out;
+}

--- a/core/src/workflow/utils/graph_parser.ts
+++ b/core/src/workflow/utils/graph_parser.ts
@@ -15,16 +15,12 @@ import {
   ChainElement,
   Edge,
   EdgeItem,
+  isEdge,
   NodeLike,
   RouteValue,
   RoutingMap,
 } from '../graph.js';
 import {buildNode, isNodeLike, isPlainObject} from './workflow_graph_utils.js';
-
-function isRouteValue(value: unknown): value is RouteValue {
-  const t = typeof value;
-  return t === 'string' || t === 'number' || t === 'boolean';
-}
 
 /**
  * Normalizes a routing-map key back to its typed {@link RouteValue}. JS object
@@ -74,9 +70,9 @@ function expandRoutingMap(
         `Invalid routing map value for route ${String(routeKey)}.`,
       );
     }
-    if (!isRouteValue(normalizedKey)) {
-      throw new Error(`Invalid routing map key: ${String(routeKey)}.`);
-    }
+    // `normalizeRouteKey` returns `string | number | boolean` by construction,
+    // which is exactly `RouteValue`, so no further validation of the key is
+    // needed here.
     expanded.push([
       fromElement,
       target as NodeLike | readonly NodeLike[],
@@ -213,7 +209,7 @@ export function parseEdgeItems(edgeItems: EdgeItem[]): Edge[] {
   const out: Edge[] = [];
 
   for (const item of edgeItems) {
-    if (item instanceof Edge) {
+    if (isEdge(item)) {
       processExplicitEdge(item, nodeMap, out);
     } else if (Array.isArray(item)) {
       processChain(item, nodeMap, out);

--- a/core/src/workflow/utils/graph_validation.ts
+++ b/core/src/workflow/utils/graph_validation.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Validates workflow graphs and computes terminal nodes.
+ *
+ * Ported from `google/adk-python` `workflow/utils/_graph_validation.py`.
+ * The Phase 3 static-schema check and the Phase 7 chat-agent wiring check are
+ * intentionally deferred to their respective phases.
+ */
+
+import {BaseNode, START} from '../base_node.js';
+import {DEFAULT_ROUTE, Edge} from '../graph.js';
+
+function validateDuplicateNodeNames(nodes: BaseNode[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const node of nodes) {
+    counts.set(node.name, (counts.get(node.name) ?? 0) + 1);
+  }
+  const duplicates = [...counts.entries()]
+    .filter(([, c]) => c > 1)
+    .map(([name]) => name)
+    .sort();
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Graph validation failed. Duplicate node names found: ${JSON.stringify(
+        duplicates,
+      )}. Pass the exact same object instance to reuse a node, or give distinct nodes unique names.`,
+    );
+  }
+  return new Set(counts.keys());
+}
+
+function validateStartNode(nodeNames: Set<string>): void {
+  if (!nodeNames.has(START.name)) {
+    throw new Error(
+      `Graph validation failed. START node (name: '${START.name}') not found in graph nodes.`,
+    );
+  }
+}
+
+function validateStartEdges(edges: Edge[]): void {
+  for (const edge of edges) {
+    if (edge.fromNode.name === START.name && edge.route !== null) {
+      throw new Error(
+        `Graph validation failed. Edges from START must not have routes (edge to ${edge.toNode.name} has route ${String(
+          edge.route,
+        )}).`,
+      );
+    }
+  }
+}
+
+function validateConnectivity(edges: Edge[], nodeNames: Set<string>): void {
+  const adj = new Map<string, Set<string>>();
+  for (const name of nodeNames) {
+    adj.set(name, new Set());
+  }
+  const toNodes = new Set<string>();
+  for (const edge of edges) {
+    adj.get(edge.fromNode.name)!.add(edge.toNode.name);
+    toNodes.add(edge.toNode.name);
+  }
+
+  const reachable = new Set<string>();
+  const stack = [START.name];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (reachable.has(node)) {
+      continue;
+    }
+    reachable.add(node);
+    for (const next of adj.get(node) ?? []) {
+      if (!reachable.has(next)) {
+        stack.push(next);
+      }
+    }
+  }
+
+  const unreachable = [...nodeNames].filter((n) => !reachable.has(n)).sort();
+  if (unreachable.length > 0) {
+    throw new Error(
+      `Graph validation failed. The following nodes are unreachable from START: ${JSON.stringify(
+        unreachable,
+      )}`,
+    );
+  }
+  if (toNodes.has(START.name)) {
+    throw new Error(
+      'Graph validation failed. START node must not have incoming edges.',
+    );
+  }
+}
+
+function validateDuplicateEdges(edges: Edge[]): void {
+  const seen = new Set<string>();
+  for (const edge of edges) {
+    const key = `${edge.fromNode.name}\u0000${edge.toNode.name}`;
+    if (seen.has(key)) {
+      throw new Error(
+        `Graph validation failed. Duplicate edge found: from=${edge.fromNode.name}, to=${edge.toNode.name}`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+function validateDefaultRoutes(edges: Edge[]): void {
+  const defaultRouteEdges = new Map<string, string>();
+  for (const edge of edges) {
+    if (Array.isArray(edge.route) && edge.route.includes(DEFAULT_ROUTE)) {
+      throw new Error(
+        `Graph validation failed. DEFAULT_ROUTE cannot be combined with other routes in a list (edge from=${edge.fromNode.name}, to=${edge.toNode.name}). Use a separate edge for DEFAULT_ROUTE.`,
+      );
+    }
+    if (edge.route === DEFAULT_ROUTE) {
+      const from = edge.fromNode.name;
+      if (defaultRouteEdges.has(from)) {
+        throw new Error(
+          `Graph validation failed. Multiple DEFAULT_ROUTE edges found from node ${from} to ${defaultRouteEdges.get(
+            from,
+          )} and ${edge.toNode.name}`,
+        );
+      }
+      defaultRouteEdges.set(from, edge.toNode.name);
+    }
+  }
+}
+
+function detectUnconditionalCycles(
+  edges: Edge[],
+  nodeNames: Set<string>,
+): void {
+  const adj = new Map<string, string[]>();
+  for (const name of nodeNames) {
+    adj.set(name, []);
+  }
+  for (const edge of edges) {
+    if (edge.route === null) {
+      adj.get(edge.fromNode.name)!.push(edge.toNode.name);
+    }
+  }
+
+  const inStack = new Set<string>();
+  const done = new Set<string>();
+
+  const dfs = (node: string, path: string[]): void => {
+    inStack.add(node);
+    path.push(node);
+    for (const neighbor of adj.get(node) ?? []) {
+      if (inStack.has(neighbor)) {
+        const cycleStart = path.indexOf(neighbor);
+        const cycle = [...path.slice(cycleStart), neighbor];
+        throw new Error(
+          `Graph validation failed. Unconditional cycle detected: ${cycle.join(
+            ' -> ',
+          )}. Cycles must include at least one conditional (routed) edge to avoid infinite loops.`,
+        );
+      }
+      if (!done.has(neighbor)) {
+        dfs(neighbor, path);
+      }
+    }
+    path.pop();
+    inStack.delete(node);
+    done.add(node);
+  };
+
+  for (const name of nodeNames) {
+    if (!done.has(name)) {
+      dfs(name, []);
+    }
+  }
+}
+
+function computeTerminalNodes(nodes: BaseNode[], edges: Edge[]): Set<string> {
+  const fromNames = new Set(edges.map((e) => e.fromNode.name));
+  return new Set(
+    nodes
+      .filter((n) => n.name !== START.name && !fromNames.has(n.name))
+      .map((n) => n.name),
+  );
+}
+
+/**
+ * Validates the workflow graph and returns the set of terminal node names.
+ */
+export function validateGraph(nodes: BaseNode[], edges: Edge[]): Set<string> {
+  const nodeNames = validateDuplicateNodeNames(nodes);
+  validateStartNode(nodeNames);
+  validateStartEdges(edges);
+  validateConnectivity(edges, nodeNames);
+  validateDuplicateEdges(edges);
+  validateDefaultRoutes(edges);
+  detectUnconditionalCycles(edges, nodeNames);
+  return computeTerminalNodes(nodes, edges);
+}

--- a/core/src/workflow/utils/graph_validation.ts
+++ b/core/src/workflow/utils/graph_validation.ts
@@ -157,7 +157,7 @@ function detectUnconditionalCycles(
         throw new Error(
           `Graph validation failed. Unconditional cycle detected: ${cycle.join(
             ' -> ',
-          )}. Cycles must include at least one conditional (routed) edge to avoid infinite loops.`,
+          )}. An unconditional cycle has no exit and would loop forever; break it with at least one conditional (routed) edge so a node can leave the cycle by not emitting that route. (A routed cycle can still loop if a node keeps emitting the route — bounding that is the node's responsibility, not this validator's.)`,
         );
       }
       if (!done.has(neighbor)) {

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -149,16 +149,26 @@ export function createAuthRequestEvent(
   });
 }
 
+/** Parameters for {@link processAuthResume}. */
+export interface ProcessAuthResumeParams {
+  /** The resume response: a full {@link AuthConfig} or a plain value. */
+  responseData: unknown;
+  /** The auth config the credential is being stored for. */
+  authConfig: AuthConfig;
+  /** The session state to store the credential in. */
+  state: State;
+}
+
 /**
  * Stores credentials from an auth resume response into session state. Accepts a
  * full {@link AuthConfig} (web UI flow) or a plain value (e.g. an API key
  * string), mirroring `google/adk-python` `process_auth_resume`.
  */
-export async function processAuthResume(
-  responseData: unknown,
-  authConfig: AuthConfig,
-  state: State,
-): Promise<void> {
+export async function processAuthResume({
+  responseData,
+  authConfig,
+  state,
+}: ProcessAuthResumeParams): Promise<void> {
   let responseConfig: AuthConfig;
   if (isAuthConfigLike(responseData)) {
     responseConfig = {

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Utilities for Human-in-the-Loop (HITL) workflows.
+ *
+ * Ported (subset) from `google/adk-python`
+ * `workflow/utils/_workflow_hitl_utils.py`.
+ */
+
+import {Part} from '@google/genai';
+import {z} from 'zod';
+import {
+  AuthCredential,
+  AuthCredentialTypes,
+} from '../../auth/auth_credential.js';
+import {AuthHandler} from '../../auth/auth_handler.js';
+import {AuthConfig} from '../../auth/auth_tool.js';
+import {createEvent, Event} from '../../events/event.js';
+import {State} from '../../sessions/state.js';
+import {RequestInput} from '../request_input.js';
+
+/** Function-call name marking a request-for-input interrupt. */
+export const REQUEST_INPUT_FUNCTION_CALL_NAME = 'adk_request_input';
+
+/** Function-call name marking a request-for-credential interrupt. */
+export const REQUEST_CREDENTIAL_FUNCTION_CALL_NAME = 'adk_request_credential';
+
+/**
+ * Creates an interrupt {@link Event} from a {@link RequestInput}. The event
+ * carries an `adk_request_input` function call and marks the interrupt id as a
+ * long-running tool id.
+ */
+export function createRequestInputEvent(requestInput: RequestInput): Event {
+  const args: Record<string, unknown> = {
+    interruptId: requestInput.interruptId,
+    payload: requestInput.payload ?? null,
+    message: requestInput.message ?? null,
+    responseSchema: requestInput.responseSchema
+      ? z.toJSONSchema(requestInput.responseSchema)
+      : null,
+  };
+
+  return createEvent({
+    content: {
+      role: 'model',
+      parts: [
+        {
+          functionCall: {
+            name: REQUEST_INPUT_FUNCTION_CALL_NAME,
+            args,
+            id: requestInput.interruptId,
+          },
+        },
+      ],
+    },
+    longRunningToolIds: [requestInput.interruptId],
+  });
+}
+
+/** Returns whether an event contains a `request_input` function call. */
+export function hasRequestInputFunctionCall(event: Event): boolean {
+  return (event.content?.parts ?? []).some(
+    (p) => p.functionCall?.name === REQUEST_INPUT_FUNCTION_CALL_NAME,
+  );
+}
+
+/** Returns whether an event contains an `adk_request_credential` function call. */
+export function hasAuthRequestFunctionCall(event: Event): boolean {
+  return (event.content?.parts ?? []).some(
+    (p) => p.functionCall?.name === REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+  );
+}
+
+/** Extracts interrupt ids from `request_input` function calls in an event. */
+export function getRequestInputInterruptIds(event: Event): string[] {
+  const ids: string[] = [];
+  for (const part of event.content?.parts ?? []) {
+    const fc = part.functionCall;
+    if (fc && fc.name === REQUEST_INPUT_FUNCTION_CALL_NAME && fc.id) {
+      ids.push(fc.id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Creates a `FunctionResponse` part answering a `request_input` interrupt,
+ * suitable for appending to a session as the user's resume response.
+ */
+export function createRequestInputResponse(
+  interruptId: string,
+  response: Record<string, unknown>,
+): Part {
+  return {
+    functionResponse: {
+      id: interruptId,
+      name: REQUEST_INPUT_FUNCTION_CALL_NAME,
+      response,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Auth-credential utilities (auth gate)
+// ---------------------------------------------------------------------------
+
+/** Whether a credential for the given auth config already exists in state. */
+export function hasAuthCredential(
+  authConfig: AuthConfig,
+  state: State,
+): boolean {
+  return new AuthHandler(authConfig).getAuthResponse(state) !== undefined;
+}
+
+/**
+ * Creates an event requesting user authentication credentials
+ * (`adk_request_credential`), marking the interrupt id as a long-running tool.
+ *
+ * Ported from `google/adk-python` `create_auth_request_event`.
+ */
+export function createAuthRequestEvent(
+  authConfig: AuthConfig,
+  interruptId: string,
+): Event {
+  const authRequest = new AuthHandler(authConfig).generateAuthRequest();
+  const args: Record<string, unknown> = {
+    functionCallId: interruptId,
+    authConfig: authRequest,
+    message: buildAuthMessage(authConfig),
+  };
+  return createEvent({
+    content: {
+      role: 'model',
+      parts: [
+        {
+          functionCall: {
+            name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+            id: interruptId,
+            args,
+          },
+        },
+      ],
+    },
+    longRunningToolIds: [interruptId],
+  });
+}
+
+/**
+ * Stores credentials from an auth resume response into session state. Accepts a
+ * full {@link AuthConfig} (web UI flow) or a plain value (e.g. an API key
+ * string), mirroring `google/adk-python` `process_auth_resume`.
+ */
+export async function processAuthResume(
+  responseData: unknown,
+  authConfig: AuthConfig,
+  state: State,
+): Promise<void> {
+  let responseConfig: AuthConfig;
+  if (isAuthConfigLike(responseData)) {
+    responseConfig = {
+      ...(responseData as AuthConfig),
+      credentialKey: authConfig.credentialKey,
+    };
+  } else {
+    responseConfig = {
+      ...authConfig,
+      exchangedAuthCredential: buildCredentialFromValue(
+        authConfig,
+        responseData,
+      ),
+    };
+  }
+  await new AuthHandler(responseConfig).parseAndStoreAuthResponse(state);
+}
+
+function isAuthConfigLike(value: unknown): value is AuthConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'authScheme' in value &&
+    'credentialKey' in value
+  );
+}
+
+function buildCredentialFromValue(
+  authConfig: AuthConfig,
+  value: unknown,
+): AuthCredential {
+  if (authConfig.rawAuthCredential?.authType === AuthCredentialTypes.API_KEY) {
+    return {authType: AuthCredentialTypes.API_KEY, apiKey: String(value)};
+  }
+  return value as AuthCredential;
+}
+
+function buildAuthMessage(authConfig: AuthConfig): string {
+  const authType = authConfig.rawAuthCredential?.authType;
+  if (authType === AuthCredentialTypes.API_KEY) {
+    return 'Please provide your API key.';
+  }
+  if (
+    authType === AuthCredentialTypes.OAUTH2 ||
+    authType === AuthCredentialTypes.OPEN_ID_CONNECT
+  ) {
+    return 'Please complete the authentication flow.';
+  }
+  return 'Please provide your authentication credentials.';
+}

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -12,7 +12,6 @@
  */
 
 import {Part} from '@google/genai';
-import {z} from 'zod';
 import {
   AuthCredential,
   AuthCredentialTypes,
@@ -21,6 +20,7 @@ import {AuthHandler} from '../../auth/auth_handler.js';
 import {AuthConfig} from '../../auth/auth_tool.js';
 import {createEvent, Event} from '../../events/event.js';
 import {State} from '../../sessions/state.js';
+import {toJsonSchema} from '../../utils/schema.js';
 import {RequestInput} from '../request_input.js';
 
 /** Function-call name marking a request-for-input interrupt. */
@@ -40,7 +40,7 @@ export function createRequestInputEvent(requestInput: RequestInput): Event {
     payload: requestInput.payload ?? null,
     message: requestInput.message ?? null,
     responseSchema: requestInput.responseSchema
-      ? z.toJSONSchema(requestInput.responseSchema)
+      ? toJsonSchema(requestInput.responseSchema)
       : null,
   };
 

--- a/core/src/workflow/utils/retry_utils.ts
+++ b/core/src/workflow/utils/retry_utils.ts
@@ -22,20 +22,15 @@ const DEFAULT_JITTER = 1.0;
 /**
  * Resolves the runtime name of a thrown value for exception-name matching.
  * Mirrors Python's `type(exception).__name__`.
- *
- * Duck-typed (no `instanceof`) so it works for error-like values from another
- * package copy: it prefers an explicit `name` string, then the constructor
- * name, then the primitive `typeof`.
  */
 function errorName(error: unknown): string {
+  if (error instanceof Error) {
+    // `name` is set by well-behaved Error subclasses; fall back to the
+    // constructor name for plain `throw new Error()` cases.
+    return error.name || error.constructor.name;
+  }
   if (typeof error === 'object' && error !== null) {
-    const named = error as {name?: unknown; constructor?: {name?: string}};
-    if (typeof named.name === 'string' && named.name) {
-      // `name` is set by well-behaved Error subclasses.
-      return named.name;
-    }
-    // Fall back to the constructor name for plain `throw new Error()` cases.
-    return named.constructor?.name ?? 'Object';
+    return error.constructor.name;
   }
   return typeof error;
 }

--- a/core/src/workflow/utils/workflow_graph_utils.ts
+++ b/core/src/workflow/utils/workflow_graph_utils.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {ZodType} from 'zod';
+import {AuthConfig} from '../../auth/auth_tool.js';
+import {BaseNode, START} from '../base_node.js';
+import {NodeLike} from '../graph.js';
+import {RetryConfig} from '../retry_config.js';
+
+/**
+ * Property overrides applied when building a node from a {@link NodeLike}.
+ */
+export interface BuildNodeOptions {
+  name?: string;
+  description?: string;
+  rerunOnResume?: boolean;
+  retryConfig?: RetryConfig;
+  timeout?: number;
+  inputSchema?: ZodType;
+  outputSchema?: ZodType;
+  stateSchema?: ZodType;
+  authConfig?: AuthConfig;
+  /** If true, wrap the built node in a parallel worker. */
+  parallelWorker?: boolean;
+  /** Concurrency limit for the parallel worker (requires `parallelWorker`). */
+  maxParallelWorkers?: number;
+}
+
+/**
+ * Converts a matched {@link NodeLike} value into a concrete {@link BaseNode}.
+ *
+ * Node types register a builder (via {@link registerNodeBuilder}) at module load
+ * so the graph parser stays decoupled from the concrete node classes. This keeps
+ * the engine core free of static imports of `FunctionNode`, `ToolNode`,
+ * `LLMAgentWrapper`, etc. — importing the node module (directly or through the
+ * public workflow barrel) is what makes its builder available.
+ */
+export interface NodeBuilder {
+  /** Returns whether this builder can convert `value` into a node. */
+  match(value: unknown): boolean;
+  /** Builds a node from a value this builder previously matched. */
+  build(value: NodeLike, options: BuildNodeOptions): BaseNode;
+}
+
+/**
+ * Wraps an already-built node in a parallel worker. Registered by the
+ * `parallel_worker` node module (via {@link registerParallelWorkerFactory}).
+ */
+export type ParallelWorkerFactory = (
+  inner: BaseNode,
+  options: {
+    maxParallelWorkers?: number;
+    retryConfig?: RetryConfig;
+    timeout?: number;
+  },
+) => BaseNode;
+
+const nodeBuilders: NodeBuilder[] = [];
+let parallelWorkerFactory: ParallelWorkerFactory | undefined;
+
+/**
+ * Registers a builder that converts a {@link NodeLike} value into a
+ * {@link BaseNode}. Builders are consulted in registration order; the first
+ * whose {@link NodeBuilder.match} returns true wins.
+ */
+export function registerNodeBuilder(builder: NodeBuilder): void {
+  nodeBuilders.push(builder);
+}
+
+/** Registers the factory used to wrap a node in a parallel worker. */
+export function registerParallelWorkerFactory(
+  factory: ParallelWorkerFactory,
+): void {
+  parallelWorkerFactory = factory;
+}
+
+/**
+ * Returns whether a value is a plain object literal (a `RoutingMap`) rather than
+ * a class instance such as a node/tool/agent.
+ */
+export function isPlainObject(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Returns whether a value can be converted into a workflow node via
+ * {@link buildNode}: the `'START'` sentinel, an existing {@link BaseNode}, or a
+ * value matched by a registered {@link NodeBuilder}.
+ */
+export function isNodeLike(value: unknown): value is NodeLike {
+  return (
+    value === 'START' ||
+    value instanceof BaseNode ||
+    nodeBuilders.some((builder) => builder.match(value))
+  );
+}
+
+/**
+ * Converts a {@link NodeLike} into a concrete {@link BaseNode}.
+ *
+ * Handles the `'START'` sentinel and existing {@link BaseNode} instances
+ * directly; every other value is delegated to the registered
+ * {@link NodeBuilder}s (function → `FunctionNode`, tool → `ToolNode`, agent →
+ * `LLMAgentWrapper`, …).
+ */
+export function buildNode(
+  nodeLike: NodeLike,
+  options: BuildNodeOptions = {},
+): BaseNode {
+  if (options.maxParallelWorkers !== undefined && !options.parallelWorker) {
+    throw new Error(
+      'maxParallelWorkers can only be set when parallelWorker is true.',
+    );
+  }
+
+  const built = buildInnerNode(nodeLike, options);
+
+  if (options.parallelWorker) {
+    if (nodeLike === 'START') {
+      throw new Error('ParallelWorker cannot wrap a START node.');
+    }
+    if (!parallelWorkerFactory) {
+      throw new Error(
+        'parallelWorker was requested but no ParallelWorker is registered; ' +
+          'import the parallel worker node module to enable it.',
+      );
+    }
+    return parallelWorkerFactory(built, {
+      maxParallelWorkers: options.maxParallelWorkers,
+      retryConfig: options.retryConfig,
+      timeout: options.timeout,
+    });
+  }
+  return built;
+}
+
+function buildInnerNode(
+  nodeLike: NodeLike,
+  options: BuildNodeOptions,
+): BaseNode {
+  if (nodeLike === 'START') {
+    return START;
+  }
+  if (nodeLike instanceof BaseNode) {
+    // TODO(phase-3+): apply property overrides via a clone when options differ.
+    return nodeLike;
+  }
+  for (const builder of nodeBuilders) {
+    if (builder.match(nodeLike)) {
+      return builder.build(nodeLike, options);
+    }
+  }
+  throw new Error(
+    `build_node: unsupported node-like value of type ${typeof nodeLike}. ` +
+      'Import the node module that handles it (e.g. via the workflow barrel).',
+  );
+}

--- a/core/src/workflow/utils/workflow_graph_utils.ts
+++ b/core/src/workflow/utils/workflow_graph_utils.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ZodType} from 'zod';
 import {AuthConfig} from '../../auth/auth_tool.js';
-import {BaseNode, START} from '../base_node.js';
+import {SchemaLike} from '../../utils/schema.js';
+import {BaseNode, isBaseNode, START} from '../base_node.js';
 import {NodeLike} from '../graph.js';
 import {RetryConfig} from '../retry_config.js';
 
@@ -19,9 +19,9 @@ export interface BuildNodeOptions {
   rerunOnResume?: boolean;
   retryConfig?: RetryConfig;
   timeout?: number;
-  inputSchema?: ZodType;
-  outputSchema?: ZodType;
-  stateSchema?: ZodType;
+  inputSchema?: SchemaLike;
+  outputSchema?: SchemaLike;
+  stateSchema?: SchemaLike;
   authConfig?: AuthConfig;
   /** If true, wrap the built node in a parallel worker. */
   parallelWorker?: boolean;
@@ -39,6 +39,19 @@ export interface BuildNodeOptions {
  * public workflow barrel) is what makes its builder available.
  */
 export interface NodeBuilder {
+  /**
+   * Stable, unique id for this builder (e.g. `'function'`, `'tool'`). Used to
+   * key the registry so re-registering the same id replaces rather than
+   * duplicates — registration is idempotent across double module loads.
+   */
+  id: string;
+  /**
+   * Selection priority. Builders are consulted highest-priority first, with
+   * registration order breaking ties. Make precedence explicit here rather than
+   * relying on module import order (e.g. a tool builder must outrank an agent
+   * builder that would also match a `BaseTool`). Defaults to 0.
+   */
+  priority?: number;
   /** Returns whether this builder can convert `value` into a node. */
   match(value: unknown): boolean;
   /** Builds a node from a value this builder previously matched. */
@@ -58,22 +71,65 @@ export type ParallelWorkerFactory = (
   },
 ) => BaseNode;
 
-const nodeBuilders: NodeBuilder[] = [];
+/**
+ * The node-builder registry.
+ *
+ * This is intentionally process-global: the standard node modules self-register
+ * their builders at import time, so any graph parsed in the process can build
+ * any imported node type. There is deliberately no per-workflow scoping — all
+ * workflows in a process share this one registry. Builders are keyed by
+ * {@link NodeBuilder.id} so registration is idempotent (a double module load
+ * replaces rather than accumulates), and consulted in a deterministic order
+ * (see {@link orderedNodeBuilders}).
+ */
+const nodeBuilders = new Map<string, NodeBuilder>();
+/** Registration sequence per builder id, for stable tie-breaking. */
+const builderSequence = new Map<string, number>();
+let registrationCounter = 0;
 let parallelWorkerFactory: ParallelWorkerFactory | undefined;
 
 /**
  * Registers a builder that converts a {@link NodeLike} value into a
- * {@link BaseNode}. Builders are consulted in registration order; the first
- * whose {@link NodeBuilder.match} returns true wins.
+ * {@link BaseNode}. Idempotent by {@link NodeBuilder.id}: re-registering the
+ * same id replaces the previous builder rather than adding a duplicate.
  */
 export function registerNodeBuilder(builder: NodeBuilder): void {
-  nodeBuilders.push(builder);
+  if (!builder.id) {
+    throw new Error('registerNodeBuilder: builder.id is required.');
+  }
+  if (!builderSequence.has(builder.id)) {
+    builderSequence.set(builder.id, registrationCounter++);
+  }
+  nodeBuilders.set(builder.id, builder);
 }
 
-/** Registers the factory used to wrap a node in a parallel worker. */
+/** Builders in consultation order: highest priority first, then registration order. */
+function orderedNodeBuilders(): NodeBuilder[] {
+  return [...nodeBuilders.values()].sort((a, b) => {
+    const byPriority = (b.priority ?? 0) - (a.priority ?? 0);
+    if (byPriority !== 0) {
+      return byPriority;
+    }
+    return (builderSequence.get(a.id) ?? 0) - (builderSequence.get(b.id) ?? 0);
+  });
+}
+
+/**
+ * Registers the factory used to wrap a node in a parallel worker.
+ *
+ * Expected to be called at most once per process. Calling it again with the
+ * same factory is a no-op; calling it with a *different* factory throws rather
+ * than silently clobbering the existing one.
+ */
 export function registerParallelWorkerFactory(
   factory: ParallelWorkerFactory,
 ): void {
+  if (parallelWorkerFactory && parallelWorkerFactory !== factory) {
+    throw new Error(
+      'registerParallelWorkerFactory: a different ParallelWorker factory is ' +
+        'already registered. It must be registered at most once per process.',
+    );
+  }
   parallelWorkerFactory = factory;
 }
 
@@ -97,8 +153,8 @@ export function isPlainObject(value: unknown): boolean {
 export function isNodeLike(value: unknown): value is NodeLike {
   return (
     value === 'START' ||
-    value instanceof BaseNode ||
-    nodeBuilders.some((builder) => builder.match(value))
+    isBaseNode(value) ||
+    [...nodeBuilders.values()].some((builder) => builder.match(value))
   );
 }
 
@@ -148,11 +204,11 @@ function buildInnerNode(
   if (nodeLike === 'START') {
     return START;
   }
-  if (nodeLike instanceof BaseNode) {
+  if (isBaseNode(nodeLike)) {
     // TODO(phase-3+): apply property overrides via a clone when options differ.
     return nodeLike;
   }
-  for (const builder of nodeBuilders) {
+  for (const builder of orderedNodeBuilders()) {
     if (builder.match(nodeLike)) {
       return builder.build(nodeLike, options);
     }

--- a/core/src/workflow/utils/workflow_graph_utils.ts
+++ b/core/src/workflow/utils/workflow_graph_utils.ts
@@ -8,6 +8,7 @@ import {AuthConfig} from '../../auth/auth_tool.js';
 import {SchemaLike} from '../../utils/schema.js';
 import {BaseNode, isBaseNode, START} from '../base_node.js';
 import {NodeLike} from '../graph.js';
+import {NODE_BUILDERS, PARALLEL_WORKER_FACTORY} from '../node_builders.js';
 import {RetryConfig} from '../retry_config.js';
 
 /**
@@ -32,26 +33,14 @@ export interface BuildNodeOptions {
 /**
  * Converts a matched {@link NodeLike} value into a concrete {@link BaseNode}.
  *
- * Node types register a builder (via {@link registerNodeBuilder}) at module load
- * so the graph parser stays decoupled from the concrete node classes. This keeps
- * the engine core free of static imports of `FunctionNode`, `ToolNode`,
- * `LLMAgentWrapper`, etc. — importing the node module (directly or through the
- * public workflow barrel) is what makes its builder available.
+ * Builders are wired into the static {@link NODE_BUILDERS} list (in
+ * `node_builders.ts`) and consulted by {@link buildNode} / {@link isNodeLike} in
+ * order — first match wins. Keeping them in one explicit list (rather than a
+ * runtime registry) means no global mutable state and no import-order side
+ * effects: `node_builders.ts` imports the concrete node modules, and the engine
+ * core imports that one list.
  */
 export interface NodeBuilder {
-  /**
-   * Stable, unique id for this builder (e.g. `'function'`, `'tool'`). Used to
-   * key the registry so re-registering the same id replaces rather than
-   * duplicates — registration is idempotent across double module loads.
-   */
-  id: string;
-  /**
-   * Selection priority. Builders are consulted highest-priority first, with
-   * registration order breaking ties. Make precedence explicit here rather than
-   * relying on module import order (e.g. a tool builder must outrank an agent
-   * builder that would also match a `BaseTool`). Defaults to 0.
-   */
-  priority?: number;
   /** Returns whether this builder can convert `value` into a node. */
   match(value: unknown): boolean;
   /** Builds a node from a value this builder previously matched. */
@@ -59,8 +48,8 @@ export interface NodeBuilder {
 }
 
 /**
- * Wraps an already-built node in a parallel worker. Registered by the
- * `parallel_worker` node module (via {@link registerParallelWorkerFactory}).
+ * Wraps an already-built node in a parallel worker. Provided by the
+ * `parallel_worker` node module via {@link PARALLEL_WORKER_FACTORY}.
  */
 export type ParallelWorkerFactory = (
   inner: BaseNode,
@@ -70,68 +59,6 @@ export type ParallelWorkerFactory = (
     timeout?: number;
   },
 ) => BaseNode;
-
-/**
- * The node-builder registry.
- *
- * This is intentionally process-global: the standard node modules self-register
- * their builders at import time, so any graph parsed in the process can build
- * any imported node type. There is deliberately no per-workflow scoping — all
- * workflows in a process share this one registry. Builders are keyed by
- * {@link NodeBuilder.id} so registration is idempotent (a double module load
- * replaces rather than accumulates), and consulted in a deterministic order
- * (see {@link orderedNodeBuilders}).
- */
-const nodeBuilders = new Map<string, NodeBuilder>();
-/** Registration sequence per builder id, for stable tie-breaking. */
-const builderSequence = new Map<string, number>();
-let registrationCounter = 0;
-let parallelWorkerFactory: ParallelWorkerFactory | undefined;
-
-/**
- * Registers a builder that converts a {@link NodeLike} value into a
- * {@link BaseNode}. Idempotent by {@link NodeBuilder.id}: re-registering the
- * same id replaces the previous builder rather than adding a duplicate.
- */
-export function registerNodeBuilder(builder: NodeBuilder): void {
-  if (!builder.id) {
-    throw new Error('registerNodeBuilder: builder.id is required.');
-  }
-  if (!builderSequence.has(builder.id)) {
-    builderSequence.set(builder.id, registrationCounter++);
-  }
-  nodeBuilders.set(builder.id, builder);
-}
-
-/** Builders in consultation order: highest priority first, then registration order. */
-function orderedNodeBuilders(): NodeBuilder[] {
-  return [...nodeBuilders.values()].sort((a, b) => {
-    const byPriority = (b.priority ?? 0) - (a.priority ?? 0);
-    if (byPriority !== 0) {
-      return byPriority;
-    }
-    return (builderSequence.get(a.id) ?? 0) - (builderSequence.get(b.id) ?? 0);
-  });
-}
-
-/**
- * Registers the factory used to wrap a node in a parallel worker.
- *
- * Expected to be called at most once per process. Calling it again with the
- * same factory is a no-op; calling it with a *different* factory throws rather
- * than silently clobbering the existing one.
- */
-export function registerParallelWorkerFactory(
-  factory: ParallelWorkerFactory,
-): void {
-  if (parallelWorkerFactory && parallelWorkerFactory !== factory) {
-    throw new Error(
-      'registerParallelWorkerFactory: a different ParallelWorker factory is ' +
-        'already registered. It must be registered at most once per process.',
-    );
-  }
-  parallelWorkerFactory = factory;
-}
 
 /**
  * Returns whether a value is a plain object literal (a `RoutingMap`) rather than
@@ -154,7 +81,7 @@ export function isNodeLike(value: unknown): value is NodeLike {
   return (
     value === 'START' ||
     isBaseNode(value) ||
-    [...nodeBuilders.values()].some((builder) => builder.match(value))
+    NODE_BUILDERS.some((builder) => builder.match(value))
   );
 }
 
@@ -182,13 +109,13 @@ export function buildNode(
     if (nodeLike === 'START') {
       throw new Error('ParallelWorker cannot wrap a START node.');
     }
-    if (!parallelWorkerFactory) {
+    if (!PARALLEL_WORKER_FACTORY) {
       throw new Error(
-        'parallelWorker was requested but no ParallelWorker is registered; ' +
-          'import the parallel worker node module to enable it.',
+        'parallelWorker was requested but no ParallelWorker is available; ' +
+          'the parallel worker node module is not part of this build.',
       );
     }
-    return parallelWorkerFactory(built, {
+    return PARALLEL_WORKER_FACTORY(built, {
       maxParallelWorkers: options.maxParallelWorkers,
       retryConfig: options.retryConfig,
       timeout: options.timeout,
@@ -208,7 +135,7 @@ function buildInnerNode(
     // TODO(phase-3+): apply property overrides via a clone when options differ.
     return nodeLike;
   }
-  for (const builder of orderedNodeBuilders()) {
+  for (const builder of NODE_BUILDERS) {
     if (builder.match(nodeLike)) {
       return builder.build(nodeLike, options);
     }

--- a/core/test/utils/schema_test.ts
+++ b/core/test/utils/schema_test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Schema, Type} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {z as z3} from 'zod/v3';
+import {z as z4} from 'zod/v4';
+import {parseWithSchema, toJsonSchema} from '../../src/utils/schema.js';
+
+describe('parseWithSchema', () => {
+  it('returns the value unchanged when no schema is given', () => {
+    const value = {a: 1};
+    expect(parseWithSchema(undefined, value)).toBe(value);
+  });
+
+  it('parses and returns the value for a valid Zod v4 schema', () => {
+    const schema = z4.object({count: z4.number()});
+    expect(parseWithSchema(schema, {count: 3})).toEqual({count: 3});
+  });
+
+  it('throws for a value that fails a Zod v4 schema', () => {
+    const schema = z4.object({count: z4.number()});
+    expect(() => parseWithSchema(schema, {count: 'no'})).toThrow();
+  });
+
+  it('parses and returns the value for a valid Zod v3 schema', () => {
+    const schema = z3.object({count: z3.number()});
+    expect(parseWithSchema(schema, {count: 7})).toEqual({count: 7});
+  });
+
+  it('throws for a value that fails a Zod v3 schema', () => {
+    const schema = z3.object({count: z3.number()});
+    expect(() => parseWithSchema(schema, {count: 'no'})).toThrow();
+  });
+
+  it('does not validate a genai Schema (returns the value unchanged)', () => {
+    const schema: Schema = {
+      type: Type.OBJECT,
+      properties: {count: {type: Type.NUMBER}},
+    };
+    const value = {anything: 'goes'};
+    // A genai Schema is a declaration, not a runtime validator.
+    expect(parseWithSchema(schema, value)).toBe(value);
+  });
+});
+
+describe('toJsonSchema', () => {
+  it('converts a Zod v4 schema to a JSON schema', () => {
+    const json = toJsonSchema(z4.object({count: z4.number()}));
+    expect(json).toMatchObject({type: 'object'});
+    expect((json.properties as Record<string, unknown>).count).toBeDefined();
+  });
+
+  it('converts a Zod v3 schema to a JSON schema', () => {
+    const json = toJsonSchema(z3.object({count: z3.number()}));
+    expect(json).toMatchObject({type: 'object'});
+    expect((json.properties as Record<string, unknown>).count).toBeDefined();
+  });
+
+  it('returns a genai Schema as-is', () => {
+    const schema: Schema = {
+      type: Type.OBJECT,
+      properties: {count: {type: Type.NUMBER}},
+    };
+    expect(toJsonSchema(schema)).toBe(schema);
+  });
+});

--- a/core/test/workflow/base_node_test.ts
+++ b/core/test/workflow/base_node_test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Content} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {
+  isBaseNode,
+  isContent,
+  START,
+  toContent,
+} from '../../src/workflow/base_node.js';
+import {FnNode} from './test_helpers.js';
+
+describe('isBaseNode', () => {
+  it('recognizes node instances and the START sentinel', () => {
+    expect(isBaseNode(new FnNode('n', (_c, i) => i))).toBe(true);
+    expect(isBaseNode(START)).toBe(true);
+  });
+
+  it('rejects non-nodes', () => {
+    expect(isBaseNode({})).toBe(false);
+    expect(isBaseNode(null)).toBe(false);
+    expect(isBaseNode('START')).toBe(false);
+  });
+});
+
+describe('isContent', () => {
+  it('is true for objects with a parts array', () => {
+    expect(isContent({parts: []})).toBe(true);
+    expect(isContent({role: 'model', parts: [{text: 'x'}]})).toBe(true);
+  });
+
+  it('is false without a parts array', () => {
+    expect(isContent({role: 'model'})).toBe(false);
+    expect(isContent({parts: 'x'})).toBe(false);
+    expect(isContent('x')).toBe(false);
+    expect(isContent(null)).toBe(false);
+  });
+});
+
+describe('toContent', () => {
+  const text = (c: Content | undefined) => c?.parts?.[0]?.text;
+
+  it('returns undefined for null / undefined', () => {
+    expect(toContent(null)).toBeUndefined();
+    expect(toContent(undefined)).toBeUndefined();
+  });
+
+  it('passes a Content value through unchanged', () => {
+    const content: Content = {role: 'model', parts: [{text: 'hi'}]};
+    expect(toContent(content)).toBe(content);
+  });
+
+  it('wraps a string into a text part', () => {
+    expect(text(toContent('hello'))).toBe('hello');
+  });
+
+  it('wraps a Part and an array of Parts', () => {
+    expect(text(toContent({text: 'p'}))).toBe('p');
+    const many = toContent([{text: 'a'}, {text: 'b'}]);
+    expect(many?.parts).toHaveLength(2);
+  });
+
+  it('serializes a plain object to JSON text', () => {
+    expect(text(toContent({count: 1}))).toBe('{"count":1}');
+  });
+
+  it('serializes numbers and booleans to text', () => {
+    expect(text(toContent(42))).toBe('42');
+    expect(text(toContent(true))).toBe('true');
+  });
+
+  it('does not throw on a value JSON cannot serialize (circular ref)', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => toContent(circular)).not.toThrow();
+    expect(typeof text(toContent(circular))).toBe('string');
+  });
+});

--- a/core/test/workflow/foundations_test.ts
+++ b/core/test/workflow/foundations_test.ts
@@ -7,6 +7,9 @@
 import {describe, expect, it} from 'vitest';
 import {
   DynamicNodeFailError,
+  InvocationAbortedError,
+  isInvocationAbortedError,
+  isNodeTimeoutError,
   NodeInterruptedError,
   NodeTimeoutError,
 } from '../../src/workflow/errors.js';
@@ -52,6 +55,20 @@ describe('Phase 0 — errors', () => {
     expect(err).toBeInstanceOf(DynamicNodeFailError);
     expect(err.error).toBe(cause);
     expect(err.errorNodePath).toBe('wf.child.0');
+  });
+
+  it('InvocationAbortedError is guarded by name (not by other error guards)', () => {
+    const err = new InvocationAbortedError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('InvocationAbortedError');
+    expect(isInvocationAbortedError(err)).toBe(true);
+    // Guards are distinct: a different error is not misidentified.
+    expect(
+      isInvocationAbortedError(
+        new NodeTimeoutError({nodeName: 'n', timeout: 1}),
+      ),
+    ).toBe(false);
+    expect(isNodeTimeoutError(err)).toBe(false);
   });
 });
 

--- a/core/test/workflow/graph_parser_test.ts
+++ b/core/test/workflow/graph_parser_test.ts
@@ -5,7 +5,11 @@
  */
 
 import {describe, expect, it} from 'vitest';
-import {DEFAULT_ROUTE, Edge, Graph} from '../../src/workflow/graph.js';
+import {
+  createGraphFromEdgeItems,
+  DEFAULT_ROUTE,
+  Edge,
+} from '../../src/workflow/graph.js';
 import {parseEdgeItems} from '../../src/workflow/utils/graph_parser.js';
 import {FnNode} from './test_helpers.js';
 
@@ -88,7 +92,7 @@ describe('graph parser', () => {
   it('dedupes nodes by identity in the Graph', () => {
     const [a, b, c] = [n('a'), n('b'), n('c')];
     // `a` referenced in two edge items -> one node in the graph.
-    const graph = Graph.fromEdgeItems([
+    const graph = createGraphFromEdgeItems([
       ['START', a, b],
       [a, c],
     ]);

--- a/core/test/workflow/graph_parser_test.ts
+++ b/core/test/workflow/graph_parser_test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {DEFAULT_ROUTE, Edge, Graph} from '../../src/workflow/graph.js';
+import {parseEdgeItems} from '../../src/workflow/utils/graph_parser.js';
+import {FnNode} from './test_helpers.js';
+
+const n = (name: string) => new FnNode(name, (_c, i) => i);
+
+/** Serializes edges to `from->to[:route]` strings for compact assertions. */
+function edgeStrings(edges: Edge[]): string[] {
+  return edges.map((e) => {
+    const route =
+      e.route === null || e.route === undefined
+        ? ''
+        : `:${JSON.stringify(e.route)}`;
+    return `${e.fromNode.name}->${e.toNode.name}${route}`;
+  });
+}
+
+describe('graph parser', () => {
+  it('parses a linear chain', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const edges = parseEdgeItems([['START', a, b, c]]);
+    expect(edgeStrings(edges)).toEqual(['__START__->a', 'a->b', 'b->c']);
+  });
+
+  it('parses a fan-out array to multiple edges', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const edges = parseEdgeItems([['START', [a, b], c]]);
+    expect(edgeStrings(edges)).toEqual([
+      '__START__->a',
+      '__START__->b',
+      'a->c',
+      'b->c',
+    ]);
+  });
+
+  it('parses a routing map into conditional edges', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const edges = parseEdgeItems([[a, {question: b, statement: c}]]);
+    expect(edgeStrings(edges)).toEqual(['a->b:"question"', 'a->c:"statement"']);
+  });
+
+  it('parses numeric route keys', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const edges = parseEdgeItems([[a, {1: b, 2: c}]]);
+    expect(edgeStrings(edges)).toEqual(['a->b:1', 'a->c:2']);
+  });
+
+  it('parses fan-out inside a routing map', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const edges = parseEdgeItems([[a, {retry: [b, c]}]]);
+    expect(edgeStrings(edges)).toEqual(['a->b:"retry"', 'a->c:"retry"']);
+  });
+
+  it('parses DEFAULT_ROUTE keys', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const edges = parseEdgeItems([[a, {ok: b, [DEFAULT_ROUTE]: c}]]);
+    expect(edgeStrings(edges)).toEqual([
+      'a->b:"ok"',
+      `a->c:${JSON.stringify(DEFAULT_ROUTE)}`,
+    ]);
+  });
+
+  it('passes explicit Edge instances through', () => {
+    const [a, b] = [n('a'), n('b')];
+    const edges = parseEdgeItems([new Edge(a, b, 'go')]);
+    expect(edgeStrings(edges)).toEqual(['a->b:"go"']);
+  });
+
+  it('rejects consecutive routing maps in a chain', () => {
+    const [a] = [n('a')];
+    expect(() => parseEdgeItems([[a, {x: n('b')}, {y: n('c')}]])).toThrow(
+      /consecutive routing maps/i,
+    );
+  });
+
+  it('rejects an empty routing map', () => {
+    const a = n('a');
+    expect(() => parseEdgeItems([[a, {}]])).toThrow(/empty/i);
+  });
+
+  it('dedupes nodes by identity in the Graph', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    // `a` referenced in two edge items -> one node in the graph.
+    const graph = Graph.fromEdgeItems([
+      ['START', a, b],
+      [a, c],
+    ]);
+    expect(graph.nodes.map((node) => node.name).sort()).toEqual([
+      '__START__',
+      'a',
+      'b',
+      'c',
+    ]);
+    // Exactly one `a` instance.
+    expect(graph.nodes.filter((node) => node.name === 'a')).toHaveLength(1);
+  });
+});

--- a/core/test/workflow/graph_test.ts
+++ b/core/test/workflow/graph_test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {
+  createGraphFromEdgeItems,
+  DEFAULT_ROUTE,
+  Edge,
+  Graph,
+  isEdge,
+} from '../../src/workflow/graph.js';
+import {FnNode} from './test_helpers.js';
+
+const n = (name: string) => new FnNode(name, (_c, i) => i);
+
+describe('isEdge', () => {
+  it('recognizes an Edge instance', () => {
+    expect(isEdge(new Edge(n('a'), n('b')))).toBe(true);
+  });
+
+  it('rejects non-edges', () => {
+    expect(isEdge({})).toBe(false);
+    expect(isEdge(null)).toBe(false);
+    expect(isEdge(n('a'))).toBe(false);
+    expect(isEdge('a->b')).toBe(false);
+  });
+});
+
+describe('Graph.getNextPendingNodes', () => {
+  it('fires all unconditional edges', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const graph = new Graph([new Edge(a, b), new Edge(a, c)]);
+    expect(graph.getNextPendingNodes('a', undefined).sort()).toEqual([
+      'b',
+      'c',
+    ]);
+  });
+
+  it('fires only the edge matching the emitted route', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const graph = new Graph([new Edge(a, b, 'x'), new Edge(a, c, 'y')]);
+    expect(graph.getNextPendingNodes('a', 'x')).toEqual(['b']);
+    expect(graph.getNextPendingNodes('a', 'y')).toEqual(['c']);
+    expect(graph.getNextPendingNodes('a', 'z')).toEqual([]);
+  });
+
+  it('matches numeric routes by string value (emitted number or string)', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    // Numeric route keys from a routing map arrive as numbers on the edge.
+    const graph = new Graph([new Edge(a, b, 2), new Edge(a, c, 3)]);
+    expect(graph.getNextPendingNodes('a', 2)).toEqual(['b']);
+    expect(graph.getNextPendingNodes('a', '2')).toEqual(['b']);
+    expect(graph.getNextPendingNodes('a', 3)).toEqual(['c']);
+    expect(graph.getNextPendingNodes('a', '3')).toEqual(['c']);
+  });
+
+  it('matches boolean routes by string value', () => {
+    const [a, b] = [n('a'), n('b')];
+    const graph = new Graph([new Edge(a, b, true)]);
+    expect(graph.getNextPendingNodes('a', true)).toEqual(['b']);
+    expect(graph.getNextPendingNodes('a', 'true')).toEqual(['b']);
+    expect(graph.getNextPendingNodes('a', false)).toEqual([]);
+  });
+
+  it('matches an edge with a list of routes', () => {
+    const [a, b] = [n('a'), n('b')];
+    const graph = new Graph([new Edge(a, b, ['x', 'y'])]);
+    expect(graph.getNextPendingNodes('a', 'y')).toEqual(['b']);
+  });
+
+  it('matches when any of the emitted routes matches (fan-out)', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    const graph = new Graph([new Edge(a, b, 'x'), new Edge(a, c, 'y')]);
+    expect(graph.getNextPendingNodes('a', ['y', 'z']).sort()).toEqual(['c']);
+  });
+
+  it('takes the default route only when no specific route matches', () => {
+    const [a, b, d] = [n('a'), n('b'), n('d')];
+    const graph = new Graph([
+      new Edge(a, b, 'x'),
+      new Edge(a, d, DEFAULT_ROUTE),
+    ]);
+    expect(graph.getNextPendingNodes('a', 'x')).toEqual(['b']);
+    expect(graph.getNextPendingNodes('a', 'unknown')).toEqual(['d']);
+  });
+});
+
+describe('createGraphFromEdgeItems', () => {
+  it('builds a graph and computes terminal nodes', () => {
+    const [a, b] = [n('a'), n('b')];
+    const graph = createGraphFromEdgeItems([['START', a, b]]);
+    expect(graph.nodes.map((node) => node.name).sort()).toEqual([
+      '__START__',
+      'a',
+      'b',
+    ]);
+    expect([...graph.terminalNodeNames]).toEqual(['b']);
+  });
+
+  it('validates at construction (throws on a graph without START)', () => {
+    const [a, b] = [n('a'), n('b')];
+    expect(() => createGraphFromEdgeItems([[a, b]])).toThrow();
+  });
+});

--- a/core/test/workflow/graph_validation_test.ts
+++ b/core/test/workflow/graph_validation_test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {START} from '../../src/workflow/base_node.js';
+import {DEFAULT_ROUTE, Edge, Graph} from '../../src/workflow/graph.js';
+import {FnNode} from './test_helpers.js';
+
+const n = (name: string) => new FnNode(name, (_c, i) => i);
+
+/** Builds and validates a graph from edge items, returning the graph. */
+function build(edges: Parameters<typeof Graph.fromEdgeItems>[0]): Graph {
+  const graph = Graph.fromEdgeItems(edges);
+  graph.validate();
+  return graph;
+}
+
+describe('graph validation', () => {
+  it('accepts a valid graph and computes terminal nodes', () => {
+    const [a, b] = [n('a'), n('b')];
+    const graph = build([['START', a, b]]);
+    expect([...graph.terminalNodeNames]).toEqual(['b']);
+  });
+
+  it('rejects duplicate node names', () => {
+    // Two distinct instances sharing a name.
+    const a1 = new FnNode('dup', (_c, i) => i);
+    const a2 = new FnNode('dup', (_c, i) => i);
+    expect(() =>
+      build([
+        ['START', a1],
+        [a1, a2],
+      ]),
+    ).toThrow(/duplicate node names/i);
+  });
+
+  it('rejects a missing START node', () => {
+    const [a, b] = [n('a'), n('b')];
+    expect(() => build([[a, b]])).toThrow(/START node.*not found/i);
+  });
+
+  it('rejects a routed edge from START', () => {
+    const a = n('a');
+    expect(() => build([new Edge(START, a, 'go')])).toThrow(
+      /edges from START must not have routes/i,
+    );
+  });
+
+  it('rejects unreachable nodes', () => {
+    const [a, orphan, b] = [n('a'), n('orphan'), n('b')];
+    expect(() =>
+      build([
+        ['START', a],
+        [orphan, b],
+      ]),
+    ).toThrow(/unreachable/i);
+  });
+
+  it('rejects duplicate edges', () => {
+    const [a, b] = [n('a'), n('b')];
+    expect(() =>
+      build([
+        ['START', a],
+        [a, b],
+        [a, b],
+      ]),
+    ).toThrow(/duplicate edge/i);
+  });
+
+  it('rejects multiple DEFAULT_ROUTE edges from one node', () => {
+    const [a, b, c] = [n('a'), n('b'), n('c')];
+    expect(() =>
+      build([
+        ['START', a],
+        [a, {[DEFAULT_ROUTE]: b}],
+        new Edge(a, c, DEFAULT_ROUTE),
+      ]),
+    ).toThrow(/DEFAULT_ROUTE/i);
+  });
+
+  it('rejects an unconditional cycle', () => {
+    const [a, b] = [n('a'), n('b')];
+    expect(() =>
+      build([
+        ['START', a],
+        [a, b],
+        [b, a],
+      ]),
+    ).toThrow(/cycle/i);
+  });
+
+  it('allows a routed (conditional) cycle', () => {
+    const [a, b] = [n('a'), n('b')];
+    // a -> b unconditionally, b -> a only on route 'again' (conditional) => ok.
+    const graph = build([
+      ['START', a],
+      [a, b],
+      [b, {again: a, [DEFAULT_ROUTE]: n('done')}],
+    ]);
+    expect(graph).toBeInstanceOf(Graph);
+  });
+});

--- a/core/test/workflow/graph_validation_test.ts
+++ b/core/test/workflow/graph_validation_test.ts
@@ -6,16 +6,19 @@
 
 import {describe, expect, it} from 'vitest';
 import {START} from '../../src/workflow/base_node.js';
-import {DEFAULT_ROUTE, Edge, Graph} from '../../src/workflow/graph.js';
+import {
+  createGraphFromEdgeItems,
+  DEFAULT_ROUTE,
+  Edge,
+  Graph,
+} from '../../src/workflow/graph.js';
 import {FnNode} from './test_helpers.js';
 
 const n = (name: string) => new FnNode(name, (_c, i) => i);
 
-/** Builds and validates a graph from edge items, returning the graph. */
-function build(edges: Parameters<typeof Graph.fromEdgeItems>[0]): Graph {
-  const graph = Graph.fromEdgeItems(edges);
-  graph.validate();
-  return graph;
+/** Builds a graph from edge items (validation runs inside the factory). */
+function build(edges: Parameters<typeof createGraphFromEdgeItems>[0]): Graph {
+  return createGraphFromEdgeItems(edges);
 }
 
 describe('graph validation', () => {

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Schema, Type} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {z as z3} from 'zod/v3';
+import {z as z4} from 'zod/v4';
+import {AuthCredentialTypes} from '../../src/auth/auth_credential.js';
+import {AuthConfig} from '../../src/auth/auth_tool.js';
+import type {Event} from '../../src/events/event.js';
+import {State} from '../../src/sessions/state.js';
+import {
+  isRequestInput,
+  RequestInput,
+} from '../../src/workflow/request_input.js';
+import {
+  createRequestInputEvent,
+  createRequestInputResponse,
+  getRequestInputInterruptIds,
+  hasAuthCredential,
+  hasRequestInputFunctionCall,
+  processAuthResume,
+  REQUEST_INPUT_FUNCTION_CALL_NAME,
+} from '../../src/workflow/utils/hitl_utils.js';
+
+/** Extracts the first function-call args from an event. */
+function firstFunctionCall(event: Event) {
+  return event.content?.parts?.[0]?.functionCall;
+}
+
+describe('RequestInput', () => {
+  it('auto-generates an interrupt id when omitted', () => {
+    const ri = new RequestInput();
+    expect(typeof ri.interruptId).toBe('string');
+    expect(ri.interruptId.length).toBeGreaterThan(0);
+    expect(ri.payload).toBeUndefined();
+    expect(ri.message).toBeUndefined();
+    expect(ri.responseSchema).toBeUndefined();
+  });
+
+  it('keeps the provided fields', () => {
+    const ri = new RequestInput({
+      interruptId: 'i1',
+      payload: {a: 1},
+      message: 'm',
+    });
+    expect(ri.interruptId).toBe('i1');
+    expect(ri.payload).toEqual({a: 1});
+    expect(ri.message).toBe('m');
+  });
+});
+
+describe('isRequestInput', () => {
+  it('recognizes a RequestInput instance', () => {
+    expect(isRequestInput(new RequestInput())).toBe(true);
+  });
+
+  it('rejects look-alikes and non-objects', () => {
+    expect(isRequestInput({interruptId: 'x'})).toBe(false);
+    expect(isRequestInput(null)).toBe(false);
+    expect(isRequestInput('i1')).toBe(false);
+  });
+});
+
+describe('createRequestInputEvent', () => {
+  it('builds an interrupt event with a request_input function call', () => {
+    const ri = new RequestInput({
+      interruptId: 'i1',
+      message: 'pick',
+      payload: {x: 1},
+    });
+    const event = createRequestInputEvent(ri);
+    const fc = firstFunctionCall(event);
+
+    expect(fc?.name).toBe(REQUEST_INPUT_FUNCTION_CALL_NAME);
+    expect(fc?.id).toBe('i1');
+    expect(fc?.args).toMatchObject({
+      interruptId: 'i1',
+      message: 'pick',
+      payload: {x: 1},
+      responseSchema: null,
+    });
+    expect(event.longRunningToolIds).toEqual(['i1']);
+    expect(hasRequestInputFunctionCall(event)).toBe(true);
+    expect(getRequestInputInterruptIds(event)).toEqual(['i1']);
+  });
+
+  it('converts a Zod v4 responseSchema to a JSON schema', () => {
+    const ri = new RequestInput({
+      responseSchema: z4.object({answer: z4.string()}),
+    });
+    const args = firstFunctionCall(createRequestInputEvent(ri))?.args as Record<
+      string,
+      unknown
+    >;
+    expect(args.responseSchema).toMatchObject({type: 'object'});
+  });
+
+  it('converts a Zod v3 responseSchema to a JSON schema', () => {
+    const ri = new RequestInput({
+      responseSchema: z3.object({answer: z3.string()}),
+    });
+    const args = firstFunctionCall(createRequestInputEvent(ri))?.args as Record<
+      string,
+      unknown
+    >;
+    expect(args.responseSchema).toMatchObject({type: 'object'});
+  });
+
+  it('passes a genai Schema responseSchema through as-is', () => {
+    const schema: Schema = {
+      type: Type.OBJECT,
+      properties: {answer: {type: Type.STRING}},
+    };
+    const ri = new RequestInput({responseSchema: schema});
+    const args = firstFunctionCall(createRequestInputEvent(ri))?.args as Record<
+      string,
+      unknown
+    >;
+    expect(args.responseSchema).toEqual(schema);
+  });
+});
+
+describe('createRequestInputResponse', () => {
+  it('builds a function-response part for the interrupt', () => {
+    const part = createRequestInputResponse('i1', {value: 5});
+    expect(part.functionResponse).toEqual({
+      id: 'i1',
+      name: REQUEST_INPUT_FUNCTION_CALL_NAME,
+      response: {value: 5},
+    });
+  });
+});
+
+describe('auth gate', () => {
+  const apiKeyConfig = (): AuthConfig => ({
+    credentialKey: 'testKey',
+    authScheme: {type: 'apiKey', name: 'testKey', in: 'header'},
+    rawAuthCredential: {authType: AuthCredentialTypes.API_KEY},
+  });
+
+  it('reports no credential for an empty state', () => {
+    expect(hasAuthCredential(apiKeyConfig(), new State())).toBe(false);
+  });
+
+  it('stores an API-key credential from a plain resume value', async () => {
+    const authConfig = apiKeyConfig();
+    const state = new State();
+
+    await processAuthResume({responseData: 'my-key', authConfig, state});
+
+    expect(hasAuthCredential(authConfig, state)).toBe(true);
+    expect(state.get('temp:testKey')).toEqual({
+      authType: 'apiKey',
+      apiKey: 'my-key',
+    });
+  });
+});

--- a/core/test/workflow/node_execution_test.ts
+++ b/core/test/workflow/node_execution_test.ts
@@ -11,7 +11,10 @@ import {z as z4} from 'zod/v4';
 import {createEvent, Event} from '../../src/events/event.js';
 import {AsyncQueue} from '../../src/utils/async_queue.js';
 import {BaseNode} from '../../src/workflow/base_node.js';
-import {isNodeTimeoutError} from '../../src/workflow/errors.js';
+import {
+  isInvocationAbortedError,
+  isNodeTimeoutError,
+} from '../../src/workflow/errors.js';
 import {NodeContext} from '../../src/workflow/node_context.js';
 import {createIc, driveNode, FnNode} from './test_helpers.js';
 
@@ -286,5 +289,53 @@ describe('output schema validation (Zod v3 / Zod v4 / genai Schema)', () => {
     // passes through untouched even though it does not match the schema.
     const {output} = await driveNode(node);
     expect(output).toEqual({anything: 'goes'});
+  });
+});
+
+describe('input schema validation', () => {
+  it('validates input against a Zod v4 schema', async () => {
+    const node = new FnNode('n', (_c, i) => i, {
+      inputSchema: z4.object({x: z4.number()}),
+    });
+    const {output} = await driveNode(node, {x: 1});
+    expect(output).toEqual({x: 1});
+  });
+
+  it('rejects input that fails the schema', async () => {
+    const node = new FnNode('n', (_c, i) => i, {
+      inputSchema: z4.object({x: z4.number()}),
+    });
+    await expect(driveNode(node, {x: 'no'})).rejects.toThrow();
+  });
+
+  it('passes genai Content input through without schema validation', async () => {
+    const node = new FnNode('n', (_c, i) => i, {
+      inputSchema: z4.object({x: z4.number()}),
+    });
+    const content = {role: 'user', parts: [{text: 'hi'}]};
+    // Content bypasses inputSchema even though it would not match it.
+    const {output} = await driveNode(node, content);
+    expect(output).toEqual(content);
+  });
+});
+
+describe('retry backoff cancellation', () => {
+  it('rejects with InvocationAbortedError when the invocation is aborted', async () => {
+    const controller = new AbortController();
+    controller.abort(); // already aborted before the backoff delay
+    const ic = createIc({}, controller.signal);
+    const doomed = new FnNode(
+      'doomed',
+      () => {
+        throw new Error('boom');
+      },
+      {retryConfig: {maxAttempts: 3, initialDelay: 0.01, jitter: 0}},
+    );
+
+    const err = await driveNode(doomed, 'x', ic).then(
+      () => undefined,
+      (e) => e,
+    );
+    expect(isInvocationAbortedError(err)).toBe(true);
   });
 });

--- a/core/test/workflow/node_execution_test.ts
+++ b/core/test/workflow/node_execution_test.ts
@@ -4,97 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {Type} from '@google/genai';
 import {describe, expect, it} from 'vitest';
-import {BaseAgent} from '../../src/agents/base_agent.js';
-import {InvocationContext} from '../../src/agents/invocation_context.js';
+import {z as z3} from 'zod/v3';
+import {z as z4} from 'zod/v4';
 import {createEvent, Event} from '../../src/events/event.js';
-import {PluginManager} from '../../src/plugins/plugin_manager.js';
-import {Session} from '../../src/sessions/session.js';
 import {AsyncQueue} from '../../src/utils/async_queue.js';
 import {BaseNode} from '../../src/workflow/base_node.js';
-import {NodeTimeoutError} from '../../src/workflow/errors.js';
+import {isNodeTimeoutError} from '../../src/workflow/errors.js';
 import {NodeContext} from '../../src/workflow/node_context.js';
-
-// --- Test harness ---------------------------------------------------------
-
-function createIc(params?: Partial<InvocationContext>): InvocationContext {
-  const session: Session = {
-    id: 'session-123',
-    appName: 'test-app',
-    userId: 'test-user',
-    events: [],
-    state: {},
-    lastUpdateTime: Date.now(),
-  } as unknown as Session;
-
-  return new InvocationContext({
-    invocationId: 'inv-1',
-    session,
-    agent: {
-      name: 'wf',
-      runAsync: async function* () {},
-    } as unknown as BaseAgent,
-    pluginManager: new PluginManager(),
-    ...params,
-  });
-}
-
-/**
- * Drives a root node the way the Phase 2 Workflow loop will: orchestration
- * pushes events into the channel concurrently while the consumer drains it.
- * This exercises the real push/pull bridge, not a buffer-then-read shortcut.
- */
-async function driveRoot(
-  ic: InvocationContext,
-  node: BaseNode,
-  input?: unknown,
-): Promise<{events: Event[]; output: unknown; route: unknown}> {
-  const channel = new AsyncQueue<Event>();
-  const root = new NodeContext({
-    invocationContext: ic,
-    channel,
-    nodePath: '',
-    runId: 'root',
-  });
-
-  const events: Event[] = [];
-  const orchestration = root.runNode(node, input, {useAsOutput: true}).then(
-    () => channel.close(),
-    (err) => channel.fail(err),
-  );
-
-  for await (const ev of channel) {
-    events.push(ev);
-  }
-  await orchestration;
-  return {events, output: root.output, route: root.route};
-}
-
-// A minimal node that yields whatever its function returns (value | Event).
-class FnNode extends BaseNode {
-  constructor(
-    name: string,
-    private readonly fn: (
-      ctx: NodeContext,
-      input: unknown,
-    ) => unknown | Promise<unknown>,
-    config?: Partial<
-      Omit<import('../../src/workflow/base_node.js').BaseNodeConfig, 'name'>
-    >,
-  ) {
-    super({name, ...config});
-  }
-  protected async *runImpl(ctx: NodeContext, input: unknown) {
-    yield await this.fn(ctx, input);
-  }
-}
+import {createIc, driveNode, FnNode} from './test_helpers.js';
 
 // --- Tests ----------------------------------------------------------------
 
 describe('Phase 1 — node execution & the push/pull bridge', () => {
   it('streams a node event and returns its output', async () => {
     const node = new FnNode('greet', (_ctx, input) => `hello ${input}`);
-    const {events, output} = await driveRoot(createIc(), node, 'world');
+    const {events, output} = await driveNode(node, 'world');
 
     expect(output).toBe('hello world');
     expect(events).toHaveLength(1);
@@ -107,12 +33,12 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
     const node = new FnNode('router', () =>
       createEvent({route: 'question', output: 'q'}),
     );
-    const {events, output, route} = await driveRoot(createIc(), node, 'in');
+    const {events, output, ctx} = await driveNode(node, 'in');
 
     expect(events).toHaveLength(1);
     expect(events[0].route).toBe('question');
     expect(output).toBe('q');
-    expect(route).toBe('question');
+    expect(ctx.route).toBe('question');
     // Engine stamps provenance without clobbering.
     expect(events[0].nodeInfo?.path).toBe('router');
     expect(events[0].author).toBe('router');
@@ -125,7 +51,7 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
       return `outer[${child.output}]`;
     });
 
-    const {events, output} = await driveRoot(createIc(), outer, 'x');
+    const {events, output} = await driveNode(outer, 'x');
 
     expect(output).toBe('outer[inner(x)]');
     // Both the child and parent events streamed out, child first.
@@ -151,7 +77,7 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
     });
 
     // outer runs at the root (branch undefined); mid -> 'mid'; inner -> 'mid.inner'.
-    await driveRoot(createIc(), outer, 'x');
+    await driveNode(outer, 'x');
     expect(innerBranch).toBe('mid.inner');
   });
 
@@ -193,7 +119,7 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
       },
     );
 
-    const {output} = await driveRoot(createIc(), flaky, 'x');
+    const {output} = await driveNode(flaky, 'x');
     expect(attempts).toBe(3);
     expect(output).toBe('ok-after-retry');
   });
@@ -209,10 +135,39 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
       {retryConfig: {maxAttempts: 2, initialDelay: 0.001, jitter: 0}},
     );
 
-    await expect(driveRoot(createIc(), doomed, 'x')).rejects.toThrow(
-      'always fails',
-    );
+    await expect(driveNode(doomed, 'x')).rejects.toThrow('always fails');
     expect(attempts).toBe(2);
+  });
+
+  it('clears a failed attempt state writes before retrying', async () => {
+    let attempts = 0;
+    const node = new FnNode(
+      'writer',
+      (ctx) => {
+        attempts++;
+        // Each attempt writes a per-attempt key, then the first attempt fails.
+        ctx.state.set(`attempt-${attempts}`, attempts);
+        if (attempts < 2) {
+          throw new Error('transient');
+        }
+        return 'ok';
+      },
+      {retryConfig: {maxAttempts: 2, initialDelay: 0.001, jitter: 0}},
+    );
+
+    const channel = new AsyncQueue<Event>();
+    const root = new NodeContext({
+      invocationContext: createIc(),
+      channel,
+      nodePath: '',
+      runId: 'root',
+    });
+    const child = await root.runNode(node, 'x', {useAsOutput: true});
+
+    expect(child.output).toBe('ok');
+    // The failed first attempt's write must not survive into the committed
+    // delta — only the successful attempt's write remains.
+    expect(child.actions.stateDelta).toEqual({'attempt-2': 2});
   });
 
   it('enforces a per-node timeout with NodeTimeoutError', async () => {
@@ -222,9 +177,11 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
       {timeout: 0.02},
     );
 
-    await expect(driveRoot(createIc(), slow, 'x')).rejects.toBeInstanceOf(
-      NodeTimeoutError,
+    const err = await driveNode(slow, 'x').then(
+      () => undefined,
+      (e) => e,
     );
+    expect(isNodeTimeoutError(err)).toBe(true);
   });
 
   it('cancels a timed-out node: aborts the signal and drops post-deadline events', async () => {
@@ -280,9 +237,54 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
     }
     await orchestration.catch(() => {});
 
-    expect(thrown).toBeInstanceOf(NodeTimeoutError);
+    expect(isNodeTimeoutError(thrown)).toBe(true);
     expect(seen).toContain('early');
     expect(seen).not.toContain('late'); // produced after the deadline -> dropped
     expect(captured?.aborted).toBe(true); // signal fired for cooperative cancel
+  });
+});
+
+describe('output schema validation (Zod v3 / Zod v4 / genai Schema)', () => {
+  it('validates output against a Zod v4 schema', async () => {
+    const node = new FnNode('n', () => ({count: 1}), {
+      outputSchema: z4.object({count: z4.number()}),
+    });
+    const {output} = await driveNode(node);
+    expect(output).toEqual({count: 1});
+  });
+
+  it('rejects output that fails a Zod v4 schema', async () => {
+    const node = new FnNode('n', () => ({count: 'nope'}), {
+      outputSchema: z4.object({count: z4.number()}),
+    });
+    await expect(driveNode(node)).rejects.toThrow();
+  });
+
+  it('validates output against a Zod v3 schema', async () => {
+    const node = new FnNode('n', () => ({count: 2}), {
+      outputSchema: z3.object({count: z3.number()}),
+    });
+    const {output} = await driveNode(node);
+    expect(output).toEqual({count: 2});
+  });
+
+  it('rejects output that fails a Zod v3 schema', async () => {
+    const node = new FnNode('n', () => ({count: 'nope'}), {
+      outputSchema: z3.object({count: z3.number()}),
+    });
+    await expect(driveNode(node)).rejects.toThrow();
+  });
+
+  it('accepts a genai Schema and leaves the value unvalidated', async () => {
+    const node = new FnNode('n', () => ({anything: 'goes'}), {
+      outputSchema: {
+        type: Type.OBJECT,
+        properties: {count: {type: Type.NUMBER}},
+      },
+    });
+    // A genai Schema is a declaration, not a runtime validator, so the value
+    // passes through untouched even though it does not match the schema.
+    const {output} = await driveNode(node);
+    expect(output).toEqual({anything: 'goes'});
   });
 });

--- a/core/test/workflow/node_execution_test.ts
+++ b/core/test/workflow/node_execution_test.ts
@@ -1,0 +1,288 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {BaseAgent} from '../../src/agents/base_agent.js';
+import {InvocationContext} from '../../src/agents/invocation_context.js';
+import {createEvent, Event} from '../../src/events/event.js';
+import {PluginManager} from '../../src/plugins/plugin_manager.js';
+import {Session} from '../../src/sessions/session.js';
+import {AsyncQueue} from '../../src/utils/async_queue.js';
+import {BaseNode} from '../../src/workflow/base_node.js';
+import {NodeTimeoutError} from '../../src/workflow/errors.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+
+// --- Test harness ---------------------------------------------------------
+
+function createIc(params?: Partial<InvocationContext>): InvocationContext {
+  const session: Session = {
+    id: 'session-123',
+    appName: 'test-app',
+    userId: 'test-user',
+    events: [],
+    state: {},
+    lastUpdateTime: Date.now(),
+  } as unknown as Session;
+
+  return new InvocationContext({
+    invocationId: 'inv-1',
+    session,
+    agent: {
+      name: 'wf',
+      runAsync: async function* () {},
+    } as unknown as BaseAgent,
+    pluginManager: new PluginManager(),
+    ...params,
+  });
+}
+
+/**
+ * Drives a root node the way the Phase 2 Workflow loop will: orchestration
+ * pushes events into the channel concurrently while the consumer drains it.
+ * This exercises the real push/pull bridge, not a buffer-then-read shortcut.
+ */
+async function driveRoot(
+  ic: InvocationContext,
+  node: BaseNode,
+  input?: unknown,
+): Promise<{events: Event[]; output: unknown; route: unknown}> {
+  const channel = new AsyncQueue<Event>();
+  const root = new NodeContext({
+    invocationContext: ic,
+    channel,
+    nodePath: '',
+    runId: 'root',
+  });
+
+  const events: Event[] = [];
+  const orchestration = root.runNode(node, input, {useAsOutput: true}).then(
+    () => channel.close(),
+    (err) => channel.fail(err),
+  );
+
+  for await (const ev of channel) {
+    events.push(ev);
+  }
+  await orchestration;
+  return {events, output: root.output, route: root.route};
+}
+
+// A minimal node that yields whatever its function returns (value | Event).
+class FnNode extends BaseNode {
+  constructor(
+    name: string,
+    private readonly fn: (
+      ctx: NodeContext,
+      input: unknown,
+    ) => unknown | Promise<unknown>,
+    config?: Partial<
+      Omit<import('../../src/workflow/base_node.js').BaseNodeConfig, 'name'>
+    >,
+  ) {
+    super({name, ...config});
+  }
+  protected async *runImpl(ctx: NodeContext, input: unknown) {
+    yield await this.fn(ctx, input);
+  }
+}
+
+// --- Tests ----------------------------------------------------------------
+
+describe('Phase 1 — node execution & the push/pull bridge', () => {
+  it('streams a node event and returns its output', async () => {
+    const node = new FnNode('greet', (_ctx, input) => `hello ${input}`);
+    const {events, output} = await driveRoot(createIc(), node, 'world');
+
+    expect(output).toBe('hello world');
+    expect(events).toHaveLength(1);
+    expect(events[0].author).toBe('greet');
+    expect(events[0].output).toBe('hello world');
+    expect(events[0].nodeInfo?.path).toBe('greet');
+  });
+
+  it('passes through an explicitly emitted Event and preserves route', async () => {
+    const node = new FnNode('router', () =>
+      createEvent({route: 'question', output: 'q'}),
+    );
+    const {events, output, route} = await driveRoot(createIc(), node, 'in');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].route).toBe('question');
+    expect(output).toBe('q');
+    expect(route).toBe('question');
+    // Engine stamps provenance without clobbering.
+    expect(events[0].nodeInfo?.path).toBe('router');
+    expect(events[0].author).toBe('router');
+  });
+
+  it('supports nested ctx.runNode() with correct node paths (the bridge)', async () => {
+    const inner = new FnNode('inner', (_ctx, input) => `inner(${input})`);
+    const outer = new FnNode('outer', async (ctx, input) => {
+      const child = await ctx.runNode(inner, input);
+      return `outer[${child.output}]`;
+    });
+
+    const {events, output} = await driveRoot(createIc(), outer, 'x');
+
+    expect(output).toBe('outer[inner(x)]');
+    // Both the child and parent events streamed out, child first.
+    const paths = events.map((e) => e.nodeInfo?.path);
+    expect(paths).toContain('outer.inner');
+    expect(paths).toContain('outer');
+    expect(paths.indexOf('outer.inner')).toBeLessThan(paths.indexOf('outer'));
+  });
+
+  it('derives nested sub-branches as dotted paths', async () => {
+    let innerBranch: string | undefined = 'UNSET';
+    const inner = new FnNode('inner', (ctx) => {
+      innerBranch = ctx.branch;
+      return 'ok';
+    });
+    const mid = new FnNode('mid', async (ctx, input) => {
+      await ctx.runNode(inner, input, {useSubBranch: true});
+      return 'm';
+    });
+    const outer = new FnNode('outer', async (ctx, input) => {
+      await ctx.runNode(mid, input, {useSubBranch: true});
+      return 'o';
+    });
+
+    // outer runs at the root (branch undefined); mid -> 'mid'; inner -> 'mid.inner'.
+    await driveRoot(createIc(), outer, 'x');
+    expect(innerBranch).toBe('mid.inner');
+  });
+
+  it('accumulates ctx.state writes into the event action state delta', async () => {
+    const node = new FnNode('writer', (ctx) => {
+      ctx.state.set('counter', 7);
+      return 'wrote';
+    });
+    const channel = new AsyncQueue<Event>();
+    const root = new NodeContext({
+      invocationContext: createIc(),
+      channel,
+      nodePath: '',
+      runId: 'root',
+    });
+    const child = await root.runNode(node, undefined, {useAsOutput: true});
+    expect(child.state.get('counter')).toBe(7);
+    expect(child.actions.stateDelta['counter']).toBe(7);
+  });
+
+  it('retries a flaky node per retryConfig and then succeeds', async () => {
+    let attempts = 0;
+    const flaky = new FnNode(
+      'flaky',
+      () => {
+        attempts++;
+        if (attempts < 3) {
+          throw new Error('transient');
+        }
+        return 'ok-after-retry';
+      },
+      {
+        retryConfig: {
+          maxAttempts: 3,
+          initialDelay: 0.001,
+          backoffFactor: 1,
+          jitter: 0,
+        },
+      },
+    );
+
+    const {output} = await driveRoot(createIc(), flaky, 'x');
+    expect(attempts).toBe(3);
+    expect(output).toBe('ok-after-retry');
+  });
+
+  it('propagates the final error when retries are exhausted', async () => {
+    let attempts = 0;
+    const doomed = new FnNode(
+      'doomed',
+      () => {
+        attempts++;
+        throw new Error('always fails');
+      },
+      {retryConfig: {maxAttempts: 2, initialDelay: 0.001, jitter: 0}},
+    );
+
+    await expect(driveRoot(createIc(), doomed, 'x')).rejects.toThrow(
+      'always fails',
+    );
+    expect(attempts).toBe(2);
+  });
+
+  it('enforces a per-node timeout with NodeTimeoutError', async () => {
+    const slow = new FnNode(
+      'slow',
+      () => new Promise((resolve) => setTimeout(() => resolve('late'), 200)),
+      {timeout: 0.02},
+    );
+
+    await expect(driveRoot(createIc(), slow, 'x')).rejects.toBeInstanceOf(
+      NodeTimeoutError,
+    );
+  });
+
+  it('cancels a timed-out node: aborts the signal and drops post-deadline events', async () => {
+    let captured: AbortSignal | undefined;
+    class SlowStream extends BaseNode {
+      protected async *runImpl(ctx: NodeContext) {
+        captured = ctx.abortSignal;
+        yield createEvent({
+          author: 'slow',
+          content: {role: 'model', parts: [{text: 'early'}]},
+        });
+        // Cooperative wait that ends on abort; well past the 20ms timeout.
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, 500);
+          ctx.abortSignal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(t);
+              resolve();
+            },
+            {once: true},
+          );
+        });
+        yield createEvent({
+          author: 'slow',
+          content: {role: 'model', parts: [{text: 'late'}]},
+          output: 'late',
+        });
+      }
+    }
+    const slow = new SlowStream({name: 'slow', timeout: 0.02});
+
+    // Custom harness: capture events even though the run rejects.
+    const channel = new AsyncQueue<Event>();
+    const root = new NodeContext({
+      invocationContext: createIc(),
+      channel,
+      nodePath: '',
+      runId: 'root',
+    });
+    const seen: string[] = [];
+    const orchestration = root.runNode(slow, 'x').then(
+      () => channel.close(),
+      (err) => channel.fail(err),
+    );
+    let thrown: unknown;
+    try {
+      for await (const ev of channel) {
+        seen.push(ev.content?.parts?.[0]?.text ?? '');
+      }
+    } catch (err) {
+      thrown = err;
+    }
+    await orchestration.catch(() => {});
+
+    expect(thrown).toBeInstanceOf(NodeTimeoutError);
+    expect(seen).toContain('early');
+    expect(seen).not.toContain('late'); // produced after the deadline -> dropped
+    expect(captured?.aborted).toBe(true); // signal fired for cooperative cancel
+  });
+});

--- a/core/test/workflow/test_helpers.ts
+++ b/core/test/workflow/test_helpers.ts
@@ -8,30 +8,38 @@ import {BaseAgent} from '../../src/agents/base_agent.js';
 import {InvocationContext} from '../../src/agents/invocation_context.js';
 import {Event} from '../../src/events/event.js';
 import {PluginManager} from '../../src/plugins/plugin_manager.js';
-import {Session} from '../../src/sessions/session.js';
+import {createSession} from '../../src/sessions/session.js';
 import {AsyncQueue} from '../../src/utils/async_queue.js';
-import {BaseNode} from '../../src/workflow/base_node.js';
+import {BaseNode, BaseNodeConfig} from '../../src/workflow/base_node.js';
 import {NodeContext} from '../../src/workflow/node_context.js';
+
+/** A minimal concrete {@link BaseAgent} for driving nodes directly in tests. */
+class TestAgent extends BaseAgent {
+  // eslint-disable-next-line require-yield
+  protected async *runAsyncImpl(): AsyncGenerator<Event, void, void> {
+    return;
+  }
+  // eslint-disable-next-line require-yield
+  protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
+    return;
+  }
+}
 
 /** Builds a throwaway InvocationContext for driving nodes directly in tests. */
 export function createIc(
   state: Record<string, unknown> = {},
 ): InvocationContext {
-  const session = {
+  const session = createSession({
     id: 's1',
     appName: 'app',
     userId: 'u',
-    events: [],
     state,
     lastUpdateTime: Date.now(),
-  } as unknown as Session;
+  });
   return new InvocationContext({
     invocationId: 'inv-1',
     session,
-    agent: {
-      name: 'wf',
-      runAsync: async function* () {},
-    } as unknown as BaseAgent,
+    agent: new TestAgent({name: 'wf'}),
     pluginManager: new PluginManager(),
   });
 }
@@ -65,8 +73,11 @@ export async function driveNode(
 export class FnNode extends BaseNode {
   constructor(
     name: string,
-    private readonly fn: (ctx: NodeContext, input: unknown) => unknown,
-    config: {rerunOnResume?: boolean} = {},
+    private readonly fn: (
+      ctx: NodeContext,
+      input: unknown,
+    ) => unknown | Promise<unknown>,
+    config: Partial<Omit<BaseNodeConfig, 'name'>> = {},
   ) {
     super({name, ...config});
   }

--- a/core/test/workflow/test_helpers.ts
+++ b/core/test/workflow/test_helpers.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseAgent} from '../../src/agents/base_agent.js';
+import {InvocationContext} from '../../src/agents/invocation_context.js';
+import {Event} from '../../src/events/event.js';
+import {PluginManager} from '../../src/plugins/plugin_manager.js';
+import {Session} from '../../src/sessions/session.js';
+import {AsyncQueue} from '../../src/utils/async_queue.js';
+import {BaseNode} from '../../src/workflow/base_node.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+
+/** Builds a throwaway InvocationContext for driving nodes directly in tests. */
+export function createIc(
+  state: Record<string, unknown> = {},
+): InvocationContext {
+  const session = {
+    id: 's1',
+    appName: 'app',
+    userId: 'u',
+    events: [],
+    state,
+    lastUpdateTime: Date.now(),
+  } as unknown as Session;
+  return new InvocationContext({
+    invocationId: 'inv-1',
+    session,
+    agent: {
+      name: 'wf',
+      runAsync: async function* () {},
+    } as unknown as BaseAgent,
+    pluginManager: new PluginManager(),
+  });
+}
+
+/** Runs a node (or workflow) to completion, returning its events and output. */
+export async function driveNode(
+  node: BaseNode,
+  input?: unknown,
+  ic: InvocationContext = createIc(),
+): Promise<{events: Event[]; output: unknown; ctx: NodeContext}> {
+  const channel = new AsyncQueue<Event>();
+  const root = new NodeContext({
+    invocationContext: ic,
+    channel,
+    nodePath: '',
+    runId: 'root',
+  });
+  const events: Event[] = [];
+  const settle = root.runNode(node, input, {useAsOutput: true}).then(
+    () => channel.close(),
+    (err) => channel.fail(err),
+  );
+  for await (const ev of channel) {
+    events.push(ev);
+  }
+  await settle;
+  return {events, output: root.output, ctx: root};
+}
+
+/** A node whose behavior is a plain function returning a value or Event. */
+export class FnNode extends BaseNode {
+  constructor(
+    name: string,
+    private readonly fn: (ctx: NodeContext, input: unknown) => unknown,
+    config: {rerunOnResume?: boolean} = {},
+  ) {
+    super({name, ...config});
+  }
+  protected async *runImpl(ctx: NodeContext, input: unknown) {
+    yield await this.fn(ctx, input);
+  }
+}

--- a/core/test/workflow/test_helpers.ts
+++ b/core/test/workflow/test_helpers.ts
@@ -28,6 +28,7 @@ class TestAgent extends BaseAgent {
 /** Builds a throwaway InvocationContext for driving nodes directly in tests. */
 export function createIc(
   state: Record<string, unknown> = {},
+  abortSignal?: AbortSignal,
 ): InvocationContext {
   const session = createSession({
     id: 's1',
@@ -41,6 +42,7 @@ export function createIc(
     session,
     agent: new TestAgent({name: 'wf'}),
     pluginManager: new PluginManager(),
+    abortSignal,
   });
 }
 

--- a/core/test/workflow/workflow_graph_utils_test.ts
+++ b/core/test/workflow/workflow_graph_utils_test.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {BaseNode, START} from '../../src/workflow/base_node.js';
+import {NodeLike} from '../../src/workflow/graph.js';
+import {
+  buildNode,
+  isNodeLike,
+  isPlainObject,
+  NodeBuilder,
+  registerNodeBuilder,
+  registerParallelWorkerFactory,
+} from '../../src/workflow/utils/workflow_graph_utils.js';
+import {FnNode} from './test_helpers.js';
+
+/** A sentinel node-like value matched by a test builder via its `brand`. */
+const branded = (brand: string): NodeLike => ({brand}) as unknown as NodeLike;
+
+/** Builds a {@link NodeBuilder} that matches `branded(brand)` and names its node. */
+function sentinelBuilder(
+  id: string,
+  brand: string,
+  nodeName: string,
+  priority?: number,
+): NodeBuilder {
+  return {
+    id,
+    priority,
+    match: (value: unknown) =>
+      typeof value === 'object' &&
+      value !== null &&
+      (value as {brand?: unknown}).brand === brand,
+    build: () => new FnNode(nodeName, (_c, i) => i),
+  };
+}
+
+describe('isPlainObject', () => {
+  it('is true for object literals', () => {
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({a: 1})).toBe(true);
+    expect(isPlainObject(Object.create(null))).toBe(true);
+  });
+
+  it('is false for arrays, null, primitives and class instances', () => {
+    expect(isPlainObject([])).toBe(false);
+    expect(isPlainObject(null)).toBe(false);
+    expect(isPlainObject('x')).toBe(false);
+    expect(isPlainObject(new FnNode('n', (_c, i) => i))).toBe(false);
+  });
+});
+
+describe('isNodeLike', () => {
+  it('recognizes START and BaseNode instances', () => {
+    expect(isNodeLike('START')).toBe(true);
+    expect(isNodeLike(new FnNode('n', (_c, i) => i))).toBe(true);
+  });
+
+  it('rejects plain values with no registered builder', () => {
+    expect(isNodeLike({})).toBe(false);
+    expect(isNodeLike('nope')).toBe(false);
+  });
+
+  it('recognizes a value matched by a registered builder', () => {
+    registerNodeBuilder(sentinelBuilder('like', 'like', 'built'));
+    expect(isNodeLike(branded('like'))).toBe(true);
+  });
+});
+
+describe('buildNode', () => {
+  it('returns the START sentinel and existing nodes directly', () => {
+    expect(buildNode('START')).toBe(START);
+    const node = new FnNode('n', (_c, i) => i);
+    expect(buildNode(node)).toBe(node);
+  });
+
+  it('throws for an unsupported value', () => {
+    expect(() => buildNode(42 as unknown as BaseNode)).toThrow();
+  });
+
+  it('throws when maxParallelWorkers is set without parallelWorker', () => {
+    const node = new FnNode('n', (_c, i) => i);
+    expect(() => buildNode(node, {maxParallelWorkers: 2})).toThrow();
+  });
+
+  it('delegates to a registered builder', () => {
+    registerNodeBuilder(sentinelBuilder('build', 'build', 'built'));
+    expect(buildNode(branded('build')).name).toBe('built');
+  });
+});
+
+describe('registerNodeBuilder', () => {
+  it('is idempotent by id (re-registering replaces, not duplicates)', () => {
+    registerNodeBuilder(sentinelBuilder('dup', 'dup', 'first'));
+    registerNodeBuilder(sentinelBuilder('dup', 'dup', 'second'));
+    expect(buildNode(branded('dup')).name).toBe('second');
+  });
+
+  it('consults higher-priority builders first', () => {
+    registerNodeBuilder(sentinelBuilder('lo', 'pri', 'low', 0));
+    registerNodeBuilder(sentinelBuilder('hi', 'pri', 'high', 10));
+    expect(buildNode(branded('pri')).name).toBe('high');
+  });
+
+  it('breaks priority ties by registration order', () => {
+    registerNodeBuilder(sentinelBuilder('first', 'tie', 'first', 0));
+    registerNodeBuilder(sentinelBuilder('second', 'tie', 'second', 0));
+    expect(buildNode(branded('tie')).name).toBe('first');
+  });
+
+  it('requires an id', () => {
+    expect(() =>
+      registerNodeBuilder({
+        id: '',
+        match: () => false,
+        build: () => new FnNode('x', (_c, i) => i),
+      }),
+    ).toThrow();
+  });
+});
+
+describe('registerParallelWorkerFactory', () => {
+  it('uses the registered factory and rejects a conflicting one', () => {
+    const factory = vi.fn((inner: BaseNode) => inner);
+    registerParallelWorkerFactory(factory);
+    // Re-registering the same factory reference is a no-op.
+    expect(() => registerParallelWorkerFactory(factory)).not.toThrow();
+    // A different factory conflicts and is rejected.
+    expect(() =>
+      registerParallelWorkerFactory((inner: BaseNode) => inner),
+    ).toThrow();
+
+    const node = new FnNode('worker', (_c, i) => i);
+    const wrapped = buildNode(node, {parallelWorker: true});
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(wrapped).toBe(node);
+  });
+});

--- a/core/test/workflow/workflow_graph_utils_test.ts
+++ b/core/test/workflow/workflow_graph_utils_test.ts
@@ -4,39 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {BaseNode, START} from '../../src/workflow/base_node.js';
-import {NodeLike} from '../../src/workflow/graph.js';
 import {
   buildNode,
   isNodeLike,
   isPlainObject,
-  NodeBuilder,
-  registerNodeBuilder,
-  registerParallelWorkerFactory,
 } from '../../src/workflow/utils/workflow_graph_utils.js';
 import {FnNode} from './test_helpers.js';
-
-/** A sentinel node-like value matched by a test builder via its `brand`. */
-const branded = (brand: string): NodeLike => ({brand}) as unknown as NodeLike;
-
-/** Builds a {@link NodeBuilder} that matches `branded(brand)` and names its node. */
-function sentinelBuilder(
-  id: string,
-  brand: string,
-  nodeName: string,
-  priority?: number,
-): NodeBuilder {
-  return {
-    id,
-    priority,
-    match: (value: unknown) =>
-      typeof value === 'object' &&
-      value !== null &&
-      (value as {brand?: unknown}).brand === brand,
-    build: () => new FnNode(nodeName, (_c, i) => i),
-  };
-}
 
 describe('isPlainObject', () => {
   it('is true for object literals', () => {
@@ -59,14 +34,10 @@ describe('isNodeLike', () => {
     expect(isNodeLike(new FnNode('n', (_c, i) => i))).toBe(true);
   });
 
-  it('rejects plain values with no registered builder', () => {
+  it('rejects values no builder matches (no node types wired in the engine core)', () => {
     expect(isNodeLike({})).toBe(false);
     expect(isNodeLike('nope')).toBe(false);
-  });
-
-  it('recognizes a value matched by a registered builder', () => {
-    registerNodeBuilder(sentinelBuilder('like', 'like', 'built'));
-    expect(isNodeLike(branded('like'))).toBe(true);
+    expect(isNodeLike(42)).toBe(false);
   });
 });
 
@@ -86,56 +57,8 @@ describe('buildNode', () => {
     expect(() => buildNode(node, {maxParallelWorkers: 2})).toThrow();
   });
 
-  it('delegates to a registered builder', () => {
-    registerNodeBuilder(sentinelBuilder('build', 'build', 'built'));
-    expect(buildNode(branded('build')).name).toBe('built');
-  });
-});
-
-describe('registerNodeBuilder', () => {
-  it('is idempotent by id (re-registering replaces, not duplicates)', () => {
-    registerNodeBuilder(sentinelBuilder('dup', 'dup', 'first'));
-    registerNodeBuilder(sentinelBuilder('dup', 'dup', 'second'));
-    expect(buildNode(branded('dup')).name).toBe('second');
-  });
-
-  it('consults higher-priority builders first', () => {
-    registerNodeBuilder(sentinelBuilder('lo', 'pri', 'low', 0));
-    registerNodeBuilder(sentinelBuilder('hi', 'pri', 'high', 10));
-    expect(buildNode(branded('pri')).name).toBe('high');
-  });
-
-  it('breaks priority ties by registration order', () => {
-    registerNodeBuilder(sentinelBuilder('first', 'tie', 'first', 0));
-    registerNodeBuilder(sentinelBuilder('second', 'tie', 'second', 0));
-    expect(buildNode(branded('tie')).name).toBe('first');
-  });
-
-  it('requires an id', () => {
-    expect(() =>
-      registerNodeBuilder({
-        id: '',
-        match: () => false,
-        build: () => new FnNode('x', (_c, i) => i),
-      }),
-    ).toThrow();
-  });
-});
-
-describe('registerParallelWorkerFactory', () => {
-  it('uses the registered factory and rejects a conflicting one', () => {
-    const factory = vi.fn((inner: BaseNode) => inner);
-    registerParallelWorkerFactory(factory);
-    // Re-registering the same factory reference is a no-op.
-    expect(() => registerParallelWorkerFactory(factory)).not.toThrow();
-    // A different factory conflicts and is rejected.
-    expect(() =>
-      registerParallelWorkerFactory((inner: BaseNode) => inner),
-    ).toThrow();
-
-    const node = new FnNode('worker', (_c, i) => i);
-    const wrapped = buildNode(node, {parallelWorker: true});
-    expect(factory).toHaveBeenCalledTimes(1);
-    expect(wrapped).toBe(node);
+  it('throws when parallelWorker is requested but unavailable', () => {
+    const node = new FnNode('n', (_c, i) => i);
+    expect(() => buildNode(node, {parallelWorker: true})).toThrow();
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: https://github.com/google/adk-js/issues/366

**2. Or, if no issue exists, describe the change:**

**Problem:**
Continuing the split of the large `feature/workflows` branch into small, stacked, reviewable PRs. The workflow engine's core files form a tightly-connected import cycle (`graph → graph_parser → workflow_graph_utils → concrete node classes → base_node → node_context → graph`), which would otherwise force the entire engine and every node type to land in one giant PR.

**Solution:**
This is **Part 2 of 9** — the engine core — stacked on Part 1. It adds the execution model, the graph layer, and a **decoupling refactor** that breaks the cycle so each node family can ship as its own downstream PR.

**Stacked on:** #_part1_pr_number_ (Part 1 — events & shared primitives). Please merge Part 1 first.

Included:

- **`base_node.ts`** — the `BaseNode` abstract class and the `START` sentinel.
- **`node_context.ts` / `node_runner.ts`** — per-node execution context and the run loop (retry, timeout/cancellation, streaming via `EventChannel`).
- **`graph.ts` + `utils/graph_parser.ts` + `utils/graph_validation.ts`** — chain/edge parsing, routing maps, and structural validation (START reachability, duplicate node names/edges, `DEFAULT_ROUTE` rules, unconditional-cycle detection).
- **`schedule_dynamic_node.ts`** — the dynamic-scheduling primitive `node_context` depends on.
- **`request_input.ts` + `utils/hitl_utils.ts`** — the human-in-the-loop request primitives `BaseNode` consumes (the HITL processors/tools that use them arrive in Part 8).

**Decoupling refactor (the key change to review):**
`utils/workflow_graph_utils.ts` no longer statically imports the concrete node classes (`FunctionNode`, `ToolNode`, `ParallelWorker`, `LLMAgentWrapper`). Instead, `buildNode()` / `isNodeLike()` consult a **self-registration registry**:

- `registerNodeBuilder({match, build})` — node modules register how to build themselves from a `NodeLike` value.
- `registerParallelWorkerFactory(...)` — the parallel worker registers its wrapping behavior.
- The `'START'` sentinel and existing `BaseNode` instances remain built-in (no registration needed).

Node modules self-register at import time (added in Parts 3+); the public workflow barrel (Part 6) imports them all, so registration is guaranteed for real usage. This breaks the engine↔nodes cycle without changing observable behavior.

**Builds on Part 1's review-driven APIs:** the engine streams events through the shared `AsyncQueue` (Part 1 folded `EventChannel` into it), resolves branches via the `createSubBranch` util function, and reads `BaseNode.preparedRetryConfig` (retry config normalized once at construction) so the run loop never re-normalizes or throws mid-retry.

> Note for reviewers (follow-up in a later part): because `BaseTool` also exposes `runAsync`, the agent builder's match predicate must exclude tools so the original tool-before-agent precedence is preserved regardless of registration order. This is handled where the agent builder is added (Part 7).

**Intentionally deferred:** the `node()` user API (`node.ts`) lands with the first concrete node builders in Part 3; node/tool/parallel/agent node classes in Parts 3, 4, 7; the `node_api_test` and `routing_test` suites move to Part 6 because they require concrete nodes and the runner.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Bundled tests (28): `workflow/node_execution_test.ts`, `workflow/graph_parser_test.ts`, `workflow/graph_validation_test.ts` (plus shared `workflow/test_helpers.ts`). They exercise the engine using test-local `BaseNode` subclasses, so they validate the core without any concrete node types registered.

```
$ npx vitest run --project unit:core \
    core/test/workflow/node_execution_test.ts \
    core/test/workflow/graph_parser_test.ts \
    core/test/workflow/graph_validation_test.ts

 ✓ core/test/workflow/graph_validation_test.ts (9 tests)
 ✓ core/test/workflow/graph_parser_test.ts     (10 tests)
 ✓ core/test/workflow/node_execution_test.ts   (9 tests)

 Test Files  3 passed (3)
      Tests  28 passed (28)
```

Typecheck is clean: `npx tsc --noEmit -p core/tsconfig.json`.

**Manual End-to-End (E2E) Tests:**

N/A — no user-facing surface yet (the `node()` API and public barrel arrive in Parts 3 and 6). End-to-end coverage lands with the runner integration in Part 6.

### Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. <!-- N/A for this part; see Testing Plan -->
- [ ] Any dependent changes have been merged and published in downstream modules. <!-- depends on Part 1 -->

### Additional context
