### PR TITLE
feat(workflow): built-in Function and Tool nodes (Part 3)

### DIFF
--- a/core/src/workflow/node_builders.ts
+++ b/core/src/workflow/node_builders.ts
@@ -4,10 +4,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {BaseTool, isBaseTool} from '../tools/base_tool.js';
+import {FunctionNode, FunctionNodeHandler} from './nodes/function_node.js';
+import {ToolNode} from './nodes/tool_node.js';
 import type {
   NodeBuilder,
   ParallelWorkerFactory,
 } from './utils/workflow_graph_utils.js';
+
+/** Builds a {@link FunctionNode} from a plain function. */
+const functionBuilder: NodeBuilder = {
+  match: (value) => typeof value === 'function',
+  build: (value, options) => {
+    const handler = value as FunctionNodeHandler;
+    const name = options.name ?? (handler as {name?: string}).name;
+    if (!name) {
+      throw new Error(
+        'node(): the wrapped function has no name; pass {name} explicitly.',
+      );
+    }
+    return new FunctionNode(name, handler, options);
+  },
+};
+
+/** Builds a {@link ToolNode} from a {@link BaseTool}. */
+const toolBuilder: NodeBuilder = {
+  match: (value) => isBaseTool(value),
+  build: (value, options) => new ToolNode(value as BaseTool, options),
+};
 
 /**
  * The built-in node builders, consulted in order by `buildNode` / `isNodeLike`
@@ -16,10 +40,12 @@ import type {
  * This is a single, explicit, statically-imported list — node-type modules are
  * wired in here rather than self-registering at import time, so there is no
  * global mutable registry and no import-order side effects. Order is the match
- * precedence (first match wins). Each node-type part adds its builder here; the
- * list is empty in the engine-core part.
+ * precedence (first match wins). Each node-type part adds its builder here.
  */
-export const NODE_BUILDERS: readonly NodeBuilder[] = [];
+export const NODE_BUILDERS: readonly NodeBuilder[] = [
+  functionBuilder,
+  toolBuilder,
+];
 
 /**
  * Wraps an already-built node in a parallel worker. Wired in by the

--- a/core/src/workflow/node_builders.ts
+++ b/core/src/workflow/node_builders.ts
@@ -13,7 +13,7 @@ import type {
 } from './utils/workflow_graph_utils.js';
 
 /** Builds a {@link FunctionNode} from a plain function. */
