### PR TITLE
Fix: skip identity preamble when agent transfer is disabled

### DIFF
--- a/core/src/agents/processors/identity_llm_request_processor.ts
+++ b/core/src/agents/processors/identity_llm_request_processor.ts
@@ -7,16 +7,20 @@
 import {Event} from '../../events/event.js';
 import {LlmRequest, appendInstructions} from '../../models/llm_request.js';
 import {InvocationContext} from '../invocation_context.js';
+import {isLlmAgent} from '../llm_agent.js';
 import {BaseLlmRequestProcessor} from './base_llm_processor.js';
 
 /**
  * Appends identity instructions to the {@link LlmRequest} system prompt,
  * informing the model of the agent's name and description.
+ *
+ * The instructions are omitted for an agent that cannot transfer control
+ * anywhere, since nothing in the prompt consumes the identity in that case.
  */
 export class IdentityLlmRequestProcessor extends BaseLlmRequestProcessor {
   /**
    * Appends agent name and description as identity instructions to the system
-   * prompt of the request.
+   * prompt of the request, unless the agent has no reachable transfer target.
    *
    * @param invocationContext - The current invocation context.
    * @param llmRequest - The request object to append instructions to.
@@ -27,6 +31,19 @@ export class IdentityLlmRequestProcessor extends BaseLlmRequestProcessor {
     llmRequest: LlmRequest,
   ): AsyncGenerator<Event, void, undefined> {
     const agent = invocationContext.agent;
+    // The preamble only exists so the model can name itself when handing off
+    // control, and embedding the agent name gives every sibling of a fan-out a
+    // distinct system prompt, which defeats prompt-prefix caching on local
+    // models (google/adk-js#613). Mirrors the condition in the LlmAgent
+    // constructor that decides whether the transfer processor runs at all.
+    if (
+      isLlmAgent(agent) &&
+      agent.disallowTransferToParent &&
+      agent.disallowTransferToPeers &&
+      agent.subAgents.length === 0
+    ) {
+      return;
+    }
     const si = [`You are an agent. Your internal name is "${agent.name}".`];
     if (agent.description) {
       si.push(`The description about you is "${agent.description}"`);

--- a/core/test/agents/processors/identity_llm_request_processor_test.ts
+++ b/core/test/agents/processors/identity_llm_request_processor_test.ts
@@ -12,8 +12,14 @@ import {
   PluginManager,
   createSession,
 } from '@google/adk';
+import {Schema, Type} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {IDENTITY_LLM_REQUEST_PROCESSOR} from '../../../src/agents/processors/identity_llm_request_processor.js';
+
+/** Forces `disallowTransferToParent` and `disallowTransferToPeers` to true. */
+const OUTPUT_SCHEMA: Schema = {type: Type.OBJECT};
+
+const SHARED_INSTRUCTION = 'Shared instruction.';
 
 class MockRootAgent extends BaseAgent {
   constructor(name: string, subAgents: BaseAgent[] = []) {
@@ -149,5 +155,114 @@ describe('IdentityLlmRequestProcessor', () => {
     const instruction = llmRequest.config?.systemInstruction as string;
     expect(instruction).toContain('my_agent');
     expect(instruction).toContain('Processes data');
+  });
+
+  it('omits the preamble when both transfer directions are disabled', async () => {
+    const agent = new LlmAgent({
+      name: 'my_agent',
+      model: 'gemini-2.5-flash',
+      disallowTransferToParent: true,
+      disallowTransferToPeers: true,
+    });
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest = makeLlmRequest();
+
+    await runProcessor(invocationContext, llmRequest);
+
+    expect(llmRequest.config?.systemInstruction).toBeUndefined();
+  });
+
+  it('omits the preamble for an agent whose outputSchema disables transfer', async () => {
+    const agent = new LlmAgent({
+      name: 'child_one',
+      model: 'gemini-2.5-flash',
+      outputSchema: OUTPUT_SCHEMA,
+    });
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest = makeLlmRequest();
+
+    await runProcessor(invocationContext, llmRequest);
+
+    expect(llmRequest.config?.systemInstruction).toBeUndefined();
+  });
+
+  it('gives fan-out siblings an identical system prompt', async () => {
+    const requests = ['child_one', 'child_two'].map((name) => {
+      const agent = new LlmAgent({
+        name,
+        model: 'gemini-2.5-flash',
+        instruction: SHARED_INSTRUCTION,
+        outputSchema: OUTPUT_SCHEMA,
+      });
+      const llmRequest = makeLlmRequest();
+      llmRequest.config = {systemInstruction: SHARED_INSTRUCTION};
+      return {
+        invocationContext: createMockInvocationContext(agent),
+        llmRequest,
+      };
+    });
+
+    for (const {invocationContext, llmRequest} of requests) {
+      await runProcessor(invocationContext, llmRequest);
+    }
+
+    expect(requests[0].llmRequest.config?.systemInstruction).toBe(
+      SHARED_INSTRUCTION,
+    );
+    expect(requests[0].llmRequest.config?.systemInstruction).toBe(
+      requests[1].llmRequest.config?.systemInstruction,
+    );
+  });
+
+  it('keeps the preamble when only transfer to the parent is disabled', async () => {
+    const agent = new LlmAgent({
+      name: 'my_agent',
+      model: 'gemini-2.5-flash',
+      disallowTransferToParent: true,
+      disallowTransferToPeers: false,
+    });
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest = makeLlmRequest();
+
+    await runProcessor(invocationContext, llmRequest);
+
+    expect(llmRequest.config?.systemInstruction).toContain(
+      'Your internal name is "my_agent"',
+    );
+  });
+
+  it('keeps the preamble when only transfer to peers is disabled', async () => {
+    const agent = new LlmAgent({
+      name: 'my_agent',
+      model: 'gemini-2.5-flash',
+      disallowTransferToParent: false,
+      disallowTransferToPeers: true,
+    });
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest = makeLlmRequest();
+
+    await runProcessor(invocationContext, llmRequest);
+
+    expect(llmRequest.config?.systemInstruction).toContain(
+      'Your internal name is "my_agent"',
+    );
+  });
+
+  it('keeps the preamble when transfer is disabled but the agent has sub-agents', async () => {
+    const agent = new LlmAgent({
+      name: 'my_agent',
+      model: 'gemini-2.5-flash',
+      disallowTransferToParent: true,
+      disallowTransferToPeers: true,
+      subAgents: [new LlmAgent({name: 'leaf', model: 'gemini-2.5-flash'})],
+    });
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest = makeLlmRequest();
+
+    await runProcessor(invocationContext, llmRequest);
+
+    expect(llmRequest.config?.systemInstruction).toContain(
+      'Your internal name is "my_agent"',
+    );
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #613
- Related: #607

**2. Or, if no issue exists, describe the change:**

**Problem:**

`IdentityLlmRequestProcessor` unconditionally prepends

```
You are an agent. Your internal name is "<agent.name>".
```

to the system instruction of every request, for every agent, on every
invocation. Because the string embeds `agent.name`, each child of a fan-out gets
a **different** system prompt even when every other input (instruction, tools,
schema) is identical. Local/on-device models that key a warm session on the
system prompt therefore miss the prompt-prefix cache on every child.

The preamble exists only to support **agent transfer** — the model must know its
own name and description to decide whether to hand off. When the agent has no
reachable transfer target, nothing in the prompt consumes it, and the processor
is installed unconditionally in the default `LlmAgent` chain, so there is no
supported way to opt out.

Measurement reported in #613 (Chrome built-in Prompt API, fan-out over 10
candidates, each child an `LlmAgent` with an identical `instruction` plus an
`outputSchema`) — quoted as reported, **not** reproduced here, as it needs
Chrome's built-in Prompt API and is not runnable in CI:

|                   | `LanguageModel.create()` | `session.clone()` |
| ----------------- | ------------------------ | ----------------- |
| with the preamble | 11                       | 1                 |
| preamble stripped | 2                        | 11                |

**Solution:**

Skip the preamble when the agent provably cannot transfer control anywhere. One
early return at the top of `runAsync`:

```ts
if (
  isLlmAgent(agent) &&
  agent.disallowTransferToParent &&
  agent.disallowTransferToPeers &&
  agent.subAgents.length === 0
) {
  return;
}
```

The wording, ordering, and `appendInstructions` call site are unchanged; this
only decides _whether_ to append. Narrowing uses the existing `isLlmAgent()`
type guard (as `agent_transfer_llm_request_processor.ts` does) — no
`instanceof`, no casts. No new types, exports, or config fields.

**Deliberate deviation from the patch proposed in the issue.** The issue gates
on the two `disallow*` flags alone. That is not quite safe:
`AgentTransferLlmRequestProcessor.getTransferTargets()` pushes `agent.subAgents`
into the target list **unconditionally**, and the `LlmAgent` constructor only
skips installing that processor when `disallowTransferToParent &&
disallowTransferToPeers && !subAgents?.length`. So an agent with both flags set
_and_ sub-agents — e.g. a parent that also declares an `outputSchema`, which
forces both flags to `true` — still receives live transfer instructions.
Dropping the preamble there would tell the model "transfer to one of these
agents if you are not the best fit according to your description" while never
telling it its own name or description. Adding the `subAgents.length === 0` term
makes the guard exactly "transfer is unreachable", loses none of the reported
benefit (the fan-out children in the report are leaves), and keeps the two
conditions in the codebase consistent. Test `keeps the preamble when transfer is
disabled but the agent has sub-agents` pins this term.

**Behavioural trade-off (intended, and the point of the fix):** a
transfer-disabled leaf agent no longer receives the identity line in its system
prompt. The model loses knowledge of an internal agent name that had no
documented consumer in that configuration. Anyone deliberately relying on the
agent name being present for a transfer-disabled agent can put it in their own
`instruction`. Public API is unchanged, so this is a patch-level change.

**Out of scope, tracked separately:** option B from the issue (an
`includeIdentityPreamble` opt-out on `LlmAgentConfig`) is a separate,
independently shippable API addition and is not implemented here.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Six new cases appended to the existing
`core/test/agents/processors/identity_llm_request_processor_test.ts`. The six
pre-existing cases are untouched — they are the regression signal for the
"preamble is present" half of the contract, including the non-`LlmAgent` case,
which keeps the preamble because there are no transfer flags to consult.

| New case                                                                    | Pins                                                            |
| --------------------------------------------------------------------------- | --------------------------------------------------------------- |
| `omits the preamble when both transfer directions are disabled`             | the guard fires; `llmRequest.config` stays `undefined`          |
| `omits the preamble for an agent whose outputSchema disables transfer`      | the reporter's exact config, via the constructor's flag-forcing |
| `gives fan-out siblings an identical system prompt`                         | the actual bug: two seeded requests stay byte-identical         |
| `keeps the preamble when only transfer to the parent is disabled`           | the `disallowTransferToPeers` conjunct                          |
| `keeps the preamble when only transfer to peers is disabled`                | the `disallowTransferToParent` conjunct                         |
| `keeps the preamble when transfer is disabled but the agent has sub-agents` | the `subAgents.length === 0` term                               |

Commands run locally on this branch, rebased onto `main`:

```
npx vitest run --project unit:core core/test/agents/processors/identity_llm_request_processor_test.ts
  -> 12 passed (12)
npx vitest run --project unit:core core/test/runner core/test/agents core/test/plugins
  -> 403 passed (403)   (the end-to-end InMemoryRunner assertion on the exact
                         concatenated system instruction stays green, unmodified)
npx vitest run --project unit:dev dev/test/conformance/yaml_agent_loader_test.ts
  -> 6 passed (6)
npm run build      -> OK
npm run lint       -> OK (0 findings)
npm run docs:check -> OK
npx prettier --check <the two changed files> -> clean
```

Coverage of the changed source file is 100% statements / 100% branches / 100%
lines:

```
npx vitest run --project unit:core core/test/agents/processors/identity_llm_request_processor_test.ts \
  --coverage.enabled --coverage.reporter=text \
  --coverage.include='core/src/agents/processors/identity_llm_request_processor.ts'

File                | % Stmts | % Branch | % Funcs | % Lines
 ...t_processor.ts  |     100 |      100 |     100 |     100
```

**Proof the tests can fail (mutation runs).** Coverage alone is not proof, so
each new assertion was run against mutated source. All three mutations were
reverted afterwards; the committed source is the unmutated version.

1. **Guard removed entirely** (pre-fix behaviour) — 3 failed | 9 passed:
   ```
   × omits the preamble when both transfer directions are disabled
     → expected 'You are an agent. Your internal name …' to be undefined
   × omits the preamble for an agent whose outputSchema disables transfer
     → expected 'You are an agent. Your internal name …' to be undefined
   × gives fan-out siblings an identical system prompt
     → expected 'Shared instruction.\n\nYou are an age…' to be 'Shared instruction.'
   ```
2. **`agent.subAgents.length === 0` term dropped** (the issue's proposed patch) —
   1 failed | 11 passed:
   ```
   × keeps the preamble when transfer is disabled but the agent has sub-agents
   ```
3. **`&&` between the two `disallow*` flags flipped to `||`** — 2 failed |
   10 passed:
   ```
   × keeps the preamble when only transfer to the parent is disabled
   × keeps the preamble when only transfer to peers is disabled
   ```

**Manual End-to-End (E2E) Tests:**

No new runner-level harness was added: the processor is already exercised end to
end by `core/test/plugins/global_instruction_plugin_test.ts` (`InMemoryRunner` +
a mock LLM capturing the last request), which asserts the exact concatenated
system instruction for a default `LlmAgent`; that assertion staying green
**unmodified** is the integration signal that unaffected agents are unaffected.

To check the fix by hand:

1. Build two `LlmAgent`s named `child_one` and `child_two` with the same
   `instruction` and an `outputSchema` (which forces
   `disallowTransferToParent`/`disallowTransferToPeers` to `true`), and fan them
   out under a `ParallelAgent`.
2. Capture `llmRequest.config.systemInstruction` in a `beforeModelCallback` (or
   a custom `BaseLlm`) for each child.
3. Before this change the two strings differ only by the embedded agent name;
   after it they are byte-identical, so a prompt-prefix cache keyed on the
   system prompt hits for the second and subsequent children.
4. Repeat with a default `LlmAgent` (no `outputSchema`, transfer allowed) and
   confirm the preamble is still present, unchanged.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
      _No dependent changes; this is self-contained._

### Additional context

`npm run format:check` reports pre-existing Prettier findings in 15 files on
`main` that this branch does not touch; the two files changed here are
Prettier-clean. Those findings are left alone to keep this diff scoped.
