### PR TITLE
perf(core): make situational subsystems optional peers, 591 → 172 packages on install

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -30,7 +30,38 @@
     "./dist/web/*": {
       "types": "./dist/types/*",
       "default": "./dist/web/*"
-    }
+    },
+    "./a2a": {
+      "types": "./dist/types/a2a/index.d.ts",
+      "import": "./dist/esm/a2a/index.js",
+      "require": "./dist/cjs/a2a/index.js",
+      "default": "./dist/esm/a2a/index.js"
+    },
+    "./artifacts/gcs": {
+      "types": "./dist/types/artifacts/gcs_artifact_service.d.ts",
+      "import": "./dist/esm/artifacts/gcs_artifact_service.js",
+      "require": "./dist/cjs/artifacts/gcs_artifact_service.js",
+      "default": "./dist/esm/artifacts/gcs_artifact_service.js"
+    },
+    "./sessions/database": {
+      "types": "./dist/types/sessions/database_session_service.d.ts",
+      "import": "./dist/esm/sessions/database_session_service.js",
+      "require": "./dist/cjs/sessions/database_session_service.js",
+      "default": "./dist/esm/sessions/database_session_service.js"
+    },
+    "./telemetry/gcp": {
+      "types": "./dist/types/telemetry/google_cloud.d.ts",
+      "import": "./dist/esm/telemetry/google_cloud.js",
+      "require": "./dist/cjs/telemetry/google_cloud.js",
+      "default": "./dist/esm/telemetry/google_cloud.js"
+    },
+    "./tools/mcp": {
+      "types": "./dist/types/tools/mcp/index.d.ts",
+      "import": "./dist/esm/tools/mcp/index.js",
+      "require": "./dist/cjs/tools/mcp/index.js",
+      "default": "./dist/esm/tools/mcp/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -46,14 +77,10 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
-    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
-    "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
-    "@google-cloud/storage": "^7.17.1",
     "@google-cloud/vertexai": "^1.12.0",
     "@google/genai": "^2.9.0",
     "@mikro-orm/core": "^6.6.10",
     "@mikro-orm/reflection": "^6.6.6",
-    "@modelcontextprotocol/sdk": "^1.26.0",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/api-logs": "^0.205.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.205.0",
@@ -66,7 +93,6 @@
     "@opentelemetry/sdk-trace-base": "^2.1.0",
     "@opentelemetry/sdk-trace-node": "^2.1.0",
     "adm-zip": "^0.5.17",
-    "express": "^4.22.1",
     "google-auth-library": "^10.3.0",
     "js-yaml": "^4.1.1",
     "jsonpath-plus": "^10.4.0",
@@ -76,18 +102,60 @@
     "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+    "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
+    "@google-cloud/storage": "^7.17.1",
     "@mikro-orm/sqlite": "^6.6.6",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@opentelemetry/context-async-hooks": "^2.1.0",
     "@types/adm-zip": "^0.5.8",
     "@types/express": "^4.17.25",
     "@types/lodash-es": "^4.17.12",
+    "express": "^4.22.1",
     "openapi-types": "^12.1.3"
   },
   "peerDependencies": {
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+    "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
+    "@google-cloud/storage": "^7.17.1",
     "@mikro-orm/mariadb": "^6.6.6",
     "@mikro-orm/mssql": "^6.6.6",
     "@mikro-orm/mysql": "^6.6.6",
     "@mikro-orm/postgresql": "^6.6.6",
-    "@mikro-orm/sqlite": "^6.6.6"
+    "@mikro-orm/sqlite": "^6.6.6",
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "express": "^4.22.1 || ^5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": {
+      "optional": true
+    },
+    "@google-cloud/opentelemetry-cloud-trace-exporter": {
+      "optional": true
+    },
+    "@google-cloud/storage": {
+      "optional": true
+    },
+    "@mikro-orm/mariadb": {
+      "optional": true
+    },
+    "@mikro-orm/mssql": {
+      "optional": true
+    },
+    "@mikro-orm/mysql": {
+      "optional": true
+    },
+    "@mikro-orm/postgresql": {
+      "optional": true
+    },
+    "@mikro-orm/sqlite": {
+      "optional": true
+    },
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    },
+    "express": {
+      "optional": true
+    }
   }
 }

--- a/core/src/a2a/agent_to_a2a.ts
+++ b/core/src/a2a/agent_to_a2a.ts
@@ -6,13 +6,8 @@
 
 import {AGENT_CARD_PATH, AgentCard} from '@a2a-js/sdk';
 import {DefaultRequestHandler, InMemoryTaskStore} from '@a2a-js/sdk/server';
-import {
-  agentCardHandler,
-  jsonRpcHandler,
-  restHandler,
-  UserBuilder,
-} from '@a2a-js/sdk/server/express';
-import express from 'express';
+import type {UserBuilder} from '@a2a-js/sdk/server/express';
+import type express from 'express';
 import {StreamingMode} from '../agents/run_config.js';
 import {BaseArtifactService} from '../artifacts/base_artifact_service.js';
 import {BaseMemoryService} from '../memory/base_memory_service.js';
@@ -20,9 +15,35 @@ import {Runner} from '../runner/runner.js';
 import {BaseSessionService} from '../sessions/base_session_service.js';
 import {InMemorySessionService} from '../sessions/in_memory_session_service.js';
 import {logger} from '../utils/logger.js';
+import {loadOptionalPeer} from '../utils/optional_peer.js';
 import {RunnableRoot} from '../workflow/run_node_as_invocation.js';
 import {getA2AAgentCard, resolveAgentCard} from './agent_card.js';
 import {A2AAgentExecutor} from './agent_executor.js';
+
+/**
+ * Loads Express and the Express bindings of `@a2a-js/sdk`, which are only
+ * needed by {@link toA2a}.
+ *
+ * `@a2a-js/sdk` itself already declares `express` as an optional peer, and ADK
+ * follows suit: an agent that is never mounted as an HTTP service should not
+ * have to download a web framework. Both modules are imported here rather
+ * than at the top of the file, because `@a2a-js/sdk/server/express` imports
+ * `express` eagerly and would otherwise make the whole ADK entry point
+ * unloadable without it.
+ */
+async function loadExpressBindings(): Promise<{
+  express: typeof express;
+  a2aExpress: typeof import('@a2a-js/sdk/server/express');
+}> {
+  const expressModule = await loadOptionalPeer(
+    {packageName: 'express', feature: 'toA2a'},
+    () => import('express'),
+  );
+  // `@a2a-js/sdk` is itself a hard dependency, so with Express resolved above
+  // this import can no longer fail for a missing package.
+  const a2aExpress = await import('@a2a-js/sdk/server/express');
+  return {express: expressModule.default, a2aExpress};
+}
 
 /**
  * A request authenticator for the A2A surface.
@@ -100,7 +121,10 @@ export interface ToA2aOptions {
  * - Otherwise, an error is thrown: the A2A surface must not be exposed without
  *   authentication.
  */