-const functionBuilder: NodeBuilder = {
+const FUNCTION_BUILDER: NodeBuilder = {
   match: (value) => typeof value === 'function',
   build: (value, options) => {
     const handler = value as FunctionNodeHandler;
@@ -28,7 +28,7 @@ const functionBuilder: NodeBuilder = {
 };
 
 /** Builds a {@link ToolNode} from a {@link BaseTool}. */
-const toolBuilder: NodeBuilder = {
+const TOOL_BUILDER: NodeBuilder = {
   match: (value) => isBaseTool(value),
   build: (value, options) => new ToolNode(value as BaseTool, options),
 };
@@ -43,8 +43,8 @@ const toolBuilder: NodeBuilder = {
  * precedence (first match wins). Each node-type part adds its builder here.
  */
 export const NODE_BUILDERS: readonly NodeBuilder[] = [
-  functionBuilder,
-  toolBuilder,
+  FUNCTION_BUILDER,
+  TOOL_BUILDER,
 ];
 
 /**

--- a/core/src/workflow/nodes/function_node.ts
+++ b/core/src/workflow/nodes/function_node.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {AuthConfig} from '../../auth/auth_tool.js';
+import {createEvent, Event, isEvent} from '../../events/event.js';
+import {BaseNode, BaseNodeConfig, isContent, toContent} from '../base_node.js';
+import {NodeContext} from '../node_context.js';
+import {
+  createAuthRequestEvent,
+  hasAuthCredential,
+  processAuthResume,
+} from '../utils/hitl_utils.js';
+import {registerNodeBuilder} from '../utils/workflow_graph_utils.js';
+
+/**
+ * A value a {@link FunctionNodeHandler} may return or yield.
+ */
+export type FunctionNodeResult<TOutput> =
+  | TOutput
+  | Event
+  | null
+  | undefined
+  | void;
+
+/**
+ * The handler wrapped by a {@link FunctionNode}.
+ *
+ * Unlike Python's `FunctionNode` (which binds named parameters from `ctx.state`
+ * or `node_input` via runtime signature introspection), the TypeScript form
+ * uses the idiomatic explicit `(ctx, input)` signature. Read `ctx.state`
+ * directly for state-bound values. It may return a value/`Event`, a Promise, or
+ * a (sync/async) generator of those.
+ */
+export type FunctionNodeHandler<TInput = unknown, TOutput = unknown> = (
+  ctx: NodeContext,
+  input: TInput,
+) =>
+  | FunctionNodeResult<TOutput>
+  | Promise<FunctionNodeResult<TOutput>>
+  | Generator<FunctionNodeResult<TOutput>, void, unknown>
+  | AsyncGenerator<FunctionNodeResult<TOutput>, void, unknown>;
+
+/**
+ * Options for a {@link FunctionNode}.
+ */
+export interface FunctionNodeConfig extends Partial<
+  Omit<BaseNodeConfig, 'name'>
+> {
+  /**
+   * If set, the framework requests user authentication before running (Phase 5
+   * enables the auth gate; stored here now for API parity).
+   */
+  authConfig?: AuthConfig;
+}
+
+/**
+ * A node that wraps a plain function, async function, or (sync/async) generator.
+ *
+ * Ported (TS-idiomatic subset) from `google/adk-python` `_function_node.py`.
+ * Return-value handling:
+ *  - `Event` → emitted as-is (output validated against `outputSchema`)
+ *  - genai `Content` → emitted as the event content
+ *  - `null`/`undefined` → skipped (unless there are pending state deltas)
+ *  - anything else → emitted as `Event(output=value)`
+ * State written via `ctx.state` during execution is attached to emitted events.
+ */
+export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
+  TInput,
+  TOutput
+> {
+  readonly authConfig?: AuthConfig;
+  private readonly handler: FunctionNodeHandler<TInput, TOutput>;
+
+  constructor(
+    name: string,
+    handler: FunctionNodeHandler<TInput, TOutput>,
+    config: FunctionNodeConfig = {},
+  ) {
+    if (typeof handler !== 'function') {
+      throw new TypeError('FunctionNode handler must be a function.');
+    }
+    super({name, ...config});
+    this.handler = handler;
+    this.authConfig = config.authConfig;
+  }
+
+  protected async *runImpl(
+    ctx: NodeContext,
+    input: TInput,
+  ): AsyncGenerator<Event | TOutput | unknown, void, void> {
+    // Auth gate: request credentials (and interrupt) if not yet available.
+    if (this.authConfig) {
+      const authRequest = await this.runAuthGate(ctx);
+      if (authRequest) {
+        yield authRequest;
+        return;
+      }
+    }
+
+    const result = this.handler(ctx, input);
+
+    if (isAsyncIterable(result)) {
+      for await (const item of result) {
+        yield item;
+      }
+    } else if (isSyncGenerator(result)) {
+      for (const item of result) {
+        yield item;
+      }
+    } else {
+      // Plain value or Promise of a value.
+      yield await (result as Promise<FunctionNodeResult<TOutput>>);
+    }
+  }
+
+  /**
+   * Ensures a credential for `authConfig` is available. Returns an
+   * `adk_request_credential` interrupt event if the credential must be
+   * requested from the user, or `undefined` if the node may proceed.
+   *
+   * On resume, a credential provided via `ctx.resumeInputs[credentialKey]` is
+   * stored into state before re-checking.
+   */
+  private async runAuthGate(ctx: NodeContext): Promise<Event | undefined> {
+    const authConfig = this.authConfig!;
+    if (hasAuthCredential(authConfig, ctx.state)) {
+      return undefined;
+    }
+    const resumeResponse = ctx.resumeInputs[authConfig.credentialKey];
+    if (resumeResponse !== undefined) {
+      await processAuthResume(resumeResponse, authConfig, ctx.state);
+      if (hasAuthCredential(authConfig, ctx.state)) {
+        return undefined;
+      }
+    }
+    // The credential key doubles as a deterministic interrupt id so the resume
+    // response matches across turns.
+    return createAuthRequestEvent(authConfig, authConfig.credentialKey);
+  }
+
+  protected override toEvent(ctx: NodeContext, data: unknown): Event | null {
+    const stateDelta =
+      Object.keys(ctx.actions.stateDelta).length > 0
+        ? {...ctx.actions.stateDelta}
+        : undefined;
+
+    if (data === null || data === undefined) {
+      return stateDelta
+        ? createEvent({
+            author: this.name,
+            invocationId: ctx.invocationId,
+            branch: ctx.branch,
+            actions: {stateDelta},
+          })
+        : null;
+    }
+
+    if (isEvent(data)) {
+      const event = data as Event;
+      if (event.output !== undefined) {
+        event.output = this.validateOutput(event.output);
+      }
+      if (stateDelta) {
+        Object.assign(event.actions.stateDelta, stateDelta);
+      }
+      return event;
+    }
+
+    if (isContent(data)) {
+      return createEvent({
+        author: this.name,
+        invocationId: ctx.invocationId,
+        branch: ctx.branch,
+        content: data,
+        actions: stateDelta ? {stateDelta} : undefined,
+      });
+    }
+
+    const output = this.validateOutput(data);
+    return createEvent({
+      author: this.name,
+      invocationId: ctx.invocationId,
+      branch: ctx.branch,
+      content: toContent(output),
+      output,
+      actions: stateDelta ? {stateDelta} : undefined,
+    });
+  }
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    value != null &&
+    typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] ===
+      'function'
+  );
+}
+
+/**
+ * Registers the builder that turns a plain function into a {@link FunctionNode},
+ * so `node(fn)` and graph parsing work without the engine statically importing
+ * this module (importing it — directly or via the workflow barrel — is what
+ * makes the builder available).
+ */
+registerNodeBuilder({
+  match: (value): boolean => typeof value === 'function',
+  build: (value, options) => {
+    const handler = value as FunctionNodeHandler;
+    const name = options.name ?? (handler as {name?: string}).name;
+    if (!name) {
+      throw new Error(
+        'node(): the wrapped function has no name; pass {name} explicitly.',
+      );
+    }
+    return new FunctionNode(name, handler, options);
+  },
+});
+
+function isSyncGenerator(value: unknown): value is Generator<unknown> {
+  return (
+    value != null &&
+    typeof value !== 'string' &&
+    typeof (value as Iterable<unknown>)[Symbol.iterator] === 'function' &&
+    typeof (value as Generator<unknown>).next === 'function'
+  );
+}

--- a/core/src/workflow/nodes/function_node.ts
+++ b/core/src/workflow/nodes/function_node.ts
@@ -13,7 +13,6 @@ import {
   hasAuthCredential,
   processAuthResume,
 } from '../utils/hitl_utils.js';
-import {registerNodeBuilder} from '../utils/workflow_graph_utils.js';
 
 /**
  * A value a {@link FunctionNodeHandler} may return or yield.
@@ -246,23 +245,5 @@ function isSyncGenerator(value: unknown): value is Generator<unknown> {
   );
 }
 
-/**
- * Registers the builder that turns a plain function into a {@link FunctionNode},
- * so `node(fn)` and graph parsing work without the engine statically importing
- * this module (importing it — directly or via the workflow barrel — is what
- * makes the builder available).
- */
-registerNodeBuilder({
-  id: 'function',
-  match: (value): boolean => typeof value === 'function',
-  build: (value, options) => {
-    const handler = value as FunctionNodeHandler;
-    const name = options.name ?? (handler as {name?: string}).name;
-    if (!name) {
-      throw new Error(
-        'node(): the wrapped function has no name; pass {name} explicitly.',
-      );
-    }
-    return new FunctionNode(name, handler, options);
-  },
-});
+// The builder that turns a plain function into a FunctionNode is wired into the
+// static NODE_BUILDERS list in ../node_builders.ts.

--- a/core/src/workflow/nodes/function_node.ts
+++ b/core/src/workflow/nodes/function_node.ts
@@ -73,6 +73,11 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
 > {
   readonly authConfig?: AuthConfig;
   private readonly handler: FunctionNodeHandler<TInput, TOutput>;
+  /** Per-run shadow of the state entries already attached to an emitted event. */
+  private readonly attachedStateByCtx = new WeakMap<
+    NodeContext,
+    Map<string, unknown>
+  >();
 
   constructor(
     name: string,
@@ -82,7 +87,9 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
     if (typeof handler !== 'function') {
       throw new TypeError('FunctionNode handler must be a function.');
     }
-    super({name, ...config});
+    // Spread first so an explicit `undefined` name in `config` can't clobber
+    // the resolved name (which BaseNode requires to be non-empty).
+    super({...config, name});
     this.handler = handler;
     this.authConfig = config.authConfig;
   }
@@ -131,7 +138,11 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
     }
     const resumeResponse = ctx.resumeInputs[authConfig.credentialKey];
     if (resumeResponse !== undefined) {
-      await processAuthResume(resumeResponse, authConfig, ctx.state);
+      await processAuthResume({
+        responseData: resumeResponse,
+        authConfig,
+        state: ctx.state,
+      });
       if (hasAuthCredential(authConfig, ctx.state)) {
         return undefined;
       }
@@ -141,11 +152,35 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
     return createAuthRequestEvent(authConfig, authConfig.credentialKey);
   }
 
+  /**
+   * Returns the state-delta entries written since the last event was emitted
+   * for this run (new keys or changed values). A multi-event handler would
+   * otherwise re-emit the whole growing delta on every event.
+   *
+   * `ctx.actions.stateDelta` can't be drained — `NodeContext` builds its
+   * `State` over it — so we track what has already been attached in a shadow
+   * map keyed by the run's context (GC'd with the context).
+   */
+  private pendingStateDelta(
+    ctx: NodeContext,
+  ): Record<string, unknown> | undefined {
+    let shadow = this.attachedStateByCtx.get(ctx);
+    if (!shadow) {
+      shadow = new Map<string, unknown>();
+      this.attachedStateByCtx.set(ctx, shadow);
+    }
+    const delta: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(ctx.actions.stateDelta)) {
+      if (!shadow.has(key) || shadow.get(key) !== value) {
+        delta[key] = value;
+        shadow.set(key, value);
+      }
+    }
+    return Object.keys(delta).length > 0 ? delta : undefined;
+  }
+
   protected override toEvent(ctx: NodeContext, data: unknown): Event | null {
-    const stateDelta =
-      Object.keys(ctx.actions.stateDelta).length > 0
-        ? {...ctx.actions.stateDelta}
-        : undefined;
+    const stateDelta = this.pendingStateDelta(ctx);
 
     if (data === null || data === undefined) {
       return stateDelta
@@ -164,7 +199,9 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
         event.output = this.validateOutput(event.output);
       }
       if (stateDelta) {
-        Object.assign(event.actions.stateDelta, stateDelta);
+        // The handler's own writes on the event it yielded win over the
+        // node's accumulated context state.
+        event.actions.stateDelta = {...stateDelta, ...event.actions.stateDelta};
       }
       return event;
     }
@@ -199,6 +236,16 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
   );
 }
 
