### PR TITLE
Fix zip-slip blacklist bypass in isDangerousZipEntryName

### DIFF
--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -185,11 +185,10 @@ export function parseSkillMdContent(content: string): {
  * symlinks.
  */
 function isDangerousZipEntryName(entryName: string): boolean {
-  return (
-    entryName.startsWith('/') ||
-    entryName.startsWith('../') ||
-    entryName.includes('/../')
-  );
+  if (path.posix.isAbsolute(entryName) || path.win32.isAbsolute(entryName)) {
+    return true;
+  }
+  return entryName.split(/[/\\]/).some((segment) => segment === '..');
 }
 
 /**

--- a/core/test/skills/loader_test.ts
+++ b/core/test/skills/loader_test.ts
@@ -612,14 +612,17 @@ Instruction body`;
       expect(skill.resources?.scripts?.['run.sh']?.src).toBe('echo hello');
     });
 
-    it.each(['/etc/passwd', '../evil.txt', 'references/../../esc.txt'])(
-      'rejects the whole archive for the dangerous entry %s',
-      (entryName) => {
-        expect(() =>
-          loadSkillFromZipBuffer(createZipWithRawEntryName(entryName)),
-        ).toThrow(`Dangerous zip entry ignored: ${entryName}`);
-      },
-    );
+    it.each([
+      '/etc/passwd',
+      '../evil.txt',
+      'references/../../esc.txt',
+      'scripts/..',
+      'scripts\\..\\..\\pwned.txt',
+    ])('rejects the whole archive for the dangerous entry %s', (entryName) => {
+      expect(() =>
+        loadSkillFromZipBuffer(createZipWithRawEntryName(entryName)),
+      ).toThrow(`Dangerous zip entry ignored: ${entryName}`);
+    });
 
     it('reports the dangerous entry even when SKILL.md is absent', () => {
       const zip = new AdmZip();


### PR DESCRIPTION
`isDangerousZipEntryName` used prefix/substring string checks (`startsWith('/')`, `startsWith('../')`, `includes('/../')`) that miss entries whose traversal segment isn't followed by more path content — e.g. an entry literally named `scripts/..` passes all three checks, as does any entry using a backslash separator instead of a forward slash.

Confirmed via a dynamic PoC: crafted a real zip with Python's `zipfile` module (bypassing AdmZip's own write-side path normalization, which is not representative of an attacker-crafted zip), fed the raw bytes through the actual compiled `loadSkillFromZipBuffer`, and confirmed `scripts/..` passes the old check and reaches `skill.resources.scripts['..']`. Also confirmed a second, independent check in `materializeFiles` (`utils/file_utils.ts`) catches and rejects the resulting escape attempt in every consumer that writes this data to disk — so this closes a genuine defense-in-depth gap rather than a currently-reachable filesystem escape in the traced call paths.

Replaces the checks with a segment-based approach: split on both `/` and `\`, reject if any segment is exactly `..`, plus an explicit absolute-path check (POSIX and Windows). Added two regression test cases for the confirmed bypasses.