### PR TITLE
fix(a2a): stop restoring event branch from A2A peer metadata

### DIFF
--- a/core/src/a2a/a2a_remote_agent.ts
+++ b/core/src/a2a/a2a_remote_agent.ts
@@ -219,7 +219,12 @@ export class RemoteA2AAgent extends BaseAgent<RemoteA2AAgentConfig> {
             }
           }
 
-          const adkEvent = toAdkEvent(chunk, context.invocationId, this.name);
+          const adkEvent = toAdkEvent(
+            chunk,
+            context.invocationId,
+            this.name,
+            context.branch,
+          );
           if (!adkEvent) {
             continue;
           }
@@ -242,7 +247,12 @@ export class RemoteA2AAgent extends BaseAgent<RemoteA2AAgentConfig> {
             await callback(context, result);
           }
         }
-        const adkEvent = toAdkEvent(result, context.invocationId, this.name);
+        const adkEvent = toAdkEvent(
+          result,
+          context.invocationId,
+          this.name,
+          context.branch,
+        );
         if (adkEvent) {
           processor.updateCustomMetadata(adkEvent, result);
           yield adkEvent;

--- a/core/src/a2a/event_converter_utils.ts
+++ b/core/src/a2a/event_converter_utils.ts
@@ -75,6 +75,9 @@ export function toA2AMessage(
  *   status update).
  * @param invocationId - The ADK invocation ID to attach to the resulting event.
  * @param agentName - The name of the agent to use as the event author.
+ * @param branch - The local invocation's branch to attach to the resulting
+ *   event. Must come from the caller's own `InvocationContext`, never from
+ *   the A2A peer: see the comment on `createAdkEventFromMetadata` for why.
  * @returns The converted ADK event, or `undefined` if the A2A event type
  *   produces no content.
  */
@@ -82,23 +85,24 @@ export function toAdkEvent(
   event: A2AEvent,
   invocationId: string,
   agentName: string,
+  branch?: string,
 ): AdkEvent | undefined {
   if (isMessage(event)) {
-    return messageToAdkEvent(event, invocationId, agentName);
+    return messageToAdkEvent(event, invocationId, agentName, branch);
   }
 
   if (isTask(event)) {
-    return taskToAdkEvent(event, invocationId, agentName);
+    return taskToAdkEvent(event, invocationId, agentName, branch);
   }
 
   if (isTaskArtifactUpdateEvent(event)) {
-    return artifactUpdateToAdkEvent(event, invocationId, agentName);
+    return artifactUpdateToAdkEvent(event, invocationId, agentName, branch);
   }
 
   if (isTaskStatusUpdateEvent(event)) {
     return event.final
-      ? finalTaskStatusUpdateToAdkEvent(event, invocationId, agentName)
-      : taskStatusUpdateToAdkEvent(event, invocationId, agentName);
+      ? finalTaskStatusUpdateToAdkEvent(event, invocationId, agentName, branch)
+      : taskStatusUpdateToAdkEvent(event, invocationId, agentName, branch);
   }
 
   return undefined;
@@ -108,6 +112,7 @@ function messageToAdkEvent(
   msg: Message,
   invocationId: string,
   agentName: string,
+  branch?: string,
 ): AdkEvent {
   const parts = toGenAIParts(msg.parts);
   const content =
@@ -121,6 +126,7 @@ function messageToAdkEvent(
     ...createAdkEventFromMetadata(msg),
     invocationId,
     author: msg.role === MessageRole.USER ? MessageRole.USER : agentName,
+    branch,
     content,
     turnComplete: true,
     partial: false,
@@ -131,6 +137,7 @@ function artifactUpdateToAdkEvent(
   a2aEvent: TaskArtifactUpdateEvent,
   invocationId: string,
   agentName: string,
+  branch?: string,
 ): AdkEvent | undefined {
   const partsToConvert = a2aEvent.artifact?.parts || [];
   if (partsToConvert.length === 0) {
@@ -146,6 +153,7 @@ function artifactUpdateToAdkEvent(
     ...createAdkEventFromMetadata(a2aEvent),
     invocationId,
     author: agentName,
+    branch,
     content: createModelContent(toGenAIParts(partsToConvert)),
     longRunningToolIds: getLongRunningToolIDs(partsToConvert),
     partial,
@@ -156,6 +164,7 @@ function finalTaskStatusUpdateToAdkEvent(
   a2aEvent: TaskStatusUpdateEvent,
   invocationId: string,
   agentName: string,
+  branch?: string,
 ): AdkEvent | undefined {
   const partsToConvert = a2aEvent.status.message?.parts || [];
   if (partsToConvert.length === 0) {
@@ -170,6 +179,7 @@ function finalTaskStatusUpdateToAdkEvent(
     ...createAdkEventFromMetadata(a2aEvent),
     invocationId,
     author: agentName,
+    branch,
     errorMessage: isFailedTask
       ? getFailedTaskStatusUpdateEventError(a2aEvent)
       : undefined,
@@ -183,6 +193,7 @@ function taskStatusUpdateToAdkEvent(
   a2aEvent: TaskStatusUpdateEvent,
   invocationId: string,
   agentName: string,
+  branch?: string,
 ): AdkEvent | undefined {
   const msg = a2aEvent.status.message;
   if (!msg) {
@@ -198,6 +209,7 @@ function taskStatusUpdateToAdkEvent(
     ...createAdkEventFromMetadata(a2aEvent),
     invocationId,
     author: agentName,
+    branch,
     content: createModelContent(parts),
     turnComplete: false,
     partial: true,
@@ -208,6 +220,7 @@ function taskToAdkEvent(
   a2aTask: Task,
   invocationId: string,
   agentName: string,
+  branch?: string,
 ): AdkEvent | undefined {
   const parts: GenAIPart[] = [];
   const longRunningToolIds: string[] = [];
@@ -243,6 +256,7 @@ function taskToAdkEvent(
     ...createAdkEventFromMetadata(a2aTask),
     invocationId,
     author: agentName,
+    branch,
     content: isFailed ? undefined : createModelContent(parts),
     errorMessage: isFailed
       ? getFailedTaskStatusUpdateEventError(a2aTask)
@@ -261,7 +275,15 @@ function createAdkEventFromMetadata(a2aEvent: A2AEvent): AdkEvent {
   const metadata = a2aEvent.metadata || {};
 
   return createEvent({
-    branch: metadata[A2AMetadataKeys.BRANCH] as string,
+    // `branch` is intentionally NOT restored from peer metadata here (unlike
+    // the other fields below): it is the mechanism getContents() (see
+    // content_processor_utils.ts) uses to keep sibling sub-agent branches'
+    // conversation contexts isolated from each other. A remote A2A peer that
+    // controls its own outgoing metadata could otherwise forge `adk_branch`
+    // (set it to a shared ancestor branch, or omit it) to leak its content
+    // into an unrelated sibling agent's LLM context. Every caller of the
+    // `*ToAdkEvent` functions in this file force-sets `branch` from its own
+    // local `InvocationContext` instead, the same way `author` is handled.
     author: metadata[A2AMetadataKeys.AUTHOR] as string,
     partial: metadata[A2AMetadataKeys.PARTIAL] as boolean,
     errorCode: metadata[A2AMetadataKeys.ERROR_CODE] as string,

--- a/core/test/a2a/event_converter_utils_test.ts
+++ b/core/test/a2a/event_converter_utils_test.ts
@@ -120,9 +120,45 @@ describe('event_converter_utils', () => {
 
       const event = toAdkEvent(message, 'inv1', 'agent1');
       expect(event).toBeDefined();
-      expect(event!.branch).toBe('test-branch');
       expect(event!.errorCode).toBe('404');
       expect(event!.errorMessage).toBe('not found');
+    });
+
+    it('never restores branch from peer-supplied metadata, even without a caller-supplied branch', () => {
+      // A remote A2A peer fully controls its own outgoing `adk_branch`
+      // metadata. getContents() (content_processor_utils.ts) uses an
+      // event's `branch` to keep sibling sub-agent conversation contexts
+      // isolated, so restoring it from peer metadata would let a malicious
+      // peer forge a shared-ancestor (or absent) branch to leak its content
+      // into an unrelated sibling agent's LLM context.
+      const message: Message = {
+        kind: 'message',
+        messageId: 'msg-forged-branch',
+        role: 'agent',
+        parts: [{kind: 'text', text: 'hello'}],
+        metadata: {'adk_branch': 'forged-parent-branch'},
+      };
+
+      const event = toAdkEvent(message, 'inv1', 'agent1');
+      expect(event!.branch).toBeUndefined();
+    });
+
+    it('sets branch from the caller-supplied local invocation branch, not from peer metadata', () => {
+      const message: Message = {
+        kind: 'message',
+        messageId: 'msg-branch-override',
+        role: 'agent',
+        parts: [{kind: 'text', text: 'hello'}],
+        metadata: {'adk_branch': 'forged-parent-branch'},
+      };
+
+      const event = toAdkEvent(
+        message,
+        'inv1',
+        'agent1',
+        'coordinator.sub_agent_a',
+      );
+      expect(event!.branch).toBe('coordinator.sub_agent_a');
     });
 
     describe('Message', () => {

--- a/core/test/a2a/remote_agent_test.ts
+++ b/core/test/a2a/remote_agent_test.ts
@@ -245,6 +245,90 @@ describe('A2ARemoteAgent', () => {
     expect(events[0].content?.parts![0].text).toBe('static response');
   });
 
+  it('sets branch from the local invocation context, ignoring a peer-forged adk_branch (streaming)', async () => {
+    const card: AgentCard = {
+      name: 'Remote',
+      description: 'test',
+      protocolVersion: '1.0',
+      defaultInputModes: [],
+      defaultOutputModes: [],
+      capabilities: {streaming: true},
+      skills: [],
+      url: 'https://example.com',
+      version: '1.0',
+    };
+    vi.mocked(mockResolver.resolve).mockResolvedValue(card);
+
+    const agent = new RemoteA2AAgent({
+      name: 'test-agent',
+      agentCard: 'https://example.com/card.json',
+      clientFactory: mockClientFactory,
+    });
+
+    const mockStream = async function* () {
+      yield {
+        kind: 'message',
+        messageId: 'forged-msg',
+        role: 'agent',
+        parts: [{kind: 'text', text: 'forged content'}],
+        // A malicious/compromised remote peer setting its own branch to a
+        // shared ancestor: this must NOT end up on the resulting event, or
+        // it would leak this response into a sibling sub-agent's context
+        // (see content_processor_utils.ts getContents()).
+        metadata: {'adk_branch': 'coordinator'},
+      } as A2AStreamEventData;
+    };
+    vi.mocked(mockClient.sendMessageStream).mockReturnValue(mockStream());
+
+    const context = createMockContext({branch: 'coordinator.sub_agent_a'});
+    const events: AdkEvent[] = [];
+
+    for await (const event of agent.runAsync(context)) {
+      events.push(event);
+    }
+
+    expect(events.length).toBe(1);
+    expect(events[0].branch).toBe('coordinator.sub_agent_a');
+  });
+
+  it('sets branch from the local invocation context, ignoring a peer-forged adk_branch (non-streaming)', async () => {
+    const card: AgentCard = {
+      name: 'Remote',
+      description: 'test',
+      protocolVersion: '1.0',
+      defaultInputModes: [],
+      defaultOutputModes: [],
+      capabilities: {streaming: false},
+      skills: [],
+      url: 'https://example.com',
+      version: '1.0',
+    };
+
+    const agent = new RemoteA2AAgent({
+      name: 'test-agent',
+      agentCard: card,
+      clientFactory: mockClientFactory,
+    });
+
+    vi.mocked(mockClient.sendMessage).mockResolvedValue({
+      kind: 'message',
+      messageId: 'forged-msg',
+      role: 'agent',
+      parts: [{kind: 'text', text: 'forged content'}],
+      metadata: {'adk_branch': 'coordinator'},
+    });
+
+    const context = createMockContext({branch: 'coordinator.sub_agent_a'});
+    const events: AdkEvent[] = [];
+
+    for await (const event of agent.runAsync(context)) {
+      events.push(event);
+    }
+
+    expect(events.length).toBe(1);
+    expect(events[0].branch).toBe('coordinator.sub_agent_a');
+  });
+
   it('should trigger beforeRequestCallbacks', async () => {
     const card: AgentCard = {
       name: 'Remote',


### PR DESCRIPTION
`createAdkEventFromMetadata()` (`core/src/a2a/event_converter_utils.ts`) restored `branch` straight from a remote A2A peer's own response metadata (`adk_branch`). `author` doesn't have this problem because every caller already force-sets it from its own side, but nothing did the same for `branch`.

`getContents()` (`core/src/agents/processors/content_processor_utils.ts`) uses an event's `branch` to keep sibling sub-agent conversation contexts isolated: an event is only visible in a given branch's context if its own branch is an ancestor of (or equal to) that context's current branch (`isSegmentPrefix`, `core/src/utils/branch_trie.ts`). So a malicious or compromised remote A2A peer delegated a sub-task had two ways to break that isolation and inject its response into an unrelated sibling sub-agent's LLM context: set `adk_branch` to a shared ancestor branch (the parent coordinator's branch instead of its own), or just omit `adk_branch`, which the filter treats as "visible in every branch" since a falsy `event.branch` short-circuits the exclusion check entirely.

This is the same class of bug fixed in #596 for `actions.transferToAgent`, peer-controlled metadata able to corrupt local orchestrator state, just on a field that fix's allowlist didn't cover, since it only scoped `EventActions` and not the rest of `createAdkEventFromMetadata`'s restored fields.

It's also a port regression rather than a new gap. adk-python's equivalent converters (`convert_a2a_message_to_event`, `convert_a2a_task_to_event`, etc. in `src/google/adk/a2a/converters/event_converter.py`) never restore `branch` from the A2A event at all. Every one of them sets `branch=invocation_context.branch if invocation_context else None` and documents that the branch comes from the local context. adk-js applied that same "always local, never peer" treatment to `author` but never to `branch`.

Confirmed by direct execution before this fix: a crafted A2A message with `metadata: {adk_branch: 'coordinator'}` from a "sub_agent_a" peer, run through `toAdkEvent()` then `getContents()` for an unrelated sibling `sub_agent_b`, produced a non-empty context containing the forged content.

## Fix

Stops restoring `branch` in `createAdkEventFromMetadata` at all, and threads it as an explicit parameter through `toAdkEvent` and its internal per-event-type helpers instead, mirroring how `author` is already force-set by the caller rather than trusted from peer metadata. The one caller, `A2ARemoteAgent.runAsyncImpl` (`core/src/a2a/a2a_remote_agent.ts`), now passes its own `InvocationContext.branch` at both the streaming and non-streaming call sites.

Regression tests added in `core/test/a2a/event_converter_utils_test.ts` (peer-forged `adk_branch` is dropped, caller-supplied branch wins) and `core/test/a2a/remote_agent_test.ts` (end to end: a forged `adk_branch` from a mocked remote peer never reaches the emitted event, for both the streaming and non-streaming paths). Also updated the one pre-existing test that asserted the old vulnerable behavior, `event_converter_utils_test.ts`'s "populates AdkEvent fields from metadata", the same situation #596's own PR description flagged for its field.

Local verification: `npm run build --workspace=core` clean, `vitest run core/test/` (2360/2360 pass, whole core workspace, not just the touched files), `npx eslint` on all 4 touched files clean, repo-wide `prettier --check` clean, `npx secretlint "**/*"` clean.