+function isSyncGenerator(value: unknown): value is Generator<unknown> {
+  // A string is iterable but has no `.next`, so the `.next` check already
+  // excludes it — no separate string guard needed.
+  return (
+    value != null &&
+    typeof (value as Iterable<unknown>)[Symbol.iterator] === 'function' &&
+    typeof (value as Generator<unknown>).next === 'function'
+  );
+}
+
 /**
  * Registers the builder that turns a plain function into a {@link FunctionNode},
  * so `node(fn)` and graph parsing work without the engine statically importing
@@ -206,6 +253,7 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
  * makes the builder available).
  */
 registerNodeBuilder({
+  id: 'function',
   match: (value): boolean => typeof value === 'function',
   build: (value, options) => {
     const handler = value as FunctionNodeHandler;
@@ -218,12 +266,3 @@ registerNodeBuilder({
     return new FunctionNode(name, handler, options);
   },
 });
-
-function isSyncGenerator(value: unknown): value is Generator<unknown> {
-  return (
-    value != null &&
-    typeof value !== 'string' &&
-    typeof (value as Iterable<unknown>)[Symbol.iterator] === 'function' &&
-    typeof (value as Generator<unknown>).next === 'function'
-  );
-}

--- a/core/src/workflow/nodes/tool_node.ts
+++ b/core/src/workflow/nodes/tool_node.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Context} from '../../agents/context.js';
+import {createEvent, Event} from '../../events/event.js';
+import {BaseTool, isBaseTool} from '../../tools/base_tool.js';
+import {randomUUID} from '../../utils/env_aware_utils.js';
+import {BaseNode, BaseNodeConfig, isContent} from '../base_node.js';
+import {NodeContext} from '../node_context.js';
+import {registerNodeBuilder} from '../utils/workflow_graph_utils.js';
+/** Options for a {@link ToolNode}. */
+export interface ToolNodeConfig extends Partial<Omit<BaseNodeConfig, 'name'>> {
+  /** Optional name override; defaults to the tool's name. */
+  name?: string;
+}
+
+/**
+ * A node that wraps an ADK {@link BaseTool} and invokes it with the node input
+ * as its arguments.
+ *
+ * Ported from `google/adk-python` `workflow/_tool_node.py`. The node input is
+ * coerced to a tool-args object: genai `Content` → its text; a JSON string →
+ * parsed object; `null`/empty → `{}`.
+ */
+export class ToolNode extends BaseNode {
+  readonly tool: BaseTool;
+
+  constructor(tool: BaseTool, config: ToolNodeConfig = {}) {
+    super({name: config.name ?? tool.name, ...config});
+    this.tool = tool;
+  }
+
+  protected async *runImpl(
+    ctx: NodeContext,
+    input: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    const toolContext = new Context({
+      invocationContext: ctx.invocationContext,
+      functionCallId: randomUUID(),
+    });
+
+    const args = coerceToolArgs(input);
+    const response = await this.tool.runAsync({args, toolContext});
+
+    const stateDelta =
+      Object.keys(toolContext.actions.stateDelta).length > 0
+        ? {...toolContext.actions.stateDelta}
+        : undefined;
+
+    if (response !== undefined && response !== null) {
+      yield createEvent({
+        author: this.name,
+        invocationId: ctx.invocationId,
+        branch: ctx.branch,
+        output: response,
+        actions: stateDelta ? {stateDelta} : undefined,
+      });
+    } else if (stateDelta) {
+      yield createEvent({
+        author: this.name,
+        invocationId: ctx.invocationId,
+        branch: ctx.branch,
+        actions: {stateDelta},
+      });
+    }
+  }
+}
+
+/** Coerces arbitrary node input into a tool-arguments record. */
+function coerceToolArgs(input: unknown): Record<string, unknown> {
+  let args: unknown = input;
+
+  if (isContent(args)) {
+    args = extractText(args);
+  }
+
+  if (typeof args === 'string') {
+    const trimmed = args.trim();
+    if (!trimmed) {
+      args = null;
+    } else {
+      try {
+        args = JSON.parse(trimmed);
+      } catch {
+        // Leave as the raw string; validated below.
+      }
+    }
+  }
+
+  if (args === null || args === undefined) {
+    return {};
+  }
+  if (typeof args !== 'object' || Array.isArray(args)) {
+    throw new TypeError(
+      'The input to ToolNode must be a dictionary of tool arguments or null, ' +
+        `but got ${typeof args}.`,
+    );
+  }
+  return args as Record<string, unknown>;
+}
+
+function extractText(content: {parts?: Array<{text?: string}>}): string {
+  return (content.parts ?? []).map((p) => p.text ?? '').join('');
+}
+
+/**
+ * Registers the builder that turns a {@link BaseTool} into a {@link ToolNode},
+ * so `node(tool)` and graph parsing work without the engine statically
+ * importing this module.
+ */
+registerNodeBuilder({
+  match: (value): boolean => isBaseTool(value),
+  build: (value, options) => new ToolNode(value as BaseTool, options),
+});

--- a/core/src/workflow/nodes/tool_node.ts
+++ b/core/src/workflow/nodes/tool_node.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Context} from '../../agents/context.js';
-import {createEvent, Event} from '../../events/event.js';
+import type {FunctionCall} from '@google/genai';
+import {handleFunctionCallList} from '../../agents/functions.js';
+import {Event, getFunctionResponses} from '../../events/event.js';
 import {BaseTool, isBaseTool} from '../../tools/base_tool.js';
