### PR TITLE
fix(utils): fix sibling-directory escape in materializeFiles path check

### DIFF
--- a/core/src/utils/file_utils.ts
+++ b/core/src/utils/file_utils.ts
@@ -9,6 +9,23 @@ import * as path from 'node:path';
 import {File} from '../code_executors/code_execution_utils.js';
 
 /**
+ * Reports whether resolvedPath is resolvedBaseDir itself, or a path nested
+ * inside it.
+ *
+ * A plain `resolvedPath.startsWith(resolvedBaseDir)` check is a path-separator-
+ * unaware prefix match: it also accepts sibling directories whose name merely
+ * starts with the same string, e.g. base dir `/tmp/agent` wrongly "contains"
+ * `/tmp/agent-evil/x`. Requiring the trailing separator (or exact equality)
+ * closes that gap.
+ */
+function isInsideDir(resolvedPath: string, resolvedBaseDir: string): boolean {
+  return (
+    resolvedPath === resolvedBaseDir ||
+    resolvedPath.startsWith(resolvedBaseDir + path.sep)
+  );
+}
+
+/**
  * Creates files with the given paths in the current working directory.
  * @param files The files to materialize.
  */
@@ -21,7 +38,7 @@ export async function materializeFiles(
   for (const file of files) {
     const fullPath = path.resolve(dir, file.name);
 
-    if (!fullPath.startsWith(resolvedBaseDir)) {
+    if (!isInsideDir(fullPath, resolvedBaseDir)) {
       throw new Error(
         `Path traversal detected: ${file.name} resolves outside of ${dir}`,
       );
@@ -51,7 +68,7 @@ export async function materializeFiles(
       }
     }
 
-    if (!finalPath.startsWith(resolvedBaseDir)) {
+    if (!isInsideDir(finalPath, resolvedBaseDir)) {
       throw new Error(
         `Path traversal detected: ${file.name} resolves outside of ${dir}`,
       );

--- a/core/test/utils/file_utils_test.ts
+++ b/core/test/utils/file_utils_test.ts
@@ -69,6 +69,29 @@ describe('file_utils', () => {
       );
     });
 
+    it('should throw an error if file attempts to escape into a sibling directory sharing a name prefix', async () => {
+      // A plain `resolvedPath.startsWith(resolvedBaseDir)` check is fooled by a
+      // sibling directory whose name merely starts with the same string as the
+      // target directory (e.g. target `.../sandbox` vs sibling
+      // `.../sandbox-evil`), since it never requires a path-separator boundary.
+      const siblingName = `${path.basename(tempDir)}-evil`;
+      const files = [
+        {
+          name: `../${siblingName}/escape.txt`,
+          content: 'dangerous',
+          contentEncoding: FileContentEncoding.UTF8,
+          mimeType: 'text/plain',
+        },
+      ];
+
+      await expect(materializeFiles(files, tempDir)).rejects.toThrow(
+        /Path traversal detected/,
+      );
+
+      const siblingPath = path.join(path.dirname(tempDir), siblingName);
+      await expect(fs.access(siblingPath)).rejects.toThrow();
+    });
+
     it('should throw an error if file attempts to escape target directory via absolute path', async () => {
       const outsidePath = path.resolve(tempDir, '../outside.txt');
       const files = [


### PR DESCRIPTION
materializeFiles (core/src/utils/file_utils.ts) guards its target directory with `fullPath.startsWith(resolvedBaseDir)` — a path-separator-unaware prefix match. A relative file name like `../<dir>-evil/x` resolves to a sibling of the target directory but still satisfies that check, since `resolvedBaseDir` and the sibling path share the same string prefix with no separator required between them. Because the resulting directory is created with `fs.mkdir(path.dirname(finalPath), {recursive: true})`, the sibling directory does not need to already exist.

`materializeFiles` is called with no `dir` argument (defaulting to `process.cwd()`) from `run_skill_script_tool.ts` and `run_skill_inline_script_tool.ts` on `result.outputFiles`, which come back from whatever `CodeExecutor` is configured — including `AgentEngineSandboxCodeExecutor`, which decodes each output file's name directly from the remote sandbox execution result's metadata (`attributes['file_name']`, base64-decoded, unvalidated). So a file name chosen by code running inside that isolated sandbox can, via this gap, land outside the directory `materializeFiles` was scoped to on the orchestrator host.

Confirmed by executing the real function: with target dir `/tmp/x/sandboxdir`, an output file named `../sandboxdir-pwned/shell.js` was written to `/tmp/x/sandboxdir-pwned/shell.js`, outside the intended directory.

This replaces the check with a helper requiring a path-separator boundary (or exact equality) — the same containment pattern already used by `FileArtifactService.assertInsideRoot` (added in #210 for a related but distinct traversal in that file). Adds a regression test for exactly this gap: the existing `../escape.txt`-style test uses `fs.mkdtemp`'s randomly-suffixed directory name, so it never happens to collide with a real sibling name and does not exercise this path.