### PR TITLE
fix(cli): surface model errors and make agent stack traces readable

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -68,21 +68,19 @@ function getArtifactServiceFromOptions(options: {
   );
 }
 
-function getAgentFileOptions(
-  options: {
-    compile?: boolean;
-    bundle?: boolean;
-    file_type?: string;
-  },
+function getAgentFileOptions(options: {
+  compile?: boolean;
+  bundle?: boolean;
+  file_type?: string;
   // Minification destroys stack traces, so it is opt-in and reserved for
   // deployment bundles where the artifact size matters more than a readable
   // trace. Local commands (run/web/api_server) keep readable output.
-  minify = false,
-) {
+  minify?: boolean;
+}) {
   return {
     compile: getBoolean(options['compile']),
     bundle: getBoolean(options['bundle']),
-    minify,
+    minify: getBoolean(options['minify']),
     moduleType: options['file_type'] as FileModuleType | undefined,
   };
 }
@@ -458,10 +456,7 @@ export function createProgram(): Command {
           allowOrigins: options['allow_origins'],
           sessionServiceUri: options['session_service_uri'],
           artifactServiceUri: options['artifact_service_uri'],
-          agentFileLoadOptions: getAgentFileOptions(
-            options,
-            /* minify= */ true,
-          ),
+          agentFileLoadOptions: getAgentFileOptions({...options, minify: true}),
           a2a: getBoolean(options['a2a']),
           a2aAuthToken: options['a2a_auth_token'],
           extraGcloudArgs,
@@ -514,10 +509,10 @@ export function createProgram(): Command {
             allowOrigins: options['allow_origins'],
             sessionServiceUri: options['session_service_uri'],
             artifactServiceUri: options['artifact_service_uri'],
-            agentFileLoadOptions: getAgentFileOptions(
-              options,
-              /* minify= */ true,
-            ),
+            agentFileLoadOptions: getAgentFileOptions({
+              ...options,
+              minify: true,
+            }),
             a2a: getBoolean(options['a2a']),
             agentEngineId: options['agent_engine_id'],
           });

--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -68,14 +68,21 @@ function getArtifactServiceFromOptions(options: {
   );
 }
 
-function getAgentFileOptions(options: {
-  compile?: boolean;
-  bundle?: boolean;
-  file_type?: string;
-}) {
+function getAgentFileOptions(
+  options: {
+    compile?: boolean;
+    bundle?: boolean;
+    file_type?: string;
+  },
+  // Minification destroys stack traces, so it is opt-in and reserved for
+  // deployment bundles where the artifact size matters more than a readable
+  // trace. Local commands (run/web/api_server) keep readable output.
+  minify = false,
+) {
   return {
     compile: getBoolean(options['compile']),
     bundle: getBoolean(options['bundle']),
+    minify,
     moduleType: options['file_type'] as FileModuleType | undefined,
   };
 }
@@ -385,7 +392,7 @@ export function createProgram(): Command {
         });
       } catch (error) {
         logger.error('Error running agent:', (error as Error).message);
-        process.exit(1);
+        process.exitCode = 1;
       }
     });
 
@@ -451,7 +458,10 @@ export function createProgram(): Command {
           allowOrigins: options['allow_origins'],
           sessionServiceUri: options['session_service_uri'],
           artifactServiceUri: options['artifact_service_uri'],
-          agentFileLoadOptions: getAgentFileOptions(options),
+          agentFileLoadOptions: getAgentFileOptions(
+            options,
+            /* minify= */ true,
+          ),
           a2a: getBoolean(options['a2a']),
           a2aAuthToken: options['a2a_auth_token'],
           extraGcloudArgs,
@@ -504,7 +514,10 @@ export function createProgram(): Command {
             allowOrigins: options['allow_origins'],
             sessionServiceUri: options['session_service_uri'],
             artifactServiceUri: options['artifact_service_uri'],
-            agentFileLoadOptions: getAgentFileOptions(options),
+            agentFileLoadOptions: getAgentFileOptions(
+              options,
+              /* minify= */ true,
+            ),
             a2a: getBoolean(options['a2a']),
             agentEngineId: options['agent_engine_id'],
           });

--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -127,12 +127,16 @@ function printEvent(event: Event, options: PrintEventOptions = {}): void {
     console.log(`[${author}]: ${renderOutput(event.output)}`);
   }
 
