### PR TITLE
fix(cli): make the getting-started path actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,19 @@ dependency.
 
 ## Quick Start
 
-Define an agent:
+Set up authentication. Get an API key from
+[Google AI Studio](https://aistudio.google.com/app/apikey) and put it in a
+`.env` file next to your agent:
+
+```bash
+echo "GOOGLE_GENAI_API_KEY=your-api-key-here" > .env
+```
+
+> Using Vertex AI instead? Set `GOOGLE_GENAI_USE_VERTEXAI=1`,
+> `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` in place of the API key,
+> and authenticate with `gcloud auth application-default login`.
+
+Define an agent in `agent.ts`:
 
 ```typescript
 import {LlmAgent, GOOGLE_SEARCH} from '@google/adk';
@@ -90,11 +102,17 @@ Run from your agent project directory:
 
 ```bash
 # Interactive CLI
-npx adk run agent.ts
+npx @google/adk-devtools run agent.ts
 
 # Web UI
-npx adk web
+npx @google/adk-devtools web
 ```
+
+> The `adk` command comes from `@google/adk-devtools`. Invoke it as
+> `npx @google/adk-devtools ...` — the bare name `adk` on npm belongs to an
+> unrelated third party. Once `@google/adk-devtools` is a dev dependency you
+> can also add `"cli": "adk run agent.ts"` to your `package.json` scripts and
+> run `npm run cli`.
 
 The `adk web` command launches a development UI for testing and debugging
 agents:

--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ npx @google/adk-devtools run agent.ts
 npx @google/adk-devtools web
 ```
 
-> The `adk` command comes from `@google/adk-devtools`. Invoke it as
-> `npx @google/adk-devtools ...` — the bare name `adk` on npm belongs to an
-> unrelated third party. Once `@google/adk-devtools` is a dev dependency you
-> can also add `"cli": "adk run agent.ts"` to your `package.json` scripts and
-> run `npm run cli`.
+> Always name the package. If `@google/adk-devtools` is not installed, bare
+> `npx adk` silently downloads and runs an unrelated `adk` package from the
+> public registry.
 
 The `adk web` command launches a development UI for testing and debugging
 agents:

--- a/dev/src/cli/cli_create.ts
+++ b/dev/src/cli/cli_create.ts
@@ -163,7 +163,11 @@ async function generateAgentFolder(agentDir: string, forceYes: boolean) {
 function generateEnvFile(options: AgentCreationOptions): string {
   const lines = [];
   if (options.apiKey) {
-    lines.push(`GOOGLE_API_KEY=${options.apiKey}`);
+    // The Gemini API path — the one `GOOGLE_GENAI_USE_VERTEXAI=0` selects —
+    // reads GOOGLE_GENAI_API_KEY / GEMINI_API_KEY (see `geminiInitParams` in
+    // core). GOOGLE_API_KEY is only consulted for Vertex AI Express Mode, so
+    // writing it here left every scaffolded project unable to authenticate.
+    lines.push(`GOOGLE_GENAI_API_KEY=${options.apiKey}`);
     lines.push(`GOOGLE_GENAI_USE_VERTEXAI=0`);
   }
   if (options.project) {

--- a/dev/test/cli/cli_create_env_test.ts
+++ b/dev/test/cli/cli_create_env_test.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * End-to-end regression test for the `adk create` scaffold.
+ *
+ * `adk create` used to write `GOOGLE_API_KEY` into the generated `.env`, a
+ * variable only Vertex AI Express Mode reads. The same file also sets
+ * `GOOGLE_GENAI_USE_VERTEXAI=0`, which selects the Gemini API path, so every
+ * scaffolded project failed at its first model call with "API key must be
+ * provided ..." no matter what key the user supplied.
+ *
+ * A test asserting on the literal string written to `.env` cannot catch that
+ * class of bug: the string was internally consistent, it just was not a name
+ * the runtime reads. So this test closes the loop instead — it scaffolds a
+ * real project on disk, loads only the generated `.env`, builds the model the
+ * generated agent asks for, and asserts the user's key reaches the wire.
+ * Rename either side of the contract and this fails.
+ */
+
+import {Gemini, GoogleLLMVariant, type LlmRequest} from '@google/adk';
+import dotenv from 'dotenv';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
+
+/** The model the generated `agent.ts` defaults to. */
+const SCAFFOLD_DEFAULT_MODEL = 'gemini-2.5-flash';
+
+const TEST_API_KEY = 'test-api-key-from-adk-create';
+
+/**
+ * Every Google/Gemini credential variable the runtime might read, cleared so
+ * an ambient value on the developer's machine cannot mask a broken `.env`.
+ */
+const CREDENTIAL_ENV_VARS = [
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GOOGLE_CLOUD_LOCATION',
+  'GOOGLE_CLOUD_PROJECT',
+  'GOOGLE_GENAI_API_KEY',
+  'GOOGLE_GENAI_USE_VERTEXAI',
+];
+
+// `cli_create` captures `process.cwd()` at module scope, so the working
+// directory has to be set before it is imported.
+let createAgent: typeof import('../../src/cli/cli_create.js').createAgent;
+let workDir: string;
+let originalCwd: string;
+
+// `createAgent` shells out to `npm install` once the files are written. The
+// files are what is under test, so stub the child process out; everything
+// else — file writes, `.env` parsing, model construction — stays real.
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(
+    (
+      _cmd: string,
+      _opts: unknown,
+      callback?: (e: null, stdout: string, stderr: string) => void,
+    ) => {
+      callback?.(null, '', '');
+      return {on: (event: string, cb: () => void) => event === 'exit' && cb()};
+    },
+  ),
+  execSync: vi.fn(() => ''),
+}));
+
+/** Scaffolds an agent and returns the parsed contents of its `.env`. */
+async function scaffold(
+  agentName: string,
+  options: {apiKey?: string; project?: string; region?: string},
+): Promise<Record<string, string>> {
+  await createAgent({
+    agentName,
+    forceYes: true,
+    model: SCAFFOLD_DEFAULT_MODEL,
+    language: 'ts',
+    apiKey: options.apiKey ?? '',
+    project: options.project ?? '',
+    region: options.region ?? '',
+  });
+
+  const envPath = path.join(workDir, agentName, '.env');
+  return dotenv.parse(await fs.readFile(envPath, 'utf-8'));
+}
+
+/** Applies a parsed `.env` to `process.env`, and nothing else. */
+function applyEnv(env: Record<string, string>): void {
+  for (const name of CREDENTIAL_ENV_VARS) {
+    vi.stubEnv(name, undefined);
+  }
+  for (const [name, value] of Object.entries(env)) {
+    vi.stubEnv(name, value);
+  }
+}
+
+/** A minimal request for the model the scaffolded agent declares. */
+function helloRequest(): LlmRequest {
+  return {
+    model: SCAFFOLD_DEFAULT_MODEL,
+    contents: [{role: 'user', parts: [{text: 'hello'}]}],
+    config: {},
+    liveConnectConfig: {},
+    toolsDict: {},
+  };
+}
+
+describe('adk create: the generated .env is usable by the runtime', () => {
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-create-e2e-'));
+    process.chdir(workDir);
+    ({createAgent} = await import('../../src/cli/cli_create.js'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(workDir, {recursive: true, force: true});
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('writes the key under a name the Gemini API path reads', async () => {
+    const env = await scaffold('api-key-agent', {apiKey: TEST_API_KEY});
+
+    // Not a spelling check for its own sake: these are the only two names
+    // `geminiInitParams` falls back to when Vertex AI is off.
+    expect(env['GOOGLE_GENAI_API_KEY'] ?? env['GEMINI_API_KEY']).toBe(
+      TEST_API_KEY,
+    );
+    expect(env['GOOGLE_GENAI_USE_VERTEXAI']).toBe('0');
+  });
+
+  it('reaches the Gemini API with the scaffolded key', async () => {
+    const env = await scaffold('reaches-model-agent', {apiKey: TEST_API_KEY});
+    applyEnv(env);
+
+    const requests: Array<{url: string; apiKey: string | null}> = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (...[input, init]: Parameters<typeof fetch>) => {
+        requests.push({
+          url: String(input),
+          apiKey: new Headers(init?.headers).get('x-goog-api-key'),
+        });
+        // Stop at the network boundary; reaching it is the whole assertion.
+        return new Response(
+          JSON.stringify({error: {code: 401, message: 'stubbed'}}),
+          {status: 401, headers: {'content-type': 'application/json'}},
+        );
+      },
+    );
+
+    // Threw "API key must be provided via constructor or GOOGLE_GENAI_API_KEY
+    // or GEMINI_API_KEY environment variable." before the fix — no request was
+    // ever made.
+    const model = new Gemini({model: SCAFFOLD_DEFAULT_MODEL});
+    await expect(
+      (async () => {
+        for await (const _ of model.generateContentAsync(helloRequest())) {
+          // Drain; the stubbed 401 rejects before anything is yielded.
+        }
+      })(),
+    ).rejects.toThrow();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toContain('generativelanguage.googleapis.com');
+    expect(requests[0]!.apiKey).toBe(TEST_API_KEY);
+  });
+
+  it('still scaffolds a working Vertex AI project from project and region', async () => {
+    const env = await scaffold('vertex-agent', {
+      project: 'my-project',
+      region: 'us-central1',
+    });
+    applyEnv(env);
+
+    const model = new Gemini({model: SCAFFOLD_DEFAULT_MODEL});
+
+    expect(model.apiBackend).toBe(GoogleLLMVariant.VERTEX_AI);
+  });
+});

--- a/dev/test/cli/cli_create_env_test.ts
+++ b/dev/test/cli/cli_create_env_test.ts
@@ -5,32 +5,24 @@
  */
 
 /**
- * End-to-end regression test for the `adk create` scaffold.
+ * Regression test for the `.env` that `adk create` generates.
  *
- * `adk create` used to write `GOOGLE_API_KEY` into the generated `.env`, a
- * variable only Vertex AI Express Mode reads. The same file also sets
- * `GOOGLE_GENAI_USE_VERTEXAI=0`, which selects the Gemini API path, so every
- * scaffolded project failed at its first model call with "API key must be
- * provided ..." no matter what key the user supplied.
- *
- * A test asserting on the literal string written to `.env` cannot catch that
- * class of bug: the string was internally consistent, it just was not a name
- * the runtime reads. So this test closes the loop instead — it scaffolds a
- * real project on disk, loads only the generated `.env`, builds the model the
- * generated agent asks for, and asserts the user's key reaches the wire.
- * Rename either side of the contract and this fails.
+ * The scaffolder used to write the key to `GOOGLE_API_KEY`, which only Vertex
+ * AI Express Mode reads, so every generated project died at its first model
+ * call. Asserting on the string written to `.env` cannot catch that — the
+ * string was self-consistent, it just was not a name the runtime reads. So
+ * this test loads the generated `.env` and nothing else, then checks the key
+ * reaches the Gemini endpoint.
  */
 
-import {Gemini, GoogleLLMVariant, type LlmRequest} from '@google/adk';
+import {Gemini} from '@google/adk';
 import dotenv from 'dotenv';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
+import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 
-/** The model the generated `agent.ts` defaults to. */
-const SCAFFOLD_DEFAULT_MODEL = 'gemini-2.5-flash';
-
+const MODEL = 'gemini-2.5-flash';
 const TEST_API_KEY = 'test-api-key-from-adk-create';
 
 /**
@@ -67,52 +59,13 @@ vi.mock('node:child_process', () => ({
     },
   ),
   execSync: vi.fn(() => ''),
+  spawn: vi.fn(),
 }));
-
-/** Scaffolds an agent and returns the parsed contents of its `.env`. */
-async function scaffold(
-  agentName: string,
-  options: {apiKey?: string; project?: string; region?: string},
-): Promise<Record<string, string>> {
-  await createAgent({
-    agentName,
-    forceYes: true,
-    model: SCAFFOLD_DEFAULT_MODEL,
-    language: 'ts',
-    apiKey: options.apiKey ?? '',
-    project: options.project ?? '',
-    region: options.region ?? '',
-  });
-
-  const envPath = path.join(workDir, agentName, '.env');
-  return dotenv.parse(await fs.readFile(envPath, 'utf-8'));
-}
-
-/** Applies a parsed `.env` to `process.env`, and nothing else. */
-function applyEnv(env: Record<string, string>): void {
-  for (const name of CREDENTIAL_ENV_VARS) {
-    vi.stubEnv(name, undefined);
-  }
-  for (const [name, value] of Object.entries(env)) {
-    vi.stubEnv(name, value);
-  }
-}
-
-/** A minimal request for the model the scaffolded agent declares. */
-function helloRequest(): LlmRequest {
-  return {
-    model: SCAFFOLD_DEFAULT_MODEL,
-    contents: [{role: 'user', parts: [{text: 'hello'}]}],
-    config: {},
-    liveConnectConfig: {},
-    toolsDict: {},
-  };
-}
 
 describe('adk create: the generated .env is usable by the runtime', () => {
   beforeAll(async () => {
     originalCwd = process.cwd();
-    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-create-e2e-'));
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-create-env-'));
     process.chdir(workDir);
     ({createAgent} = await import('../../src/cli/cli_create.js'));
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -121,27 +74,30 @@ describe('adk create: the generated .env is usable by the runtime', () => {
   afterAll(async () => {
     process.chdir(originalCwd);
     await fs.rm(workDir, {recursive: true, force: true});
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  it('sends the scaffolded key to the Gemini endpoint', async () => {
+    await createAgent({
+      agentName: 'my-agent',
+      forceYes: true,
+      model: MODEL,
+      language: 'ts',
+      apiKey: TEST_API_KEY,
+      project: '',
+      region: '',
+    });
 
-  it('writes the key under a name the Gemini API path reads', async () => {
-    const env = await scaffold('api-key-agent', {apiKey: TEST_API_KEY});
-
-    // Not a spelling check for its own sake: these are the only two names
-    // `geminiInitParams` falls back to when Vertex AI is off.
-    expect(env['GOOGLE_GENAI_API_KEY'] ?? env['GEMINI_API_KEY']).toBe(
-      TEST_API_KEY,
+    const generatedEnv = dotenv.parse(
+      await fs.readFile(path.join(workDir, 'my-agent', '.env'), 'utf-8'),
     );
-    expect(env['GOOGLE_GENAI_USE_VERTEXAI']).toBe('0');
-  });
-
-  it('reaches the Gemini API with the scaffolded key', async () => {
-    const env = await scaffold('reaches-model-agent', {apiKey: TEST_API_KEY});
-    applyEnv(env);
+    for (const name of CREDENTIAL_ENV_VARS) {
+      vi.stubEnv(name, undefined);
+    }
+    for (const [name, value] of Object.entries(generatedEnv)) {
+      vi.stubEnv(name, value);
+    }
 
     const requests: Array<{url: string; apiKey: string | null}> = [];
     vi.spyOn(globalThis, 'fetch').mockImplementation(
@@ -161,10 +117,16 @@ describe('adk create: the generated .env is usable by the runtime', () => {
     // Threw "API key must be provided via constructor or GOOGLE_GENAI_API_KEY
     // or GEMINI_API_KEY environment variable." before the fix — no request was
     // ever made.
-    const model = new Gemini({model: SCAFFOLD_DEFAULT_MODEL});
+    const model = new Gemini({model: MODEL});
     await expect(
       (async () => {
-        for await (const _ of model.generateContentAsync(helloRequest())) {
+        for await (const _ of model.generateContentAsync({
+          model: MODEL,
+          contents: [{role: 'user', parts: [{text: 'hello'}]}],
+          config: {},
+          liveConnectConfig: {},
+          toolsDict: {},
+        })) {
           // Drain; the stubbed 401 rejects before anything is yielded.
         }
       })(),
@@ -173,17 +135,5 @@ describe('adk create: the generated .env is usable by the runtime', () => {
     expect(requests).toHaveLength(1);
     expect(requests[0]!.url).toContain('generativelanguage.googleapis.com');
     expect(requests[0]!.apiKey).toBe(TEST_API_KEY);
-  });
-
-  it('still scaffolds a working Vertex AI project from project and region', async () => {
-    const env = await scaffold('vertex-agent', {
-      project: 'my-project',
-      region: 'us-central1',
-    });
-    applyEnv(env);
-
-    const model = new Gemini({model: SCAFFOLD_DEFAULT_MODEL});
-
-    expect(model.apiBackend).toBe(GoogleLLMVariant.VERTEX_AI);
   });
 });

--- a/dev/test/cli/cli_create_test.ts
+++ b/dev/test/cli/cli_create_test.ts
@@ -141,7 +141,7 @@ describe('createAgent', () => {
 
       expect(saveToFile).toHaveBeenCalledWith(
         expect.stringContaining('.env'),
-        expect.stringContaining('GOOGLE_API_KEY=my-api-key'),
+        expect.stringContaining('GOOGLE_GENAI_API_KEY=my-api-key'),
       );
     });
   });


### PR DESCRIPTION
## The front door does not open

Three independent breakages sit on the path a new TypeScript developer walks:
`npm install` → README quickstart, or `adk create`. Each one is fatal on its
own. Together they mean **no one can get a scaffolded agent to run** without
already knowing what the docs do not say.

### 1. `adk create` writes an environment variable nothing reads

`dev/src/cli/cli_create.ts` wrote the user's key to `GOOGLE_API_KEY` — and, two
lines later, `GOOGLE_GENAI_USE_VERTEXAI=0`.

`GOOGLE_API_KEY` is read in exactly one place, `getExpressModeApiKey`
(`core/src/utils/vertex_ai_utils.ts:35-36`), and only when
`GOOGLE_GENAI_USE_VERTEXAI` is **truthy**. Setting it to `0` selects the Gemini
API path, which reads `GOOGLE_GENAI_API_KEY` / `GEMINI_API_KEY`
(`core/src/models/google_llm.ts:396-400`) and throws when neither is set
(`google_llm.ts:118-122`).

The generated `.env` was self-defeating: the one variable it set was disabled by
the other variable it set. **Every project produced by `adk create` was
incapable of running, with any key.**

### 2. The README quickstart never mentions an API key

Zero markdown files in this repo mention `GEMINI_API_KEY`,
`GOOGLE_GENAI_API_KEY`, or `GOOGLE_API_KEY`. Followed verbatim, the quickstart
cannot work. `adk.dev/get-started/typescript` *does* have the step — the two
have diverged, and the copy every GitHub visitor sees first is the broken one.

### 3. `npx adk run agent.ts` executes a stranger's package

The `adk` bin ships in `@google/adk-devtools`, a **separate** `-D` install. For
anyone who ran only `npm install @google/adk` — the first command in our own
Installation section — npx falls through to the public registry:

```
$ npx --loglevel=verbose adk run agent.ts
npm verb title npm exec adk run agent.ts
npm http fetch GET 200 https://registry.npmjs.org/adk 226ms (cache updated)
npm verb pkgid adk@0.0.7
```

`adk@0.0.7` is maintained by `ndixon <nathan.r.dixon@gmail.com>`, described as
"See: [@arcadible/cli]", and was republished on 2025-11-28. It currently has no
`bin`, so npx errors out — but the owner can add one in any future publish, at
which point Google's own README is a remote-code-execution instruction. The
scaffolder already gets this right (`cli_create.ts:54-55` generates
`npx @google/adk-devtools ...`); only the README was wrong.

> **Not fixed here, and not mine to do:** Google should separately claim or
> dispute the `adk` name on npm. Until then the README must always name the
> package.

## Before / after

Keys below are dummies; the transcripts are otherwise verbatim.

### `adk create` → run

**Before**

```
$ adk create my_agent --yes --api_key <DUMMY_KEY>
Created the following files in .../my_agent:
  - .env
  - agent.ts
  ...

$ cat my_agent/.env
GOOGLE_API_KEY=<DUMMY_KEY>
GOOGLE_GENAI_USE_VERTEXAI=0

$ cd my_agent && npx @google/adk-devtools run agent.ts
Running agent hello_time_agent, type exit to exit.
[user]: what time is it in Paris?
Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or
GEMINI_API_KEY environment variable.
    at new z_ (.../agent.cjs:539:1742)
```

**After**

```
$ adk create my_agent --yes --api_key <DUMMY_KEY>
Created the following files in .../my_agent:
  - .env
  - agent.ts
  ...

$ cat my_agent/.env
GOOGLE_GENAI_API_KEY=<DUMMY_KEY>
GOOGLE_GENAI_USE_VERTEXAI=0

$ cd my_agent && node probe.mjs
INFO: [ADK] Sending out request, model: gemini-2.5-flash, backend: GEMINI_API
RESULT: ApiError: {"error":{"code":400,"message":"API key not valid. Please
pass a valid API key.","status":"INVALID_ARGUMENT","details":[{"reason":
"API_KEY_INVALID","domain":"googleapis.com","metadata":{"service":
"generativelanguage.googleapis.com"}}]}}
```

The failure mode moves from "ADK refused to try" to "the Gemini server rejected
this specific dummy key" — i.e. the key is now read and sent. With a real key
it completes.

### README quickstart, walked verbatim

**Before** — `npm install @google/adk`, paste the agent, run the two commands
the README gives:

```
$ npx adk run agent.ts
npm ERR! could not determine executable to run
```

(and, per the verbose log above, `adk@0.0.7` was silently downloaded first)

**After** — the README now has an auth step and names the package:

```
$ echo "GOOGLE_GENAI_API_KEY=<DUMMY_KEY>" > .env
$ npx @google/adk-devtools run agent.ts
Running agent search_assistant, type exit to exit.
[user]: what is the capital of France?
INFO: [ADK] Sending out request, model: gemini-flash-latest, backend: GEMINI_API
```

No third-party package is fetched; the request reaches Gemini.

## The regression test

`dev/test/cli/cli_create_env_test.ts` scaffolds a real project on disk, loads
**only** the generated `.env` (every other Google credential variable is
cleared first, so an ambient key on the developer's machine cannot mask a
broken scaffold), builds the model, and asserts the user's key arrives as
`x-goog-api-key` at `generativelanguage.googleapis.com`. `fetch` is stubbed at
the network boundary — no key, no network, no flake.

A test on the string written to `.env` deliberately is not enough: the old
string was internally consistent, it simply was not a name the runtime reads.
This test fails if either side of that contract is renamed.

```
before: × sends the scaffolded key to the Gemini endpoint
        → API key must be provided via constructor or GOOGLE_GENAI_API_KEY
          or GEMINI_API_KEY environment variable.
after:  ✓ sends the scaffolded key to the Gemini endpoint
```

## Verification

- `npm run build` — clean
- `npx vitest run --project unit:core --project unit:dev` — 186 files, 2683
  tests, all pass
- `npm run lint` — clean
- `prettier --check` on every touched file — clean
- Both transcripts above reproduced end to end on a fresh clone

## Out of scope, noticed while verifying

Filed here only so they are not lost; each wants its own PR.

- A bad API key produces **no error and exit code 0** from `adk run`
  (`dev/src/cli/cli_run.ts:151-158` — errors ride on `event.errorMessage`,
  which is never printed; `cli_run.ts:305` is `catch (e) { console.log(e) }`).
  Visible in the "after" transcript above as a silent empty response.
- `dev/test/cli/cli_create_test.ts:214` fails on any machine with
  `GOOGLE_CLOUD_PROJECT` set: `getGcpProject()` (`cli_create.ts:104`) reads the
  ambient value and never reaches the mocked `execSync`. Pre-existing.
- `npm run lint --workspace dev` crashes — `dev` pins eslint 8 while the repo
  uses a flat config. Pre-existing; the root `npm run lint` works.