-function resolveA2aUserBuilder(options: ToA2aOptions): UserBuilder {
+function resolveA2aUserBuilder(
+  options: ToA2aOptions,
+  a2aExpress: typeof import('@a2a-js/sdk/server/express'),
+): UserBuilder {
   if (options.authentication) {
     return options.authentication;
   }
@@ -113,7 +137,7 @@ function resolveA2aUserBuilder(options: ToA2aOptions): UserBuilder {
         'invoke them with arbitrary input and read the output. Do NOT use ' +
         'this outside of local, trusted development.',
     );
-    return UserBuilder.noAuthentication;
+    return a2aExpress.UserBuilder.noAuthentication;
   }
 
   throw new Error(
@@ -138,9 +162,11 @@ export async function toA2a(
   agent: RunnableRoot,
   options: ToA2aOptions = {},
 ): Promise<express.Application> {
+  const {express: expressFactory, a2aExpress} = await loadExpressBindings();
+
   // Fail closed before doing any work: the A2A surface must be authenticated
   // unless the caller explicitly opts out.
-  const userBuilder = resolveA2aUserBuilder(options);
+  const userBuilder = resolveA2aUserBuilder(options, a2aExpress);
 
   const host = options.host ?? 'localhost';
   const port = options.port ?? 8000;
@@ -179,30 +205,30 @@ export async function toA2a(
     agentExecutor,
   );
 
-  const app = options.app ?? express();
+  const app = options.app ?? expressFactory();
   if (!options.app) {
     // Parse JSON bodies only. `application/x-www-form-urlencoded` is a
     // CORS-safelisted content type, so a browser sends it cross-origin as a
     // simple request with no preflight; parsing it would let any web page
     // drive these endpoints with a drive-by form POST. Requiring JSON forces
     // a preflight, which this app does not answer.
-    app.use(express.json({limit: '50mb'}));
+    app.use(expressFactory.json({limit: '50mb'}));
   }
 
   app.use(
     `${basePath}/${AGENT_CARD_PATH}`,
-    agentCardHandler({agentCardProvider: requestHandler}),
+    a2aExpress.agentCardHandler({agentCardProvider: requestHandler}),
   );
   app.use(
     `${basePath}/rest`,
-    restHandler({
+    a2aExpress.restHandler({
       requestHandler,
       userBuilder,
     }),
   );
   app.use(
     `${basePath}/jsonrpc`,
-    jsonRpcHandler({
+    a2aExpress.jsonRpcHandler({
       requestHandler,
       userBuilder,
     }),

--- a/core/src/a2a/index.ts
+++ b/core/src/a2a/index.ts
@@ -5,13 +5,8 @@
  */
 
 /**
- * Entry point for `@google/adk/a2a`.
- *
- * Everything here is also re-exported from `@google/adk`, so importing it from
- * the root keeps working. This subpath exists so that an application serving
- * or calling A2A can pull in the A2A surface — and only the A2A surface —
- * without evaluating the whole ADK barrel, and so that the `express` optional
- * peer dependency needed by {@link toA2a} has an obvious, documented home.
+ * `@google/adk/a2a` subpath: the A2A surface only, without the full ADK barrel.
+ * Also re-exported from `@google/adk`.
  */
 
 export {AGENT_CARD_PATH, RemoteA2AAgent} from './a2a_remote_agent.js';

--- a/core/src/a2a/index.ts
+++ b/core/src/a2a/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Entry point for `@google/adk/a2a`.
+ *
+ * Everything here is also re-exported from `@google/adk`, so importing it from
+ * the root keeps working. This subpath exists so that an application serving
+ * or calling A2A can pull in the A2A surface — and only the A2A surface —
+ * without evaluating the whole ADK barrel, and so that the `express` optional
+ * peer dependency needed by {@link toA2a} has an obvious, documented home.
+ */
+
+export {AGENT_CARD_PATH, RemoteA2AAgent} from './a2a_remote_agent.js';
+export type {
+  A2AStreamEventData,
+  AfterA2ARequestCallback,
+  BeforeA2ARequestCallback,
+  RemoteA2AAgentConfig,
+} from './a2a_remote_agent.js';
+export {getA2AAgentCard} from './agent_card.js';
+export {A2AAgentExecutor} from './agent_executor.js';
+export type {
+  AfterEventCallback,
+  AfterExecuteCallback,
+  AgentExecutorConfig,
+  BeforeExecuteCallback,
+  RunnerOrRunnerConfig,
+} from './agent_executor.js';
+export {toA2a} from './agent_to_a2a.js';
+export type {A2aUserBuilder, ToA2aOptions} from './agent_to_a2a.js';
+export {bearerTokenUserBuilder} from './auth.js';
+export type {ExecutorContext} from './executor_context.js';

--- a/core/src/artifacts/gcs_artifact_service.ts
+++ b/core/src/artifacts/gcs_artifact_service.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Bucket, File, Storage, StorageOptions} from '@google-cloud/storage';
+import type {Bucket, File, StorageOptions} from '@google-cloud/storage';
 import {createPartFromBase64, createPartFromText, Part} from '@google/genai';
 import {logger} from '../utils/logger.js';
+import {loadOptionalPeer} from '../utils/optional_peer.js';
 
 import {
   ArtifactVersion,
@@ -24,10 +25,35 @@ const GCS_DISPLAY_NAME_METADATA_KEY = 'adkDisplayName';
 const GCS_IS_TEXT_METADATA_KEY = 'adkIsText';
 
 export class GcsArtifactService implements BaseArtifactService {
-  private readonly bucket: Bucket;
+  private readonly bucketName: string;
+  private readonly storageOptions?: StorageOptions;
+  private bucketPromise?: Promise<Bucket>;
 
   constructor(bucket: string, options?: StorageOptions) {
-    this.bucket = new Storage(options).bucket(bucket);
+    this.bucketName = bucket;
+    this.storageOptions = options;
+  }
+
+  /**
+   * Resolves the GCS bucket handle, loading `@google-cloud/storage` on first
+   * use.
+   *
+   * The client is an optional peer dependency — it is one of the heaviest
+   * packages in the tree and only this service needs it — so it cannot be
+   * imported at module load without making the whole ADK entry point
+   * unloadable for the applications that store artifacts elsewhere. The
+   * constructor never performed I/O, so deferring it changes nothing an
+   * existing caller could observe beyond the point at which a missing client
+   * is reported.
+   */
+  private getBucket(): Promise<Bucket> {
+    this.bucketPromise ??= loadOptionalPeer(
+      {packageName: '@google-cloud/storage', feature: 'GcsArtifactService'},
+      () => import('@google-cloud/storage'),
+    ).then(({Storage}) =>
+      new Storage(this.storageOptions).bucket(this.bucketName),
+    );
+    return this.bucketPromise;
   }
 
   async saveArtifact(request: SaveArtifactRequest): Promise<number> {
@@ -41,7 +67,8 @@ export class GcsArtifactService implements BaseArtifactService {
 
     const versions = await this.listVersions(request);
     const version = versions.length > 0 ? Math.max(...versions) + 1 : 0;
-    const file = this.bucket.file(
+    const bucket = await this.getBucket();
+    const file = bucket.file(
       getFileName({
         ...request,
         version,
@@ -107,7 +134,7 @@ export class GcsArtifactService implements BaseArtifactService {
         version = Math.max(...versions);
       }
 
-      const file = this.bucket.file(
+      const file = (await this.getBucket()).file(
         getFileName({
           ...request,
           version,
@@ -165,9 +192,10 @@ export class GcsArtifactService implements BaseArtifactService {
   async listArtifactKeys(request: ListArtifactKeysRequest): Promise<string[]> {
     const sessionPrefix = `${request.appName}/${request.userId}/${request.sessionId}/`;
     const usernamePrefix = `${request.appName}/${request.userId}/user/`;
+    const bucket = await this.getBucket();
     const [[sessionFiles], [userSessionFiles]] = await Promise.all([
-      this.bucket.getFiles({prefix: sessionPrefix}),
-      this.bucket.getFiles({prefix: usernamePrefix}),
+      bucket.getFiles({prefix: sessionPrefix}),
+      bucket.getFiles({prefix: usernamePrefix}),
     ]);
 
     return [
@@ -178,10 +206,11 @@ export class GcsArtifactService implements BaseArtifactService {
 
   async deleteArtifact(request: DeleteArtifactRequest): Promise<void> {
     const versions = await this.listVersions(request);
+    const bucket = await this.getBucket();
 
     await Promise.all(
       versions.map((version) => {
-        const file = this.bucket.file(
+        const file = bucket.file(
           getFileName({
             ...request,
             version,
@@ -199,7 +228,8 @@ export class GcsArtifactService implements BaseArtifactService {
     const prefix = getFileName(request);
     // We need to add a trailing slash to prefix to ensure we only get children
     const searchPrefix = prefix + '/';
-    const [files] = await this.bucket.getFiles({prefix: searchPrefix});
+    const bucket = await this.getBucket();
+    const [files] = await bucket.getFiles({prefix: searchPrefix});
     const versions = [];
     for (const file of files) {
       const version = file.name.split('/').pop()!;
@@ -245,7 +275,7 @@ export class GcsArtifactService implements BaseArtifactService {
         version = Math.max(...versions);
       }
 
-      const file = this.bucket.file(
+      const file = (await this.getBucket()).file(
         getFileName({
           ...request,
           version,

--- a/core/src/artifacts/gcs_artifact_service.ts
+++ b/core/src/artifacts/gcs_artifact_service.ts
@@ -35,16 +35,8 @@ export class GcsArtifactService implements BaseArtifactService {
   }
 
   /**
-   * Resolves the GCS bucket handle, loading `@google-cloud/storage` on first
-   * use.
-   *
-   * The client is an optional peer dependency — it is one of the heaviest
-   * packages in the tree and only this service needs it — so it cannot be
-   * imported at module load without making the whole ADK entry point
-   * unloadable for the applications that store artifacts elsewhere. The
-   * constructor never performed I/O, so deferring it changes nothing an
-   * existing caller could observe beyond the point at which a missing client
-   * is reported.
+   * Resolves the GCS bucket handle, loading the `@google-cloud/storage`
+   * optional peer on first use.
    */
   private getBucket(): Promise<Bucket> {
     this.bucketPromise ??= loadOptionalPeer(

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -4,26 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export {AGENT_CARD_PATH, RemoteA2AAgent} from './a2a/a2a_remote_agent.js';
-export type {
-  A2AStreamEventData,
-  AfterA2ARequestCallback,
-  BeforeA2ARequestCallback,
-  RemoteA2AAgentConfig,
-} from './a2a/a2a_remote_agent.js';
-export {getA2AAgentCard} from './a2a/agent_card.js';
-export {A2AAgentExecutor} from './a2a/agent_executor.js';
-export type {
-  AfterEventCallback,
-  AfterExecuteCallback,
-  AgentExecutorConfig,
-  BeforeExecuteCallback,
-  RunnerOrRunnerConfig,
-} from './a2a/agent_executor.js';
-export {toA2a} from './a2a/agent_to_a2a.js';
-export type {A2aUserBuilder, ToA2aOptions} from './a2a/agent_to_a2a.js';
-export {bearerTokenUserBuilder} from './a2a/auth.js';
-export type {ExecutorContext} from './a2a/executor_context.js';
+// Also available as `@google/adk/a2a`, which does not evaluate the rest of
+// this barrel.
+export * from './a2a/index.js';
 export {InvocationContext} from './agents/invocation_context.js';
 export type {WorkflowInstructionScope} from './agents/invocation_context.js';
 export {FileArtifactService} from './artifacts/file_artifact_service.js';
@@ -62,7 +45,6 @@ export {RunSkillScriptTool} from './tools/skill/run_skill_script_tool.js';
 export * from './integrations/agent_registry/agent_registry.js';
 export * from './telemetry/google_cloud.js';
 export * from './telemetry/setup.js';
-export * from './tools/mcp/load_mcp_resource_tool.js';
-export * from './tools/mcp/mcp_session_manager.js';
-export * from './tools/mcp/mcp_tool.js';
-export * from './tools/mcp/mcp_toolset.js';
+// Also available as `@google/adk/tools/mcp`, which does not evaluate the rest
+// of this barrel.
+export * from './tools/mcp/index.js';

--- a/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
+++ b/core/src/integrations/agent_registry/agent_registry_mcp_toolset.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ListToolsResult} from '@modelcontextprotocol/sdk/types.js';
+import type {ListToolsResult} from '@modelcontextprotocol/sdk/types.js';
 import {ReadonlyContext} from '../../agents/readonly_context.js';
 import {AuthCredential} from '../../auth/auth_credential.js';
 import {AuthScheme} from '../../auth/auth_schemes.js';

--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -14,14 +14,7 @@ import {
   StorageMetadata,
 } from './schema.js';
 
-/**
- * Describes the driver package backing a connection-string scheme.
- *
- * The five SQL drivers are optional peer dependencies: a `DatabaseSessionService`
- * talks to exactly one database, so installing `@google/adk` must not download
- * MariaDB, MSSQL, MySQL, PostgreSQL *and* SQLite clients (one of which compiles
- * native code) on the chance that one of them is wanted.
- */
+/** Describes the optional driver peer backing a connection-string scheme. */
 function driverPeer(packageName: string, scheme: string) {
   return {
     packageName,

--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -5,6 +5,7 @@
  */
 
 import {MikroORM, Options as MikroORMOptions} from '@mikro-orm/core';
+import {loadOptionalPeer} from '../../utils/optional_peer.js';
 import {redactUriPassword} from '../../utils/redact_uri.js';
 import {
   ENTITIES,
@@ -12,6 +13,21 @@ import {
   SCHEMA_VERSION_KEY,
   StorageMetadata,
 } from './schema.js';
+
+/**
+ * Describes the driver package backing a connection-string scheme.
+ *
+ * The five SQL drivers are optional peer dependencies: a `DatabaseSessionService`
+ * talks to exactly one database, so installing `@google/adk` must not download
+ * MariaDB, MSSQL, MySQL, PostgreSQL *and* SQLite clients (one of which compiles
+ * native code) on the chance that one of them is wanted.
+ */
+function driverPeer(packageName: string, scheme: string) {
+  return {
+    packageName,
+    feature: `DatabaseSessionService with a "${scheme}" connection string`,
+  };
+}
 
 /**
  * Parses a database connection URI and returns MikroORM Options.
@@ -26,19 +42,34 @@ export async function getConnectionOptionsFromUri(
   let driver: unknown;
 
   if (uri.startsWith('postgres://') || uri.startsWith('postgresql://')) {
-    const {PostgreSqlDriver} = await import('@mikro-orm/postgresql');
+    const {PostgreSqlDriver} = await loadOptionalPeer(
+      driverPeer('@mikro-orm/postgresql', 'postgres'),
+      () => import('@mikro-orm/postgresql'),
+    );
     driver = PostgreSqlDriver;
   } else if (uri.startsWith('mysql://')) {
-    const {MySqlDriver} = await import('@mikro-orm/mysql');
+    const {MySqlDriver} = await loadOptionalPeer(
+      driverPeer('@mikro-orm/mysql', 'mysql'),
+      () => import('@mikro-orm/mysql'),
+    );
     driver = MySqlDriver;
   } else if (uri.startsWith('mariadb://')) {
-    const {MariaDbDriver} = await import('@mikro-orm/mariadb');
+    const {MariaDbDriver} = await loadOptionalPeer(
+      driverPeer('@mikro-orm/mariadb', 'mariadb'),
+      () => import('@mikro-orm/mariadb'),
+    );
     driver = MariaDbDriver;
   } else if (uri.startsWith('sqlite://')) {
-    const {SqliteDriver} = await import('@mikro-orm/sqlite');
+    const {SqliteDriver} = await loadOptionalPeer(
+      driverPeer('@mikro-orm/sqlite', 'sqlite'),
+      () => import('@mikro-orm/sqlite'),
+    );
     driver = SqliteDriver;
   } else if (uri.startsWith('mssql://')) {
-    const {MsSqlDriver} = await import('@mikro-orm/mssql');
+    const {MsSqlDriver} = await loadOptionalPeer(
+      driverPeer('@mikro-orm/mssql', 'mssql'),
+      () => import('@mikro-orm/mssql'),
+    );
     driver = MsSqlDriver;
   } else {
     throw new Error(`Unsupported database URI: ${redactUriPassword(uri)}`);

--- a/core/src/telemetry/google_cloud.ts
+++ b/core/src/telemetry/google_cloud.ts
@@ -29,14 +29,7 @@ async function getGcpProjectId(): Promise<string | undefined> {
   }
 }
 
-/**
- * Builds the Cloud Trace span processor, loading its exporter on demand.
- *
- * The two Cloud exporters are optional peer dependencies: they are only
- * reachable from {@link getGcpExporters}, so an application that exports
- * telemetry somewhere else — or nowhere at all — should not have to download
- * them. Each is loaded only when its signal is actually enabled.
- */
+/** Builds the Cloud Trace span processor, loading its exporter on demand. */
 async function createCloudTraceProcessor(
   projectId: string,
 ): Promise<BatchSpanProcessor> {

--- a/core/src/telemetry/google_cloud.ts
+++ b/core/src/telemetry/google_cloud.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {MetricExporter} from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
-import {TraceExporter} from '@google-cloud/opentelemetry-cloud-trace-exporter';
 import {gcpDetector} from '@opentelemetry/resource-detector-gcp';
 import {detectResources, Resource} from '@opentelemetry/resources';
 import {PeriodicExportingMetricReader} from '@opentelemetry/sdk-metrics';
@@ -13,6 +11,7 @@ import {BatchSpanProcessor} from '@opentelemetry/sdk-trace-base';
 import {GoogleAuth} from 'google-auth-library';
 
 import {logger} from '../utils/logger.js';
+import {loadOptionalPeer} from '../utils/optional_peer.js';
 
 import {OtelExportersConfig, OTelHooks} from './setup.js';
 
@@ -28,6 +27,44 @@ async function getGcpProjectId(): Promise<string | undefined> {
   } catch (_e: unknown) {
     return undefined;
   }
+}
+
+/**
+ * Builds the Cloud Trace span processor, loading its exporter on demand.
+ *
+ * The two Cloud exporters are optional peer dependencies: they are only
+ * reachable from {@link getGcpExporters}, so an application that exports
+ * telemetry somewhere else — or nowhere at all — should not have to download
+ * them. Each is loaded only when its signal is actually enabled.
+ */
+async function createCloudTraceProcessor(
+  projectId: string,
+): Promise<BatchSpanProcessor> {
+  const {TraceExporter} = await loadOptionalPeer(
+    {
+      packageName: '@google-cloud/opentelemetry-cloud-trace-exporter',
+      feature: 'getGcpExporters({enableTracing: true})',
+    },
+    () => import('@google-cloud/opentelemetry-cloud-trace-exporter'),
+  );
+  return new BatchSpanProcessor(new TraceExporter({projectId}));
+}
+
+/** Builds the Cloud Monitoring metric reader, loading its exporter on demand. */
+async function createCloudMetricReader(
+  projectId: string,
+): Promise<PeriodicExportingMetricReader> {
+  const {MetricExporter} = await loadOptionalPeer(
+    {
+      packageName: '@google-cloud/opentelemetry-cloud-monitoring-exporter',
+      feature: 'getGcpExporters({enableMetrics: true})',
+    },
+    () => import('@google-cloud/opentelemetry-cloud-monitoring-exporter'),
+  );
+  return new PeriodicExportingMetricReader({
+    exporter: new MetricExporter({projectId}),
+    exportIntervalMillis: 5000,
+  });
 }
 
 export async function getGcpExporters(
@@ -47,15 +84,10 @@ export async function getGcpExporters(
 
   return {
     spanProcessors: enableTracing
-      ? [new BatchSpanProcessor(new TraceExporter({projectId}))]
+      ? [await createCloudTraceProcessor(projectId)]
       : [],
     metricReaders: enableMetrics
-      ? [
-          new PeriodicExportingMetricReader({
-            exporter: new MetricExporter({projectId}),
-            exportIntervalMillis: 5000,
-          }),
-        ]
+      ? [await createCloudMetricReader(projectId)]
       : [],
     logRecordProcessors: [],
   };

--- a/core/src/tools/mcp/index.ts
+++ b/core/src/tools/mcp/index.ts
@@ -5,13 +5,8 @@
  */
 
 /**
- * Entry point for `@google/adk/tools/mcp`.
- *
- * Everything here is also re-exported from `@google/adk`, so importing it from
- * the root keeps working. This subpath exists so that an application using MCP
- * can pull in the MCP tools — and only the MCP tools — without evaluating the
- * whole ADK barrel, and so that the `@modelcontextprotocol/sdk` optional peer
- * dependency has an obvious, documented home.
+ * `@google/adk/tools/mcp` subpath: the MCP tools only, without the full ADK
+ * barrel. Also re-exported from `@google/adk`.
  */
 
 export * from './load_mcp_resource_tool.js';

--- a/core/src/tools/mcp/index.ts
+++ b/core/src/tools/mcp/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Entry point for `@google/adk/tools/mcp`.
+ *
+ * Everything here is also re-exported from `@google/adk`, so importing it from
+ * the root keeps working. This subpath exists so that an application using MCP
+ * can pull in the MCP tools — and only the MCP tools — without evaluating the
+ * whole ADK barrel, and so that the `@modelcontextprotocol/sdk` optional peer
+ * dependency has an obvious, documented home.
+ */
+
+export * from './load_mcp_resource_tool.js';
+export * from './mcp_session_manager.js';
+export * from './mcp_tool.js';
+export * from './mcp_toolset.js';

--- a/core/src/tools/mcp/load_mcp_resource_tool.ts
+++ b/core/src/tools/mcp/load_mcp_resource_tool.ts
@@ -5,7 +5,7 @@
  */
 
 import {FunctionDeclaration, Part, Type} from '@google/genai';
-import {
+import type {
   BlobResourceContents,
   TextResourceContents,
 } from '@modelcontextprotocol/sdk/types.js';

--- a/core/src/tools/mcp/mcp_session_manager.ts
+++ b/core/src/tools/mcp/mcp_session_manager.ts
@@ -4,18 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Client} from '@modelcontextprotocol/sdk/client/index.js';
-import {
-  StdioClientTransport,
-  StdioServerParameters,
-} from '@modelcontextprotocol/sdk/client/stdio.js';
-import {
-  StreamableHTTPClientTransport,
-  StreamableHTTPClientTransportOptions,
-} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import type {StdioServerParameters} from '@modelcontextprotocol/sdk/client/stdio.js';
+import type {StreamableHTTPClientTransportOptions} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 import {formatError} from '../../utils/error_utils.js';
 import {logger} from '../../utils/logger.js';
+import {loadOptionalPeer, OptionalPeer} from '../../utils/optional_peer.js';
+
+/**
+ * The optional peer backing every MCP connection.
+ *
+ * `@modelcontextprotocol/sdk` is the single largest transitive dependency
+ * ADK ever pulled in, and it is only reachable through the MCP tools, so it
+ * is loaded lazily from {@link MCPSessionManager.createSession}.
+ */
+const MCP_SDK: OptionalPeer = {
+  packageName: '@modelcontextprotocol/sdk',
+  feature: 'MCPSessionManager (and the MCP tools built on it)',
+};
 
 /** Surfaces a background transport error that would otherwise be dropped. */
 function logTransportError(err: unknown): void {
@@ -87,11 +94,19 @@ export class MCPSessionManager {
   }
 
   async createSession(): Promise<Client> {
+    const {Client} = await loadOptionalPeer(
+      MCP_SDK,
+      () => import('@modelcontextprotocol/sdk/client/index.js'),
+    );
     const client = new Client({name: 'MCPClient', version: '1.0.0'});
 
     try {
       switch (this.connectionParams.type) {
         case 'StdioConnectionParams': {
+          const {StdioClientTransport} = await loadOptionalPeer(
+            MCP_SDK,
+            () => import('@modelcontextprotocol/sdk/client/stdio.js'),
+          );
           const transport = new StdioClientTransport(
             this.connectionParams.serverParams,
           );
@@ -111,6 +126,10 @@ export class MCPSessionManager {
             };
           }
 
+          const {StreamableHTTPClientTransport} = await loadOptionalPeer(
+            MCP_SDK,
+            () => import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
+          );
           const transport = new StreamableHTTPClientTransport(
             new URL(this.connectionParams.url),
             options,

--- a/core/src/tools/mcp/mcp_tool.ts
+++ b/core/src/tools/mcp/mcp_tool.ts
@@ -5,7 +5,7 @@
  */
 
 import {FunctionDeclaration} from '@google/genai';
-import {
+import type {
   CallToolRequest,
   CallToolResult,
   Tool,

--- a/core/src/tools/mcp/mcp_toolset.ts
+++ b/core/src/tools/mcp/mcp_toolset.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
+import type {
   BlobResourceContents,
   ListResourcesResult,
   ListToolsResult,

--- a/core/src/utils/optional_peer.ts
+++ b/core/src/utils/optional_peer.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Loader for ADK's optional peer dependencies.
+ *
+ * A handful of ADK subsystems are backed by large, situational packages (a
+ * cloud storage client, an MCP client, a SQL driver, an HTTP server). Those
+ * packages are declared as optional `peerDependencies` so that installing
+ * `@google/adk` does not download them for the many applications that never
+ * touch the corresponding subsystem. They are loaded lazily, at the point of
+ * first use, and a missing one has to produce an error that names both the
+ * feature and the exact install command instead of a bare
+ * `ERR_MODULE_NOT_FOUND`.
+ */
+
+/** Node's error codes for an unresolvable module, in ESM and in CJS. */
+const MODULE_NOT_FOUND_CODES = new Set([
+  'ERR_MODULE_NOT_FOUND',
+  'MODULE_NOT_FOUND',
+]);
+
+/** Describes the optional peer dependency a feature is asking for. */
+export interface OptionalPeer {
+  /** The npm package name, e.g. `@google-cloud/storage`. */
+  packageName: string;
+  /** The ADK feature that needs it, used in the error message. */
+  feature: string;
+}
+
+/**
+ * Returns true when `err` is Node reporting that `packageName` itself could
+ * not be resolved, as opposed to any other failure raised while evaluating
+ * the module (a syntax error, a failing side effect, a missing transitive
+ * dependency), which must be surfaced unchanged.
+ */
+function isMissingModule(err: unknown, packageName: string): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const code = (err as Error & {code?: string}).code;
+  return (
+    code !== undefined &&
+    MODULE_NOT_FOUND_CODES.has(code) &&
+    err.message.includes(packageName)
+  );
+}
+
+/**
+ * Loads an optional peer dependency, translating "not installed" into an
+ * actionable error.
+ *
+ * The dynamic `import()` is passed in as a thunk rather than being built from
+ * `packageName`, so that the specifier stays a literal in the calling module
+ * and remains visible to bundlers and to test doubles installed with
+ * `vi.mock()`.
+ *
+ * ```ts
+ * const {Storage} = await loadOptionalPeer(
+ *   {packageName: '@google-cloud/storage', feature: 'GcsArtifactService'},
+ *   () => import('@google-cloud/storage'),
+ * );
+ * ```
+ *
+ * @param peer The package being loaded and the feature that needs it.
+ * @param load Thunk performing the dynamic `import()`.
+ * @return The imported module namespace.
+ * @throws If the package is not installed, an error naming the feature and
+ *   the `npm install` command that fixes it. Any other load failure is
+ *   rethrown unchanged.
+ */
+export async function loadOptionalPeer<T>(
+  peer: OptionalPeer,
+  load: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await load();
+  } catch (err: unknown) {
+    if (!isMissingModule(err, peer.packageName)) {
+      throw err;
+    }
+    throw new Error(
+      `${peer.feature} requires the optional peer dependency ` +
+        `"${peer.packageName}", which is not installed. It is optional so ` +
+        `that applications that do not use ${peer.feature} are not made to ` +
+        `download it. Install it with:\n\n` +
+        `  npm install ${peer.packageName}\n`,
+      {cause: err},
+    );
+  }
+}

--- a/core/test/artifacts/registry_test.ts
+++ b/core/test/artifacts/registry_test.ts
@@ -21,7 +21,10 @@ describe('getArtifactServiceFromUri', () => {
   it('returns GcsArtifactService for gs uri', () => {
     const service = getArtifactServiceFromUri('gs://my-bucket');
     expect(service).toBeInstanceOf(GcsArtifactService);
-    expect((service as unknown as {bucket: {name: string}}).bucket.name).toBe(
+    // The GCS client is an optional peer loaded on first use, so the bucket
+    // handle does not exist until then; the parsed name is what the registry
+    // is responsible for and it is all that can be asserted synchronously.
+    expect((service as unknown as {bucketName: string}).bucketName).toBe(
       'my-bucket',
     );
   });

--- a/core/test/package_install_weight_test.ts
+++ b/core/test/package_install_weight_test.ts
@@ -97,8 +97,12 @@ describe('core/package.json install weight', () => {
 });
 
 describe('core/package.json subpath exports', () => {
+  // `.` is the root entry, and `./dist/web/*` is a wildcard passthrough for the
+  // browser bundle whose target is a glob, not a single source module. Neither
+  // is a situational subsystem entry point, so both stay out of these checks.
   const subpaths = Object.entries(pkg.exports).filter(
-    ([subpath, target]) => subpath !== '.' && typeof target === 'object',
+    ([subpath, target]) =>
+      subpath !== '.' && !subpath.includes('*') && typeof target === 'object',
   ) as Array<[string, Record<string, string>]>;
 
   it('exports the situational subsystems as their own entry points', () => {

--- a/core/test/package_install_weight_test.ts
+++ b/core/test/package_install_weight_test.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Guards the shape of `core/package.json` that keeps `npm install @google/adk`
+ * small.
+ *
+ * npm 7+ installs `peerDependencies` automatically unless they are marked
+ * optional, so a peer added without a matching `peerDependenciesMeta` entry
+ * silently lands in every hello-world install — that is exactly how five SQL
+ * drivers (one of which compiles native code) ended up in a tree that never
+ * touches a database. These assertions fail the build instead.
+ */
+
+import {readdirSync, readFileSync} from 'node:fs';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from 'vitest';
+
+const CORE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+interface CorePackageJson {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  peerDependenciesMeta?: Record<string, {optional?: boolean}>;
+  exports: Record<string, Record<string, string> | string>;
+}
+
+const pkg: CorePackageJson = JSON.parse(
+  readFileSync(join(CORE_DIR, 'package.json'), 'utf8'),
+);
+
+/**
+ * Packages that must stay out of `dependencies`.
+ *
+ * Each backs a single situational subsystem, is loaded lazily at the point of
+ * use, and is far too heavy to impose on an application that never reaches
+ * that subsystem.
+ */
+const OPTIONAL_SUBSYSTEM_PEERS = [
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter',
+  '@google-cloud/opentelemetry-cloud-trace-exporter',
+  '@google-cloud/storage',
+  '@mikro-orm/mariadb',
+  '@mikro-orm/mssql',
+  '@mikro-orm/mysql',
+  '@mikro-orm/postgresql',
+  '@mikro-orm/sqlite',
+  '@modelcontextprotocol/sdk',
+  'express',
+];
+
+describe('core/package.json install weight', () => {
+  it.each(Object.keys(pkg.peerDependencies))(
+    'declares the peer dependency %s optional',
+    (peer) => {
+      // Without this, npm 7+ downloads the peer for every consumer.
+      expect(pkg.peerDependenciesMeta?.[peer]?.optional).toBe(true);
+    },
+  );
+
+  it.each(OPTIONAL_SUBSYSTEM_PEERS)(
+    '%s is an optional peer, not a hard dependency',
+    (name) => {
+      expect(pkg.dependencies).not.toHaveProperty(name);
+      expect(pkg.peerDependencies).toHaveProperty(name);
+    },
+  );
+
+  it.each([
+    '@google-cloud/opentelemetry-cloud-monitoring-exporter',
+    '@google-cloud/opentelemetry-cloud-trace-exporter',
+    '@google-cloud/storage',
+    '@mikro-orm/sqlite',
+    '@modelcontextprotocol/sdk',
+    'express',
+  ])(
+    '%s is still a devDependency so the repo can build and test against it',
+    (name) => {
+      // The peers whose types `core/src` references, and the one SQL driver
+      // the database tests actually run against. The other four drivers are
+      // interchangeable alternatives to `@mikro-orm/sqlite` and are not
+      // needed to build or test this package.
+      expect(pkg.devDependencies).toHaveProperty(name);
+    },
+  );
+
+  it('has no peerDependenciesMeta entry without a matching peer', () => {
+    expect(Object.keys(pkg.peerDependenciesMeta ?? {}).sort()).toEqual(
+      Object.keys(pkg.peerDependencies).sort(),
+    );
+  });
+});
+
+describe('core/package.json subpath exports', () => {
+  const subpaths = Object.entries(pkg.exports).filter(
+    ([subpath, target]) => subpath !== '.' && typeof target === 'object',
+  ) as Array<[string, Record<string, string>]>;
+
+  it('exports the situational subsystems as their own entry points', () => {
+    expect(subpaths.map(([subpath]) => subpath).sort()).toEqual([
+      './a2a',
+      './artifacts/gcs',
+      './sessions/database',
+      './telemetry/gcp',
+      './tools/mcp',
+    ]);
+  });
+
+  it.each(subpaths)(
+    '%s maps every condition onto a module that exists in src',
+    (_subpath, conditions) => {
+      for (const target of Object.values(conditions)) {
+        // `./dist/<esm|cjs|types>/a/b.<js|d.ts>` is emitted from
+        // `./src/a/b.ts`, so the source is what has to exist here: `dist` is a
+        // build artifact and is absent on a clean checkout.
+        const source = target
+          .replace(/^\.\/dist\/(esm|cjs|types)\//, './src/')
+          .replace(/\.d\.ts$|\.js$/, '.ts');
+        expect(() =>
+          readFileSync(join(CORE_DIR, source), 'utf8'),
+        ).not.toThrow();
+      }
+    },
+  );
+
+  it('resolves ./package.json, which tooling reads for the version', () => {
+    expect(pkg.exports['./package.json']).toBe('./package.json');
+  });
+});
+
+/** Every `.ts` file under `core/src`, recursively. */
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, {withFileTypes: true}).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return sourceFiles(full);
+    }
+    return entry.isFile() && entry.name.endsWith('.ts') ? [full] : [];
+  });
+}
+
+describe('optional peers are not imported at module load', () => {
+  const sources = sourceFiles(join(CORE_DIR, 'src')).map((file) => ({
+    file,
+    text: readFileSync(file, 'utf8'),
+  }));
+
+  it.each(OPTIONAL_SUBSYSTEM_PEERS)(
+    'no source file has a value import of %s',
+    (name) => {
+      // A value `import` anywhere in the graph reachable from `src/index.ts`
+      // makes the whole package unloadable without the peer installed, which
+      // is the failure mode the lazy loading exists to prevent. `import type`
+      // is erased at compile time and is therefore fine.
+      const valueImport = new RegExp(
+        String.raw`(^|\n)import\s+(?!type\s)[^;]*?from\s*'${name.replace('/', '\\/')}(\/[^']*)?'`,
+      );
+      const offenders = sources
+        .filter(({text}) => valueImport.test(text))
+        .map(({file}) => file);
+      expect(offenders).toEqual([]);
+    },
+  );
+});

--- a/core/test/utils/optional_peer_test.ts
+++ b/core/test/utils/optional_peer_test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {loadOptionalPeer} from '../../src/utils/optional_peer.js';
+
+const PEER = {packageName: '@example/driver', feature: 'ExampleService'};
+
+/** Builds the error Node raises for an unresolvable ESM specifier. */
+function moduleNotFound(specifier: string, code: string): Error {
+  const err = new Error(
+    `Cannot find package '${specifier}' imported from /app/index.js`,
+  ) as Error & {code?: string};
+  err.code = code;
+  return err;
+}
+
+describe('loadOptionalPeer', () => {
+  it('returns the module when the peer is installed', async () => {
+    const loaded = await loadOptionalPeer(PEER, async () => ({value: 42}));
+    expect(loaded).toEqual({value: 42});
+  });
+
+  it.each(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND'])(
+    'turns a %s into an error naming the feature and install command',
+    async (code) => {
+      const promise = loadOptionalPeer(PEER, () => {
+        throw moduleNotFound('@example/driver', code);
+      });
+
+      await expect(promise).rejects.toThrow(/ExampleService requires/);
+      await expect(promise).rejects.toThrow(/npm install @example\/driver/);
+    },
+  );
+
+  it('keeps the original error as the cause', async () => {
+    const original = moduleNotFound('@example/driver', 'ERR_MODULE_NOT_FOUND');
+
+    await expect(
+      loadOptionalPeer(PEER, () => Promise.reject(original)),
+    ).rejects.toMatchObject({cause: original});
+  });
+
+  it('rethrows a failure that is not the peer being missing', async () => {
+    // A module that resolves but throws while evaluating, or one whose own
+    // transitive dependency is missing, must not be reported as "install the
+    // peer" — that would send the caller after the wrong problem.
+    const evaluationError = new Error('boom');
+
+    await expect(
+      loadOptionalPeer(PEER, () => Promise.reject(evaluationError)),
+    ).rejects.toBe(evaluationError);
+  });
+
+  it('rethrows a module-not-found error for a different package', async () => {
+    await expect(
+      loadOptionalPeer(PEER, () =>
+        Promise.reject(
+          moduleNotFound('@example/something-else', 'ERR_MODULE_NOT_FOUND'),
+        ),
+      ),
+    ).rejects.toThrow(/Cannot find package '@example\/something-else'/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,14 +45,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.10",
-        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
-        "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
-        "@google-cloud/storage": "^7.17.1",
         "@google-cloud/vertexai": "^1.12.0",
         "@google/genai": "^2.9.0",
         "@mikro-orm/core": "^6.6.10",
         "@mikro-orm/reflection": "^6.6.6",
-        "@modelcontextprotocol/sdk": "^1.26.0",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-logs": "^0.205.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.205.0",
@@ -65,7 +61,6 @@
         "@opentelemetry/sdk-trace-base": "^2.1.0",
         "@opentelemetry/sdk-trace-node": "^2.1.0",
         "adm-zip": "^0.5.17",
-        "express": "^4.22.1",
         "google-auth-library": "^10.3.0",
         "js-yaml": "^4.1.1",
         "jsonpath-plus": "^10.4.0",
@@ -75,19 +70,61 @@
         "zod-to-json-schema": "^3.25.1"
       },
       "devDependencies": {
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+        "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
+        "@google-cloud/storage": "^7.17.1",
         "@mikro-orm/sqlite": "^6.6.6",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@opentelemetry/context-async-hooks": "^2.1.0",
         "@types/adm-zip": "^0.5.8",
         "@types/express": "^4.17.25",
         "@types/lodash-es": "^4.17.12",
+        "express": "^4.22.1",
         "openapi-types": "^12.1.3"
       },
       "peerDependencies": {
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+        "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
+        "@google-cloud/storage": "^7.17.1",
         "@mikro-orm/mariadb": "^6.6.6",
         "@mikro-orm/mssql": "^6.6.6",
         "@mikro-orm/mysql": "^6.6.6",
         "@mikro-orm/postgresql": "^6.6.6",
-        "@mikro-orm/sqlite": "^6.6.6"
+        "@mikro-orm/sqlite": "^6.6.6",
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "express": "^4.22.1 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": {
+          "optional": true
+        },
+        "@google-cloud/opentelemetry-cloud-trace-exporter": {
+          "optional": true
+        },
+        "@google-cloud/storage": {
+          "optional": true
+        },
+        "@mikro-orm/mariadb": {
+          "optional": true
+        },
+        "@mikro-orm/mssql": {
+          "optional": true
+        },
+        "@mikro-orm/mysql": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "@mikro-orm/sqlite": {
+          "optional": true
+        },
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
       }
     },
     "dev": {
@@ -1350,6 +1387,7 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-monitoring-exporter/-/opentelemetry-cloud-monitoring-exporter-0.21.0.tgz",
       "integrity": "sha512-+lAew44pWt6rA4l8dQ1gGhH7Uo95wZKfq/GBf9aEyuNDDLQ2XppGEEReu6ujesSqTtZ8ueQFt73+7SReSHbwqg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^3.0.0",
@@ -1371,6 +1409,7 @@
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -1388,6 +1427,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-trace-exporter/-/opentelemetry-cloud-trace-exporter-3.0.0.tgz",
       "integrity": "sha512-mUfLJBFo+ESbO0dAGboErx2VyZ7rbrHcQvTP99yH/J72dGaPbH2IzS+04TFbTbEd1VW5R9uK3xq2CqawQaG+1Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^3.0.0",
@@ -1409,6 +1449,7 @@
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -1426,6 +1467,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-resource-util/-/opentelemetry-resource-util-3.0.0.tgz",
       "integrity": "sha512-CGR/lNzIfTKlZoZFfS6CkVzx+nsC9gzy6S8VcyaLegfEJbiPjxbMLP7csyhJTvZe/iRRcQJxSk0q8gfrGqD3/Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -1443,6 +1485,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
       "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "arrify": "^2.0.0",
@@ -1456,6 +1499,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1465,6 +1509,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-4.0.0.tgz",
       "integrity": "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
@@ -1474,6 +1519,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
       "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
@@ -1483,6 +1529,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
       "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -1492,6 +1539,7 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
       "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -1517,6 +1565,7 @@
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -1534,6 +1583,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -1721,6 +1771,7 @@
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -1734,6 +1785,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -1752,6 +1804,7 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2012,6 +2065,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2212,6 +2266,7 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -2252,6 +2307,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -2265,6 +2321,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2281,6 +2338,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -2305,6 +2363,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2318,6 +2377,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2331,6 +2391,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -2340,6 +2401,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -2383,6 +2445,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2404,6 +2467,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2413,6 +2477,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2429,12 +2494,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2444,6 +2511,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2456,6 +2524,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2465,6 +2534,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -2481,6 +2551,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2490,6 +2561,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -2505,6 +2577,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -2531,6 +2604,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -2550,6 +2624,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -2568,6 +2643,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2581,6 +2657,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4016,6 +4093,7 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/chai": {
@@ -4200,6 +4278,7 @@
       "version": "2.48.13",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
       "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/caseless": "*",
@@ -4258,6 +4337,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
@@ -5304,6 +5384,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -5360,6 +5441,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -5377,6 +5459,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5393,6 +5476,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ansi-escapes": {
@@ -5428,6 +5512,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5437,6 +5522,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5452,6 +5538,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
       "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5555,6 +5642,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "retry": "0.13.1"
@@ -5564,6 +5652,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -5573,6 +5662,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/aws-ssl-profiles": {
@@ -6103,6 +6193,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6117,6 +6208,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6153,6 +6245,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6165,6 +6258,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -6229,6 +6323,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -6368,6 +6463,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6532,6 +6628,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6636,6 +6733,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -6687,6 +6785,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
@@ -6830,6 +6929,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7400,6 +7500,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -7412,6 +7513,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -7510,6 +7612,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -7564,6 +7667,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -7619,6 +7723,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -7635,6 +7740,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7651,6 +7757,7 @@
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.0.tgz",
       "integrity": "sha512-duBuXbyIhEeNO4GjFuVqr0nF047oNwr18aum+zJyqo0MUG/n7Afgs3Qv3D6VN3ONedUKxiuFlPiMGIa0Z11chA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7915,6 +8022,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
       "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8121,6 +8229,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -8385,6 +8494,7 @@
       "version": "137.1.0",
       "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-137.1.0.tgz",
       "integrity": "sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.0.0",
@@ -8398,6 +8508,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
       "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -8415,6 +8526,7 @@
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -8433,6 +8545,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -8446,6 +8559,7 @@
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -8914,6 +9028,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8958,6 +9073,7 @@
       "version": "4.12.25",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9006,6 +9122,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
       "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9114,6 +9231,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -9339,6 +9457,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9485,6 +9604,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-property": {
@@ -9509,6 +9629,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
       "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9536,6 +9657,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -9630,6 +9752,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -9713,6 +9836,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -10061,6 +10185,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -11284,6 +11409,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -11424,6 +11550,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11449,6 +11576,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11666,6 +11794,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -12247,6 +12376,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12256,6 +12386,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12327,6 +12458,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
       "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/request": "^2.48.8",
@@ -12420,6 +12552,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -12436,6 +12569,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -12794,6 +12928,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -12806,6 +12941,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13208,6 +13344,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stubs": "^3.0.0"
@@ -13217,6 +13354,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
@@ -13242,6 +13380,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13282,6 +13421,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13291,6 +13431,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13373,6 +13514,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
       "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13398,6 +13540,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -13691,6 +13834,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
       "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
@@ -13707,6 +13851,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
       "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -13716,6 +13861,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -13731,6 +13877,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -14530,6 +14677,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
       "license": "BSD"
     },
     "node_modules/util-deprecate": {
@@ -15311,6 +15459,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -15559,6 +15708,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15583,6 +15733,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -15614,6 +15765,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -15642,6 +15794,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -15651,6 +15804,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"


### PR DESCRIPTION
## The problem

`npm install @google/adk` installs **591 packages and 403 MB** for a hello-world agent, and
compiles a native addon on the way. Measured on the same machine, with the same warm npm cache:

| Package | Packages installed |
|---|---:|
| `ai` (Vercel AI SDK) | 11 |
| `@google/genai` | 52 |
| `openai` | 53 |
| **`@google/adk`** | **591** |

The root cause is `core/package.json`: five SQL drivers were declared as `peerDependencies`
with no `peerDependenciesMeta`, and **npm 7+ installs peers automatically unless they are
marked optional**. So every consumer downloaded MariaDB, MSSQL, MySQL, PostgreSQL *and*
SQLite — including `sqlite3`, whose `node-gyp` build is where the intermittent
`npm ERR! gyp ERR! not ok` on a first install comes from. A nondeterministic failure on
someone's first command is an abandonment event.

## Measurement

Both rows built from this repo with `npm pack`, then installed into an empty directory with a
warm npm cache. `before` = `upstream/main` (81c1422), `after` = this branch.

| | Packages | `node_modules` | Wall clock | Native addons built |
|---|---:|---:|---:|---:|
| before | 591 | 403 MB | 70.2 s | 1 (`sqlite3`) |
| **after** | **172** | **157 MB** | **35.3 s** | **0** |
| delta | **−419 (−71%)** | **−246 MB (−61%)** | **−49%** | **−1** |

For reference, `npm install @google/adk@1.5.0` straight from the registry on the same machine
reproduces the `before` row exactly: 591 packages, 403 MB.

## What changed

**1. Every peer dependency is now marked optional.** This alone accounts for 217 of the 419
packages. The five drivers were already loaded through `await import()` in
`sessions/db/operations.ts` — a `DatabaseSessionService` talks to exactly one database, so
auto-installing all five was never the intent. Note `@google/adk-devtools` already declares
all five drivers itself, so `adk web` / `adk run` are unaffected.

**2. Four more subsystem-only packages moved from `dependencies` to optional peers**, each
loaded lazily at its point of use:

| Package | Only reachable from | Now loaded in |
|---|---|---|
| `@modelcontextprotocol/sdk` | MCP tools | `MCPSessionManager.createSession()` |
| `express` | the A2A HTTP surface | `toA2a()` |
| `@google-cloud/storage` | GCS artifacts | first `GcsArtifactService` call |
| `@google-cloud/opentelemetry-cloud-{trace,monitoring}-exporter` | GCP telemetry | `getGcpExporters()` |

**3. A missing peer now produces an actionable error** instead of a bare
`ERR_MODULE_NOT_FOUND`. The new `loadOptionalPeer` helper names the feature and the exact
command:

```
GcsArtifactService requires the optional peer dependency "@google-cloud/storage", which is
not installed. It is optional so that applications that do not use GcsArtifactService are
not made to download it. Install it with:

  npm install @google-cloud/storage
```

It only rewrites a genuine "this package is not installed" error — an evaluation failure, or a
missing *transitive* dependency, is rethrown unchanged so it does not send the caller after
the wrong problem.

**4. Subpath exports** for the five situational subsystems: `@google/adk/a2a`,
`@google/adk/artifacts/gcs`, `@google/adk/sessions/database`, `@google/adk/telemetry/gcp`,
`@google/adk/tools/mcp` (plus `./package.json`, which tooling reads for the version). These
are purely additive. To be precise about what they do and do not buy: subpath exports have
**no effect on what npm installs** — only the peer-dependency change does that. What they buy
is not evaluating the whole root barrel to reach one subsystem, and an obvious documented
home for each optional peer.

## Compatibility

**The top-level API is unchanged.** Every symbol still exports from `@google/adk`; the root
index now re-exports the new `a2a/index.ts` and `tools/mcp/index.ts` barrels, whose contents
are identical to what it listed inline before. Verified against a real `npm pack` install with
*none* of the optional peers present:

- `import {LlmAgent, GcsArtifactService, DatabaseSessionService, MCPSessionManager, toA2a, getGcpExporters} from '@google/adk'` resolves, in ESM and in CJS
- all five subpaths resolve, in ESM and in CJS
- every entry point still constructs; only actually *using* one without its peer throws, with the message above
- installing the peers back restores full function (`DatabaseSessionService` round-trips a session on SQLite, `toA2a` returns a mounted app, MCP connects)

**What does change for existing users of these four subsystems:** the package is no longer
installed for them automatically, so they need one `npm install` line. `express` is declared
as `^4.22.1 || ^5.1.0` rather than `^4.22.1`, because `@modelcontextprotocol/sdk` depends on
Express 5 and the narrower range would `ERESOLVE` for anyone installing both;
`@a2a-js/sdk` already declares Express as an optional peer over the same range. Verified: ADK
+ MCP + Express 5 installs clean, and `toA2a` works on Express 5.

## Not in this PR

`@mikro-orm/core` and `@mikro-orm/reflection` are the obvious next candidates — moving them
takes the same measurement to **127 packages / 133 MB**. They are held back because
`sessions/db/schema.ts` applies MikroORM entity decorators at module scope, which cannot be
deferred behind a dynamic import without restructuring the entity definitions; that is a
separate, self-contained change. `@google-cloud/vertexai` (18 MB) and the OTLP exporter stack
(~33 MB, blocked on `maybeSetOtelProviders` being synchronous) are the other two worth doing.

## Testing

- `npm run build --workspace core` — clean; `npm run build --workspace dev` — clean
- `npm run ts:check` — clean
- `npx vitest run --project unit:core` — **2490 passed / 172 files**
- `npm run lint --workspace core` and `prettier --check` — clean
- `unit:dev` and `unit:integrations` each have 1 failure, both pre-existing on `upstream/main`
  (verified by stashing this branch and re-running)

New regression tests:

- `core/test/package_install_weight_test.ts` — asserts every peer has
  `peerDependenciesMeta.optional`, that the ten subsystem packages are peers and not
  `dependencies`, that every subpath export maps onto a real source module, and — walking
  `core/src` — that no source file has a *value* import of an optional peer. The first and last
  groups fail on `upstream/main` and pass here.
- `core/test/utils/optional_peer_test.ts` — covers the error rewriting, the preserved `cause`,
  and the two rethrow paths.