### PR TITLE
refactor(core): create the unsafe executor's temp directory with mkdtemp

### DIFF
--- a/core/src/code_executors/unsafe_local_code_executor.ts
+++ b/core/src/code_executors/unsafe_local_code_executor.ts
@@ -65,10 +65,7 @@ async function createTempScriptFile(
   language: CodeExecutionLanguage,
   shellCommandPath?: string,
 ): Promise<{filePath: string; tempDir: string}> {
-  // mkdtemp creates the directory itself, exclusively and mode 0o700. The
-  // previous Date.now()/Math.random() name was predictable, and mkdir with
-  // `recursive` does not fail on a path that already exists, so a directory
-  // pre-created by another local user was adopted rather than rejected.
+  // mkdtemp names the directory itself and creates it exclusively at 0o700.
   const tempDir = await fs.mkdtemp(
     path.join(os.tmpdir(), 'adk_js_unsafe_code_executor_'),
   );

--- a/core/src/code_executors/unsafe_local_code_executor.ts
+++ b/core/src/code_executors/unsafe_local_code_executor.ts
@@ -65,12 +65,13 @@ async function createTempScriptFile(
   language: CodeExecutionLanguage,
   shellCommandPath?: string,
 ): Promise<{filePath: string; tempDir: string}> {
-  const tempDir = path.join(
-    os.tmpdir(),
-    'adk_js_unsafe_code_executor',
-    Date.now().toString() + '_' + Math.random().toString(36).slice(2),
+  // mkdtemp creates the directory itself, exclusively and mode 0o700. The
+  // previous Date.now()/Math.random() name was predictable, and mkdir with
+  // `recursive` does not fail on a path that already exists, so a directory
+  // pre-created by another local user was adopted rather than rejected.
+  const tempDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'adk_js_unsafe_code_executor_'),
   );
-  await fs.mkdir(tempDir, {recursive: true});
 
   const ext = getExtensionForLanguage(language, shellCommandPath) || '.js';
   const filePath = path.join(tempDir, `script${ext}`);

--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -15,6 +15,7 @@ import {
 } from '@google/adk';
 import {EventEmitter} from 'node:events';
 import * as os from 'node:os';
+import * as path from 'node:path';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 // Only `spawn` is mocked; it defaults to the real implementation (see
@@ -88,6 +89,37 @@ describe('UnsafeLocalCodeExecutor', () => {
 
     expect(result.stdout).toContain('Hello, World!');
     expect(result.stderr).toBe('');
+  });
+
+  // The script runs with the temporary directory as its cwd, so it can report
+  // the name and mode the executor actually created.
+  it('creates a private, unpredictable temporary directory', async () => {
+    const params: ExecuteCodeParams = {
+      invocationContext,
+      codeExecutionInput: {
+        code: [
+          'const fs = require("node:fs");',
+          'const dir = process.cwd();',
+          'const mode = (fs.statSync(dir).mode & 0o777).toString(8);',
+          'console.log(JSON.stringify({dir, mode}));',
+        ].join('\n'),
+        language: CodeExecutionLanguage.JAVASCRIPT,
+        inputFiles: [],
+      },
+    };
+
+    const first = JSON.parse((await executor.executeCode(params)).stdout);
+    const second = JSON.parse((await executor.executeCode(params)).stdout);
+
+    // mkdtemp appends six random characters to the prefix it is given.
+    expect(path.basename(first.dir)).toMatch(
+      /^adk_js_unsafe_code_executor_.{6}$/,
+    );
+    expect(second.dir).not.toBe(first.dir);
+
+    if (os.platform() !== 'win32') {
+      expect(first.mode).toBe('700');
+    }
   });
 
   it('should capture stderr', async () => {

--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -108,8 +108,13 @@ describe('UnsafeLocalCodeExecutor', () => {
       },
     };
 
-    const first = JSON.parse((await executor.executeCode(params)).stdout);
-    const second = JSON.parse((await executor.executeCode(params)).stdout);
+    const firstResult = await executor.executeCode(params);
+    const secondResult = await executor.executeCode(params);
+    expect(firstResult.stderr).toBe('');
+    expect(secondResult.stderr).toBe('');
+
+    const first = JSON.parse(firstResult.stdout);
+    const second = JSON.parse(secondResult.stdout);
 
     // mkdtemp appends six random characters to the prefix it is given.
     expect(path.basename(first.dir)).toMatch(


### PR DESCRIPTION
The hardening @AmaadMartin offered to review in https://github.com/google/adk-js/issues/598#issuecomment-5149441330, split out from #599 since it is unrelated to `randomUUID`.

`createTempScriptFile` built its directory name from `Date.now()` and `Math.random()`, then created it with `fs.mkdir(tempDir, {recursive: true})`. `recursive` does not fail on a path that already exists, so a directory pre-created by another local user under `os.tmpdir()` is adopted rather than rejected, and it keeps whatever permissions that user gave it.

`fs.mkdtemp` names the directory itself, creates it exclusively, and does so at mode `0o700`. Using the old fixed segment as its prefix instead of as a parent directory also removes the one directory the executor never cleaned up — `fs.rm` at the end of `executeCode` only ever removed the leaf, so `os.tmpdir()/adk_js_unsafe_code_executor` accumulated and stayed behind.

```diff
-  const tempDir = path.join(
-    os.tmpdir(),
-    'adk_js_unsafe_code_executor',
-    Date.now().toString() + '_' + Math.random().toString(36).slice(2),
-  );
-  await fs.mkdir(tempDir, {recursive: true});
+  const tempDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'adk_js_unsafe_code_executor_'),
+  );
```

To be clear about what this is and is not: it is ordinary hardening, not a fix for a reachable weakness. `UnsafeLocalCodeExecutor` executes untrusted code locally with no sandbox by design, so a predictable temporary path is a weaker primitive than what the component already grants. That is the reason I did not file it as a security issue — it just should not be the weak link.

## Test

`creates a private, unpredictable temporary directory` uses the public API: the script runs with the temporary directory as its cwd, so it reports its own directory name and mode back through stdout. It asserts the mkdtemp naming, that two runs differ, and mode `700` off Windows.

Negative control run rather than assumed — with the old `mkdir` restored, that test is the only one that fails, on `expected '1785598236728_3zkn5o6rehu' to match /^adk_js_unsafe_code_executor_.{6}$/`.

`tsc --noEmit`, prettier and eslint are clean, and the executor suite is green at 19 tests.
