### PR TITLE
Fix: create dev-package temp directories atomically with mkdtemp (no predictable parent)

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -19,7 +19,6 @@ import * as path from 'path';
 import {runIntegrationTests} from '../integration/run_integration_tests.js';
 import {AdkApiServer} from '../server/adk_api_server.js';
 import {FileModuleType} from '../utils/agent_loader.js';
-import {getTempDir} from '../utils/file_utils.js';
 import {AdkLogger} from '../utils/logger.js';
 import {version} from '../version.js';
 import {createAgent} from './cli_create.js';
@@ -410,8 +409,7 @@ export function createProgram(): Command {
     )
     .option(
       '--temp_folder [string]',
-      'Optional. Temp folder for the generated Cloud Run source files (default: a timestamped folder in the system temp directory).',
-      getTempDir('cloud_run_deploy_src'),
+      'Optional. Temp folder for the generated Cloud Run source files (default: a private directory created in the system temp directory).',
     )
     .addOption(ADK_VERSION_OPTION)
     .addOption(WITH_UI_OPTION)
@@ -475,8 +473,7 @@ export function createProgram(): Command {
       .addOption(REPOSITORY_DEPLOY_OPTION)
       .option(
         '--temp_folder [string]',
-        'Optional. Temp folder for the generated source files (default: a timestamped folder in the system temp directory).',
-        getTempDir('agent_engine_deploy_src'),
+        'Optional. Temp folder for the generated source files (default: a private directory created in the system temp directory).',
       )
       .addOption(ADK_VERSION_OPTION)
       .addOption(WITH_UI_OPTION)

--- a/dev/src/cli/deploy/cli_deploy_agent_engine.ts
+++ b/dev/src/cli/deploy/cli_deploy_agent_engine.ts
@@ -79,11 +79,10 @@ export async function deployToAgentEngine(options: DeployToAgentEngineOptions) {
 
   console.info('Starting deployment to Agent Engine...');
 
-  const callerTempFolder = options.tempFolder;
   const tempFolder =
-    callerTempFolder ?? (await createTempDir('agent_engine_deploy_src'));
+    options.tempFolder ?? (await createTempDir('agent_engine_deploy_src'));
 
-  if (callerTempFolder && (await isFolderExists(tempFolder))) {
+  if (options.tempFolder && (await isFolderExists(tempFolder))) {
     await fs.rm(tempFolder, {recursive: true, force: true});
   }
 

--- a/dev/src/cli/deploy/cli_deploy_agent_engine.ts
+++ b/dev/src/cli/deploy/cli_deploy_agent_engine.ts
@@ -10,7 +10,7 @@ import {Client} from '@google-cloud/vertexai/build/src/genai/client.js';
 import {ReasoningEngine as VertexReasoningEngine} from '@google-cloud/vertexai/build/src/genai/types.js';
 
 import {AgentLoader} from '../../utils/agent_loader.js';
-import {isFile, isFolderExists} from '../../utils/file_utils.js';
+import {createTempDir, isFile, isFolderExists} from '../../utils/file_utils.js';
 import {
   BaseDeployOptions,
   copyAgentFiles,
@@ -79,24 +79,25 @@ export async function deployToAgentEngine(options: DeployToAgentEngineOptions) {
 
   console.info('Starting deployment to Agent Engine...');
 
-  if (await isFolderExists(options.tempFolder)) {
-    await fs.rm(options.tempFolder, {recursive: true, force: true});
+  const callerTempFolder = options.tempFolder;
+  const tempFolder =
+    callerTempFolder ?? (await createTempDir('agent_engine_deploy_src'));
+
+  if (callerTempFolder && (await isFolderExists(tempFolder))) {
+    await fs.rm(tempFolder, {recursive: true, force: true});
   }
 
   try {
-    await fs.mkdir(options.tempFolder, {recursive: true});
+    await fs.mkdir(tempFolder, {recursive: true});
 
     console.info('Copying agent source files...');
-    await copyAgentFiles(
-      agentLoader,
-      path.join(options.tempFolder, 'agents', appName),
-    );
+    await copyAgentFiles(agentLoader, path.join(tempFolder, 'agents', appName));
 
     console.info('Creating package.json...');
-    await createPackageJson(agentDir, options.tempFolder);
+    await createPackageJson(agentDir, tempFolder);
 
     console.info('Creating Dockerfile...');
-    await createDockerFile(options.tempFolder, {
+    await createDockerFile(tempFolder, {
       appName,
       project: options.project,
       region: options.region,
@@ -124,7 +125,7 @@ export async function deployToAgentEngine(options: DeployToAgentEngineOptions) {
         'submit',
         '--tag',
         imageTag,
-        options.tempFolder,
+        tempFolder,
         '--project',
         options.project,
         '--gcs-log-dir',
@@ -215,7 +216,7 @@ export async function deployToAgentEngine(options: DeployToAgentEngineOptions) {
     throw e;
   } finally {
     console.info('Cleaning up temporary files...');
-    await fs.rm(options.tempFolder, {recursive: true, force: true});
+    await fs.rm(tempFolder, {recursive: true, force: true});
     await agentLoader.disposeAll();
     console.info('Temporary files cleaned up.');
   }

--- a/dev/src/cli/deploy/cli_deploy_cloud_run.ts
+++ b/dev/src/cli/deploy/cli_deploy_cloud_run.ts
@@ -8,7 +8,7 @@ import * as path from 'node:path';
 
 import {A2A_AUTH_TOKEN_ENV_VAR} from '../../server/adk_api_server.js';
 import {AgentLoader} from '../../utils/agent_loader.js';
-import {isFile, isFolderExists} from '../../utils/file_utils.js';
+import {createTempDir, isFile, isFolderExists} from '../../utils/file_utils.js';
 import {
   BaseDeployOptions,
   CreateDockerFileContentOptions,
@@ -57,7 +57,10 @@ function validateGcloudExtraArgs(
   }
 }
 
-function prepareGCloudArguments(options: DeployToCloudRunOptions): string[] {
+function prepareGCloudArguments(
+  options: DeployToCloudRunOptions,
+  tempFolder: string,
+): string[] {
   const regionOptions: string[] = options.region
     ? ['--region', options.region]
     : [];
@@ -85,7 +88,7 @@ function prepareGCloudArguments(options: DeployToCloudRunOptions): string[] {
     'deploy',
     options.serviceName,
     '--source',
-    options.tempFolder,
+    tempFolder,
     '--project',
     options.project,
     ...regionOptions,
@@ -152,7 +155,11 @@ export async function deployToCloudRun(options: DeployToCloudRunOptions) {
     );
   }
 
-  const gcloudCommands = prepareGCloudArguments(options);
+  const callerTempFolder = options.tempFolder;
+  const tempFolder =
+    callerTempFolder ?? (await createTempDir('cloud_run_deploy_src'));
+
+  const gcloudCommands = prepareGCloudArguments(options, tempFolder);
 
   if (options.a2a && !options.a2aAuthToken) {
     console.warn(
@@ -181,23 +188,20 @@ export async function deployToCloudRun(options: DeployToCloudRunOptions) {
 
   console.info('Starting deployment to Cloud Run...');
 
-  if (await isFolderExists(options.tempFolder)) {
+  if (callerTempFolder && (await isFolderExists(tempFolder))) {
     console.info('Cleaning up existing temporary files...');
-    await fs.rm(options.tempFolder, {recursive: true, force: true});
+    await fs.rm(tempFolder, {recursive: true, force: true});
   }
 
   try {
     console.info('Copying agent source files...');
-    await copyAgentFiles(
-      agentLoader,
-      path.join(options.tempFolder, 'agents', appName),
-    );
+    await copyAgentFiles(agentLoader, path.join(tempFolder, 'agents', appName));
 
     console.info('Creating package.json...');
-    await createPackageJson(agentDir, options.tempFolder);
+    await createPackageJson(agentDir, tempFolder);
 
     console.info('Creating Dockerfile...');
-    await createDockerFile(options.tempFolder, {
+    await createDockerFile(tempFolder, {
       appName,
       project: options.project,
       region: options.region,
@@ -219,7 +223,7 @@ export async function deployToCloudRun(options: DeployToCloudRunOptions) {
     );
   } finally {
     console.info('Cleaning up temporary files...');
-    await fs.rm(options.tempFolder, {recursive: true, force: true});
+    await fs.rm(tempFolder, {recursive: true, force: true});
     await agentLoader.disposeAll();
     console.info('Temporary files cleaned up.');
   }

--- a/dev/src/cli/deploy/cli_deploy_cloud_run.ts
+++ b/dev/src/cli/deploy/cli_deploy_cloud_run.ts
@@ -57,10 +57,7 @@ function validateGcloudExtraArgs(
   }
 }
 
-function prepareGCloudArguments(
-  options: DeployToCloudRunOptions,
-  tempFolder: string,
-): string[] {
+function prepareGCloudArguments(options: DeployToCloudRunOptions): string[] {
   const regionOptions: string[] = options.region
     ? ['--region', options.region]
     : [];
@@ -87,8 +84,6 @@ function prepareGCloudArguments(
     'run',
     'deploy',
     options.serviceName,
-    '--source',
-    tempFolder,
     '--project',
     options.project,
     ...regionOptions,
@@ -155,11 +150,10 @@ export async function deployToCloudRun(options: DeployToCloudRunOptions) {
     );
   }
 
-  const callerTempFolder = options.tempFolder;
-  const tempFolder =
-    callerTempFolder ?? (await createTempDir('cloud_run_deploy_src'));
-
-  const gcloudCommands = prepareGCloudArguments(options, tempFolder);
+  // Built before any directory is created: a conflicting extra gcloud arg
+  // throws out of deployToCloudRun, and there is no `finally` this early to
+  // remove a temp folder.
+  const gcloudCommands = prepareGCloudArguments(options);
 
   if (options.a2a && !options.a2aAuthToken) {
     console.warn(
@@ -188,7 +182,11 @@ export async function deployToCloudRun(options: DeployToCloudRunOptions) {
 
   console.info('Starting deployment to Cloud Run...');
 
-  if (callerTempFolder && (await isFolderExists(tempFolder))) {
+  const tempFolder =
+    options.tempFolder ?? (await createTempDir('cloud_run_deploy_src'));
+  gcloudCommands.push('--source', tempFolder);
+
+  if (options.tempFolder && (await isFolderExists(tempFolder))) {
     console.info('Cleaning up existing temporary files...');
     await fs.rm(tempFolder, {recursive: true, force: true});
   }

--- a/dev/src/cli/deploy/deploy_utils.ts
+++ b/dev/src/cli/deploy/deploy_utils.ts
@@ -51,7 +51,12 @@ export interface CreateDockerFileContentOptions {
 
 export interface BaseDeployOptions extends CreateDockerFileContentOptions {
   agentPath: string;
-  tempFolder: string;
+  /**
+   * Directory the generated deployment sources are staged in. When omitted, the
+   * deploy command creates a private temporary directory for the run and
+   * removes it when the deployment finishes.
+   */
+  tempFolder?: string;
   adkVersion: string;
   agentFileLoadOptions?: AgentFileOptions;
 }

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -16,7 +16,7 @@ import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 
 import {
-  getTempDir,
+  createTempDir,
   isFile,
   isFileExists,
   isFolderExists,
@@ -169,13 +169,12 @@ export class AgentFile {
       const moduleType =
         this.options.moduleType || (await getFileModuleType(filePath));
       const parsedPath = path.parse(filePath);
-      const outputDir = getTempDir('adk_agent_loader');
+      const outputDir = await createTempDir('adk_agent_loader');
       const compiledFilePath = path.join(
         outputDir,
         parsedPath.name + FILE_MODULE_TYPE_EXTENSION_MAP[moduleType],
       );
       const originalDir = path.dirname(filePath);
-      await fsPromises.mkdir(outputDir, {recursive: true});
       await linkProjectNodeModules(outputDir, parsedPath.dir);
 
       await esbuild.build({
@@ -187,7 +186,6 @@ export class AgentFile {
         packages: 'bundle',
         bundle: this.options.bundle,
         minify: this.options.bundle,
-        allowOverwrite: true,
         plugins: [replaceDirnamePlugin(filePath, originalDir), shimPlugin()],
         // See http://mikro-orm.io/docs/deployment#deploy-a-bundle-of-entities-and-dependencies-with-esbuild for more details
         external: [

--- a/dev/src/utils/file_utils.ts
+++ b/dev/src/utils/file_utils.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -100,20 +99,20 @@ export async function saveToFile<T>(filePath: string, data: T): Promise<void> {
 }
 
 /**
- * Return a temporary directory path.
- * @param prefix Optional prefix for the temp directory
- * @returns
+ * Atomically creates a private temporary directory and returns its path.
+ *
+ * The directory is created by a single `mkdtemp` call directly under the system
+ * temp root, with a random name and, on POSIX, mode 0700. Composing the path
+ * from a fixed prefix and materialising it later with a recursive `mkdir` would
+ * leave a predictable intermediate directory that another local user can
+ * pre-create or replace with a symlink, placing everything written afterwards
+ * under their control.
+ *
+ * @param prefix Name prefix for the directory. Must be a single path segment.
+ * @returns The absolute path of the newly created directory.
  */
-export function getTempDir(prefix?: string): string {
-  const pathParts = [os.tmpdir()];
-
-  if (prefix) {
-    pathParts.push(prefix);
-  }
-
-  pathParts.push(crypto.randomUUID());
-
-  return path.join(...pathParts);
+export async function createTempDir(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
 }
 
 /**

--- a/dev/test/cli/cli_deploy_agent_engine_test.ts
+++ b/dev/test/cli/cli_deploy_agent_engine_test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/cli/deploy/cli_deploy_agent_engine.js';
 import {AgentLoader} from '../../src/utils/agent_loader.js';
 import {
+  createTempDir,
   isFile,
   isFolderExists,
   loadFileData,
@@ -130,6 +131,7 @@ vi.mock('../../src/utils/agent_loader.js', () => ({
 }));
 
 vi.mock('../../src/utils/file_utils.js', () => ({
+  createTempDir: vi.fn(),
   isFile: vi.fn(),
   isFolderExists: vi.fn(),
   loadFileData: vi.fn(),
@@ -298,6 +300,25 @@ describe('deployToAgentEngine', () => {
       exists = false;
     }
     expect(exists).toBe(false);
+  });
+
+  it('should create a private temp folder when none is supplied', async () => {
+    const createdTempFolder = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'agent_engine_deploy_src-'),
+    );
+    globalThis.fsMockTempFolder = createdTempFolder;
+    (createTempDir as Mock).mockResolvedValue(createdTempFolder);
+
+    await deployToAgentEngine({...defaultOptions, tempFolder: undefined});
+
+    expect(createTempDir).toHaveBeenCalledWith('agent_engine_deploy_src');
+    expect(spawnMock).toHaveBeenCalledWith(
+      'gcloud',
+      expect.arrayContaining(['builds', 'submit', createdTempFolder]),
+      expect.any(Object),
+    );
+    expect(isFolderExists).not.toHaveBeenCalled();
+    await expect(fs.access(createdTempFolder)).rejects.toThrow();
   });
 
   it('should deploy successfully with all optional parameters', async () => {

--- a/dev/test/cli/cli_deploy_cloud_run_test.ts
+++ b/dev/test/cli/cli_deploy_cloud_run_test.ts
@@ -350,6 +350,19 @@ describe('deployToCloudRun', () => {
     },
   );
 
+  it('should not create a temp folder when the gcloud args are rejected', async () => {
+    await expect(
+      deployToCloudRun({
+        ...defaultOptions,
+        tempFolder: undefined,
+        extraGcloudArgs: ['--project=other'],
+      }),
+    ).rejects.toThrow(/conflict with ADK's automatic configuration/);
+
+    expect(createTempDir).not.toHaveBeenCalled();
+    expect(fs.rm).not.toHaveBeenCalled();
+  });
+
   it('should still allow user env-var flags when no A2A token is given', async () => {
     await deployToCloudRun({
       ...defaultOptions,

--- a/dev/test/cli/cli_deploy_cloud_run_test.ts
+++ b/dev/test/cli/cli_deploy_cloud_run_test.ts
@@ -14,6 +14,7 @@ import {
 import {A2A_AUTH_TOKEN_ENV_VAR} from '../../src/server/adk_api_server.js';
 import {AgentLoader} from '../../src/utils/agent_loader.js';
 import {
+  createTempDir,
   isFile,
   isFolderExists,
   loadFileData,
@@ -57,6 +58,7 @@ vi.mock('../../src/utils/agent_loader.js', () => ({
 }));
 
 vi.mock('../../src/utils/file_utils.js', () => ({
+  createTempDir: vi.fn(),
   isFile: vi.fn(),
   isFolderExists: vi.fn(),
   loadFileData: vi.fn(),
@@ -245,6 +247,22 @@ describe('deployToCloudRun', () => {
     await expect(deployToCloudRun(optionsWithoutProject)).rejects.toThrow(
       /Project is not specified/,
     );
+  });
+
+  it('should create a private temp folder when none is supplied', async () => {
+    const createdTempFolder = '/tmp/cloud_run_deploy_src-abc123';
+    (createTempDir as Mock).mockResolvedValue(createdTempFolder);
+
+    await deployToCloudRun({...defaultOptions, tempFolder: undefined});
+
+    expect(createTempDir).toHaveBeenCalledWith('cloud_run_deploy_src');
+    expect(spawnMock.mock.calls[0][1]).toContain(createdTempFolder);
+    expect(isFolderExists).not.toHaveBeenCalled();
+    expect(fs.rm).toHaveBeenCalledTimes(1);
+    expect(fs.rm).toHaveBeenCalledWith(createdTempFolder, {
+      recursive: true,
+      force: true,
+    });
   });
 
   it('should clean up existing temp folder before deploying', async () => {

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -278,6 +278,14 @@ describe('CLI Entrypoint', () => {
       );
     });
 
+    it('should leave tempFolder unset so no temp directory is created eagerly', async () => {
+      await parse(['deploy', 'cloud_run']);
+
+      expect(
+        (deployToCloudRun as Mock).mock.calls[0][0].tempFolder,
+      ).toBeUndefined();
+    });
+
     it('should pass args to deployToCloudRun including unknowns', async () => {
       const args = [
         'deploy',
@@ -348,6 +356,14 @@ describe('CLI Entrypoint', () => {
           withUi: false,
         }),
       );
+    });
+
+    it('should leave tempFolder unset so no temp directory is created eagerly', async () => {
+      await parse(['deploy', 'agent_engine']);
+
+      expect(
+        (deployToAgentEngine as Mock).mock.calls[0][0].tempFolder,
+      ).toBeUndefined();
     });
 
     it('should pass args to deployToAgentEngine', async () => {

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -29,7 +29,7 @@ import {
 import * as fileUtils from '../../src/utils/file_utils.js';
 
 vi.mock('../../src/utils/file_utils.js', () => ({
-  getTempDir: vi.fn(),
+  createTempDir: vi.fn(),
   isFile: vi.fn(),
   isFileExists: vi.fn(),
   isFolderExists: vi.fn(),
@@ -161,7 +161,10 @@ describe('AgentLoader', () => {
   });
 
   beforeEach(async () => {
-    (fileUtils.getTempDir as Mock).mockImplementation(() => tempLoaderDir);
+    (fileUtils.createTempDir as Mock).mockImplementation(async () => {
+      await fs.mkdir(tempLoaderDir, {recursive: true});
+      return tempLoaderDir;
+    });
     (fileUtils.isFile as Mock).mockImplementation(async (filePath) => {
       try {
         const stat = await fs.stat(filePath as string);
@@ -281,12 +284,32 @@ describe('AgentLoader', () => {
         packages: 'bundle',
         bundle: true,
         minify: true,
-        allowOverwrite: true,
         external: expect.arrayContaining(['onnxruntime-node']),
       });
 
       await agentFile.dispose();
       await expect(fs.access(compiledAgentPath)).rejects.toThrow();
+    });
+
+    it('compiles into a private temp dir without allowing overwrite', async () => {
+      const agentPath = path.join(tempAgentsDir, 'agent1.js');
+      await fs.writeFile(agentPath, agent1JsContent);
+
+      const compiledAgentPath = compiledPath('agent1.cjs');
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledAgentPath, agent1JsContent);
+        return Promise.resolve();
+      });
+
+      const agentFile = new AgentFile(agentPath);
+      await agentFile.load();
+
+      expect(fileUtils.createTempDir).toHaveBeenCalledWith('adk_agent_loader');
+      expect(
+        (esbuild.build as Mock).mock.calls[0][0].allowOverwrite,
+      ).toBeUndefined();
+
+      await agentFile.dispose();
     });
 
     it('throws if rootAgent is not found', async () => {
@@ -643,13 +666,10 @@ describe('AgentLoader', () => {
 
   describe('AgentLoader', () => {
     beforeEach(async () => {
-      let loaderOutputDirIndex = 0;
-      (fileUtils.getTempDir as Mock).mockImplementation(() =>
-        path.join(
-          tempLoaderDir,
-          `agent-${Date.now()}-${Math.random().toString(36).slice(2)}-${loaderOutputDirIndex++}`,
-        ),
-      );
+      (fileUtils.createTempDir as Mock).mockImplementation(async () => {
+        await fs.mkdir(tempLoaderDir, {recursive: true});
+        return fs.mkdtemp(path.join(tempLoaderDir, 'agent-'));
+      });
 
       await fs.writeFile(
         path.join(tempAgentsDir, 'agent1.js'),

--- a/dev/test/utils/file_utils_temp_dir_test.ts
+++ b/dev/test/utils/file_utils_temp_dir_test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// These cases run against the real filesystem. They cannot live in
+// file_utils_test.ts, which mocks `node:fs/promises` module-wide and therefore
+// makes the actual `mkdtemp` behaviour under test here unobservable.
+
+import {randomUUID} from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {createTempDir} from '../../src/utils/file_utils.js';
+
+describe('createTempDir', () => {
+  const createdDirs: string[] = [];
+  const plantedLinks: string[] = [];
+  let prefix = '';
+
+  function trackedPrefix(): string {
+    prefix = `adk_test_${randomUUID()}`;
+    return prefix;
+  }
+
+  async function create(): Promise<string> {
+    const dir = await createTempDir(prefix);
+    createdDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    for (const link of plantedLinks.splice(0)) {
+      await fs.unlink(link);
+    }
+    for (const dir of createdDirs.splice(0)) {
+      await fs.rm(dir, {recursive: true, force: true});
+    }
+  });
+
+  it('returns a directory that exists and is empty', async () => {
+    trackedPrefix();
+
+    const dir = await create();
+
+    expect((await fs.stat(dir)).isDirectory()).toBe(true);
+    expect(await fs.readdir(dir)).toHaveLength(0);
+  });
+
+  it('creates the directory directly under the temp root', async () => {
+    trackedPrefix();
+
+    const dir = await create();
+
+    expect(path.dirname(dir)).toBe(path.resolve(os.tmpdir()));
+    expect(path.basename(dir).startsWith(`${prefix}-`)).toBe(true);
+  });
+
+  it('creates no predictable intermediate directory', async () => {
+    trackedPrefix();
+
+    await create();
+
+    await expect(fs.stat(path.join(os.tmpdir(), prefix))).rejects.toThrow();
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'creates the directory private to the current user',
+    async () => {
+      trackedPrefix();
+
+      const dir = await create();
+
+      expect((await fs.stat(dir)).mode & 0o777).toBe(0o700);
+    },
+  );
+
+  it('returns a distinct directory on every call', async () => {
+    trackedPrefix();
+
+    const first = await create();
+    const second = await create();
+
+    expect(first).not.toBe(second);
+    expect((await fs.stat(first)).isDirectory()).toBe(true);
+    expect((await fs.stat(second)).isDirectory()).toBe(true);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'ignores a symlink planted at the predictable parent path',
+    async () => {
+      trackedPrefix();
+      const attackerDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'adk_test_attacker-'),
+      );
+      createdDirs.push(attackerDir);
+      const link = path.join(os.tmpdir(), prefix);
+      await fs.symlink(attackerDir, link);
+      plantedLinks.push(link);
+      expect(await fs.realpath(link)).toBe(await fs.realpath(attackerDir));
+
+      const dir = await create();
+
+      expect(path.dirname(dir)).toBe(path.resolve(os.tmpdir()));
+      expect(path.dirname(await fs.realpath(dir))).not.toBe(
+        await fs.realpath(attackerDir),
+      );
+      expect(await fs.readdir(attackerDir)).toHaveLength(0);
+    },
+  );
+});

--- a/dev/test/utils/file_utils_test.ts
+++ b/dev/test/utils/file_utils_test.ts
@@ -7,7 +7,7 @@ import * as path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it, Mock, vi} from 'vitest';
 
 import {
-  getTempDir,
+  createTempDir,
   isFile,
   isFileExists,
   isFolderExists,
@@ -25,6 +25,7 @@ vi.mock('node:fs/promises', async () => {
     access: vi.fn(),
     stat: vi.fn(),
     mkdir: vi.fn(),
+    mkdtemp: vi.fn(),
     rm: vi.fn(),
     readdir: vi.fn(),
   };
@@ -44,6 +45,7 @@ describe('file_utils', () => {
     access: Mock;
     stat: Mock;
     mkdir: Mock;
+    mkdtemp: Mock;
     rm: Mock;
     readdir: Mock;
   };
@@ -61,6 +63,7 @@ describe('file_utils', () => {
       access: Mock;
       stat: Mock;
       mkdir: Mock;
+      mkdtemp: Mock;
       rm: Mock;
       readdir: Mock;
     };
@@ -122,15 +125,15 @@ describe('file_utils', () => {
     );
   });
 
-  it('getTempDir uses os.tmpdir and optional prefix and crypto.randomUUID', () => {
+  it('createTempDir creates the directory atomically under os.tmpdir', async () => {
     osMock.tmpdir.mockReturnValue('/tmp');
-    const dir = getTempDir('myprefix');
-    const basename = path.basename(dir);
-    const parentDir = path.dirname(dir);
+    fsPromises.mkdtemp.mockResolvedValue('/tmp/myprefix-a1b2c3');
 
-    expect(parentDir).toBe(path.join('/tmp', 'myprefix'));
-    expect(basename).toMatch(
-      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
+    await expect(createTempDir('myprefix')).resolves.toBe(
+      '/tmp/myprefix-a1b2c3',
+    );
+    expect(fsPromises.mkdtemp).toHaveBeenCalledWith(
+      path.join('/tmp', 'myprefix-'),
     );
   });
 


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change

1. Link to an existing issue (if applicable):
   Closes: #issue_number
   Related: #issue_number
2. Or, if no issue exists, describe the change:

_(No public issue exists for this; the description below is self-contained.)_

**Problem**: Every temporary directory the `dev` package creates was composed from a **fixed, predictable parent** under the system temp root.

`getTempDir()` returned `path.join(os.tmpdir(), <prefix>, randomUUID())` — e.g. `/tmp/adk_agent_loader/<uuid>`. The leaf was random, but the intermediate component (`adk_agent_loader`, `cloud_run_deploy_src`, `agent_engine_deploy_src`) was a constant. The path was only _computed_ there; the directory was materialised later by `fsPromises.mkdir(outputDir, {recursive: true})`, and a recursive `mkdir` **traverses an existing symlink** at an intermediate component instead of failing.

So on a shared host, another local user who wins the race to create `<tmp>/adk_agent_loader` — as a directory they own, or as a symlink into one — owns the parent of every "random" directory ADK creates afterwards. The random leaf buys nothing, because the attacker controls the container it lands in. Two concrete consequences:

1. **Code execution as the ADK user.** `AgentFile.load()` writes the compiled agent bundle there with esbuild and then `import()`s it. An attacker who owns the directory can swap the bundle between the write and the import. `allowOverwrite: true` also meant ADK silently clobbered a file the attacker had planted rather than failing.
2. **Poisoned deployment artifacts.** The same scheme supplied the `--temp_folder` default for `adk deploy cloud_run` and `adk deploy agent_engine`. That folder is the source directory handed to `gcloud run deploy --source` / `gcloud builds submit`, so tampering ships attacker code into the user's Cloud Run service or Agent Engine image.

A second instance of the same class lived in the deploy path: both deploy functions did "if the temp folder exists, `rm -rf` it, then recreate it". Applied to a directory we had just created safely, that delete-then-recreate reopens a symlink race on a now-known path and recreates the directory with default umask permissions instead of `0700`.

**Solution**: `getTempDir` is replaced by `createTempDir(prefix)`, which creates the directory with a **single `fs.mkdtemp` call directly under `os.tmpdir()`** — the whole path is unpredictable, no fixed intermediate component is ever created or relied upon, and on POSIX the directory is mode `0700`. It is cross-platform, so Windows is not weakened. Callers absorb one behavioural change: the returned directory already exists.

Follow-on changes that close the rest of the hole:

- **`agent_loader.ts`**: dropped the now-redundant `fsPromises.mkdir(outputDir, {recursive: true})` (leaving the symlink-traversing call in place invites a future refactor to trip over it), and dropped `allowOverwrite: true` from the esbuild options. The output directory is freshly created and empty, so an overwrite can never be legitimate; without the flag esbuild fails loudly instead of silently clobbering.
- **`cli.ts`**: `--temp_folder` no longer carries an eager `getTempDir(...)` default. An eager default would have created a real directory on **every** CLI invocation, `adk --help` included. Verified: with the built CLI and a clean `TMPDIR`, `adk --help` and `adk deploy cloud_run --help` create zero entries in the temp root, and `--help` now renders "default: a private directory created in the system temp directory" instead of a path that differed on every invocation.
- **`deploy_utils.ts`**: `BaseDeployOptions.tempFolder` becomes optional (`tempFolder?: string`), documented as "the deploy command creates a private temporary directory and removes it when the deployment finishes". The repo guideline "don't make strictly-required options optional" does not apply here — the option is now _genuinely_ optional with a documented safe default, and the deploy function is the only place that knows whether the folder was caller-supplied, which is exactly what decides whether the destructive pre-clean may run.
- **Both deploy functions**: resolve `tempFolder = options.tempFolder ?? await createTempDir(<prefix>)`, and **gate the destructive pre-clean on `options.tempFolder`**. `adk deploy --temp_folder <dir>` keeps its current "clean the folder first" semantics because the user chose that path; a directory we just created privately is never torn down and rebuilt.
- **Creation happens after everything that can throw, in both files.** `prepareGCloudArguments` validates the user's extra gcloud args and throws on a conflict, and that error is deliberately propagated out of `deployToCloudRun` rather than caught (pinned by an existing test). So in `cli_deploy_cloud_run.ts` the argument array is built **first**, while nothing exists on disk, and the temp directory is created immediately before the `try`/`finally` that removes it; `gcloudCommands.push('--source', tempFolder)` supplies the path once it exists. Creating the directory any earlier would leak an empty `0700` directory on that user-error path, because there is no `finally` that early to remove it. `cli_deploy_agent_engine.ts` already had this ordering (all of its throwing validation - project, region, repository - precedes creation). This also removes the need for the `tempFolder: string` parameter that an earlier revision of this PR threaded through `prepareGCloudArguments`, so that signature is now unchanged from `main`.

No new suppressions of any kind (`@ts-expect-error`, `@ts-ignore`, `eslint-disable`, `any`, `as any`, coverage ignores) are added anywhere in this diff.

`createTempDir` takes a **required** prefix: all three call sites pass a string literal, so an optional parameter would only add an untested default branch.

**Collision check (open PRs on the fork, scanned all 502).** No open PR lands this change. Adjacent-but-disjoint work I found and deliberately did not stack on:

- **#355** — same vulnerability class (`fs.mkdtemp`) but in `core/src/code_executors/unsafe_local_code_executor.ts`. Completely disjoint files and package.
- **#285** — a perf PR that refactors the same esbuild options block in `dev/src/utils/agent_loader.ts` into a `buildAgentFile` helper, but _keeps_ `allowOverwrite: true`. Textual overlap only, different purpose.
- **#103** — a feature PR that relocates the agent-loader output out of the temp root into a `.adk_build_cache` beside the agent source for module-resolution reasons. It leaves `getTempDir` in place and does not touch the deploy paths, so the vulnerability survives it.

No open PR touches `getTempDir` in `dev/src/utils/file_utils.ts` or the `--temp_folder` defaults. Branched from `main`.

### Testing Plan

Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.
Unit Tests:
[x] I have added or updated unit tests for my change.
[x] All unit tests pass locally.

```
npx vitest run --project unit:dev \
  dev/test/utils/file_utils_test.ts \
  dev/test/utils/file_utils_temp_dir_test.ts \
  dev/test/utils/agent_loader_test.ts \
  dev/test/cli/cli_deploy_cloud_run_test.ts \
  dev/test/cli/cli_deploy_agent_engine_test.ts \
  dev/test/cli/cli_test.ts
# Test Files  6 passed (6)
#      Tests  114 passed (114)

npm run build && npm run lint && npm run format:check     # all clean
npx tsc --noEmit   # 281 errors, byte-identical to the pre-existing count on the
                   # base commit; 0 of them in dev/
```

**New test file** — `dev/test/utils/file_utils_temp_dir_test.ts` (6 cases, real filesystem). The sibling `file_utils_test.ts` mocks `node:fs/promises` module-wide, which makes real `mkdtemp` behaviour unobservable, so these cases cannot live there; the file opens with a comment saying exactly that. Each case uses a `randomUUID`-derived prefix so the suite is hermetic on a shared machine, and every created path is cleaned up in `afterEach`. Cases: the directory exists and is empty; it is a direct child of `path.resolve(os.tmpdir())` with the expected basename prefix; **no predictable intermediate directory is created** (`fs.stat(path.join(os.tmpdir(), prefix))` rejects); mode is `0700` (POSIX only); consecutive calls return distinct live directories; and **a symlink planted at the predictable parent path cannot redirect the output** — the fixture asserts the symlink is live via `fs.realpath` first, so the case cannot pass vacuously.

**Error / non-happy paths exercised**: the guarded pre-clean is covered in both directions in both deploy suites — caller-supplied folder (existing `'should clean up existing temp folder before deploying'`, kept as-is, which now covers the caller branch) and no folder supplied (new cases). `createTempDir` adds no new error handling by design: a `mkdtemp` rejection propagates into each caller's existing error handling rather than silently falling back to a less safe path.

**Coverage.** 100% line and branch coverage on every line this change adds. Measured from the v8 JSON report over the four touched source files: no statement or branch I added appears in the uncovered set. The remaining uncovered regions are all pre-existing (`createFolder`/`removeFolder`/`listFiles` in `file_utils.ts`, the region-unset error and `--labels` handling in `cli_deploy_cloud_run.ts`, the repository-unset error in `cli_deploy_agent_engine.ts`). No `finally` block, guard, or cleanup was removed to move a number.

#### Prove the tests can fail (mutation testing)

Each mutation was applied, the suite run, and the mutation reverted.

| #   | Mutation                                                                                                             | Result                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
| --- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| 1   | Restore the old body of the temp helper (`path.join(os.tmpdir(), prefix, randomUUID())` + `mkdir {recursive: true}`) | `file_utils_temp_dir_test.ts`: **4 of 6 fail** — "directly under the temp root" `AssertionError: expected '<tmp>/adk_test_<uuid>' to be '<tmp>'`; "no predictable intermediate directory" `AssertionError: promise resolved "Stats{ dev: 64769, mode: 16877, …(12) }" instead of rejecting`; "private to the current user" `AssertionError: expected 493 to be 448` (0755 vs 0700); "ignores a symlink planted at the predictable parent path" `AssertionError: expected '<tmp>/adk_test_<uuid>' to be '<tmp>'`. `file_utils_test.ts` also fails: `AssertionError: expected '/tmp/myprefix/af86ac68-…' to be '/tmp/myprefix-a1b2c3'` |
| 2   | Re-add `allowOverwrite: true` in `agent_loader.ts`                                                                   | `agent_loader_test.ts` "compiles into a private temp dir without allowing overwrite" fails: `AssertionError: expected true to be undefined`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| 3   | Drop the `callerTempFolder &&` guard in `cli_deploy_cloud_run.ts`                                                    | "should create a private temp folder when none is supplied" fails: `AssertionError: expected "spy" to not be called at all, but actually been called 1 times`                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| 4   | Drop the same guard in `cli_deploy_agent_engine.ts`                                                                  | "should create a private temp folder when none is supplied" fails with the same assertion                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| 5   | Re-add an eager default value to both `--temp_folder` option definitions in `cli.ts`                                 | Both new `cli_test.ts` cases fail: `AssertionError: expected '/tmp/cloud_run_deploy_src/eager' to be undefined` and `AssertionError: expected '/tmp/agent_engine_deploy_src/eager' to be undefined`                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| 6   | Move the `createTempDir` call back above `prepareGCloudArguments` in `cli_deploy_cloud_run.ts` (the ordering that leaks an empty dir when the gcloud args are rejected) | New case "should not create a temp folder when the gcloud args are rejected" fails: `AssertionError: expected "spy" to not be called at all, but actually been called 1 times` |

#### Declared: existing assertions that had to change, and why

> Called out explicitly rather than left for a reviewer to find. Two existing assertions were **edited in place** instead of being added alongside. Both edits are forced by the changed shape - they pinned an API and a flag that no longer exist - and neither removes a surviving regression signal.

Three, all forced by the changed shape — no test was skipped, disabled, weakened, or deleted.

1. `dev/test/utils/file_utils_test.ts` — the case `'getTempDir uses os.tmpdir and optional prefix and crypto.randomUUID'` asserted `path.dirname(dir) === path.join('/tmp', 'myprefix')` and a UUID leaf. It pinned **exactly the vulnerable shape this PR removes**, so it cannot survive the fix. Replaced with `'createTempDir creates the directory atomically under os.tmpdir'`, which pins the new contract: a single `mkdtemp` call with `path.join('/tmp', 'myprefix-')`. `mkdtemp: vi.fn()` was added to the `node:fs/promises` mock factory and to both `fsPromises` type literals.
2. `dev/test/utils/agent_loader_test.ts` — `allowOverwrite: true` removed from the existing esbuild `toMatchObject`. Every other key in that assertion (`entryPoints`, `outfile`, `target`, `platform`, `format`, `packages`, `bundle`, `minify`, `external`) is untouched, and the new case `'compiles into a private temp dir without allowing overwrite'` positively pins `allowOverwrite` as `undefined` and the prefix as `'adk_agent_loader'` — see mutation 2.
3. `dev/test/utils/agent_loader_test.ts` — the two `getTempDir` mock implementations became `createTempDir` mocks that **create** the directory. Production no longer calls `mkdir` on the returned path, and `AgentFile.dispose()` deletes it between tests, so a straight rename would have handed the loader a non-existent directory. No behavioural assertion changed; the now-unused `loaderOutputDirIndex` counter was dropped in favour of a real `fs.mkdtemp` per call.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.

Ran on Linux (Node v22) against the built `dev` package, with the attacker symlink actually planted — no mocks anywhere in this path:

```bash
mkdir -p "$TMPDIR/attacker-owned"
ln -s "$TMPDIR/attacker-owned" "$TMPDIR/adk_agent_loader"
# then load a real sample agent through AgentFile({compile: true, bundle: true})
node -e "... new AgentFile('dev/samples/agent_with_tool.ts', {compile:true,bundle:true}).load() ..."
```

**Before the fix** (same script against the vulnerable helper):

```
outputDir:            <tmp>/adk_agent_loader/da502f3d-e04b-4102-ad23-e02ba6967a6f
parentIsTmpRoot:      false
mode:                 755
attackerDirEntries:   ["da502f3d-e04b-4102-ad23-e02ba6967a6f"]
```

The compiled bundle landed **inside the attacker-owned directory**, in a world-readable `0755` directory — then got `import()`ed.

**After the fix**:

```
loadedAgent:          weather_time_agent
outputDir:            <tmp>/adk_agent_loader-fM5dWh
parentIsTmpRoot:      true
mode:                 700
attackerDirEntries:   []
outputDir removed after dispose: true
```

The agent still loads correctly, the bundle lives in a `0700` directory directly under the temp root, the attacker directory stays empty, and the directory is removed on `dispose()`.

CLI checks with the built entrypoint and a clean `TMPDIR`:

```
adk deploy cloud_run --help   ->  "--temp_folder [string]  Optional. Temp folder for the generated
                                   Cloud Run source files (default: a private directory created in
                                   the system temp directory)."   0 entries created in the temp root
adk --help                    ->  0 entries created in the temp root
```

### Checklist

[x] I have read the CONTRIBUTING.md document.
[x] I have performed a self-review of my own code.
[x] I have commented my code, particularly in hard-to-understand areas.
[x] I have added tests that prove my fix is effective or that my feature works.
[x] New and existing unit tests pass locally with my changes.