-  // Reported on the event, not as a text part, so text-only printing drops it.
+  // Model failures (invalid API key, quota, safety blocks, ...) are surfaced as
+  // events carrying `errorCode`/`errorMessage` and no `content`, so printing
+  // only `content.parts` makes the whole run look like it succeeded silently.
+  // Report the error on stderr and mark the process as failed.
   if (event.errorCode || event.errorMessage) {
     const detail = [event.errorCode, event.errorMessage]
       .filter(Boolean)
       .join(': ');
     console.error(`[${author}] error: ${detail}`);
+    process.exitCode = 1;
   }
 
   if (!announcePauses) {
@@ -335,46 +339,50 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
     options.artifactService || new InMemoryArtifactService();
   const sessionService = options.sessionService || new InMemorySessionService();
   const memoryService = options.memoryService || new InMemoryMemoryService();
-  await using agentFile = new AgentFile(
-    getAbsolutePath(options.agentPath),
-    options.agentFileLoadOptions,
-  );
-  const loaded = await agentFile.load();
-  const rootAgent = isApp(loaded) ? loaded.rootAgent : loaded;
-  const app = isApp(loaded) ? loaded : undefined;
 
-  let session = await sessionService.createSession({
-    appName: app?.name ?? rootAgent.name,
-    userId,
-  });
-
-  const reloadSubscribers: Array<(agent: RunnableRoot) => void> = [];
+  // The whole run is wrapped so a failure loading, building or running the
+  // agent is reported (with a readable stack) on stderr and marks the process
+  // as failed, rather than being swallowed or printed to stdout with exit 0.
   let watcher: fs.FSWatcher | undefined;
-
-  if (options.reloadAgents) {
-    const agentFilePath = getAbsolutePath(options.agentPath);
-    watcher = fs.watch(agentFilePath, async () => {
-      try {
-        await using reloadedFile = new AgentFile(
-          agentFilePath,
-          options.agentFileLoadOptions,
-        );
-        const reloaded = await reloadedFile.load();
-        const newAgent = isApp(reloaded) ? reloaded.rootAgent : reloaded;
-        for (const subscriber of reloadSubscribers) {
-          subscriber(newAgent);
-        }
-      } catch (err) {
-        console.warn('Failed to reload agent:', (err as Error).message);
-      }
-    });
-  }
-
-  const onAgentFileReloaded = (subscribe: (agent: RunnableRoot) => void) => {
-    reloadSubscribers.push(subscribe);
-  };
-
   try {
+    await using agentFile = new AgentFile(
+      getAbsolutePath(options.agentPath),
+      options.agentFileLoadOptions,
+    );
+    const loaded = await agentFile.load();
+    const rootAgent = isApp(loaded) ? loaded.rootAgent : loaded;
+    const app = isApp(loaded) ? loaded : undefined;
+
+    let session = await sessionService.createSession({
+      appName: app?.name ?? rootAgent.name,
+      userId,
+    });
+
+    const reloadSubscribers: Array<(agent: RunnableRoot) => void> = [];
+
+    if (options.reloadAgents) {
+      const agentFilePath = getAbsolutePath(options.agentPath);
+      watcher = fs.watch(agentFilePath, async () => {
+        try {
+          await using reloadedFile = new AgentFile(
+            agentFilePath,
+            options.agentFileLoadOptions,
+          );
+          const reloaded = await reloadedFile.load();
+          const newAgent = isApp(reloaded) ? reloaded.rootAgent : reloaded;
+          for (const subscriber of reloadSubscribers) {
+            subscriber(newAgent);
+          }
+        } catch (err) {
+          console.warn('Failed to reload agent:', (err as Error).message);
+        }
+      });
+    }
+
+    const onAgentFileReloaded = (subscribe: (agent: RunnableRoot) => void) => {
+      reloadSubscribers.push(subscribe);
+    };
+
     if (options.inputFile) {
       session =
         (await runFromInputFile({
@@ -452,6 +460,9 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
 
       console.log('Session saved to', sessionPath);
     }
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
   } finally {
     // A throw out of the run or the save step must still release these, or the
     // shared interface holds stdin open for an in-process caller.

--- a/dev/src/cli_entrypoint.ts
+++ b/dev/src/cli_entrypoint.ts
@@ -10,4 +10,5 @@ try {
   createProgram().parse(process.argv);
 } catch (e) {
   console.error(e);
+  process.exitCode = 1;
 }

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -86,6 +86,13 @@ export interface AgentFileOptions {
   compile?: boolean;
   bundle?: boolean;
   moduleType?: FileModuleType;
+  /**
+   * Minify the generated bundle. Off by default: minification mangles
+   * identifiers and collapses line numbers, which makes every stack trace
+   * thrown by an agent unreadable. Only deployment bundles, where size
+   * matters more than debuggability, turn it on.
+   */
+  minify?: boolean;
 }
 
 /**
@@ -128,6 +135,11 @@ export function replaceDirnamePlugin(filePath: string, originalDir: string) {
               '__filename': JSON.stringify(filePath),
               'import.meta.url': JSON.stringify(fileUrl),
             },
+            // Hand the build an inline map back to the original file. Without
+            // it the outer build can only map as far as this pre-transformed
+            // text, and stack traces land on the wrong line of the agent file.
+            sourcemap: 'inline',
+            sourcefile: filePath,
           });
 
           return {
@@ -191,6 +203,15 @@ export class AgentFile {
       const originalDir = path.dirname(filePath);
       await linkProjectNodeModules(outputDir, parsedPath.dir);
 
+      const minify = this.options.minify ?? false;
+      if (!minify) {
+        // The bundle lives in a temp dir that is deleted when the run ends, so
+        // an external .map file would be gone by the time anyone read a stack
+        // trace. Inline the map instead and tell Node to apply it, so traces
+        // point at the developer's own source file and line.
+        process.setSourceMapsEnabled(true);
+      }
+
       await esbuild.build({
         entryPoints: [filePath],
         outfile: compiledFilePath,
@@ -198,7 +219,11 @@ export class AgentFile {
         platform: 'node',
         format: moduleType,
         bundle: this.options.bundle,
-        minify: this.options.bundle,
+        minify,
+        sourcemap: minify ? false : 'inline',
+        // The original sources are still on disk, so leaving them out of the
+        // map halves the size of an unminified bundle.
+        sourcesContent: false,
         plugins: [replaceDirnamePlugin(filePath, originalDir), shimPlugin()],
         // esbuild rejects `packages` and `external` unless it is bundling, so
         // both have to be withheld when `--bundle false` asks it only to

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -87,10 +87,22 @@ export interface AgentFileOptions {
   bundle?: boolean;
   moduleType?: FileModuleType;
   /**
-   * Minify the generated bundle. Off by default: minification mangles
-   * identifiers and collapses line numbers, which makes every stack trace
-   * thrown by an agent unreadable. Only deployment bundles, where size
-   * matters more than debuggability, turn it on.
+   * Minify the generated bundle.
+   *
+   * Passing `false` explicitly asks for a *debug build*: esbuild keeps the
+   * original identifiers and emits an inline source map, so a stack trace
+   * thrown by an agent names the developer's own function, file and line
+   * instead of `at new H_ (/tmp/.../agent.cjs:537:1742)`.
+   *
+   * A debug build is ~3.5x larger than a minified one (23.6 MB -> 83.1 MB
+   * across the four agents in the app_loader fixture) and costs roughly a
+   * second of extra load time per agent, so it is opt-in per call site. The
+   * interactive commands — `adk run`, `adk web`, `adk api_server` — ask for
+   * it because a human reads their output. Deployment bundles and
+   * programmatic callers leave it unset and keep the small artifact.
+   *
+   * When unset, a bundled file is minified, which is the historical
+   * behaviour.
    */
   minify?: boolean;
 }
@@ -113,9 +125,15 @@ const DEFAULT_AGENT_FILE_OPTIONS: AgentFileOptions = {
  *
  * @param filePath - The path to the agent file.
  * @param originalDir - The original directory path of the agent file.
+ * @param sourcemap - Whether this is a debug build, in which case the entry
+ *   file is handed back to the outer build with a chained inline map.
  * @returns An esbuild plugin that replaces path and URL references in the agent file.
  */
-export function replaceDirnamePlugin(filePath: string, originalDir: string) {
+export function replaceDirnamePlugin(
+  filePath: string,
+  originalDir: string,
+  sourcemap = false,
+) {
   return {
     name: 'replace-dirname',
     setup(build: esbuild.PluginBuild) {
@@ -135,11 +153,13 @@ export function replaceDirnamePlugin(filePath: string, originalDir: string) {
               '__filename': JSON.stringify(filePath),
               'import.meta.url': JSON.stringify(fileUrl),
             },
-            // Hand the build an inline map back to the original file. Without
-            // it the outer build can only map as far as this pre-transformed
-            // text, and stack traces land on the wrong line of the agent file.
-            sourcemap: 'inline',
-            sourcefile: filePath,
+            // On a debug build, hand the outer build an inline map back to
+            // the original file. Without it the outer build can only map as
+            // far as this pre-transformed text, and stack traces land on the
+            // wrong line of the agent file.
+            ...(sourcemap
+              ? {sourcemap: 'inline' as const, sourcefile: filePath}
+              : {}),
           });
 
           return {
@@ -203,8 +223,14 @@ export class AgentFile {
       const originalDir = path.dirname(filePath);
       await linkProjectNodeModules(outputDir, parsedPath.dir);
 
-      const minify = this.options.minify ?? false;
-      if (!minify) {
+      // An explicit `minify: false` is a request for a debug build: readable
+      // identifiers plus a source map. Callers that say nothing keep the
+      // small minified bundle, so nobody pays 3.5x the bundle size for a
+      // stack trace they will never read.
+      const debugBuild = this.options.minify === false;
+      const minify = this.options.minify ?? !!this.options.bundle;
+
+      if (debugBuild) {
         // The bundle lives in a temp dir that is deleted when the run ends, so
         // an external .map file would be gone by the time anyone read a stack
         // trace. Inline the map instead and tell Node to apply it, so traces
@@ -220,11 +246,14 @@ export class AgentFile {
         format: moduleType,
         bundle: this.options.bundle,
         minify,
-        sourcemap: minify ? false : 'inline',
+        sourcemap: debugBuild ? 'inline' : false,
         // The original sources are still on disk, so leaving them out of the
-        // map halves the size of an unminified bundle.
+        // map halves the size of a debug bundle.
         sourcesContent: false,
-        plugins: [replaceDirnamePlugin(filePath, originalDir), shimPlugin()],
+        plugins: [
+          replaceDirnamePlugin(filePath, originalDir, debugBuild),
+          shimPlugin(),
+        ],
         // esbuild rejects `packages` and `external` unless it is bundling, so
         // both have to be withheld when `--bundle false` asks it only to
         // transpile. Nothing is being inlined in that mode, so there is
@@ -405,6 +434,7 @@ export class AgentFile {
  */
 export class AgentLoader {
   private agentsAlreadyPreloaded = false;
+  private preloadInFlight?: Promise<void>;
   private readonly preloadedAgents: Record<string, AgentFile> = {};
   private readonly loadFailures: Record<string, AgentLoadFailure> = {};
   private watcher?: fs.FSWatcher;
@@ -485,6 +515,9 @@ export class AgentLoader {
     }
 
     this.agentsAlreadyPreloaded = false;
+    // Drop any pass still in flight so the next caller starts a fresh one
+    // rather than awaiting a result gathered before the file changed.
+    this.preloadInFlight = undefined;
   }
 
   /**
@@ -559,11 +592,24 @@ export class AgentLoader {
     );
   }
 
-  async preloadAgents() {
+  async preloadAgents(): Promise<void> {
     if (this.agentsAlreadyPreloaded) {
       return;
     }
 
+    // Callers overlap in practice: `adk web` serves concurrent requests and
+    // lists agents from several routes. Without sharing the in-flight pass,
+    // every caller that arrives before the first one finishes bundles all
+    // agents again — three overlapping callers turned 4 esbuild builds into
+    // 12 and 5.1s into 13.6s on the app_loader fixture.
+    this.preloadInFlight ??= this.runPreload().finally(() => {
+      this.preloadInFlight = undefined;
+    });
+
+    return this.preloadInFlight;
+  }
+
+  private async runPreload(): Promise<void> {
     const files = (await isFile(this.agentsDirPath))
       ? [await getFileMetadata(this.agentsDirPath)]
       : await getDirFiles(this.agentsDirPath);

--- a/dev/test/cli/cli_run_bad_api_key_test.ts
+++ b/dev/test/cli/cli_run_bad_api_key_test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseLlm,
+  BaseLlmConnection,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+} from '@google/adk';
+import {afterEach, beforeEach, describe, expect, it, Mock, vi} from 'vitest';
+import {runAgent} from '../../src/cli/cli_run.js';
+import {AgentFile} from '../../src/utils/agent_loader.js';
+import {loadFileData} from '../../src/utils/file_utils.js';
+
+// Only the agent file loading and the replay file are faked. `@google/adk`
+// stays real so the error travels the same path it does in production:
+// model throws -> LlmAgent turns it into an event carrying errorCode /
+// errorMessage and no content -> the CLI has to print it.
+vi.mock('../../src/utils/agent_loader.js', () => ({AgentFile: vi.fn()}));
+// getAbsolutePath is the real resolver; only the I/O is faked.
+vi.mock('../../src/utils/file_utils.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/utils/file_utils.js')>()),
+  loadFileData: vi.fn(),
+  saveToFile: vi.fn(),
+}));
+
+/** Verbatim body the Gemini API returns for a rejected API key. */
+const INVALID_API_KEY_RESPONSE = JSON.stringify({
+  error: {
+    code: 400,
+    message: 'API key not valid. Please pass a valid API key.',
+    status: 'INVALID_ARGUMENT',
+  },
+});
+
+class RejectingLlm extends BaseLlm {
+  // eslint-disable-next-line require-yield
+  override async *generateContentAsync(
+    _llmRequest: LlmRequest,
+    _stream?: boolean,
+  ): AsyncGenerator<LlmResponse, void> {
+    throw new Error(INVALID_API_KEY_RESPONSE);
+  }
+
+  override connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    throw new Error('not supported');
+  }
+}
+
+describe('adk run with an invalid API key', () => {
+  let errorSpy: Mock;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {}) as unknown as Mock;
+    originalExitCode = process.exitCode;
+
+    const rootAgent = new LlmAgent({
+      name: 'test_agent',
+      model: new RejectingLlm({model: 'gemini-flash-latest'}),
+    });
+    (AgentFile as unknown as Mock).mockImplementation(() => ({
+      load: async () => rootAgent,
+      [Symbol.asyncDispose]: async () => {},
+    }));
+    (loadFileData as Mock).mockResolvedValue({state: {}, queries: ['hello']});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  it('writes a diagnostic to stderr and exits non-zero', async () => {
+    await runAgent({agentPath: 'agent.ts', inputFile: 'input.json'});
+
+    expect(errorSpy).toHaveBeenCalled();
+    const stderr = errorSpy.mock.calls
+      .map((args) => String(args[0]))
+      .join('\n');
+    expect(stderr).not.toBe('');
+    expect(stderr).toContain('API key not valid');
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {BaseAgent, BaseSessionService, Runner} from '@google/adk';
+import {
+  BaseAgent,
+  BaseSessionService,
+  InMemorySessionService,
+  isApp,
+  Runner,
+} from '@google/adk';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 import {afterEach, beforeEach, describe, expect, it, Mock, vi} from 'vitest';
@@ -68,21 +74,45 @@ vi.mock('node:readline', () => ({
   createInterface: vi.fn(),
 }));
 
+const createMockSessionService = () =>
+  ({
+    createSession: vi.fn().mockResolvedValue({
+      id: 'session-123',
+      appName: 'test-agent',
+      userId: 'test_user',
+      events: [],
+    }),
+    appendEvent: vi.fn(),
+    getSession: vi.fn().mockResolvedValue({
+      id: 'session-123',
+      appName: 'test-agent',
+      userId: 'test_user',
+      events: [],
+    }),
+  }) as unknown as BaseSessionService;
+
 describe('cli_run', () => {
   let mockAgentFile: AgentFile;
   let mockRootAgent: BaseAgent;
   let mockRl: readline.Interface;
+  let errorSpy: Mock;
+  let originalExitCode: typeof process.exitCode;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {}) as unknown as Mock;
+    originalExitCode = process.exitCode;
 
     runnerState.events = [
       {author: 'model', content: {parts: [{text: 'Response from model'}]}},
     ];
 
-    // `restoreAllMocks` in afterEach strips the implementation set in the
-    // module factory, so re-establish it for every test.
+    // Re-established every test: `restoreAllMocks` drops the implementations
+    // set in the module factory, which would otherwise leave the runner and
+    // the session service inert from the second test onwards.
     (Runner as unknown as Mock).mockImplementation(() => ({
       runAsync: async function* () {
         for (const event of runnerState.events) {
@@ -90,6 +120,10 @@ describe('cli_run', () => {
         }
       },
     }));
+    (InMemorySessionService as unknown as Mock).mockImplementation(
+      createMockSessionService,
+    );
+    (isApp as unknown as Mock).mockReturnValue(false);
 
     mockRootAgent = {
       name: 'test-agent',
@@ -113,6 +147,7 @@ describe('cli_run', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
   });
 
   it('should run interactively by default', async () => {
@@ -126,23 +161,6 @@ describe('cli_run', () => {
     expect(readline.createInterface).toHaveBeenCalled();
     expect(mockRl.question).toHaveBeenCalled();
   });
-
-  const createMockSessionService = () =>
-    ({
-      createSession: vi.fn().mockResolvedValue({
-        id: 'session-123',
-        appName: 'test-agent',
-        userId: 'test_user',
-        events: [],
-      }),
-      appendEvent: vi.fn(),
-      getSession: vi.fn().mockResolvedValue({
-        id: 'session-123',
-        appName: 'test-agent',
-        userId: 'test_user',
-        events: [],
-      }),
-    }) as unknown as BaseSessionService;
 
   it('keeps the REPL alive when a turn fails', async () => {
     const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -210,15 +228,19 @@ describe('cli_run', () => {
     // — so the throw that still has to release stdin comes from the save step.
     (saveToFile as Mock).mockRejectedValue(new Error('save exploded'));
 
-    await expect(
-      runAgent({
-        agentPath: 'agent.ts',
-        saveSession: true,
-        sessionId: 'session-123',
-        sessionService: createMockSessionService(),
-      }),
-    ).rejects.toThrow('save exploded');
+    // runAgent now reports a thrown error and exits non-zero rather than
+    // propagating it, but the shared readline interface must still be released.
+    await runAgent({
+      agentPath: 'agent.ts',
+      saveSession: true,
+      sessionId: 'session-123',
+      sessionService: createMockSessionService(),
+    });
 
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({message: 'save exploded'}),
+    );
+    expect(process.exitCode).toBe(1);
     expect(mockRl.close as Mock).toHaveBeenCalledTimes(1);
   });
 
@@ -273,6 +295,18 @@ describe('cli_run', () => {
     expect(mockSessionService.createSession).toHaveBeenCalled();
   });
 
+  it('should handle missing input file', async () => {
+    (loadFileData as Mock).mockResolvedValue(null);
+    const mockSessionService = createMockSessionService();
+
+    await runAgent({
+      agentPath: 'agent.ts',
+      inputFile: 'input.json',
+      sessionService: mockSessionService,
+    });
+    expect(loadFileData).toHaveBeenCalled();
+  });
+
   it('honours an absolute --replay path instead of rebasing it on cwd', async () => {
     // `path.join(cwd, '/abs/input.json')` silently strips the leading
     // separator and looks for `<cwd>/abs/input.json`, which does not exist.
@@ -313,18 +347,27 @@ describe('cli_run', () => {
     );
   });
 
-  it('propagates an unreadable --replay file instead of swallowing it', async () => {
+  it('surfaces an unreadable --replay file instead of swallowing it', async () => {
     (loadFileData as Mock).mockRejectedValue(
       new Error('Failed to read or parse file input.json: ENOENT'),
     );
 
-    await expect(
-      runAgent({
-        agentPath: 'agent.ts',
-        inputFile: 'input.json',
-        sessionService: createMockSessionService(),
+    // runAgent now reports the failure on stderr and marks the process failed
+    // instead of rejecting; the error must still not be swallowed silently.
+    await runAgent({
+      agentPath: 'agent.ts',
+      inputFile: 'input.json',
+      sessionService: createMockSessionService(),
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Failed to read or parse file input.json',
+        ),
       }),
-    ).rejects.toThrow(/Failed to read or parse file input\.json/);
+    );
+    expect(process.exitCode).toBe(1);
     expect(loadFileData).toHaveBeenCalled();
   });
 
@@ -613,8 +656,6 @@ describe('cli_run', () => {
     });
 
     it('reports an error carried on the event', async () => {
-      vi.spyOn(console, 'error').mockImplementation(() => {});
-
       await runOneTurn({
         author: 'draft_email',
         errorCode: 'SAFETY',
@@ -630,7 +671,6 @@ describe('cli_run', () => {
     });
 
     it('warns when a scripted run ends still waiting on the user', async () => {
-      vi.spyOn(console, 'error').mockImplementation(() => {});
       (loadFileData as Mock).mockResolvedValue({state: {}, queries: ['start']});
       runnerState.events = [savedInterrupt('interrupt-1')];
 
@@ -714,6 +754,104 @@ describe('cli_run', () => {
       });
 
       expect(output).not.toContain('[streamer]');
+    });
+  });
+
+  describe('error reporting', () => {
+    // A failing model call (invalid API key, quota, safety block) is delivered
+    // as an event with no `content`, so it used to be dropped silently.
+    const errorEvent = {
+      author: 'test-agent',
+      errorCode: '400',
+      errorMessage: 'API key not valid. Please pass a valid API key.',
+    };
+
+    const answerOnce = (query: string) => {
+      (mockRl.question as Mock)
+        .mockImplementationOnce((_prompt: string, cb: (a: string) => void) =>
+          cb(query),
+        )
+        .mockImplementation((_prompt: string, cb: (a: string) => void) =>
+          cb('exit'),
+        );
+    };
+
+    it('reports an error event to stderr and exits non-zero interactively', async () => {
+      runnerState.events = [errorEvent];
+      answerOnce('hello');
+
+      await runAgent({
+        agentPath: 'agent.ts',
+        sessionService: createMockSessionService(),
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('API key not valid'),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('400'));
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('reports an error event to stderr and exits non-zero when replaying', async () => {
+      runnerState.events = [errorEvent];
+      (loadFileData as Mock).mockResolvedValue({state: {}, queries: ['Hello']});
+
+      await runAgent({
+        agentPath: 'agent.ts',
+        inputFile: 'input.json',
+        sessionService: createMockSessionService(),
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('API key not valid'),
+      );
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('still prints text that accompanies an error event', async () => {
+      runnerState.events = [
+        {...errorEvent, content: {parts: [{text: 'partial'}]}},
+      ];
+      answerOnce('hello');
+
+      await runAgent({
+        agentPath: 'agent.ts',
+        sessionService: createMockSessionService(),
+      });
+
+      expect(console.log).toHaveBeenCalledWith('[test-agent]: partial');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('leaves the exit code alone on a successful run', async () => {
+      answerOnce('hello');
+
+      await runAgent({
+        agentPath: 'agent.ts',
+        sessionService: createMockSessionService(),
+      });
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(originalExitCode);
+    });
+
+    it('reports a thrown error to stderr and exits non-zero', async () => {
+      (mockAgentFile.load as Mock).mockRejectedValue(
+        new Error('Agent file agent.ts does not exists'),
+      );
+
+      await runAgent({
+        agentPath: 'agent.ts',
+        sessionService: createMockSessionService(),
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Agent file agent.ts does not exists',
+        }),
+      );
+      expect(console.log).not.toHaveBeenCalledWith(expect.any(Error));
+      expect(process.exitCode).toBe(1);
     });
   });
 });

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -241,13 +241,14 @@ describe('CLI Entrypoint', () => {
       (runAgent as Mock).mockRejectedValueOnce(
         new Error('Agent file /nope/agent.ts does not exists'),
       );
-      const exit = vi
-        .spyOn(process, 'exit')
-        .mockImplementation((() => undefined) as never);
+      // The handler sets process.exitCode rather than calling process.exit, so
+      // async stderr (the error being surfaced) is not truncated on the way out.
+      const originalExitCode = process.exitCode;
 
       await parse(['run', '/nope/agent.ts']);
 
-      expect(exit).toHaveBeenCalledWith(1);
+      expect(process.exitCode).toBe(1);
+      process.exitCode = originalExitCode;
     });
 
     it('should call runAgent with required args', async () => {
@@ -298,6 +299,36 @@ describe('CLI Entrypoint', () => {
           otelToCloud: true,
         }),
       );
+    });
+  });
+
+  // Minification mangles identifiers and line numbers, so local commands must
+  // leave it off to keep an agent's stack traces readable; only deployment
+  // bundles, where size matters, turn it on.
+  describe('agent bundle minification', () => {
+    it.each([
+      ['run', ['run', 'agent.ts'], () => runAgent],
+      ['web', ['web'], () => AdkApiServer],
+      ['api_server', ['api_server'], () => AdkApiServer],
+    ])('is off for %s', async (_name, args, target) => {
+      await parse(args);
+
+      const call = (target() as unknown as Mock).mock.calls[0][0];
+      expect(call.agentFileLoadOptions.minify).toBe(false);
+    });
+
+    it.each([
+      ['deploy cloud_run', ['deploy', 'cloud_run'], () => deployToCloudRun],
+      [
+        'deploy agent_engine',
+        ['deploy', 'agent_engine'],
+        () => deployToAgentEngine,
+      ],
+    ])('is on for %s', async (_name, args, target) => {
+      await parse(args);
+
+      const call = (target() as unknown as Mock).mock.calls[0][0];
+      expect(call.agentFileLoadOptions.minify).toBe(true);
     });
   });
 

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -150,6 +150,7 @@ export default new App({ name: 'test_app_default', rootAgent: agent });
 describe('AgentLoader', () => {
   let tempAgentsDir: string;
   let tempLoaderDir: string;
+  let setSourceMapsEnabledSpy: Mock;
 
   const compiledPath = (fileName: string) => path.join(tempLoaderDir, fileName);
 
@@ -169,6 +170,9 @@ describe('AgentLoader', () => {
   });
 
   beforeEach(async () => {
+    setSourceMapsEnabledSpy = vi
+      .spyOn(process, 'setSourceMapsEnabled')
+      .mockImplementation(() => {}) as unknown as Mock;
     (fileUtils.createTempDir as Mock).mockImplementation(async () => {
       await fs.mkdir(tempLoaderDir, {recursive: true});
       return tempLoaderDir;
@@ -227,6 +231,7 @@ describe('AgentLoader', () => {
       // ignore
     }
 
+    setSourceMapsEnabledSpy.mockRestore();
     vi.clearAllMocks();
   });
 
@@ -310,7 +315,6 @@ describe('AgentLoader', () => {
         format: 'cjs',
         packages: 'bundle',
         bundle: true,
-        minify: true,
         external: expect.arrayContaining(['onnxruntime-node']),
       });
 
@@ -341,6 +345,53 @@ describe('AgentLoader', () => {
       expect(buildOptions.bundle).toBe(false);
       expect(buildOptions).not.toHaveProperty('external');
       expect(buildOptions).not.toHaveProperty('packages');
+
+      await agentFile.dispose();
+    });
+
+    it('builds a readable, source-mapped bundle by default', async () => {
+      const agentPath = path.join(tempAgentsDir, 'agent2.ts');
+      await fs.writeFile(agentPath, agent2TsContent);
+
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledPath('agent2.cjs'), agent2CjsContentMocked);
+      });
+
+      const agentFile = new AgentFile(agentPath);
+      await agentFile.load();
+
+      // Minified identifiers and collapsed line numbers make every stack
+      // trace out of an agent useless, so `adk run` / `adk web` must not
+      // minify and must emit a map the deleted temp bundle cannot lose.
+      expect((esbuild.build as Mock).mock.calls[0][0]).toMatchObject({
+        minify: false,
+        sourcemap: 'inline',
+      });
+      expect(setSourceMapsEnabledSpy).toHaveBeenCalledWith(true);
+
+      await agentFile.dispose();
+    });
+
+    it('minifies and drops the source map when asked to (deployment bundles)', async () => {
+      const agentPath = path.join(tempAgentsDir, 'agent2.ts');
+      await fs.writeFile(agentPath, agent2TsContent);
+
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledPath('agent2.cjs'), agent2CjsContentMocked);
+      });
+
+      const agentFile = new AgentFile(agentPath, {
+        compile: true,
+        bundle: true,
+        minify: true,
+      });
+      await agentFile.load();
+
+      expect((esbuild.build as Mock).mock.calls[0][0]).toMatchObject({
+        minify: true,
+        sourcemap: false,
+      });
+      expect(setSourceMapsEnabledSpy).not.toHaveBeenCalled();
 
       await agentFile.dispose();
     });

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -315,6 +315,7 @@ describe('AgentLoader', () => {
         format: 'cjs',
         packages: 'bundle',
         bundle: true,
+        minify: true,
         external: expect.arrayContaining(['onnxruntime-node']),
       });
 
@@ -349,30 +350,7 @@ describe('AgentLoader', () => {
       await agentFile.dispose();
     });
 
-    it('builds a readable, source-mapped bundle by default', async () => {
-      const agentPath = path.join(tempAgentsDir, 'agent2.ts');
-      await fs.writeFile(agentPath, agent2TsContent);
-
-      (esbuild.build as Mock).mockImplementation(async () => {
-        await fs.writeFile(compiledPath('agent2.cjs'), agent2CjsContentMocked);
-      });
-
-      const agentFile = new AgentFile(agentPath);
-      await agentFile.load();
-
-      // Minified identifiers and collapsed line numbers make every stack
-      // trace out of an agent useless, so `adk run` / `adk web` must not
-      // minify and must emit a map the deleted temp bundle cannot lose.
-      expect((esbuild.build as Mock).mock.calls[0][0]).toMatchObject({
-        minify: false,
-        sourcemap: 'inline',
-      });
-      expect(setSourceMapsEnabledSpy).toHaveBeenCalledWith(true);
-
-      await agentFile.dispose();
-    });
-
-    it('minifies and drops the source map when asked to (deployment bundles)', async () => {
+    it('builds a readable, source-mapped bundle when minify is off', async () => {
       const agentPath = path.join(tempAgentsDir, 'agent2.ts');
       await fs.writeFile(agentPath, agent2TsContent);
 
@@ -383,8 +361,34 @@ describe('AgentLoader', () => {
       const agentFile = new AgentFile(agentPath, {
         compile: true,
         bundle: true,
-        minify: true,
+        minify: false,
       });
+      await agentFile.load();
+
+      // Minified identifiers and collapsed line numbers make every stack
+      // trace out of an agent useless, so the interactive commands ask for a
+      // debug build and get a map the deleted temp bundle cannot lose.
+      // cli_test.ts asserts run/web/api_server are the callers that do so.
+      expect((esbuild.build as Mock).mock.calls[0][0]).toMatchObject({
+        minify: false,
+        sourcemap: 'inline',
+      });
+      expect(setSourceMapsEnabledSpy).toHaveBeenCalledWith(true);
+
+      await agentFile.dispose();
+    });
+
+    it('minifies and drops the source map by default (deployment bundles)', async () => {
+      const agentPath = path.join(tempAgentsDir, 'agent2.ts');
+      await fs.writeFile(agentPath, agent2TsContent);
+
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledPath('agent2.cjs'), agent2CjsContentMocked);
+      });
+
+      // A debug build is ~3.5x larger, so a caller that does not ask for one
+      // keeps the small artifact.
+      const agentFile = new AgentFile(agentPath);
       await agentFile.load();
 
       expect((esbuild.build as Mock).mock.calls[0][0]).toMatchObject({
@@ -921,6 +925,24 @@ describe('AgentLoader', () => {
       await loader.preloadAgents();
 
       expect(spy).not.toHaveBeenCalled();
+      await loader.disposeAll();
+    });
+
+    it('shares one preload pass between concurrent callers', async () => {
+      // `agentsAlreadyPreloaded` is only set once the pass finishes, so
+      // callers that overlap it used to each start their own full pass and
+      // bundle every agent again. `adk web` does exactly this: several routes
+      // list agents, and requests arrive concurrently.
+      const loader = new AgentLoader(tempAgentsDir);
+
+      await Promise.all([
+        loader.listAgents(),
+        loader.listApps(),
+        loader.getAgentFile('agent1'),
+      ]);
+
+      // Three agents in the fixture, so three builds - not nine.
+      expect((esbuild.build as Mock).mock.calls).toHaveLength(3);
       await loader.disposeAll();
     });
 


### PR DESCRIPTION
## Problem

A developer whose API key is bad, expired, or simply the wrong variable — the single most
common first-run failure — gets **no diagnostic output and exit code 0**:

```
$ npx adk run agent.ts
[user]: INFO: [ADK] Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
[user]:
EXITCODE=0
```

Nothing on stderr, nothing on stdout, a success exit code. There is no thread to pull on.

Three independent defects produce that:

1. **Model errors are never printed.** `llm_agent.ts` turns every model failure into an `Event`
   carrying `errorCode`/`errorMessage` and **no `content`**. Both event loops in `cli_run.ts`
   printed only `event.content.parts`, so the error was silently dropped.
2. **Exceptions went to stdout with exit 0.** `runAgent`'s handler was `catch (e) { console.log(e) }`.
3. **Stack traces were useless.** The agent loader esbuild-bundles *and minifies* the user's file
   into a temp dir that is deleted on exit, so every frame looked like
   `at new H_ (/tmp/adk_agent_loader/29d078dd-.../agent.cjs:537:1742)` — mangled name,
   meaningless line, file gone.

## Fix

- `cli_run.ts`: one `printEvent` helper used by both the interactive and the `--replay` loop.
  Text still goes to stdout; `errorCode`/`errorMessage` go to **stderr** and set
  `process.exitCode = 1`. An event carrying both is printed both ways.
- `runAgent`'s catch → `console.error` + non-zero exit code. Same for the `run` subcommand
  handler and the CLI entrypoint.
- Minification is now **opt-in** (`AgentFileOptions.minify`, default `false`). `adk run`,
  `adk web` and `adk api_server` build unminified with an **inline** source map (inline because
  the bundle's temp dir is deleted before anyone reads the trace) and enable Node's source-map
  support. `adk deploy cloud_run` / `deploy agent_engine` pass `minify: true` and skip the map,
  so deployment artifacts are unchanged.
- `replaceDirnamePlugin` now returns a chained inline map for the entry file. Without it the
  outer build can only map back to the plugin's pre-transformed text and traces land on the
  wrong line of the agent file (off by one or two in practice).

## Before / after — bad API key

Real run against the Gemini API with a deliberately invalid key.

**Before**

```
$ node adk run agent.ts
Running agent demo_agent, type exit to exit.
[user]: INFO: [ADK] Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
[user]:
--- stderr: (empty) ---
EXITCODE=0
```

**After**

```
$ node adk run agent.ts
Running agent demo_agent, type exit to exit.
[user]: INFO: [ADK] Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
[demo_agent] ERROR (400): API key not valid. Please pass a valid API key.   <-- stderr
[user]:
EXITCODE=1
```

## Before / after — stack trace from the developer's own code

`runtime_boom_agent.ts` throws from a `beforeAgentCallback` at line 4 (`loadUserProfile`),
called at line 12.

**Before** — printed to **stdout**, exit **0**, every frame inside a minified bundle in a
temp dir that no longer exists:

```
[user]: Error: profile store unreachable
    at DGn (file:///…/adk_agent_loader-4YUlW0/runtime_boom_agent.mjs?t=…:716:55077)
    at beforeAgentCallback (file:///…/adk_agent_loader-4YUlW0/runtime_boom_agent.mjs?t=…:716:55251)
    at t.handleBeforeAgentCallback (file:///…/adk_agent_loader-4YUlW0/runtime_boom_agent.mjs?t=…:547:60939)
    at t.<anonymous> (file:///…/adk_agent_loader-4YUlW0/runtime_boom_agent.mjs?t=…:547:59755)
    at t.runAsync (file:///…/adk_agent_loader-4YUlW0/runtime_boom_agent.mjs?t=…:547:59668)
EXITCODE=0
```

**After** — **stderr**, exit **1**, real function names and real line numbers in the user's file:

```
Error: profile store unreachable
    at loadUserProfile (/home/…/runtime_boom_agent.ts:4:9)
    at beforeAgentCallback (/home/…/runtime_boom_agent.ts:12:5)
    at _LlmAgent.handleBeforeAgentCallback (…/core/dist/esm/agents/base_agent.js:219:29)
    …
EXITCODE=1
```

Same for a throw at agent construction time (the `at new H_ (…)` shape from the original report):
`at new WeatherClient (/home/…/boom_agent.ts:6:13)` / `at <anonymous> (/home/…/boom_agent.ts:11:16)`.

## Tests

`dev/test/cli/cli_run_bad_api_key_test.ts` is the headline regression test: a real `LlmAgent`
and a real `Runner` (only the file loader is faked) driven by a model that throws the verbatim
`{"error":{"code":400,"message":"API key not valid…"}}` body the Gemini API returns. It asserts
stderr is non-empty, contains the reason, and `process.exitCode === 1`. It fails on `main`
(`expected "error" to be called at least once`).

Also added:

- `cli_run_test.ts` — error event surfaces in interactive **and** `--replay` mode, text
  accompanying an error event still prints, a successful run leaves the exit code alone, and a
  thrown error goes to `console.error` rather than `console.log`. 4 of these fail on `main`.
  The mocked `Runner`/session service are now re-established per test; `restoreAllMocks` was
  wiping the implementations set in the module factory, which left the runner inert from the
  second test onwards — invisible before because `runAgent` swallowed the resulting `TypeError`.
- `agent_loader_test.ts` — an explicit `{minify: false}` gives `sourcemap: 'inline'` with Node
  source maps enabled; the default gives `minify: true, sourcemap: false` and no global
  source-map opt-in, plus a regression test that concurrent callers share one preload pass.
- `cli_test.ts` — `run`/`web`/`api_server` pass `minify: false`, both deploy targets pass `true`.

Verified: `npm run build`, `npx vitest run --project unit:dev` (only pre-existing
`cli_create_test.ts > Vertex AI selection with gcloud defaults` fails, on `main` too — it
depends on local gcloud config), `eslint`, `prettier --check`, and
`vitest --project integration tests/integration/build_setup` (20 passed, incl. both
native-addon fixtures).

## Trade-off worth knowing

An unminified bundle with an inline source map is a **debug build**: it is what makes the trace
readable, and it is ~3.5x larger. Measured over the four agents the `app_loader` discovery
fixture loads (min of 3, esbuild + import, Linux workstation):

| build | bundle | build | import | total |
|---|---:|---:|---:|---:|
| `main` (minified, no map) | 23.6 MB | 1554 ms | 1940 ms | 3527 ms |
| unminified, no map | 48.5 MB | 1611 ms | 2016 ms | 3629 ms |
| **debug build** (unminified + inline map, `sourcesContent: false`) | 83.1 MB | 1931 ms | 2332 ms | 4301 ms |

So the debug build is worth about +1 s of `adk run` startup, which is a good trade when a human
is about to read the output — and a bad one for a caller that will never look at a stack trace.

It is therefore **opt-in per call site**. `adk run`, `adk web` and `adk api_server` pass
`minify: false` and get readable traces; both deploy targets pass `minify: true`; anything that
says nothing keeps the historical minified bundle. Every CLI entry point already routed through
`getAgentFileOptions`, so this costs the fix nothing: deployment artifacts are unchanged, and
`adk run` still prints

```
Error: weather endpoint must be https
    at new WeatherClient (/…/boom_agent.ts:6:13)
    at Object.<anonymous> (/…/boom_agent.ts:11:16)
```

on **stderr** with exit code **1**.

Alternatives measured and rejected:

- **External `.map`** — 48.5 MB + a 25.9 MB map, and still 2.05x `main`'s bundle. Worse, `runAgent`'s
  `await using agentFile` deletes the temp dir when the `try` block exits, *before* the `catch`
  formats the stack, so a lazily-read external map would already be gone. Slower *and* broken.
- **`minify: true` + `keepNames: true` + map** — 59.4 MB and *slower* than the debug build
  (4415 ms), while still degrading names in the developer's own frames. Strictly worse.
- **`packages: 'external'`** — the real prize: 0.008 MB and 25 ms, ~140x faster than `main`,
  because the temp dir already symlinks the project's `node_modules`. It would make `adk run`
  faster than today *and* fully debuggable. But it changes what `--bundle` means and can break
  agents outside a `node_modules`-bearing project, so it belongs in its own PR rather than
  smuggled into a CI fix.

## Out of scope (noticed while verifying)

An exception thrown inside a **tool** never reaches the CLI at all: `FunctionTool.runAsync`
rethrows with only `error.message` (`core/src/tools/function_tool.ts:167`) and
`core/src/agents/functions.ts` keeps only `e.message` in the tool response so the model can
recover. The stack is discarded in core before the CLI sees anything, so no CLI-side change can
surface it. Left alone here — this PR only touches `dev/`.

`tests/integration/skills/script_js/agent_test.ts` has the same
`beforeAll(…, TEST_EXECUTION_TIMEOUT)` bug fixed here for `app_loader_test.ts` — an `npm install`
held to a per-test budget. Not touched, but worth a follow-up.

## The macOS failure, and the two bugs underneath it

The earlier revision of this PR failed `run-tests (macos-latest)` three times running. It was
not flake, and the cause was mine — but it landed on a test that was already close to the edge.

**1. This PR's regression (fixed).** The debug build was the loader's *default*, so
`app_loader_test.ts`'s discovery test — which bundles four agents through `AgentLoader` — paid
for it. Measured locally, same machine, same fixture:

| loader | discovery test | budget used |
|---|---:|---:|
| `main` | 18,322 ms | 46% |
| this PR, before this commit | 29,626 ms | **74%** |
| this PR, now | 15,725 ms | 26% |

On a **green** macos-latest run of `main` that test takes **29,806 ms**. Applying the measured
+62% gives ~48 s against a 40 s budget: a deterministic failure, which is exactly what CI showed.

**2. `preloadAgents()` had no in-flight dedup (fixed).** The "already preloaded" flag was only
set after the whole pass finished, so any caller arriving during the pass started its own.
Three overlapping callers → **12 esbuild builds instead of 4, 5.1 s instead of 13.6 s**. When
the first `it()` timed out mid-pass, the next two each kicked off a *fresh* full pass, which is
why the failures arrived in clusters of two or three and why `build_setup_test.ts` sometimes got
dragged down with them — 12 concurrent 83 MB bundles starve every other test file in the pool.
This is also a live `adk web` bug: several routes call `listAgents()` and requests are
concurrent. `agent_loader_test.ts` gains a regression test (9 builds before, 3 after).

**3. `app_loader_test.ts` pinned everything to 40 s (fixed).** That predates #548, which gave the
`integration` project a 60 s test budget and a 120 s hook budget precisely because these fixtures
run `npm install` and bundle agent trees. The local override applied to **hooks** too, so a cold
`npm install` (~60 s) blew a 40 s hook budget — reproducible locally by clearing the fixture's
`node_modules`. And 40 s never suited the discovery test: 29.8 s on a *green* macOS run is 25%
headroom on a shared runner. Both budgets now come from `vitest.config.ts` like every other
integration test. (Diff looks large; it is mostly reindentation — `?w=1` shows 29 lines.)

This is the standing tax #622 describes. `main` itself failed 5 of its last 12 validation runs.

`build_setup_test.ts`'s 20 s budget is **not** touched: on green macOS it uses 5.9 s, and the
debug build's +1 s takes that to ~7 s. Its "Don't raise TEST_EXECUTION_TIMEOUT" comment stands.

Verified locally: full `--project integration` suite — `app_loader_test.ts` 6/6 green (discovery
16.5 s), `build_setup_test.ts` green. `--project unit:dev` 255/256, the one failure being the
pre-existing gcloud-dependent `cli_create_test.ts` case that also fails on `main`. `eslint`,
`prettier --check`, and `tsc --noEmit` (280 pre-existing errors, identical count on `main`).