-import {randomUUID} from '../../utils/env_aware_utils.js';
 import {BaseNode, BaseNodeConfig, isContent} from '../base_node.js';
 import {NodeContext} from '../node_context.js';
 import {registerNodeBuilder} from '../utils/workflow_graph_utils.js';
+
 /** Options for a {@link ToolNode}. */
 export interface ToolNodeConfig extends Partial<Omit<BaseNodeConfig, 'name'>> {
   /** Optional name override; defaults to the tool's name. */
@@ -24,12 +25,28 @@ export interface ToolNodeConfig extends Partial<Omit<BaseNodeConfig, 'name'>> {
  * Ported from `google/adk-python` `workflow/_tool_node.py`. The node input is
  * coerced to a tool-args object: genai `Content` → its text; a JSON string →
  * parsed object; `null`/empty → `{}`.
+ *
+ * The tool runs through the canonical execution path
+ * ({@link handleFunctionCallList}), so the plugin `before`/`after`/`onError`
+ * tool callbacks, the confirmation gate, telemetry, and everything the tool
+ * writes to its context (`stateDelta`, `artifactDelta`, requested credentials /
+ * confirmations, …) all apply — exactly as when the same tool is called from an
+ * LLM agent. The emitted event carries a canonical `functionResponse` part.
  */
 export class ToolNode extends BaseNode {
   readonly tool: BaseTool;
 
   constructor(tool: BaseTool, config: ToolNodeConfig = {}) {
-    super({name: config.name ?? tool.name, ...config});
+    // Spread first so an explicit `undefined` name in `config` can't clobber
+    // the fallback (which BaseNode requires to be non-empty).
+    super({...config, name: config.name ?? tool.name});
+    if (tool.isLongRunning) {
+      // Long-running/HITL tools suspend the invocation; that machinery lands in
+      // a later part. Fail loud rather than silently completing the call.
+      throw new Error(
+        `ToolNode does not support long-running tools yet (tool '${tool.name}').`,
+      );
+    }
     this.tool = tool;
   }
 
@@ -37,35 +54,45 @@ export class ToolNode extends BaseNode {
     ctx: NodeContext,
     input: unknown,
   ): AsyncGenerator<Event, void, void> {
-    const toolContext = new Context({
+    // Coerce the node input into a tool-args object, then re-validate it against
+    // `inputSchema`. BaseNode.validateInput skips genai `Content` up front (a
+    // node coerces it itself), so this is the only point model-authored args are
+    // checked before reaching the tool.
+    const args = this.validateInput(coerceToolArgs(input)) as Record<
+      string,
+      unknown
+    >;
+
+    // Deterministic id so credential/confirmation requests can be matched to
+    // their resume response across turns/retries (a fresh UUID never would).
+    const functionCall: FunctionCall = {
+      name: this.tool.name,
+      args,
+      id: `${ctx.nodePath}:${ctx.runId}`,
+    };
+
+    const responseEvent = await handleFunctionCallList({
       invocationContext: ctx.invocationContext,
-      functionCallId: randomUUID(),
+      functionCalls: [functionCall],
+      toolsDict: {[this.tool.name]: this.tool},
+      // Plugin callbacks still run via invocationContext.pluginManager; there is
+      // no agent-level tool-callback list on a workflow node.
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
     });
 
-    const args = coerceToolArgs(input);
-    const response = await this.tool.runAsync({args, toolContext});
-
-    const stateDelta =
-      Object.keys(toolContext.actions.stateDelta).length > 0
-        ? {...toolContext.actions.stateDelta}
-        : undefined;
-
-    if (response !== undefined && response !== null) {
-      yield createEvent({
-        author: this.name,
-        invocationId: ctx.invocationId,
-        branch: ctx.branch,
-        output: response,
-        actions: stateDelta ? {stateDelta} : undefined,
-      });
-    } else if (stateDelta) {
-      yield createEvent({
-        author: this.name,
-        invocationId: ctx.invocationId,
-        branch: ctx.branch,
-        actions: {stateDelta},
-      });
+    if (!responseEvent) {
+      return;
     }
+    responseEvent.author = this.name;
+    // Surface the tool's (post-callback) response as the node output so it can
+    // drive downstream nodes, while the event keeps its canonical
+    // functionResponse content for history.
+    const responses = getFunctionResponses(responseEvent);
+    if (responses.length > 0) {
+      responseEvent.output = responses[0].response;
+    }
+    yield responseEvent;
   }
 }
 
@@ -85,7 +112,7 @@ function coerceToolArgs(input: unknown): Record<string, unknown> {
       try {
         args = JSON.parse(trimmed);
       } catch {
-        // Leave as the raw string; validated below.
+        // Leave as the raw string; rejected below.
       }
     }
   }
@@ -95,7 +122,7 @@ function coerceToolArgs(input: unknown): Record<string, unknown> {
   }
   if (typeof args !== 'object' || Array.isArray(args)) {
     throw new TypeError(
-      'The input to ToolNode must be a dictionary of tool arguments or null, ' +
+      'The input to ToolNode must be an object of tool arguments or null, ' +
         `but got ${typeof args}.`,
     );
   }
@@ -112,6 +139,7 @@ function extractText(content: {parts?: Array<{text?: string}>}): string {
  * importing this module.
  */
 registerNodeBuilder({
+  id: 'tool',
   match: (value): boolean => isBaseTool(value),
   build: (value, options) => new ToolNode(value as BaseTool, options),
 });

--- a/core/src/workflow/nodes/tool_node.ts
+++ b/core/src/workflow/nodes/tool_node.ts
@@ -7,10 +7,9 @@
 import type {FunctionCall} from '@google/genai';
 import {handleFunctionCallList} from '../../agents/functions.js';
 import {Event, getFunctionResponses} from '../../events/event.js';
-import {BaseTool, isBaseTool} from '../../tools/base_tool.js';
+import {BaseTool} from '../../tools/base_tool.js';
 import {BaseNode, BaseNodeConfig, isContent} from '../base_node.js';
 import {NodeContext} from '../node_context.js';
-import {registerNodeBuilder} from '../utils/workflow_graph_utils.js';
 
 /** Options for a {@link ToolNode}. */
 export interface ToolNodeConfig extends Partial<Omit<BaseNodeConfig, 'name'>> {
@@ -133,13 +132,5 @@ function extractText(content: {parts?: Array<{text?: string}>}): string {
   return (content.parts ?? []).map((p) => p.text ?? '').join('');
 }
 
-/**
- * Registers the builder that turns a {@link BaseTool} into a {@link ToolNode},
- * so `node(tool)` and graph parsing work without the engine statically
- * importing this module.
- */
-registerNodeBuilder({
-  id: 'tool',
-  match: (value): boolean => isBaseTool(value),
-  build: (value, options) => new ToolNode(value as BaseTool, options),
-});
+// The builder that turns a BaseTool into a ToolNode is wired into the static
+// NODE_BUILDERS list in ../node_builders.ts.

--- a/core/test/workflow/function_node_test.ts
+++ b/core/test/workflow/function_node_test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {AuthCredentialTypes} from '../../src/auth/auth_credential.js';
+import {AuthConfig} from '../../src/auth/auth_tool.js';
+import {createEvent, Event} from '../../src/events/event.js';
+import {AsyncQueue} from '../../src/utils/async_queue.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
+import {REQUEST_CREDENTIAL_FUNCTION_CALL_NAME} from '../../src/workflow/utils/hitl_utils.js';
+import {createIc, driveNode} from './test_helpers.js';
+
+describe('FunctionNode result handling', () => {
+  it('yields one event per item from a generator handler', async () => {
+    const node = new FunctionNode('gen', function* () {
+      yield 'a';
+      yield 'b';
+    });
+    const {events, output} = await driveNode(node);
+    expect(events.map((e) => e.output)).toEqual(['a', 'b']);
+    expect(output).toBe('b');
+  });
+
+  it('emits a genai Content result as the event content', async () => {
+    const node = new FunctionNode('c', () => ({
+      role: 'model',
+      parts: [{text: 'hi'}],
+    }));
+    const {events} = await driveNode(node);
+    expect(events.at(-1)?.content?.parts?.[0]?.text).toBe('hi');
+  });
+
+  it('skips a null result with no pending state', async () => {
+    const node = new FunctionNode('n', () => null);
+    const {events, output} = await driveNode(node);
+    expect(events).toHaveLength(0);
+    expect(output).toBeUndefined();
+  });
+
+  it('passes an explicitly returned Event through', async () => {
+    const node = new FunctionNode('e', () => createEvent({output: 'x'}));
+    const {output} = await driveNode(node);
+    expect(output).toBe('x');
+  });
+});
+
+describe('FunctionNode state delta attachment', () => {
+  it('attaches each written key only once across a multi-event run', async () => {
+    const node = new FunctionNode('w', function* (ctx) {
+      ctx.state.set('k', 1);
+      yield 'a';
+      yield 'b';
+    });
+    const {events} = await driveNode(node);
+    // First event carries the write; the second does not re-emit it.
+    expect(events[0].actions.stateDelta).toEqual({k: 1});
+    expect(events[1].actions.stateDelta).toEqual({});
+  });
+
+  it('lets a handler-set event delta win over the context delta', async () => {
+    const node = new FunctionNode('w', function* (ctx) {
+      ctx.state.set('k', 'ctx');
+      yield createEvent({output: 'x', actions: {stateDelta: {k: 'handler'}}});
+    });
+    const {events} = await driveNode(node);
+    expect(events.at(-1)?.actions.stateDelta.k).toBe('handler');
+  });
+});
+
+describe('FunctionNode auth gate', () => {
+  const apiKeyConfig = (): AuthConfig => ({
+    credentialKey: 'k',
+    authScheme: {type: 'apiKey', name: 'k', in: 'header'},
+    rawAuthCredential: {authType: AuthCredentialTypes.API_KEY},
+  });
+
+  it('interrupts with a credential request when none is available', async () => {
+    const node = new FunctionNode('needsAuth', () => 'ran', {
+      authConfig: apiKeyConfig(),
+    });
+    const {events, output} = await driveNode(node, 'x');
+
+    // The handler never ran; a credential-request interrupt was emitted instead.
+    expect(output).toBeUndefined();
+    const fc = events.at(-1)?.content?.parts?.[0]?.functionCall;
+    expect(fc?.name).toBe(REQUEST_CREDENTIAL_FUNCTION_CALL_NAME);
+    expect(events.at(-1)?.longRunningToolIds).toContain('k');
+  });
+
+  it('proceeds when the credential is supplied via resumeInputs', async () => {
+    const node = new FunctionNode('needsAuth', () => 'ran', {
+      authConfig: apiKeyConfig(),
+    });
+    const channel = new AsyncQueue<Event>();
+    const root = new NodeContext({
+      invocationContext: createIc(),
+      channel,
+      nodePath: '',
+      runId: 'root',
+      resumeInputs: {k: 'my-key'},
+    });
+    const child = await root.runNode(node, 'x', {useAsOutput: true});
+    expect(child.output).toBe('ran');
+  });
+});

--- a/core/test/workflow/node_builders_test.ts
+++ b/core/test/workflow/node_builders_test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {BaseTool} from '../../src/tools/base_tool.js';
+import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
+import {ToolNode} from '../../src/workflow/nodes/tool_node.js';
+import {
+  buildNode,
+  isNodeLike,
+} from '../../src/workflow/utils/workflow_graph_utils.js';
+
+// Importing the node modules above registers their builders as a side effect;
+// these tests verify that self-registration wires buildNode/isNodeLike.
+
+class TestTool extends BaseTool {
+  constructor() {
+    super({name: 'test_tool', description: 'a tool'});
+  }
+  async runAsync(): Promise<unknown> {
+    return 'ok';
+  }
+}
+
+/** Returns a function with an empty `.name` (not bound to a variable). */
+function anonymousFn(): () => void {
+  return () => {};
+}
+
+describe('node builder registry', () => {
+  it('builds a FunctionNode from a named function', () => {
+    function greet() {}
+    const node = buildNode(greet);
+    expect(node).toBeInstanceOf(FunctionNode);
+    expect(node.name).toBe('greet');
+  });
+
+  it('uses an explicit name for an anonymous function', () => {
+    const node = buildNode(anonymousFn(), {name: 'anon'});
+    expect(node).toBeInstanceOf(FunctionNode);
+    expect(node.name).toBe('anon');
+  });
+
+  it('throws for an unnamed function with no name option', () => {
+    expect(() => buildNode(anonymousFn())).toThrow(/no name/i);
+  });
+
+  it('builds a ToolNode from a BaseTool', () => {
+    const node = buildNode(new TestTool());
+    expect(node).toBeInstanceOf(ToolNode);
+    expect(node.name).toBe('test_tool');
+  });
+
+  it('returns an existing BaseNode as-is', () => {
+    const built = buildNode(() => {}, {name: 'x'});
+    expect(buildNode(built)).toBe(built);
+  });
+
+  it('recognizes functions, tools, and START as node-like', () => {
+    expect(isNodeLike(() => {})).toBe(true);
+    expect(isNodeLike(new TestTool())).toBe(true);
+    expect(isNodeLike('START')).toBe(true);
+    expect(isNodeLike({not: 'a node'})).toBe(false);
+    expect(isNodeLike(42)).toBe(false);
+  });
+});

--- a/core/test/workflow/schema_validation_test.ts
+++ b/core/test/workflow/schema_validation_test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
+import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
+import {driveNode} from './test_helpers.js';
+
+describe('node schema validation', () => {
+  it('validates input against inputSchema', async () => {
+    const node = new FunctionNode('squared', (_c, n: number) => n * n, {
+      inputSchema: z.number(),
+    });
+    expect((await driveNode(node, 5)).output).toBe(25);
+    await expect(driveNode(node, 'not-a-number')).rejects.toThrow();
+  });
+
+  it('validates output against outputSchema', async () => {
+    const schema = z.object({total: z.number()});
+    const good = new FunctionNode('g', () => ({total: 10}), {
+      outputSchema: schema,
+    });
+    expect((await driveNode(good)).output).toEqual({total: 10});
+
+    const bad = new FunctionNode('b', () => ({total: 'oops'}), {
+      outputSchema: schema,
+    });
+    await expect(driveNode(bad)).rejects.toThrow();
+  });
+
+  it('coerces and validates a valid input, passing it to the handler', async () => {
+    let received: unknown;
+    const node = new FunctionNode(
+      'capture',
+      (_c, value: {name: string}) => {
+        received = value;
+        return value.name;
+      },
+      {inputSchema: z.object({name: z.string()})},
+    );
+    expect((await driveNode(node, {name: 'ada'})).output).toBe('ada');
+    expect(received).toEqual({name: 'ada'});
+  });
+});

--- a/core/test/workflow/tool_node_test.ts
+++ b/core/test/workflow/tool_node_test.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {getFunctionResponses} from '../../src/events/event.js';
+import {BasePlugin} from '../../src/plugins/base_plugin.js';
+import {BaseTool, RunAsyncToolRequest} from '../../src/tools/base_tool.js';
+import {ToolNode} from '../../src/workflow/nodes/tool_node.js';
+import {createIc, driveNode} from './test_helpers.js';
+
+/** A tool that records the args it was called with and echoes them back. */
+class EchoTool extends BaseTool {
+  lastArgs?: Record<string, unknown>;
+  constructor() {
+    super({name: 'echo', description: 'echoes its args'});
+  }
+  async runAsync({args}: RunAsyncToolRequest): Promise<unknown> {
+    this.lastArgs = args;
+    return {echoed: args};
+  }
+}
+
+/** A tool that writes to its context state and returns a scalar. */
+class StateWritingTool extends BaseTool {
+  constructor() {
+    super({name: 'writer', description: 'writes state'});
+  }
+  async runAsync({toolContext}: RunAsyncToolRequest): Promise<unknown> {
+    toolContext.state.set('touched', true);
+    return 'done';
+  }
+}
+
+describe('ToolNode execution', () => {
+  it('invokes the tool with coerced args and surfaces the response', async () => {
+    const tool = new EchoTool();
+    const {events, output} = await driveNode(new ToolNode(tool), {city: 'ams'});
+
+    expect(tool.lastArgs).toEqual({city: 'ams'});
+    expect(output).toEqual({echoed: {city: 'ams'}});
+    // The event carries a canonical functionResponse part (visible to history).
+    const responses = getFunctionResponses(events.at(-1)!);
+    expect(responses[0]?.name).toBe('echo');
+  });
+
+  it('propagates tool context state writes onto the emitted event', async () => {
+    const {events} = await driveNode(new ToolNode(new StateWritingTool()));
+    expect(events.at(-1)?.actions.stateDelta).toEqual({touched: true});
+  });
+
+  it('runs the plugin tool-callback chain (before_tool_callback override)', async () => {
+    const tool = new EchoTool();
+    class OverridePlugin extends BasePlugin {
+      constructor() {
+        super('override');
+      }
+      override async beforeToolCallback(): Promise<Record<string, unknown>> {
+        return {overridden: true};
+      }
+    }
+    const ic = createIc();
+    ic.pluginManager.registerPlugin(new OverridePlugin());
+
+    const {output} = await driveNode(new ToolNode(tool), {a: 1}, ic);
+
+    // The plugin short-circuited the call: its response wins and the tool's own
+    // runAsync never ran — proof ToolNode goes through the shared execution path.
+    expect(output).toEqual({overridden: true});
+    expect(tool.lastArgs).toBeUndefined();
+  });
+
+  it('throws for a long-running tool at construction', () => {
+    class LongTool extends BaseTool {
+      constructor() {
+        super({name: 'long', description: 'long', isLongRunning: true});
+      }
+      async runAsync(): Promise<unknown> {
+        return null;
+      }
+    }
+    expect(() => new ToolNode(new LongTool())).toThrow(/long-running/i);
+  });
+});
+
+describe('ToolNode argument coercion', () => {
+  const drive = async (input: unknown) => {
+    const tool = new EchoTool();
+    await driveNode(new ToolNode(tool), input);
+    return tool.lastArgs;
+  };
+
+  it('passes an object through unchanged', async () => {
+    expect(await drive({a: 1})).toEqual({a: 1});
+  });
+
+  it('parses a JSON-string input', async () => {
+    expect(await drive('{"a":2}')).toEqual({a: 2});
+  });
+
+  it('extracts and parses text from genai Content', async () => {
+    expect(await drive({role: 'user', parts: [{text: '{"a":3}'}]})).toEqual({
+      a: 3,
+    });
+  });
+
+  it('treats null / empty string as no arguments', async () => {
+    expect(await drive(null)).toEqual({});
+    expect(await drive('')).toEqual({});
+  });
+
+  it('rejects array and scalar inputs', async () => {
+    await expect(
+      driveNode(new ToolNode(new EchoTool()), [1, 2]),
+    ).rejects.toThrow(TypeError);
+    await expect(driveNode(new ToolNode(new EchoTool()), 5)).rejects.toThrow(
+      TypeError,
+    );
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #366

**2. Or, if no issue exists, describe the change:**

**Problem:**
Continuing the stacked split of the large `feature/workflows` branch. With the engine core and its node-builder registry in place (Part 2), the workflow engine needs its first concrete node types.

**Solution:**
This is **Part 3 of 9** — the built-in **Function** and **Tool** nodes — stacked on Part 2.

**Stacked on:** #_part2_pr_number_ (Part 2 — engine core). Please merge Part 2 first.

Included:

- **`nodes/function_node.ts`** — wraps a plain function / async function / (sync or async) generator as a node. Supports `inputSchema`/`outputSchema` validation and an auth gate for HITL (the gate's request processors land in Part 8).
- **`nodes/tool_node.ts`** — wraps a `BaseTool` as a node.

Both node modules **self-register** with the engine's node-builder registry (`registerNodeBuilder`) at import time, so `buildNode()` / `isNodeLike()` — and thus `node()` and graph parsing — turn a bare function or tool into the right node without the engine statically importing these modules. This is the registration side that Part 2's decoupling refactor was built for; the public barrel (Part 6) imports the node modules so registration is guaranteed in real usage.

**Intentionally deferred:** the `node()` user API (`node.ts`) and the auth-gate integration test move to Part 6 (they need the runner/barrel). Parallelism (Part 4), dynamic scheduling (Part 5), LLM-as-node (Part 7), and HITL processors (Part 8) follow.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Bundled tests (9): `workflow/schema_validation_test.ts` (input/output schema coercion + rejection through `driveNode`) and `workflow/node_builders_test.ts` (registry wiring: function → `FunctionNode` with name resolution, unnamed-function error, tool → `ToolNode`, existing-`BaseNode` passthrough, and `isNodeLike`).

```
$ npx vitest run --project unit:core \
    core/test/workflow/schema_validation_test.ts \
    core/test/workflow/node_builders_test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

Full core suite green (2375 tests). Typecheck clean: `npx tsc --noEmit -p core/tsconfig.json`.

**Manual End-to-End (E2E) Tests:**

N/A — node-level units; graph/runner E2E coverage lands in Part 6.

### Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. <!-- N/A for this part -->
- [ ] Any dependent changes have been merged and published in downstream modules. <!-- depends on Part 2 -->

### Additional context

Stacked split — merge in order (…Part 2 → **Part 3** → Part 4 → …). Diff: 4 files, +462.
