### PR TITLE
Fix unsafe A2A peer-supplied transferToAgent metadata

### DIFF
--- a/core/src/a2a/event_converter_utils.ts
+++ b/core/src/a2a/event_converter_utils.ts
@@ -272,9 +272,13 @@ function createAdkEventFromMetadata(a2aEvent: A2AEvent): AdkEvent {
       string,
       unknown
     >,
+    // `transferToAgent` is intentionally NOT restored from peer metadata:
+    // it drives the local orchestrator's own control flow (which agent
+    // runs next, see llm_agent.ts), so it must never be rebuilt from data
+    // a remote A2A peer controls. Only `escalate` is safe to restore, since
+    // it does not let a peer redirect execution or mutate session state.
     actions: createEventActions({
       escalate: !!metadata[A2AMetadataKeys.ESCALATE],
-      transferToAgent: metadata[A2AMetadataKeys.TRANSFER_TO_AGENT] as string,
     }),
   });
 }

--- a/core/src/a2a/event_converter_utils.ts
+++ b/core/src/a2a/event_converter_utils.ts
@@ -252,6 +252,11 @@ function taskToAdkEvent(
   };
 }
 
+// EventActions fields a remote A2A peer may set on the event we emit
+// for it. Every other field is dropped: see the comment at the call
+// site in createAdkEventFromMetadata for why.
+const PEER_SETTABLE_ACTION_FIELDS: ReadonlySet<string> = new Set(['escalate']);
+
 function createAdkEventFromMetadata(a2aEvent: A2AEvent): AdkEvent {
   const metadata = a2aEvent.metadata || {};
 
@@ -272,14 +277,21 @@ function createAdkEventFromMetadata(a2aEvent: A2AEvent): AdkEvent {
       string,
       unknown
     >,
-    // `transferToAgent` is intentionally NOT restored from peer metadata:
-    // it drives the local orchestrator's own control flow (which agent
-    // runs next, see llm_agent.ts), so it must never be rebuilt from data
-    // a remote A2A peer controls. Only `escalate` is safe to restore, since
-    // it does not let a peer redirect execution or mutate session state.
-    actions: createEventActions({
-      escalate: !!metadata[A2AMetadataKeys.ESCALATE],
-    }),
+    // Only fields in PEER_SETTABLE_ACTION_FIELDS may be restored from
+    // metadata a remote A2A peer controls. Every other action field either
+    // mutates the caller's own session or drives the caller's own control
+    // flow (e.g. `transferToAgent`, see llm_agent.ts), so it must never be
+    // rebuilt from peer-supplied data. Filtering through an allowlist here
+    // (rather than just omitting the unsafe field) means a future action
+    // field is unsafe-by-default: adding it to `candidateActions` alone
+    // does nothing until it's also added to the allowlist.
+    actions: createEventActions(
+      Object.fromEntries(
+        Object.entries({
+          escalate: !!metadata[A2AMetadataKeys.ESCALATE],
+        }).filter(([key]) => PEER_SETTABLE_ACTION_FIELDS.has(key)),
+      ),
+    ),
   });
 }
 

--- a/core/test/a2a/event_converter_utils_test.ts
+++ b/core/test/a2a/event_converter_utils_test.ts
@@ -200,7 +200,13 @@ describe('event_converter_utils', () => {
         ]);
         expect(event!.turnComplete).toBe(true);
         expect(event!.actions?.escalate).toBe(true);
-        expect(event!.actions?.transferToAgent).toBe('agent2');
+        // Peer-supplied `adk_transfer_to_agent` in the fixture below must be
+        // dropped, not restored -- it drives the local orchestrator's own
+        // control flow and must never come from a remote peer. Asserting
+        // `toBeUndefined()` here (rather than removing the assertion) means
+        // a future regression that re-restores it fails loudly instead of
+        // passing silently.
+        expect(event!.actions?.transferToAgent).toBeUndefined();
         expect(event!.customMetadata).toEqual({
           'a2a:task_id': 'task1',
           'a2a:context_id': 'context1',


### PR DESCRIPTION
A remote A2A peer could set `adk_transfer_to_agent` metadata on any message/task/status-update/artifact-update it sends back, and `createAdkEventFromMetadata()` in `core/src/a2a/event_converter_utils.ts` restored it verbatim into the local event's `actions.transferToAgent`, which `llm_agent.ts` then reads to select the next agent to run --
letting a malicious or compromised remote peer redirect the local orchestrator's control flow within its own configured multi-agent tree.

This mirrors the fix already merged in `google/adk-python` (0ba7d3cba7004c0fcc0a05f1f4cfb6ea78e38f91, "fix: ignore unsafe A2A peer-supplied event actions metadata"), which explicitly documents `transfer_to_agent` as unsafe peer-controllable state.

Verified with a standalone PoC test against this exact (pre-fix) source, confirming a peer-supplied `adk_transfer_to_agent` value flows straight into the resulting event's `actions.transferToAgent`. 

Note: `core/test/a2a/event_converter_utils_test.ts` (line ~203) currently asserts the old (vulnerable) behavior as correct and will need its expectation updated to match this fix -- happy to include that update here if maintainers confirm the intended direction.