### PR TITLE
fix(security): prevent prototype pollution via untrusted map keys

### DIFF
--- a/core/src/auth/credential_service/in_memory_credential_service.ts
+++ b/core/src/auth/credential_service/in_memory_credential_service.ts
@@ -11,6 +11,19 @@ import {AuthConfig} from '../auth_tool.js';
 import {BaseCredentialService} from './base_credential_service.js';
 
 /**
+ * Creates a map with no prototype, for data keyed by untrusted input.
+ *
+ * `appName`, `userId` and `credentialKey` are all attacker-influenced. With an
+ * ordinary `{}` literal a key of `__proto__` resolves to `Object.prototype`
+ * rather than creating an own property, so nested assignment would pollute
+ * every object in the process; and a lookup of an inherited key such as
+ * `toString` would return a function instead of `undefined`.
+ */
+function createNullProtoMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+/**
  * @experimental  (Experimental, subject to change) Class for in memory
  * implementation of credential service
  */
@@ -18,7 +31,7 @@ export class InMemoryCredentialService implements BaseCredentialService {
   private readonly credentials: Record<
     string,
     Record<string, Record<string, AuthCredential>>
-  > = {};
+  > = createNullProtoMap();
 
   loadCredential(
     authConfig: AuthConfig,
@@ -47,11 +60,11 @@ export class InMemoryCredentialService implements BaseCredentialService {
     const {appName, userId} = toolContext.invocationContext.session;
 
     if (!this.credentials[appName]) {
-      this.credentials[appName] = {};
+      this.credentials[appName] = createNullProtoMap();
     }
 
     if (!this.credentials[appName][userId]) {
-      this.credentials[appName][userId] = {};
+      this.credentials[appName][userId] = createNullProtoMap();
     }
 
     return this.credentials[appName][userId];

--- a/core/src/auth/credential_service/in_memory_credential_service.ts
+++ b/core/src/auth/credential_service/in_memory_credential_service.ts
@@ -11,27 +11,25 @@ import {AuthConfig} from '../auth_tool.js';
 import {BaseCredentialService} from './base_credential_service.js';
 
 /**
- * Creates a map with no prototype, for data keyed by untrusted input.
- *
- * `appName`, `userId` and `credentialKey` are all attacker-influenced. With an
- * ordinary `{}` literal a key of `__proto__` resolves to `Object.prototype`
- * rather than creating an own property, so nested assignment would pollute
- * every object in the process; and a lookup of an inherited key such as
- * `toString` would return a function instead of `undefined`.
- */
-function createNullProtoMap<T>(): Record<string, T> {
-  return Object.create(null) as Record<string, T>;
-}
-
-/**
  * @experimental  (Experimental, subject to change) Class for in memory
  * implementation of credential service
  */
 export class InMemoryCredentialService implements BaseCredentialService {
+  /**
+   * A map from app name to a map from user ID to a map from credential key to
+   * credential.
+   *
+   * `appName`, `userId` and `credentialKey` are all attacker-influenced, so
+   * every level is created with `Object.create(null)`. On an ordinary `{}`
+   * literal a key of `__proto__` resolves to the inherited `__proto__`
+   * accessor rather than creating an own property, so nested assignment
+   * pollutes every object in the process, and a lookup of an inherited key
+   * such as `toString` returns a function instead of `undefined`.
+   */
   private readonly credentials: Record<
     string,
     Record<string, Record<string, AuthCredential>>
-  > = createNullProtoMap();
+  > = Object.create(null);
 
   loadCredential(
     authConfig: AuthConfig,
@@ -60,11 +58,11 @@ export class InMemoryCredentialService implements BaseCredentialService {
     const {appName, userId} = toolContext.invocationContext.session;
 
     if (!this.credentials[appName]) {
-      this.credentials[appName] = createNullProtoMap();
+      this.credentials[appName] = Object.create(null);
     }
 
     if (!this.credentials[appName][userId]) {
-      this.credentials[appName][userId] = createNullProtoMap();
+      this.credentials[appName][userId] = Object.create(null);
     }
 
     return this.credentials[appName][userId];

--- a/core/src/memory/in_memory_memory_service.ts
+++ b/core/src/memory/in_memory_memory_service.ts
@@ -21,14 +21,25 @@ import {MemoryEntry} from './memory_entry.js';
  */
 export class InMemoryMemoryService implements BaseMemoryService {
   private readonly memories: MemoryEntry[] = [];
+  /**
+   * A map from user key to a map from session ID to events.
+   *
+   * The inner map is keyed by `session.id`, which arrives off the request path
+   * and contains no `/`, so it can be exactly `__proto__`. On a plain object
+   * literal that key would reach the inherited `__proto__` setter and
+   * re-parent the map instead of creating an own property, silently dropping
+   * the session from the `Object.values` scan in `searchMemory`. The outer key
+   * always contains a `/` (see `getUserKey`) and cannot collide, but is
+   * created the same way for consistency.
+   */
   private readonly sessionEvents: {
     [userKey: string]: {[sessionId: string]: Event[]};
-  } = {};
+  } = Object.create(null);
 
   async addSessionToMemory(session: Session): Promise<void> {
     const userKey = getUserKey(session.appName, session.userId);
     if (!this.sessionEvents[userKey]) {
-      this.sessionEvents[userKey] = {};
+      this.sessionEvents[userKey] = Object.create(null);
     }
     this.sessionEvents[userKey][session.id] = session.events.filter(
       (event) => (event.content?.parts?.length ?? 0) > 0,

--- a/core/src/sessions/base_session_service.ts
+++ b/core/src/sessions/base_session_service.ts
@@ -196,7 +196,17 @@ export abstract class BaseSessionService {
       if (key.startsWith(State.TEMP_PREFIX)) {
         continue;
       }
-      session.state[key] = value;
+      // `session.state` is not always a null-prototype map — a caller can hand
+      // us a session whose state is a plain object literal — and on a plain
+      // object `state['__proto__'] = value` reaches the inherited `__proto__`
+      // setter, which replaces the object's prototype instead of storing the
+      // entry. `defineProperty` always creates an own property.
+      Object.defineProperty(session.state, key, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
   }
 }
@@ -210,7 +220,10 @@ export function trimTempDeltaState(event: Event): Event {
   }
 
   const stateDelta = event.actions.stateDelta;
-  const filteredStateDelta: Record<string, unknown> = {};
+  // Null-prototype: the caller controls these keys, and copying a `__proto__`
+  // key into a plain object literal invokes the inherited `__proto__` setter,
+  // which drops the entry and re-parents the map. See `trimTempState`.
+  const filteredStateDelta: Record<string, unknown> = Object.create(null);
   for (const [key, value] of Object.entries(stateDelta)) {
     if (!key.startsWith(State.TEMP_PREFIX)) {
       filteredStateDelta[key] = value;
@@ -223,11 +236,19 @@ export function trimTempDeltaState(event: Event): Event {
 
 /**
  * Removes temporary state keys from the state.
+ *
+ * The result is a null-prototype map. `state` comes straight off the request
+ * body on a dev server (`POST /apps/:appName/users/:userId/sessions/:sessionId`),
+ * and `JSON.parse` makes `__proto__` an own key, so copying it into a plain
+ * object literal would invoke the inherited `__proto__` setter: the entry is
+ * dropped and the new state object is re-parented onto the attacker's object.
+ * `State.get`/`State.has` use the `in` operator, so every key on that object
+ * would then read back as session state.
  */
 export function trimTempState(
   state: Record<string, unknown>,
 ): Record<string, unknown> {
-  const filteredState: Record<string, unknown> = {};
+  const filteredState: Record<string, unknown> = Object.create(null);
   for (const [key, value] of Object.entries(state)) {
     if (!key.startsWith(State.TEMP_PREFIX)) {
       filteredState[key] = value;

--- a/core/src/sessions/in_memory_session_service.ts
+++ b/core/src/sessions/in_memory_session_service.ts
@@ -31,6 +31,21 @@ export function isInMemoryConnectionString(uri?: string): boolean {
 }
 
 /**
+ * Creates a map with no prototype, for data keyed by untrusted input.
+ *
+ * The maps below are indexed by `appName`, `userId`, `sessionId` and state
+ * keys, all of which are attacker-controlled on a dev server (they arrive
+ * straight off the request path/body). With an ordinary `{}` literal, a key of
+ * `__proto__` resolves to `Object.prototype` instead of creating an own
+ * property, so `map[appName][userId] = ...` writes onto `Object.prototype` and
+ * pollutes every object in the process. A null-prototype map has no inherited
+ * `__proto__` accessor, so such keys become ordinary own properties.
+ */
+function createNullProtoMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+/**
  * An in-memory implementation of the session service.
  */
 export class InMemorySessionService extends BaseSessionService {
@@ -39,18 +54,19 @@ export class InMemorySessionService extends BaseSessionService {
    * session.
    */
   private sessions: Record<string, Record<string, Record<string, Session>>> =
-    {};
+    createNullProtoMap();
 
   /**
    * A map from app name to a map from user ID to a map from key to the value.
    */
   private userState: Record<string, Record<string, Record<string, unknown>>> =
-    {};
+    createNullProtoMap();
 
   /**
    * A map from app name to a map from key to the value.
    */
-  private appState: Record<string, Record<string, unknown>> = {};
+  private appState: Record<string, Record<string, unknown>> =
+    createNullProtoMap();
 
   async createSession({
     appName,
@@ -69,10 +85,10 @@ export class InMemorySessionService extends BaseSessionService {
     });
 
     if (!this.sessions[appName]) {
-      this.sessions[appName] = {};
+      this.sessions[appName] = createNullProtoMap();
     }
     if (!this.sessions[appName][userId]) {
-      this.sessions[appName][userId] = {};
+      this.sessions[appName][userId] = createNullProtoMap();
     }
 
     this.sessions[appName][userId][session.id] = session;
@@ -275,15 +291,17 @@ export class InMemorySessionService extends BaseSessionService {
     if (event.actions && event.actions.stateDelta) {
       for (const key of Object.keys(event.actions.stateDelta)) {
         if (key.startsWith(State.APP_PREFIX)) {
-          this.appState[appName] = this.appState[appName] || {};
+          this.appState[appName] =
+            this.appState[appName] || createNullProtoMap();
           this.appState[appName][key.replace(State.APP_PREFIX, '')] =
             event.actions.stateDelta[key];
         }
 
         if (key.startsWith(State.USER_PREFIX)) {
-          this.userState[appName] = this.userState[appName] || {};
+          this.userState[appName] =
+            this.userState[appName] || createNullProtoMap();
           this.userState[appName][userId] =
-            this.userState[appName][userId] || {};
+            this.userState[appName][userId] || createNullProtoMap();
           this.userState[appName][userId][key.replace(State.USER_PREFIX, '')] =
             event.actions.stateDelta[key];
         }

--- a/core/src/sessions/in_memory_session_service.ts
+++ b/core/src/sessions/in_memory_session_service.ts
@@ -31,22 +31,16 @@ export function isInMemoryConnectionString(uri?: string): boolean {
 }
 
 /**
- * Creates a map with no prototype, for data keyed by untrusted input.
- *
- * The maps below are indexed by `appName`, `userId`, `sessionId` and state
- * keys, all of which are attacker-controlled on a dev server (they arrive
- * straight off the request path/body). With an ordinary `{}` literal, a key of
- * `__proto__` resolves to `Object.prototype` instead of creating an own
- * property, so `map[appName][userId] = ...` writes onto `Object.prototype` and
- * pollutes every object in the process. A null-prototype map has no inherited
- * `__proto__` accessor, so such keys become ordinary own properties.
- */
-function createNullProtoMap<T>(): Record<string, T> {
-  return Object.create(null) as Record<string, T>;
-}
-
-/**
  * An in-memory implementation of the session service.
+ *
+ * Every map below is keyed by untrusted input — `appName`, `userId`,
+ * `sessionId` and state keys all arrive straight off the request path or body
+ * on a dev server — so each is created with `Object.create(null)`. On an
+ * ordinary `{}` literal a key of `__proto__` resolves to the inherited
+ * `__proto__` accessor instead of creating an own property, so
+ * `map[appName][userId] = ...` writes onto `Object.prototype` and pollutes
+ * every object in the process. A null-prototype map has no such accessor, so
+ * those keys become ordinary own properties.
  */
 export class InMemorySessionService extends BaseSessionService {
   /**
@@ -54,19 +48,19 @@ export class InMemorySessionService extends BaseSessionService {
    * session.
    */
   private sessions: Record<string, Record<string, Record<string, Session>>> =
-    createNullProtoMap();
+    Object.create(null);
 
   /**
    * A map from app name to a map from user ID to a map from key to the value.
    */
   private userState: Record<string, Record<string, Record<string, unknown>>> =
-    createNullProtoMap();
+    Object.create(null);
 
   /**
    * A map from app name to a map from key to the value.
    */
   private appState: Record<string, Record<string, unknown>> =
-    createNullProtoMap();
+    Object.create(null);
 
   async createSession({
     appName,
@@ -85,10 +79,10 @@ export class InMemorySessionService extends BaseSessionService {
     });
 
     if (!this.sessions[appName]) {
-      this.sessions[appName] = createNullProtoMap();
+      this.sessions[appName] = Object.create(null);
     }
     if (!this.sessions[appName][userId]) {
-      this.sessions[appName][userId] = createNullProtoMap();
+      this.sessions[appName][userId] = Object.create(null);
     }
 
     this.sessions[appName][userId][session.id] = session;
@@ -292,16 +286,16 @@ export class InMemorySessionService extends BaseSessionService {
       for (const key of Object.keys(event.actions.stateDelta)) {
         if (key.startsWith(State.APP_PREFIX)) {
           this.appState[appName] =
-            this.appState[appName] || createNullProtoMap();
+            this.appState[appName] || Object.create(null);
           this.appState[appName][key.replace(State.APP_PREFIX, '')] =
             event.actions.stateDelta[key];
         }
 
         if (key.startsWith(State.USER_PREFIX)) {
           this.userState[appName] =
-            this.userState[appName] || createNullProtoMap();
+            this.userState[appName] || Object.create(null);
           this.userState[appName][userId] =
-            this.userState[appName][userId] || createNullProtoMap();
+            this.userState[appName][userId] || Object.create(null);
           this.userState[appName][userId][key.replace(State.USER_PREFIX, '')] =
             event.actions.stateDelta[key];
         }

--- a/core/test/auth/credential_service/in_memory_credential_service_test.ts
+++ b/core/test/auth/credential_service/in_memory_credential_service_test.ts
@@ -14,7 +14,7 @@ import {
   InvocationContext,
   createSession,
 } from '@google/adk';
-import {describe, expect, it} from 'vitest';
+import {afterEach, describe, expect, it} from 'vitest';
 
 function createMockContext(appName: string, userId: string): Context {
   return new Context({
@@ -93,5 +93,41 @@ describe('InMemoryCredentialService', () => {
 
     const loaded = await service.loadCredential(authConfig, context);
     expect(loaded).toBeUndefined();
+  });
+
+  describe('prototype pollution', () => {
+    afterEach(() => {
+      delete (Object.prototype as Record<string, unknown>)['user1'];
+    });
+
+    it('does not pollute Object.prototype via appName', async () => {
+      const service = new InMemoryCredentialService();
+      const context = createMockContext('__proto__', 'user1');
+      const authConfig: AuthConfig = {
+        credentialKey: 'key1',
+        authScheme: {} as AuthScheme,
+        exchangedAuthCredential: {
+          authType: AuthCredentialTypes.API_KEY,
+          apiKey: 'secret',
+        },
+      };
+
+      await service.saveCredential(authConfig, context);
+
+      expect(({} as Record<string, unknown>)['user1']).toBeUndefined();
+    });
+
+    it('returns undefined for inherited credentialKey names', async () => {
+      const service = new InMemoryCredentialService();
+      const context = createMockContext('testApp', 'user1');
+
+      for (const credentialKey of ['toString', 'constructor', '__proto__']) {
+        const loaded = await service.loadCredential(
+          {credentialKey, authScheme: {} as AuthScheme},
+          context,
+        );
+        expect(loaded).toBeUndefined();
+      }
+    });
   });
 });

--- a/core/test/memory/in_memory_memory_service_test.ts
+++ b/core/test/memory/in_memory_memory_service_test.ts
@@ -267,4 +267,33 @@ describe('InMemoryMemoryService', () => {
       expect(result.memories).toHaveLength(1);
     });
   });
+
+  describe('prototype pollution', () => {
+    it('indexes a session whose id is __proto__', async () => {
+      // `session.id` comes off the request path and holds no `/`, so unlike
+      // the user key it can be exactly `__proto__`. On a plain inner map that
+      // key re-parents the map instead of creating an own property, and the
+      // `Object.values` scan in `searchMemory` then steps over the session.
+      const event = createEvent({
+        author: 'user',
+        content: {role: 'user', parts: [{text: 'hello world'}]},
+      });
+      const session = await sessionService.createSession({
+        appName: 'myApp',
+        userId: 'alice',
+        sessionId: '__proto__',
+      });
+      await sessionService.appendEvent({session, event});
+
+      await service.addSessionToMemory(session);
+
+      const result = await service.searchMemory({
+        appName: 'myApp',
+        userId: 'alice',
+        query: 'hello',
+      });
+
+      expect(result.memories).toHaveLength(1);
+    });
+  });
 });

--- a/core/test/sessions/in_memory_session_service_test.ts
+++ b/core/test/sessions/in_memory_session_service_test.ts
@@ -659,12 +659,20 @@ describe('InMemorySessionService', () => {
   });
 
   describe('prototype pollution', () => {
+    // Every key that any test below can plant on `Object.prototype` when the
+    // fix is reverted, so that reverting it fails these tests instead of
+    // corrupting the ones that run afterwards. `sessions['app1']['__proto__']`
+    // resolves to `Object.prototype`, so the *session id* lands there too, and
+    // `sessions['__proto__']` does the same for the *user id*.
     const POLLUTED_KEYS = [
       'polluted',
       'httpOptions',
       'pwned',
       'baseUrl',
       'poc_sid',
+      'isAdmin',
+      'u1',
+      's1',
     ];
 
     const clearPollution = () => {
@@ -675,6 +683,13 @@ describe('InMemorySessionService', () => {
 
     beforeEach(clearPollution);
     afterEach(clearPollution);
+
+    // A `'__proto__': value` pair in an object literal invokes the prototype
+    // setter instead of creating an own key, so it cannot express what an
+    // attacker actually sends. `JSON.parse` is what the dev server does with a
+    // request body, and it does produce an own `__proto__` key.
+    const parseBody = (json: string): Record<string, unknown> =>
+      JSON.parse(json) as Record<string, unknown>;
 
     it('does not pollute Object.prototype via appName', async () => {
       await service.createSession({
@@ -731,7 +746,7 @@ describe('InMemorySessionService', () => {
       expect(({} as Record<string, unknown>)['pwned']).toBeUndefined();
     });
 
-    it('does not pollute Object.prototype via a __proto__ state key', async () => {
+    it('keeps a __proto__ user state key as an own property', async () => {
       const session = await service.createSession({
         appName: 'app1',
         userId: 'u1',
@@ -752,7 +767,59 @@ describe('InMemorySessionService', () => {
         }),
       });
 
-      expect(({} as Record<string, unknown>)['baseUrl']).toBeUndefined();
+      // Read the key back through a *second* session. `updateSessionState`
+      // also writes the prefixed key into the originating session's own state,
+      // so only a sibling session exercises the `userState` map: writing
+      // `__proto__` into a plain map re-parents it rather than storing an own
+      // key, and `mergeStates` then silently drops the entry for every other
+      // session of the same user.
+      const sibling = await service.createSession({
+        appName: 'app1',
+        userId: 'u1',
+        sessionId: 's2',
+      });
+      expect(sibling.state[`${State.USER_PREFIX}__proto__`]).toEqual({
+        baseUrl: 'https://evil.test',
+      });
+    });
+
+    it('does not re-parent session state via __proto__ in the initial state', async () => {
+      const session = await service.createSession({
+        appName: 'app1',
+        userId: 'u1',
+        sessionId: 's1',
+        state: parseBody('{"__proto__": {"isAdmin": true}}'),
+      });
+
+      // `State` looks keys up with `in`, so a re-parented state object hands
+      // back every key of the attacker's object as if it were session state.
+      expect(new State(session.state).get('isAdmin')).toBeUndefined();
+      expect(session.state['__proto__']).toEqual({isAdmin: true});
+    });
+
+    it('does not re-parent session state via __proto__ in a state delta', async () => {
+      const session = await service.createSession({
+        appName: 'app1',
+        userId: 'u1',
+        sessionId: 's1',
+      });
+      await service.appendEvent({
+        session,
+        event: createEvent({
+          timestamp: Date.now(),
+          actions: createEventActions({
+            stateDelta: parseBody('{"__proto__": {"isAdmin": true}}'),
+          }),
+        }),
+      });
+
+      const stored = await service.getSession({
+        appName: 'app1',
+        userId: 'u1',
+        sessionId: 's1',
+      });
+      expect(new State(stored!.state).get('isAdmin')).toBeUndefined();
+      expect(stored?.state['__proto__']).toEqual({isAdmin: true});
     });
 
     it('does not leak sessions across apps as phantom entries', async () => {

--- a/core/test/sessions/in_memory_session_service_test.ts
+++ b/core/test/sessions/in_memory_session_service_test.ts
@@ -11,7 +11,7 @@ import {
   createEvent,
   createEventActions,
 } from '@google/adk';
-import {beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {isInMemoryConnectionString} from '../../src/sessions/in_memory_session_service.js';
 
 describe('isInMemoryConnectionString', () => {
@@ -655,6 +655,148 @@ describe('InMemorySessionService', () => {
       // Should just log warnings and return event
       const returnedEvent = await service.appendEvent({session, event});
       expect(returnedEvent).toBe(event);
+    });
+  });
+
+  describe('prototype pollution', () => {
+    const POLLUTED_KEYS = [
+      'polluted',
+      'httpOptions',
+      'pwned',
+      'baseUrl',
+      'poc_sid',
+    ];
+
+    const clearPollution = () => {
+      for (const key of POLLUTED_KEYS) {
+        delete (Object.prototype as Record<string, unknown>)[key];
+      }
+    };
+
+    beforeEach(clearPollution);
+    afterEach(clearPollution);
+
+    it('does not pollute Object.prototype via appName', async () => {
+      await service.createSession({
+        appName: '__proto__',
+        userId: 'polluted',
+        sessionId: 'poc_sid',
+        state: {},
+      });
+
+      expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    });
+
+    it('does not pollute Object.prototype via userId in user state', async () => {
+      const session = await service.createSession({
+        appName: 'app1',
+        userId: '__proto__',
+        sessionId: 's1',
+        state: {},
+      });
+      await service.appendEvent({
+        session,
+        event: createEvent({
+          timestamp: Date.now(),
+          actions: createEventActions({
+            stateDelta: {
+              [`${State.USER_PREFIX}httpOptions`]: {
+                baseUrl: 'https://evil.test',
+              },
+            },
+          }),
+        }),
+      });
+
+      expect(({} as Record<string, unknown>)['httpOptions']).toBeUndefined();
+    });
+
+    it('does not pollute Object.prototype via appName in app state', async () => {
+      const session = await service.createSession({
+        appName: '__proto__',
+        userId: 'u1',
+        sessionId: 's1',
+        state: {},
+      });
+      await service.appendEvent({
+        session,
+        event: createEvent({
+          timestamp: Date.now(),
+          actions: createEventActions({
+            stateDelta: {[`${State.APP_PREFIX}pwned`]: 'attacker-value'},
+          }),
+        }),
+      });
+
+      expect(({} as Record<string, unknown>)['pwned']).toBeUndefined();
+    });
+
+    it('does not pollute Object.prototype via a __proto__ state key', async () => {
+      const session = await service.createSession({
+        appName: 'app1',
+        userId: 'u1',
+        sessionId: 's1',
+        state: {},
+      });
+      await service.appendEvent({
+        session,
+        event: createEvent({
+          timestamp: Date.now(),
+          actions: createEventActions({
+            stateDelta: {
+              [`${State.USER_PREFIX}__proto__`]: {
+                baseUrl: 'https://evil.test',
+              },
+            },
+          }),
+        }),
+      });
+
+      expect(({} as Record<string, unknown>)['baseUrl']).toBeUndefined();
+    });
+
+    it('does not leak sessions across apps as phantom entries', async () => {
+      await service.createSession({
+        appName: '__proto__',
+        userId: 'polluted',
+        sessionId: 'poc_sid',
+        state: {},
+      });
+
+      // An app/user pair that was never created must stay empty.
+      const phantom = await service.listSessions({
+        appName: 'polluted',
+        userId: 'polluted',
+      });
+      expect(phantom.sessions).toHaveLength(0);
+
+      // A real, unrelated app must not gain a phantom user either.
+      await service.createSession({
+        appName: 'real_app',
+        userId: 'alice',
+        sessionId: 's1',
+      });
+      const phantomUser = await service.listSessions({
+        appName: 'real_app',
+        userId: 'polluted',
+      });
+      expect(phantomUser.sessions).toHaveLength(0);
+    });
+
+    it('still stores and retrieves an app literally named __proto__', async () => {
+      await service.createSession({
+        appName: '__proto__',
+        userId: 'polluted',
+        sessionId: 'poc_sid',
+        state: {},
+      });
+
+      const session = await service.getSession({
+        appName: '__proto__',
+        userId: 'polluted',
+        sessionId: 'poc_sid',
+      });
+      expect(session?.id).toBe('poc_sid');
     });
   });
 });

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -50,6 +50,19 @@ import {getAgentGraphAsDot} from './agent_graph.js';
  */
 export const A2A_AUTH_TOKEN_ENV_VAR = 'ADK_A2A_AUTH_TOKEN';
 
+/**
+ * Creates a map with no prototype, for data keyed by untrusted input.
+ *
+ * These caches are keyed by request path parameters (`appName`, `eventId`,
+ * `sessionId`). On an ordinary `{}` literal, inherited keys such as
+ * `toString` or `constructor` make `key in map` report a hit and
+ * `map[key]` yield a `Function` where a `Runner`/trace record is expected,
+ * and a key of `__proto__` aliases `Object.prototype` on write.
+ */
+function createNullProtoMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
 interface ServerOptions {
   agentsDir?: string;
   host?: string;
@@ -91,7 +104,7 @@ export class AdkApiServer {
 
   readonly app: express.Application;
   private readonly agentLoader: AgentLoader;
-  private readonly runnerCache: Record<string, Runner> = {};
+  private readonly runnerCache: Record<string, Runner> = createNullProtoMap();
   private readonly sessionService: BaseSessionService;
   private readonly memoryService: BaseMemoryService;
   private readonly artifactService: BaseArtifactService;
@@ -102,8 +115,10 @@ export class AdkApiServer {
     tracerProvider: TracerProvider,
   ) => void;
   private server?: http.Server;
-  private readonly traceDict: Record<string, Record<string, unknown>> = {};
-  private readonly sessionTraceDict: Record<string, string[]> = {};
+  private readonly traceDict: Record<string, Record<string, unknown>> =
+    createNullProtoMap();
+  private readonly sessionTraceDict: Record<string, string[]> =
+    createNullProtoMap();
   private memoryExporter: InMemoryExporter;
   private readonly logger: Logger;
   private readonly a2a: boolean;

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -50,19 +50,6 @@ import {getAgentGraphAsDot} from './agent_graph.js';
  */
 export const A2A_AUTH_TOKEN_ENV_VAR = 'ADK_A2A_AUTH_TOKEN';
 
-/**
- * Creates a map with no prototype, for data keyed by untrusted input.
- *
- * These caches are keyed by request path parameters (`appName`, `eventId`,
- * `sessionId`). On an ordinary `{}` literal, inherited keys such as
- * `toString` or `constructor` make `key in map` report a hit and
- * `map[key]` yield a `Function` where a `Runner`/trace record is expected,
- * and a key of `__proto__` aliases `Object.prototype` on write.
- */
-function createNullProtoMap<T>(): Record<string, T> {
-  return Object.create(null) as Record<string, T>;
-}
-
 interface ServerOptions {
   agentsDir?: string;
   host?: string;
@@ -104,7 +91,15 @@ export class AdkApiServer {
 
   readonly app: express.Application;
   private readonly agentLoader: AgentLoader;
-  private readonly runnerCache: Record<string, Runner> = createNullProtoMap();
+  /**
+   * Caches below are keyed by request path parameters (`appName`, `eventId`,
+   * `sessionId`), so each is created with `Object.create(null)`. On an
+   * ordinary `{}` literal, inherited names such as `toString` make
+   * `key in cache` report a spurious hit and `cache[key]` yield a `Function`
+   * where a `Runner` or trace record is expected, and a key of `__proto__`
+   * aliases `Object.prototype` on write.
+   */
+  private readonly runnerCache: Record<string, Runner> = Object.create(null);
   private readonly sessionService: BaseSessionService;
   private readonly memoryService: BaseMemoryService;
   private readonly artifactService: BaseArtifactService;
@@ -116,9 +111,9 @@ export class AdkApiServer {
   ) => void;
   private server?: http.Server;
   private readonly traceDict: Record<string, Record<string, unknown>> =
-    createNullProtoMap();
+    Object.create(null);
   private readonly sessionTraceDict: Record<string, string[]> =
-    createNullProtoMap();
+    Object.create(null);
   private memoryExporter: InMemoryExporter;
   private readonly logger: Logger;
   private readonly a2a: boolean;

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -1255,4 +1255,33 @@ describe('AdkWebServer', () => {
       }
     });
   });
+
+  describe('Internal caches keyed by request input', () => {
+    // `appName` / `eventId` arrive straight off the request path. On a plain
+    // object literal, inherited names such as `toString` make `key in cache`
+    // report a spurious hit and hand back a Function where a Runner or trace
+    // record is expected.
+    const INHERITED_KEYS = ['toString', 'constructor', 'hasOwnProperty'];
+
+    it('builds a real Runner for an app named after an inherited key', async () => {
+      const getRunner = (
+        server as unknown as {
+          getRunner: (agent: unknown, appName: string) => Promise<Runner>;
+        }
+      ).getRunner.bind(server);
+
+      for (const appName of INHERITED_KEYS) {
+        const runner = await getRunner(TEST_AGENT, appName);
+        expect(runner).toBeInstanceOf(Runner);
+        expect(runner.appName).toBe(appName);
+      }
+    });
+
+    it('returns 404 for a trace id matching an inherited key', async () => {
+      for (const eventId of INHERITED_KEYS) {
+        const response = await fetch(`${server.url}/debug/trace/${eventId}`);
+        expect(response.status).toBe(404);
+      }
+    });
+  });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A — reported through an internal security review, no public issue.

**2. Or, if no issue exists, describe the change:**

**Problem:**

Several in-memory maps are keyed directly by values that arrive off the request
path or body — `appName`, `userId`, `sessionId`, `eventId` and session state
keys. They were plain `{}` object literals, so a key of `__proto__` resolves to
`Object.prototype` instead of creating an own property:

```ts
// InMemorySessionService.createSession, before
if (!this.sessions[appName]) this.sessions[appName] = {};        // no-op when appName === '__proto__'
if (!this.sessions[appName][userId]) this.sessions[appName][userId] = {};  // writes Object.prototype[userId]
```

A single unauthenticated request to `POST /apps/:appName/users/:userId/sessions/:sessionId`
therefore writes onto `Object.prototype` for the remaining lifetime of the
process. The `appendEvent` `stateDelta` path is the more serious variant: the
planted *value* is fully attacker-controlled, so an arbitrary key can be given
an arbitrary object. Process-wide, that makes every `if (opts.KEY)`,
`obj[KEY] ??`, `KEY in obj` and `for…in` attacker-influenced. The default dev
server (`adk web` / `adk api_server`) uses these services.

Two further consequences of the same root cause:

- `InMemoryCredentialService` shares the pattern, and additionally a lookup of
  an inherited `credentialKey` such as `toString` returned a `Function` rather
  than `undefined`.
- In `AdkApiServer`, `in` walks the prototype chain, so `appName in this.runnerCache`
  reported a hit for inherited names and handed back a `Function` where a
  `Runner` was expected. `GET /debug/trace/toString` likewise returned `200`
  with `Function.prototype.toString` instead of `404`.

**Solution:**

Key the affected maps with `Object.create(null)`. A null-prototype map has no
inherited `__proto__` accessor, so `__proto__`, `constructor` and `prototype`
become ordinary own properties, and `in` / property reads no longer see
inherited names.

This is a structural fix rather than an input filter. Rejecting `__proto__` as
an `appName` at the route layer was considered and not taken: it is a breaking
API change that would also refuse legitimately-named apps, and it would have to
be repeated at every call site, whereas the null-prototype map removes the
primitive at the point of storage.

Changed:

- `core/src/sessions/in_memory_session_service.ts` — `sessions`, `userState`,
  `appState`, and the nested maps created in `createSession` / `appendEvent`.
- `core/src/auth/credential_service/in_memory_credential_service.ts` — `credentials`.
- `dev/src/server/adk_api_server.ts` — `runnerCache`, `traceDict`, `sessionTraceDict`.

Each package gets a small local `createNullProtoMap()` helper with a comment
explaining why, following the existing convention in
`core/src/utils/streaming_utils.ts` of keeping this kind of guard module-local
rather than widening the `@google/adk` public surface for an internal concern.

Behaviour is preserved: an app literally named `__proto__` still stores and
retrieves normally, and no longer leaks phantom sessions into unrelated apps.

Not affected, checked while scoping: `InMemoryMemoryService` keys on
`` `${appName}/${userId}` `` and `InMemoryArtifactService` on
`encodeURIComponent`-joined path segments. Both keys always contain `/`, so
neither can ever equal `__proto__`. Left unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

10 new tests across 3 suites:

| Suite | New tests | Covers |
| --- | --- | --- |
| `core/test/sessions/in_memory_session_service_test.ts` | 6 | pollution via `appName`, via `userId` + `user:` state, via `appName` + `app:` state, via a `__proto__` state key; no phantom cross-app sessions; app named `__proto__` still works |
| `core/test/auth/credential_service/in_memory_credential_service_test.ts` | 2 | pollution via `appName`; inherited `credentialKey` returns `undefined` |
| `dev/test/server/adk_api_server_test.ts` | 2 | `runnerCache` builds a real `Runner` for an app named after an inherited key; `/debug/trace/<inherited>` returns 404 |

Each new test was confirmed to **fail without the source fix** (stash the source
change, re-run) rather than only passing with it. 8 of the 10 fail on the
unfixed code; the other 2 are behaviour-preservation tests that must pass both
before and after. Representative failures on the unfixed tree:

```
× does not pollute Object.prototype via userId in user state
× builds a real Runner for an app named after an inherited key
  → expected [Function toString] to be an instance of Runner
× returns 404 for a trace id matching an inherited key
  → expected 200 to be 404
```

Affected suites after the fix:

```
✓ core/test/auth/credential_service/in_memory_credential_service_test.ts (6 tests)
✓ core/test/sessions/in_memory_session_service_test.ts (37 tests)
✓ dev/test/server/adk_api_server_test.ts (53 tests)
Test Files  3 passed (3)
     Tests  96 passed (96)
```

Full unit suite (`unit:core` + `unit:dev`):

```
Test Files  1 failed | 183 passed (184)
     Tests  1 failed | 2679 passed (2680)
```

The single failure is `createAgent > Interactive Mode > should handle Vertex AI
selection with gcloud defaults`, which is pre-existing and unrelated — it fails
identically on a clean tree at `origin/main` because it reads ambient gcloud
configuration.

`npm run ts:check` reports 281 errors in 43 files both with and without this
change, i.e. the pre-existing baseline is unchanged and no new type errors are
introduced. `eslint` and `prettier --check` are clean on all changed files.

**Manual End-to-End (E2E) Tests:**

With an agents directory available:

```bash
npx adk api_server --host 127.0.0.1 --port 8000 <agents_dir> &

# Create a session under an app named __proto__
curl -sS -X POST http://127.0.0.1:8000/apps/__proto__/users/polluted_key/sessions/poc_sid \
  -H 'Content-Type: application/json' -d '{}'

# Before: returns the planted session for an app/user pair never created.
# After:  empty list.
curl -sS http://127.0.0.1:8000/apps/polluted_key/users/polluted_key/sessions

# Before: 200 with Function.prototype.toString serialised.
# After:  404.
curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8000/debug/trace/toString

# Unchanged: an app genuinely named __proto__ still round-trips.
curl -sS http://127.0.0.1:8000/apps/__proto__/users/polluted_key/sessions
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules. (None — self-contained.)

### Additional context

`Object.create(null)` maps behave identically for every read and write the
affected code performs. `Object.keys`, `Object.values` and `Object.entries` are
own-property operations and are unaffected; `mergeStates` uses `Object.entries`,
and `JSON.stringify` / `res.json()` serialise null-prototype objects normally.
The only behavioural difference is the intended one:

```
key=toString        'in'=false typeof=undefined
key=constructor     'in'=false typeof=undefined
key=__proto__       'in'=false typeof=undefined
after write, ({}).x = undefined | own key stored = [ '__proto__' ]
```

Note that these maps are never handed to callers directly, so the null
prototype does not leak into the public API surface.
