### PR TITLE
fix(core): fall back to node:crypto so randomUUID cannot throw on Node

### DIFF
--- a/core/build.js
+++ b/core/build.js
@@ -53,6 +53,7 @@ function build({
   if (platform === 'browser' && bundle) {
     buildOptions.alias = {
       'node:async_hooks': './src/utils/async_hooks_shim.ts',
+      'node:crypto': './src/utils/crypto_shim.ts',
     };
   }
 

--- a/core/src/utils/crypto_shim.ts
+++ b/core/src/utils/crypto_shim.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Browser stand-in for the `node:crypto` builtin, wired up by the alias in
+ * `build.js` so that the Node fallback in `env_aware_utils.ts` does not pull a
+ * Node builtin into the web bundle.
+ *
+ * `randomUUID` is reached here only after both `globalThis.crypto` branches in
+ * `env_aware_utils.ts` have been ruled out. In a browser that means the Web
+ * Crypto API is genuinely absent, so there is no secure source left to fall
+ * back to and the only correct move is to fail rather than degrade.
+ */
+export function randomUUID(): string {
+  throw new Error(
+    'randomUUID: no cryptographically secure source of randomness is ' +
+      'available. Neither crypto.randomUUID() nor crypto.getRandomValues() is ' +
+      'present in this environment.',
+  );
+}

--- a/core/src/utils/env_aware_utils.ts
+++ b/core/src/utils/env_aware_utils.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {randomUUID as nodeRandomUUID} from 'node:crypto';
+
 /**
  * Returns true if the environment is a browser.
  */
@@ -18,6 +20,13 @@ export function isBrowser() {
  * plain-HTTP origins even though `crypto` itself is present.
  * `crypto.getRandomValues()` carries no such restriction, so it is used as the
  * fallback rather than `Math.random()`.
+ *
+ * In Node the `globalThis.crypto` global was added in v17.4.0 and stayed behind
+ * `--experimental-global-webcrypto` until v19.0.0, so neither of those branches
+ * matches on a default Node 18 or earlier. `node:crypto` carries no such gate —
+ * its `randomUUID` has existed since v14.17.0 — so it is the last resort. In
+ * the web build that import is aliased to `crypto_shim.ts`, which throws,
+ * because a browser without the Web Crypto API has no secure source left.
  *
  * Some callers use this value to make security decisions — the OAuth2 `state`
  * parameter in `AuthHandler` and the session identifiers minted by the session
@@ -48,11 +57,7 @@ export function randomUUID(): string {
       .join('-');
   }
 
-  throw new Error(
-    'randomUUID: no cryptographically secure source of randomness is ' +
-      'available. Neither crypto.randomUUID() nor crypto.getRandomValues() is ' +
-      'present in this environment.',
-  );
+  return nodeRandomUUID();
 }
 
 /**

--- a/core/src/utils/env_aware_utils.ts
+++ b/core/src/utils/env_aware_utils.ts
@@ -25,8 +25,11 @@ export function isBrowser() {
  * `--experimental-global-webcrypto` until v19.0.0, so neither of those branches
  * matches on a default Node 18 or earlier. `node:crypto` carries no such gate —
  * its `randomUUID` has existed since v14.17.0 — so it is the last resort. In
- * the web build that import is aliased to `crypto_shim.ts`, which throws,
- * because a browser without the Web Crypto API has no secure source left.
+ * the bundled web build the import is aliased to `crypto_shim.ts`, which
+ * throws, because a browser without the Web Crypto API has no secure source
+ * left. The non-bundle `dist/web` output that `package.json#browser` points
+ * at keeps the import verbatim, as it already does for `node:async_hooks`
+ * and `node:path`.
  *
  * Some callers use this value to make security decisions — the OAuth2 `state`
  * parameter in `AuthHandler` and the session identifiers minted by the session

--- a/core/test/utils/env_aware_utils_test.ts
+++ b/core/test/utils/env_aware_utils_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {afterEach, describe, expect, it} from 'vitest';
+import {randomUUID as shimRandomUUID} from '../../src/utils/crypto_shim.js';
 import {getBooleanEnvVar, randomUUID} from '../../src/utils/env_aware_utils.js';
 
 describe('env_aware_utils', () => {
@@ -109,10 +110,27 @@ describe('env_aware_utils', () => {
       expect(randomUUID()).toBe('abababab-abab-4bab-abab-abababababab');
     });
 
-    it('throws instead of degrading when no secure source exists', () => {
+    // globalThis.crypto was added in Node v17.4.0 and stayed behind
+    // --experimental-global-webcrypto until v19.0.0, so on a default Node 18 or
+    // earlier neither globalThis branch matches.
+    it('falls back to node:crypto when globalThis.crypto is absent', () => {
       setCrypto(undefined);
 
-      expect(() => randomUUID()).toThrow(
+      expect(randomUUID()).toMatch(UUID_V4);
+    });
+
+    it('does not repeat itself across calls without globalThis.crypto', () => {
+      setCrypto(undefined);
+
+      const ids = new Set(Array.from({length: 1000}, () => randomUUID()));
+
+      expect(ids.size).toBe(1000);
+    });
+
+    // The web build aliases node:crypto to this shim, so it stands in for the
+    // Node fallback in a browser that has no Web Crypto API at all.
+    it('throws instead of degrading in the browser shim', () => {
+      expect(() => shimRandomUUID()).toThrow(
         /no cryptographically secure source of randomness/,
       );
     });


### PR DESCRIPTION
Fixes #598.

`randomUUID()` consults only `globalThis.crypto`. That global was added in Node v17.4.0 and stayed behind `--experimental-global-webcrypto` until v19.0.0, so on a default Node 18 or earlier neither branch matches and the function throws, where it previously returned a weak UUID — a hard failure in `createSession`, `AuthHandler.generateAuthUri` and every A2A message id.

`node:crypto`'s `randomUUID` has existed since v14.17.0 and does not depend on the global, so it becomes the last resort and the throw becomes unreachable on any Node this package could plausibly target. The two `globalThis.crypto` branches keep precedence, so browsers and Node 19+ behave exactly as they do today.

## Browser build

`randomUUID` does reach the web bundle — `index_web.ts` re-exports `./common.js`, and `common.ts:145` re-exports `./events/event.js`, an existing caller. So the `node:crypto` import is aliased to a shim, following the existing `node:async_hooks` precedent at `build.js:53-57`.

`core/src/utils/crypto_shim.ts` throws the message `randomUUID` used to throw. In a browser it is reached only after both `globalThis.crypto` branches have been ruled out, which means the Web Crypto API is genuinely absent and there is nothing left to fall back to — so failing is still the correct move there.

Verified on the output rather than assumed: after `npm run build:bundle`, `dist/web/index.js` contains no `node:crypto` import and does contain the shim's message.

## One thing the alias does not cover

Flagging this rather than leaving it to be discovered later. esbuild's `alias` only takes effect while it is resolving imports, i.e. when `bundle` is true. But `npm run build` — the non-bundle path, which is what `prepublishOnly` runs — also emits `dist/web/`, and `core/package.json` points `browser` at `./dist/web/index_web.js`. That output keeps its imports verbatim:

```
$ npm run build && head -8 dist/web/utils/env_aware_utils.js
import {createRequire as topLevelCreateRequire} from 'module';
const require = topLevelCreateRequire(import.meta.url);
/**
 * @license
 * Copyright 2025 Google LLC
 * SPDX-License-Identifier: Apache-2.0
 */
import { randomUUID as nodeRandomUUID } from "node:crypto";
```

This is a pre-existing gap rather than one this PR opens — the same non-bundle web output already ships unaliased `node:async_hooks`, `node:path`, `node:os`, `node:net` and `node:child_process`, and the `format === 'esm'` banner injects `import {createRequire} from 'module'` into it as well. Closing it needs a different mechanism than `alias` (a resolve plugin, or a `browser` field map in `package.json`). Happy to send that separately — I left it out here to keep this PR to what #598 describes.

## Tests

- `falls back to node:crypto when globalThis.crypto is absent` — the regression this fixes.
- `does not repeat itself across calls without globalThis.crypto` — 1000 ids, all distinct, so the fallback is not a constant or a stub.
- the previous `throws instead of degrading when no secure source exists` now targets the shim directly, since that is the only place the throw is still reachable.

Negative control run rather than assumed: with `return nodeRandomUUID()` reverted to the old `throw`, exactly the two new assertions fail and the other eleven pass.

`tsc --noEmit`, prettier and eslint are clean, and `vitest --project unit:core` is green — 168 files, 2358 tests.

## Not included

No `engines` field. As discussed on #577 it is advisory unless the consumer sets `engine-strict`, so it would have made the mismatch visible without preventing the throw. After this change the supported-Node floor is a documentation question rather than a correctness one, which is the point of doing this one first.
