### PR TITLE
docs(core): describe the TypeScript API on its own terms

### DIFF
--- a/core/src/a2a/auth.ts
+++ b/core/src/a2a/auth.ts
@@ -32,7 +32,11 @@ function timingSafeEqualStrings(a: string, b: string): boolean {
  * text on every call.
  *
  * ```ts
- * toA2a(agent, {authentication: bearerTokenUserBuilder(process.env.MY_TOKEN)});
+ * const token = process.env.MY_TOKEN;
+ * if (!token) {
+ *   throw new Error('MY_TOKEN is not set');
+ * }
+ * toA2a(agent, {authentication: bearerTokenUserBuilder(token)});
  * ```
  *
  * A rejected request surfaces as whatever the `@a2a-js/sdk` handler produces

--- a/core/src/agents/base_agent.ts
+++ b/core/src/agents/base_agent.ts
@@ -150,8 +150,14 @@ export abstract class BaseAgent<
    * order they are listed until a callback does not return undefined.
    *
    * Each callback takes a single {@link Context} argument. Returning `Content`
-   * ends the invocation and emits that content as the agent's response instead
-   * of running the agent; return `undefined` to let the run proceed.
+   * skips this agent's own run — its `runAsyncImpl` body and its
+   * `afterAgentCallback` — and emits the returned content as this agent's
+   * response; return `undefined` to let the run proceed.
+   *
+   * That skip is scoped to this agent. It sets `endInvocation` on the
+   * invocation context the agent created for itself, which is a copy of its
+   * parent's, so callers above are unaffected: a `SequentialAgent` still runs
+   * the remaining sub-agents.
    */
   readonly beforeAgentCallback: SingleAgentCallback[];
 

--- a/core/src/agents/base_agent.ts
+++ b/core/src/agents/base_agent.ts
@@ -192,15 +192,16 @@ export abstract class BaseAgent<
   /**
    * Creates a copy of this agent with the given config fields overridden.
    *
-   * Mirrors adk-python's `BaseAgent.clone(update=...)`. The clone is a detached
-   * root: its `parentAgent` is always `undefined`. Sub-agents are recursively
-   * cloned (and re-parented to the clone) unless `subAgents` is overridden.
-   * Rebuilding via the concrete constructor re-derives all state, so a cloned
-   * `LlmAgent` gets a fresh `requestProcessors` array rather than sharing the
-   * original's. See google/adk-js#534.
+   * The clone is a detached root: its `parentAgent` is always `undefined`.
+   * Sub-agents are recursively cloned (and re-parented to the clone) unless
+   * `subAgents` is overridden. Rebuilding via the concrete constructor
+   * re-derives all state, so a cloned `LlmAgent` gets a fresh
+   * `requestProcessors` array rather than sharing the original's.
+   * See google/adk-js#534.
    *
    * @param overrides Config fields to override on the clone. Overriding
-   *     `parentAgent` is rejected, matching adk-python.
+   *     `parentAgent` is rejected: parentage is assigned only when a parent
+   *     agent is constructed with its sub-agents.
    * @returns A new detached agent instance of the same concrete class.
    */
   clone(overrides?: Partial<TConfig>): this {
@@ -213,13 +214,12 @@ export abstract class BaseAgent<
 
     const merged: TConfig = {...this.config, ...overrides};
 
-    // A clone is always a detached root (matches adk-python setting parent to
-    // None); the rebuilt parent constructor re-parents any cloned children.
+    // A clone is always a detached root; the rebuilt parent constructor
+    // re-parents any cloned children.
     merged.parentAgent = undefined;
 
-    // Shallow-copy any list-typed field not provided in overrides so the clone
-    // never shares a mutable array (e.g. `tools`) with the original, mirroring
-    // adk-python's per-field list copy.
+    // Shallow-copy any array-typed field not provided in overrides so the
+    // clone never shares a mutable array (e.g. `tools`) with the original.
     const mergedRecord = merged as Record<string, unknown>;
     for (const key of Object.keys(mergedRecord)) {
       if (key === 'subAgents' || (overrides && key in overrides)) {

--- a/core/src/agents/base_agent.ts
+++ b/core/src/agents/base_agent.ts
@@ -149,11 +149,9 @@ export abstract class BaseAgent<
    * When a list of callbacks is provided, the callbacks will be called in the
    * order they are listed until a callback does not return undefined.
    *
-   * @param callbackContext: MUST be named 'callbackContext' (enforced).
-   *
-   * @return Content: The content to return to the user. When the content is
-   *     present, the agent run will be skipped and the provided content will be
-   *     returned to user.
+   * Each callback takes a single {@link Context} argument. Returning `Content`
+   * ends the invocation and emits that content as the agent's response instead
+   * of running the agent; return `undefined` to let the run proceed.
    */
   readonly beforeAgentCallback: SingleAgentCallback[];
 
@@ -163,11 +161,9 @@ export abstract class BaseAgent<
    * When a list of callbacks is provided, the callbacks will be called in the
    * order they are listed until a callback does not return undefined.
    *
-   * @param callbackContext: MUST be named 'callbackContext' (enforced).
-   *
-   * @return Content: The content to return to the user. When the content is
-   *     present, the provided content will be used as agent response and
-   *     appended to event history as agent response.
+   * Each callback takes a single {@link Context} argument. Returning `Content`
+   * emits it as the agent's response, appended to the event history; return
+   * `undefined` to leave the response as the agent produced it.
    */
   readonly afterAgentCallback: SingleAgentCallback[];
 

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -586,8 +586,8 @@ export function mergeParallelFunctionResponseEvents(
 // TODO - b/425992518: support function call in live connection.
 
 /**
- * Finds the function call event that matches the function call ID.
- * Mirrors Python ADK's `find_event_by_function_call_id`.
+ * Finds the most recent event before `endIndex` that contains a function call
+ * with the given ID.
  */
 export function findEventByFunctionCallId(
   events: Event[],
@@ -607,8 +607,9 @@ export function findEventByFunctionCallId(
 }
 
 /**
- * Finds the function call event that matches the function response ID of the last event.
- * Mirrors Python ADK's `find_matching_function_call`.
+ * Finds the event holding the function call that the last event's first
+ * function response answers, or `undefined` if the last event carries no
+ * function response.
  */
 export function findMatchingFunctionCall(events: Event[]): Event | undefined {
   if (!events.length) {

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -448,7 +448,7 @@ export async function handleFunctionCallList({
       functionResponse = normalizeCallbackResponse(alteredFunctionResponse);
     }
 
-    // Allow long running function to return None as response.
+    // Allow a long-running function to return no response.
     // Only a nullish response defers the event. A falsy-but-present response
     // ('', 0, false) is a real result and still emits one, so long-running
     // tools that return such a value now produce a response event where they

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -740,8 +740,8 @@ export function mergeParallelFunctionResponseEvents(
 // TODO - b/425992518: support function call in live connection.
 
 /**
- * Finds the function call event that matches the function call ID.
- * Mirrors Python ADK's `find_event_by_function_call_id`.
+ * Finds the most recent event before `endIndex` that contains a function call
+ * with the given ID.
  */
 export function findEventByFunctionCallId(
   events: Event[],
@@ -761,8 +761,9 @@ export function findEventByFunctionCallId(
 }
 
 /**
- * Finds the function call event that matches the function response ID of the last event.
- * Mirrors Python ADK's `find_matching_function_call`.
+ * Finds the event holding the function call that the last event's first
+ * function response answers, or `undefined` if the last event carries no
+ * function response.
  */
 export function findMatchingFunctionCall(events: Event[]): Event | undefined {
   if (!events.length) {

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -618,7 +618,7 @@ export async function handleFunctionCallList({
       functionResponse = normalizeCallbackResponse(alteredFunctionResponse);
     }
 
-    // Allow long running function to return None as response.
+    // Allow a long-running function to return no response.
     // Only a nullish response defers the event. A falsy-but-present response
     // ('', 0, false) is a real result and still emits one, so long-running
     // tools that return such a value now produce a response event where they

--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -279,7 +279,7 @@ const VALID_PREFIXES = [State.APP_PREFIX, State.USER_PREFIX, State.TEMP_PREFIX];
  *   - <prefix>:<identifier>
  *
  * @param variableName The variable name to check.
- * @returns True if the variable name is valid, False otherwise.
+ * @returns True if the variable name is valid, false otherwise.
  */
 function isValidStateName(variableName: string): boolean {
   const parts = variableName.split(':');

--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -269,7 +269,7 @@ const VALID_PREFIXES = [State.APP_PREFIX, State.USER_PREFIX, State.TEMP_PREFIX];
  *   - <prefix>:<identifier>
  *
  * @param variableName The variable name to check.
- * @returns True if the variable name is valid, False otherwise.
+ * @returns True if the variable name is valid, false otherwise.
  */
 function isValidStateName(variableName: string): boolean {
   const parts = variableName.split(':');

--- a/core/src/agents/invocation_context.ts
+++ b/core/src/agents/invocation_context.ts
@@ -111,7 +111,7 @@ class InvocationCostManager {
  *  An LLM agent runs steps in a loop until:
  *    1. A final response is generated.
  *    2. The agent transfers to another agent.
- *    3. The end_invocation is set to true by any callbacks or tools.
+ *    3. `endInvocation` is set to true by any callbacks or tools.
  *
  *  A step:
  *    1. Calls the LLM only once and yields its response.
@@ -119,7 +119,7 @@ class InvocationCostManager {
  *
  *  The summarization of the function response is considered another step, since
  *  it is another llm call.
- *  A step ends when it's done calling llm and tools, or if the end_invocation
+ *  A step ends when it's done calling llm and tools, or if `endInvocation`
  *  is set to true at any time.
  *
  *  ```
@@ -178,7 +178,7 @@ export class InvocationContext {
 
   /**
    * Whether to end this invocation.
-   * Set to True in callbacks or tools to terminate this invocation.
+   * Set to `true` in callbacks or tools to terminate this invocation.
    */
   endInvocation: boolean;
 

--- a/core/src/agents/invocation_context.ts
+++ b/core/src/agents/invocation_context.ts
@@ -118,7 +118,7 @@ class InvocationCostManager {
  *  An LLM agent runs steps in a loop until:
  *    1. A final response is generated.
  *    2. The agent transfers to another agent.
- *    3. The end_invocation is set to true by any callbacks or tools.
+ *    3. `endInvocation` is set to true by any callbacks or tools.
  *
  *  A step:
  *    1. Calls the LLM only once and yields its response.
@@ -126,7 +126,7 @@ class InvocationCostManager {
  *
  *  The summarization of the function response is considered another step, since
  *  it is another llm call.
- *  A step ends when it's done calling llm and tools, or if the end_invocation
+ *  A step ends when it's done calling llm and tools, or if `endInvocation`
  *  is set to true at any time.
  *
  *  ```
@@ -185,7 +185,7 @@ export class InvocationContext {
 
   /**
    * Whether to end this invocation.
-   * Set to True in callbacks or tools to terminate this invocation.
+   * Set to `true` in callbacks or tools to terminate this invocation.
    */
   endInvocation: boolean;
 

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -235,9 +235,10 @@ export interface LlmAgentConfig extends BaseAgentConfig {
   /**
    * The additional content generation configurations.
    *
-   * NOTE: not all fields are usable, e.g. tools must be configured via
-   * `tools`, and `thinkingConfig` must be configured via `planner` in
-   * LlmAgent.
+   * Three fields are rejected by the constructor, because the agent owns them:
+   * `tools` (set them through `tools`), `systemInstruction` (through
+   * `instruction`) and `responseSchema` (through `outputSchema`). Every other
+   * field is forwarded to the model as given — `thinkingConfig` included.
    *
    * For example: use this config to adjust model temperature, configure safety
    * settings, etc.

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -110,7 +110,7 @@ export type SingleBeforeModelCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- * order they are listed until a callback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type BeforeModelCallback =
   | SingleBeforeModelCallback
@@ -134,7 +134,7 @@ export type SingleAfterModelCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- order they are listed until a callback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type AfterModelCallback =
   | SingleAfterModelCallback
@@ -162,7 +162,7 @@ export type SingleBeforeToolCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- * order they are listed until a callback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type BeforeToolCallback =
   | SingleBeforeToolCallback
@@ -191,7 +191,7 @@ export type SingleAfterToolCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- * order they are listed until acallback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type AfterToolCallback =
   | SingleAfterToolCallback
@@ -236,7 +236,8 @@ export interface LlmAgentConfig extends BaseAgentConfig {
    * The additional content generation configurations.
    *
    * NOTE: not all fields are usable, e.g. tools must be configured via
-   * `tools`, thinking_config must be configured via `planner` in LlmAgent.
+   * `tools`, and `thinkingConfig` must be configured via `planner` in
+   * LlmAgent.
    *
    * For example: use this config to adjust model temperature, configure safety
    * settings, etc.
@@ -246,7 +247,7 @@ export interface LlmAgentConfig extends BaseAgentConfig {
   /**
    * Disallows LLM-controlled transferring to the parent agent.
    *
-   * NOTE: Setting this as True also prevents this agent to continue reply to
+   * NOTE: Setting this to `true` also prevents this agent to continue reply to
    * the end-user. This behavior prevents one-way transfer, in which end-user
    * may be stuck with one agent that cannot transfer to other agents in the
    * agent tree.
@@ -1439,7 +1440,7 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
   // #END LlmFlow Logic
   // --------------------------------------------------------------------------
 
-  // TODO - b/425992518: omitted Py LlmAgent features.
-  // - code_executor
-  // - configurable agents by yaml config
+  // TODO - b/425992518: LlmAgent features not implemented yet.
+  // - codeExecutor
+  // - configuring agents from a YAML file
 }

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -315,9 +315,10 @@ export interface LlmAgentConfig extends BaseAgentConfig {
   /**
    * The additional content generation configurations.
    *
-   * NOTE: not all fields are usable, e.g. tools must be configured via
-   * `tools`, and `thinkingConfig` must be configured via `planner` in
-   * LlmAgent.
+   * Three fields are rejected by the constructor, because the agent owns them:
+   * `tools` (set them through `tools`), `systemInstruction` (through
+   * `instruction`) and `responseSchema` (through `outputSchema`). Every other
+   * field is forwarded to the model as given — `thinkingConfig` included.
    *
    * For example: use this config to adjust model temperature, configure safety
    * settings, etc.

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -190,7 +190,7 @@ export type SingleBeforeModelCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- * order they are listed until a callback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type BeforeModelCallback =
   | SingleBeforeModelCallback
@@ -214,7 +214,7 @@ export type SingleAfterModelCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- order they are listed until a callback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type AfterModelCallback =
   | SingleAfterModelCallback
@@ -242,7 +242,7 @@ export type SingleBeforeToolCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- * order they are listed until a callback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type BeforeToolCallback =
   | SingleBeforeToolCallback
@@ -271,7 +271,7 @@ export type SingleAfterToolCallback = (params: {
  * A single callback or a list of callbacks.
  *
  * When a list of callbacks is provided, the callbacks will be called in the
- * order they are listed until acallback does not return None.
+ * order they are listed until a callback does not return `undefined`.
  */
 export type AfterToolCallback =
   | SingleAfterToolCallback
@@ -316,7 +316,8 @@ export interface LlmAgentConfig extends BaseAgentConfig {
    * The additional content generation configurations.
    *
    * NOTE: not all fields are usable, e.g. tools must be configured via
-   * `tools`, thinking_config must be configured via `planner` in LlmAgent.
+   * `tools`, and `thinkingConfig` must be configured via `planner` in
+   * LlmAgent.
    *
    * For example: use this config to adjust model temperature, configure safety
    * settings, etc.
@@ -326,7 +327,7 @@ export interface LlmAgentConfig extends BaseAgentConfig {
   /**
    * Disallows LLM-controlled transferring to the parent agent.
    *
-   * NOTE: Setting this as True also prevents this agent to continue reply to
+   * NOTE: Setting this to `true` also prevents this agent to continue reply to
    * the end-user. This behavior prevents one-way transfer, in which end-user
    * may be stuck with one agent that cannot transfer to other agents in the
    * agent tree.
@@ -2025,7 +2026,7 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
   // #END LlmFlow Logic
   // --------------------------------------------------------------------------
 
-  // TODO - b/425992518: omitted Py LlmAgent features.
-  // - code_executor
-  // - configurable agents by yaml config
+  // TODO - b/425992518: LlmAgent features not implemented yet.
+  // - codeExecutor
+  // - configuring agents from a YAML file
 }

--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -95,8 +95,9 @@ export interface RunConfig {
    * A limit on the total number of llm calls for a given run.
    *
    * Valid Values:
-   *   - More than 0 and less than sys.maxsize: The bound on the number of llm
-   *     calls is enforced, if the value is set in this range.
+   *   - More than 0 and at most `Number.MAX_SAFE_INTEGER`: The bound on the
+   *     number of llm calls is enforced. `createRunConfig()` throws for
+   *     anything larger.
    *   - Less than or equal to 0: This allows for unbounded number of llm calls.
    */
   maxLlmCalls?: number;

--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -18,12 +18,17 @@ import {logger} from '../utils/logger.js';
  * The streaming mode for the run config.
  */
 export enum StreamingMode {
+  /** Deliver the response as a single event once the turn completes. */
   NONE = 'none',
+  /**
+   * Deliver the response incrementally, as a series of partial events
+   * followed by a final event carrying the complete text.
+   */
   SSE = 'sse',
   /**
-   * Bidirectional streaming. Not yet supported; passing this value to
-   * `createRunConfig` throws. Use {@link StreamingMode.SSE} for token
-   * streaming.
+   * Reserved for bidirectional streaming, which is not implemented. Passing
+   * this value to `createRunConfig` throws. Use {@link StreamingMode.SSE} for
+   * incremental responses.
    */
   BIDI = 'bidi',
 }
@@ -58,9 +63,11 @@ export interface RunConfig {
   supportCfc?: boolean;
 
   /**
-   * Streaming mode. Supported values are {@link StreamingMode.NONE} and
-   * {@link StreamingMode.SSE}. {@link StreamingMode.BIDI} is not yet
-   * supported and is rejected by `createRunConfig`.
+   * How the response is delivered. Defaults to {@link StreamingMode.NONE},
+   * which emits one event when the turn completes; set
+   * {@link StreamingMode.SSE} to receive partial events as the response is
+   * produced. {@link StreamingMode.BIDI} is not implemented and is rejected by
+   * `createRunConfig`.
    */
   streamingMode?: StreamingMode;
 

--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -19,12 +19,17 @@ import {logger} from '../utils/logger.js';
  * The streaming mode for the run config.
  */
 export enum StreamingMode {
+  /** Deliver the response as a single event once the turn completes. */
   NONE = 'none',
+  /**
+   * Deliver the response incrementally, as a series of partial events
+   * followed by a final event carrying the complete text.
+   */
   SSE = 'sse',
   /**
-   * Bidirectional streaming. Not yet supported; passing this value to
-   * `createRunConfig` throws. Use {@link StreamingMode.SSE} for token
-   * streaming.
+   * Reserved for bidirectional streaming, which is not implemented. Passing
+   * this value to `createRunConfig` throws. Use {@link StreamingMode.SSE} for
+   * incremental responses.
    */
   BIDI = 'bidi',
 }
@@ -59,9 +64,11 @@ export interface RunConfig {
   supportCfc?: boolean;
 
   /**
-   * Streaming mode. Supported values are {@link StreamingMode.NONE} and
-   * {@link StreamingMode.SSE}. {@link StreamingMode.BIDI} is not yet
-   * supported and is rejected by `createRunConfig`.
+   * How the response is delivered. Defaults to {@link StreamingMode.NONE},
+   * which emits one event when the turn completes; set
+   * {@link StreamingMode.SSE} to receive partial events as the response is
+   * produced. {@link StreamingMode.BIDI} is not implemented and is rejected by
+   * `createRunConfig`.
    */
   streamingMode?: StreamingMode;
 

--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -102,8 +102,9 @@ export interface RunConfig {
    * A limit on the total number of llm calls for a given run.
    *
    * Valid Values:
-   *   - More than 0 and less than sys.maxsize: The bound on the number of llm
-   *     calls is enforced, if the value is set in this range.
+   *   - More than 0 and at most `Number.MAX_SAFE_INTEGER`: The bound on the
+   *     number of llm calls is enforced. `createRunConfig()` throws for
+   *     anything larger.
    *   - Less than or equal to 0: This allows for unbounded number of llm calls.
    */
   maxLlmCalls?: number;

--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -27,9 +27,9 @@ export enum StreamingMode {
    */
   SSE = 'sse',
   /**
-   * Reserved for bidirectional streaming, which is not implemented. Passing
-   * this value to `createRunConfig` throws. Use {@link StreamingMode.SSE} for
-   * incremental responses.
+   * Reserved. Bidirectional streaming is reached through `Runner.runLive()`,
+   * not through this value: `runLive` itself calls `createRunConfig`, which
+   * rejects `BIDI`. Use {@link StreamingMode.SSE} for incremental responses.
    */
   BIDI = 'bidi',
 }
@@ -67,8 +67,8 @@ export interface RunConfig {
    * How the response is delivered. Defaults to {@link StreamingMode.NONE},
    * which emits one event when the turn completes; set
    * {@link StreamingMode.SSE} to receive partial events as the response is
-   * produced. {@link StreamingMode.BIDI} is not implemented and is rejected by
-   * `createRunConfig`.
+   * produced. {@link StreamingMode.BIDI} is rejected by `createRunConfig`;
+   * bidirectional streaming is reached through `Runner.runLive()` instead.
    */
   streamingMode?: StreamingMode;
 

--- a/core/src/auth/auth_credential.ts
+++ b/core/src/auth/auth_credential.ts
@@ -65,7 +65,7 @@ export interface OAuth2Auth {
 /**
  * Represents Google Service Account configuration.
  * @example
- * config = {
+ * const config: ServiceAccountCredential = {
  *   type: "service_account",
  *   projectId: "your_project_id",
  *   privateKeyId: "your_private_key_id",
@@ -77,7 +77,7 @@ export interface OAuth2Auth {
  *   authProviderX509CertUrl: "https://www.googleapis.com/oauth2/v1/certs",
  *   clientX509CertUrl: "https://www.googleapis.com/robot/v1/metadata/x509/...",
  *   universeDomain: "googleapis.com",
- * }
+ * };
  */
 export interface ServiceAccountCredential {
   /**
@@ -191,10 +191,11 @@ export enum AuthCredentialTypes {
 }
 
 /**
- * Data class representing an authentication credential.
+ * An authentication credential, in one of several shapes selected by
+ * `authType`.
  *
- * To exchange for the actual credential, please use
- * CredentialExchanger.exchangeCredential().
+ * To turn one of these into the credential a request actually carries, use the
+ * `exchange()` method of a {@link BaseCredentialExchanger}.
  *
  * @example
  * // API Key Auth
@@ -238,7 +239,7 @@ export enum AuthCredentialTypes {
  *   }
  * }
  *
- * @example:
+ * @example
  * // Open ID Connect Auth
  * const authCredential: AuthCredential = {
  *   authType: AuthCredentialTypes.OPEN_ID_CONNECT,
@@ -246,11 +247,10 @@ export enum AuthCredentialTypes {
  *     clientId: "1234",
  *     clientSecret: "secret",
  *     redirectUri: "https://example.com",
- *     scopes: ["scope1", "scope2"],
  *   }
  * }
  *
- * @example:
+ * @example
  * // Auth with resource reference
  * const authCredential: AuthCredential = {
  *   authType: AuthCredentialTypes.API_KEY,

--- a/core/src/auth/oauth2/oauth2_credential_refresher.ts
+++ b/core/src/auth/oauth2/oauth2_credential_refresher.ts
@@ -23,7 +23,7 @@ export class OAuth2CredentialRefresher implements BaseCredentialRefresher {
    *
    * @param authCredential The OAuth2 credential to check.
    * @param authScheme The OAuth2 authentication scheme (optional).
-   * @returns True if the credential needs to be refreshed, False otherwise.
+   * @returns True if the credential needs to be refreshed, false otherwise.
    */
   async isRefreshNeeded(authCredential: AuthCredential): Promise<boolean> {
     if (!authCredential.oauth2) {

--- a/core/src/auth/oauth2/oauth2_credential_refresher.ts
+++ b/core/src/auth/oauth2/oauth2_credential_refresher.ts
@@ -99,7 +99,8 @@ export class OAuth2CredentialRefresher implements BaseCredentialRefresher {
       };
     } catch (error) {
       logger.error('Failed to refresh tokens:', error);
-      // Return original credential on failure, as per Python implementation
+      // Refresh is best-effort: return the credential unchanged and let the
+      // eventual request surface the auth failure.
       return authCredential;
     }
   }

--- a/core/src/auth/refresher/base_credential_refresher.ts
+++ b/core/src/auth/refresher/base_credential_refresher.ts
@@ -29,7 +29,7 @@ export interface BaseCredentialRefresher {
    *
    * @param authCredential The credential to check.
    * @param authScheme The authentication scheme (optional).
-   * @returns True if the credential needs to be refreshed, False otherwise.
+   * @returns True if the credential needs to be refreshed, false otherwise.
    */
   isRefreshNeeded(
     authCredential: AuthCredential,

--- a/core/src/code_executors/code_execution_utils.ts
+++ b/core/src/code_executors/code_execution_utils.ts
@@ -127,7 +127,7 @@ interface CodeGroupMatch {
  * @param content The mutable content to extract the code from.
  * @param codeBlockDelimiters The list of the enclosing delimiters to identify
  *     the code blocks.
- * @return The first code block if found, otherwise None.
+ * @return The first code block if found, otherwise an empty string.
  */
 export function extractCodeAndTruncateContent(
   content: Content,

--- a/core/src/context/token_based_context_compactor.ts
+++ b/core/src/context/token_based_context_compactor.ts
@@ -126,8 +126,7 @@ export class TokenBasedContextCompactor implements BaseContextCompactor {
 /**
  * Returns the most recently observed prompt token count, if available.
  *
- * Mirrors the Python ADK (`apps/compaction.py::_latest_prompt_token_count`):
- * each model response's `usageMetadata.promptTokenCount` is the measured size
+ * Each model response's `usageMetadata.promptTokenCount` is the measured size
  * of the entire request that produced it (system instruction + tools + full
  * history), so the latest one is used directly. These values must not be
  * summed across events: each already includes all prior history, so a sum

--- a/core/src/memory/vertex_ai_memory_bank_service.ts
+++ b/core/src/memory/vertex_ai_memory_bank_service.ts
@@ -246,7 +246,8 @@ export class VertexAiMemoryBankService implements BaseMemoryService {
       if (shouldFilterOutEvent(event.content)) {
         continue;
       }
-      // Content might need to be serialized or dumped as in Python
+      // Deep-clone into a plain JSON object so nothing non-serializable
+      // reaches the request body.
       directEvents.push({
         content: JSON.parse(JSON.stringify(event.content)),
       });

--- a/core/src/models/google_llm.ts
+++ b/core/src/models/google_llm.ts
@@ -154,8 +154,10 @@ export class Gemini extends BaseLlm {
    * @param stream Whether to make a streaming call. Defaults to `false`.
    * @yields Each {@link LlmResponse} produced by the model. A non-streaming
    *     call yields exactly one; a streaming call yields the partial responses
-   *     as they arrive, then a final aggregated response if any content was
-   *     accumulated.
+   *     as they arrive, then a final aggregated response whenever the stream
+   *     carried either content or usage/grounding/citation metadata. A
+   *     metadata-only stream therefore still ends with one, holding the
+   *     metadata and no `content`; only a stream with neither ends silently.
    */
   override async *generateContentAsync(
     llmRequest: LlmRequest,

--- a/core/src/models/google_llm.ts
+++ b/core/src/models/google_llm.ts
@@ -150,9 +150,12 @@ export class Gemini extends BaseLlm {
   /**
    * Sends a request to the Gemini model.
    *
-   * @param llmRequest LlmRequest, the request to send to the Gemini model.
-   * @param stream bool = false, whether to do streaming call.
-   * @yields LlmResponse: The model response.
+   * @param llmRequest The request to send to the Gemini model.
+   * @param stream Whether to make a streaming call. Defaults to `false`.
+   * @yields Each {@link LlmResponse} produced by the model. A non-streaming
+   *     call yields exactly one; a streaming call yields the partial responses
+   *     as they arrive, then a final aggregated response if any content was
+   *     accumulated.
    */
   override async *generateContentAsync(
     llmRequest: LlmRequest,

--- a/core/src/models/google_llm.ts
+++ b/core/src/models/google_llm.ts
@@ -155,8 +155,10 @@ export class Gemini extends BaseLlm {
    * @param stream Whether to make a streaming call. Defaults to `false`.
    * @yields Each {@link LlmResponse} produced by the model. A non-streaming
    *     call yields exactly one; a streaming call yields the partial responses
-   *     as they arrive, then a final aggregated response if any content was
-   *     accumulated.
+   *     as they arrive, then a final aggregated response whenever the stream
+   *     carried either content or usage/grounding/citation metadata. A
+   *     metadata-only stream therefore still ends with one, holding the
+   *     metadata and no `content`; only a stream with neither ends silently.
    */
   override async *generateContentAsync(
     llmRequest: LlmRequest,

--- a/core/src/models/google_llm.ts
+++ b/core/src/models/google_llm.ts
@@ -151,9 +151,12 @@ export class Gemini extends BaseLlm {
   /**
    * Sends a request to the Gemini model.
    *
-   * @param llmRequest LlmRequest, the request to send to the Gemini model.
-   * @param stream bool = false, whether to do streaming call.
-   * @yields LlmResponse: The model response.
+   * @param llmRequest The request to send to the Gemini model.
+   * @param stream Whether to make a streaming call. Defaults to `false`.
+   * @yields Each {@link LlmResponse} produced by the model. A non-streaming
+   *     call yields exactly one; a streaming call yields the partial responses
+   *     as they arrive, then a final aggregated response if any content was
+   *     accumulated.
    */
   override async *generateContentAsync(
     llmRequest: LlmRequest,

--- a/core/src/models/registry.ts
+++ b/core/src/models/registry.ts
@@ -11,8 +11,9 @@ import {BaseLlm} from './base_llm.js';
 import {Gemini} from './google_llm.js';
 
 /**
- * type[BaseLlm] equivalent in TypeScript, represents a class that can be new-ed
- * to create a BaseLlm instance.
+ * The constructor of a {@link BaseLlm} subclass, rather than an instance of
+ * one: a class that can be `new`-ed with a model name, and that also exposes
+ * the static `supportedModels` patterns the registry matches against.
  */
 export type BaseLlmType = (new (params: {model: string}) => BaseLlm) & {
   readonly supportedModels: Array<string | RegExp>;

--- a/core/src/models/registry.ts
+++ b/core/src/models/registry.ts
@@ -111,8 +111,8 @@ export class LLMRegistry {
     }
 
     for (const [regex, llmClass] of LLMRegistry.llmRegistryDict.entries()) {
-      // Replicates Python's `re.fullmatch` by anchoring the regex
-      // to the start (^) and end ($) of the string.
+      // A registered pattern must match the whole model name, so anchor it
+      // with ^...$; `RegExp.test` would otherwise match anywhere in the string.
       // TODO - b/425992518: validate it works well.
       const pattern = new RegExp(
         `^${regex instanceof RegExp ? regex.source : regex}$`,

--- a/core/src/plugins/base_plugin.ts
+++ b/core/src/plugins/base_plugin.ts
@@ -65,38 +65,40 @@ export enum ContextCompactionTrigger {
  * Example:
  * A simple plugin that logs every tool call.
  * ```typescript
+ * import {BasePlugin, BaseTool, Context, getLogger} from '@google/adk';
+ *
+ * const logger = getLogger();
+ *
  * class ToolLoggerPlugin extends BasePlugin {
  *   constructor() {
  *     super('tool_logger');
  *   }
  *
  *   override async beforeToolCallback(
- *     {tool, toolArgs, toolContext}: {
+ *     {tool, toolArgs}: {
  *       tool: BaseTool,
  *       toolArgs: Record<string, unknown>,
  *       toolContext: Context,
  *     },
  *   ): Promise<Record<string, unknown> | undefined> {
- *     this.logger.info(
- *       `[${this.name}] Calling tool '${tool.name}' with args:
- * ${JSON.stringify( toolArgs,
- *       )}`,
+ *     logger.info(
+ *       `[${this.name}] calling tool '${tool.name}' with args: ` +
+ *         JSON.stringify(toolArgs),
  *     );
  *     return;
  *   }
  *
  *   override async afterToolCallback(
- *     {tool, toolArgs, toolContext, result}: {
+ *     {tool, result}: {
  *       tool: BaseTool,
  *       toolArgs: Record<string, unknown>,
  *       toolContext: Context,
  *       result: Record<string, unknown>,
  *     },
  *   ): Promise<Record<string, unknown> | undefined> {
- *     this.logger.info(
- *       `[${this.name}] Tool '${tool.name}' finished with result:
- * ${JSON.stringify( result,
- *       )}`,
+ *     logger.info(
+ *       `[${this.name}] tool '${tool.name}' finished with result: ` +
+ *         JSON.stringify(result),
  *     );
  *     return;
  *   }

--- a/core/src/plugins/logging_plugin.ts
+++ b/core/src/plugins/logging_plugin.ts
@@ -42,8 +42,9 @@ import {BasePlugin} from './base_plugin.js';
  * ```typescript
  * const loggingPlugin = new LoggingPlugin();
  * const runner = new Runner({
- *   agents: [myAgent],
- *   // ...
+ *   appName: 'my_app',
+ *   agent: myAgent,
+ *   sessionService: new InMemorySessionService(),
  *   plugins: [loggingPlugin],
  * });
  * ```

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -415,8 +415,8 @@ export class Runner {
                 author: 'model',
                 content: beforeRunCallbackResponse,
               });
-              // TODO: b/447446338 - In the future, do *not* save live call audio
-              // content to session This is a feature in Python ADK
+              // TODO: b/447446338 - In the future, do *not* save live call
+              // audio content to the session.
               await this.sessionService.appendEvent({
                 session,
                 event: earlyExitEvent,

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -617,7 +617,7 @@ export class Runner {
    * Whether the agent to run can transfer to any other agent in the agent tree.
    *
    * @param agentToRun The agent to check for transferability.
-   * @returns True if the agent can transfer, False otherwise.
+   * @returns True if the agent can transfer, false otherwise.
    */
   private isRoutableLlmAgent(agentToRun: BaseAgent): boolean {
     return isRoutableLlmAgent(agentToRun);
@@ -716,7 +716,7 @@ function isWorkflowNodeEvent(event: Event): boolean {
  *    `disallowTransferToParent` set to false).
  *
  * @param agentToRun The agent to check for transferability.
- * @returns True if the agent can transfer, False otherwise.
+ * @returns True if the agent can transfer, false otherwise.
  */
 export function isRoutableLlmAgent(agentToRun: BaseAgent): boolean {
   let agent: BaseAgent | undefined = agentToRun;

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -421,8 +421,8 @@ export class Runner {
                 author: 'model',
                 content: beforeRunCallbackResponse,
               });
-              // TODO: b/447446338 - In the future, do *not* save live call audio
-              // content to session This is a feature in Python ADK
+              // TODO: b/447446338 - In the future, do *not* save live call
+              // audio content to the session.
               await this.sessionService.appendEvent({
                 session,
                 event: earlyExitEvent,

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -623,7 +623,7 @@ export class Runner {
    * Whether the agent to run can transfer to any other agent in the agent tree.
    *
    * @param agentToRun The agent to check for transferability.
-   * @returns True if the agent can transfer, False otherwise.
+   * @returns True if the agent can transfer, false otherwise.
    */
   private isRoutableLlmAgent(agentToRun: BaseAgent): boolean {
     return isRoutableLlmAgent(agentToRun);
@@ -904,7 +904,7 @@ function isWorkflowNodeEvent(event: Event): boolean {
  *    `disallowTransferToParent` set to false).
  *
  * @param agentToRun The agent to check for transferability.
- * @returns True if the agent can transfer, False otherwise.
+ * @returns True if the agent can transfer, false otherwise.
  */
 export function isRoutableLlmAgent(agentToRun: BaseAgent): boolean {
   let agent: BaseAgent | undefined = agentToRun;

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -69,8 +69,7 @@ export interface RunnerConfig {
    * A bare node — a `Workflow`, most usefully — is accepted as the root and
    * driven directly, so a graph does not have to be wrapped by hand to be run.
    * The accepted set is the one an edge takes: any other node-like value
-   * becomes the single node of a one-node workflow. Mirrors adk-python, whose
-   * `Runner.agent` is typed `BaseNode`.
+   * becomes the single node of a one-node workflow.
    */
   agent?: RunnableNode;
 

--- a/core/src/sessions/db/schema.ts
+++ b/core/src/sessions/db/schema.ts
@@ -18,9 +18,9 @@ export const STORAGE_KEY_COLUMN_LENGTH = 191;
 /**
  * Custom type for serializing and deserializing ADK Event objects.
  *
- * This type handles the conversion between camelCase (TypeScript ADK) and
- * snake_case (Python ADK) for Event objects, ensuring that nested
- * properties are converted correctly while preserving specific keys.
+ * Events are persisted with snake_case keys and surfaced in memory with
+ * camelCase keys. This type converts between the two, recursing into nested
+ * properties while preserving specific keys verbatim.
  */
 class CamelCaseToSnakeCaseJsonType extends JsonType {
   convertToDatabaseValue(value: Event): string {

--- a/core/src/sessions/db/schema.ts
+++ b/core/src/sessions/db/schema.ts
@@ -21,6 +21,14 @@ export const STORAGE_KEY_COLUMN_LENGTH = 191;
  * Events are persisted with snake_case keys and surfaced in memory with
  * camelCase keys. This type converts between the two, recursing into nested
  * properties while preserving specific keys verbatim.
+ *
+ * The snake_case form is a compatibility requirement, not a style choice. The
+ * on-disk schema — the table names, the `fieldName` overrides below, and the
+ * keys inside `event_data` — is a versioned contract, stamped as
+ * `schema_version` in `adk_internal_metadata`, and adk-python's
+ * `DatabaseSessionService` reads and writes these very same tables. Renaming
+ * a table, a column, or a key here silently breaks any database shared with
+ * it; change them only together with a schema version bump.
  */
 class CamelCaseToSnakeCaseJsonType extends JsonType {
   convertToDatabaseValue(value: Event): string {

--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -187,9 +187,8 @@ export function parseSkillMdContent(content: string): {
 
 /**
  * Checks whether a zip member name attempts to escape the extraction root (zip
- * slip), mirroring adk-python's `_load_skill_from_zip_bytes`. This is a
- * name-shape check on archive metadata, not a sandbox: it says nothing about
- * symlinks.
+ * slip). This is a name-shape check on archive metadata, not a sandbox: it
+ * says nothing about symlinks.
  */
 function isDangerousZipEntryName(entryName: string): boolean {
   if (path.posix.isAbsolute(entryName) || path.win32.isAbsolute(entryName)) {
@@ -199,10 +198,9 @@ function isDangerousZipEntryName(entryName: string): boolean {
 }
 
 /**
- * Checks that a skill name is a single bare path segment, mirroring
- * adk-python's `pathlib.Path(name).name != name`. '.' and '..' are rejected
- * explicitly because `path.basename('..') === '..'` whereas
- * `pathlib.Path('..').name === ''`.
+ * Checks that a skill name is a single bare path segment. '.' and '..' need an
+ * explicit check because `path.basename()` returns them unchanged, so the
+ * bare-segment test alone would accept them.
  */
 function isBareSkillName(name: string): boolean {
   return name !== '.' && name !== '..' && path.basename(name) === name;

--- a/core/src/tools/agent_tool.ts
+++ b/core/src/tools/agent_tool.ts
@@ -88,8 +88,7 @@ export class AgentTool extends BaseTool {
         name: this.name,
         description: this.description,
         // TODO(b/425992518): We should not use the agent's input schema as is.
-        // It should be validated and possibly transformed. Consider similar
-        // logic to one we have in Python ADK.
+        // It should be validated and possibly transformed first.
         parameters: this.agent.inputSchema,
       };
     } else {
@@ -135,8 +134,8 @@ export class AgentTool extends BaseTool {
       role: 'user',
       parts: [
         {
-          // TODO(b/425992518): Should be validated. Consider similar
-          // logic to one we have in Python ADK.
+          // TODO(b/425992518): Args should be validated against the agent's
+          // input schema before being forwarded.
           text: hasInputSchema
             ? JSON.stringify(args)
             : (args['request'] as string),
@@ -206,7 +205,7 @@ export class AgentTool extends BaseTool {
       .join('\n');
 
     // TODO - b/425992518: In case of output schema, the output should be
-    // validated. Consider similar logic to one we have in Python ADK.
+    // validated against that schema before being returned.
     return hasOutputSchema ? JSON.parse(mergedText) : mergedText;
   }
 }

--- a/core/src/tools/function_tool.ts
+++ b/core/src/tools/function_tool.ts
@@ -153,7 +153,9 @@ export function isFunctionTool(obj: unknown): obj is FunctionTool {
  *
  * Those arguments are checked only when `parameters` is a Zod object schema:
  * it is applied with `parse()`, so a call that does not match is rejected and
- * `execute` receives the parsed value with unknown keys removed. A plain
+ * `execute` receives the parsed value. Keys the schema does not declare are
+ * handled however that schema says: a plain `z.object()` drops them,
+ * `.passthrough()` forwards them, `.strict()` rejects the call. A plain
  * genai `Schema`, or no `parameters` at all, is shown to the model but is not
  * a runtime guard — the arguments reach `execute` exactly as the model
  * produced them, wrong types and extra keys included. Validate them inside

--- a/core/src/tools/function_tool.ts
+++ b/core/src/tools/function_tool.ts
@@ -58,11 +58,11 @@ export type RequireConfirmation<TParameters extends ToolInputParameters> =
 /**
  * The configuration options for creating a function-based tool.
  *
- * Everything the model is told about the tool comes from these options: `name`,
- * `description`, and the `parameters` schema. TypeScript types and JSDoc are
- * erased at runtime and cannot be read back, so `description` is required and
- * per-argument descriptions have to live in the schema — typically as Zod
- * `.describe()` calls.
+ * What the model is shown about the tool is built from these options: `name`,
+ * `description` and the `parameters` schema become its function declaration.
+ * TypeScript types and JSDoc are erased at runtime and cannot be read back, so
+ * `description` is required and per-argument descriptions have to live in the
+ * schema — typically as Zod `.describe()` calls.
  *
  * ```ts
  * new FunctionTool({
@@ -74,6 +74,14 @@ export type RequireConfirmation<TParameters extends ToolInputParameters> =
  *   execute: async ({city}) => fetchWeather(city),
  * });
  * ```
+ *
+ * A subclass may add to the declaration it derives from these options: given
+ * the identical options, {@link LongRunningFunctionTool} appends a sentence to
+ * `description` telling the model not to re-invoke a call that is still in
+ * flight.
+ *
+ * `parameters` is a description for the model, and only a Zod object schema is
+ * additionally enforced at call time — see {@link FunctionTool.runAsync}.
  */
 export type ToolOptions<TParameters extends ToolInputParameters> = {
   name?: string;
@@ -140,8 +148,16 @@ export function isFunctionTool(obj: unknown): obj is FunctionTool {
  *
  * The tool's name, description, and parameter schema are exposed to the
  * model as a function declaration. When the model requests a call, the
- * framework validates the arguments and invokes the user-provided `execute`
- * callback.
+ * framework invokes the user-provided `execute` callback with the arguments
+ * the model produced.
+ *
+ * Those arguments are checked only when `parameters` is a Zod object schema:
+ * it is applied with `parse()`, so a call that does not match is rejected and
+ * `execute` receives the parsed value with unknown keys removed. A plain
+ * genai `Schema`, or no `parameters` at all, is shown to the model but is not
+ * a runtime guard — the arguments reach `execute` exactly as the model
+ * produced them, wrong types and extra keys included. Validate them inside
+ * `execute` on that path.
  */
 export class FunctionTool<
   TParameters extends ToolInputParameters = undefined,
@@ -190,11 +206,14 @@ export class FunctionTool<
   }
 
   /**
-   * Validates the model-provided arguments against the parameter schema and
-   * invokes the user-defined `execute` function.
+   * Invokes the user-defined `execute` function with the model-provided
+   * arguments, after parsing them when `parameters` is a Zod object schema.
+   * Any other `parameters` value is passed through unchecked.
    *
    * @param req The tool request containing arguments and tool context.
    * @returns A promise resolving to the function's return value.
+   * @throws {Error} Wrapped as `Error in tool '<name>': …` when a Zod
+   *     `parameters` schema rejects the arguments or `execute` throws.
    */
   override async runAsync(req: RunAsyncToolRequest): Promise<unknown> {
     try {

--- a/core/src/tools/function_tool.ts
+++ b/core/src/tools/function_tool.ts
@@ -57,11 +57,23 @@ export type RequireConfirmation<TParameters extends ToolInputParameters> =
 
 /**
  * The configuration options for creating a function-based tool.
- * The `name`, `description` and `parameters` fields are used to generate the
- * tool definition that is passed to the LLM prompt.
  *
- * Note: Unlike Python's ADK, JSDoc on the `execute` function is ignored
- * for tool definition generation.
+ * Everything the model is told about the tool comes from these options: `name`,
+ * `description`, and the `parameters` schema. TypeScript types and JSDoc are
+ * erased at runtime and cannot be read back, so `description` is required and
+ * per-argument descriptions have to live in the schema — typically as Zod
+ * `.describe()` calls.
+ *
+ * ```ts
+ * new FunctionTool({
+ *   name: 'get_weather',
+ *   description: 'Returns the current weather for a city.',
+ *   parameters: z.object({
+ *     city: z.string().describe('City name, e.g. "San Francisco".'),
+ *   }),
+ *   execute: async ({city}) => fetchWeather(city),
+ * });
+ * ```
  */
 export type ToolOptions<TParameters extends ToolInputParameters> = {
   name?: string;
@@ -126,7 +138,7 @@ export function isFunctionTool(obj: unknown): obj is FunctionTool {
 /**
  * A tool that wraps a user-defined function, making it callable by an LLM.
  *
- * The function's name, description, and parameter schema are exposed to the
+ * The tool's name, description, and parameter schema are exposed to the
  * model as a function declaration. When the model requests a call, the
  * framework validates the arguments and invokes the user-provided `execute`
  * callback.

--- a/core/src/tools/load_web_page.ts
+++ b/core/src/tools/load_web_page.ts
@@ -25,7 +25,9 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
  * IPv4 ranges that are not globally routable and therefore blocked to defeat
- * SSRF.
+ * SSRF. "Not globally routable" is used in the sense of RFC 6890 and the IANA
+ * special-purpose address registry it establishes; consult those before adding
+ * to or removing from this list.
  */
 const BLOCKED_IPV4_CIDRS = [
   '0.0.0.0/8', // "this host on this network"

--- a/core/src/tools/load_web_page.ts
+++ b/core/src/tools/load_web_page.ts
@@ -25,8 +25,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
  * IPv4 ranges that are not globally routable and therefore blocked to defeat
- * SSRF. Mirrors the non-global ranges rejected by Python's
- * `ipaddress.is_global`.
+ * SSRF.
  */
 const BLOCKED_IPV4_CIDRS = [
   '0.0.0.0/8', // "this host on this network"
@@ -62,14 +61,17 @@ const BLOCKED_IPV6_CIDRS = [
   'ff00::/8', // multicast
 ].map(parseIpv6Cidr);
 
-/** Builds the parity failure message for a URL. */
+/**
+ * Builds the single failure message returned for every unsuccessful fetch, so
+ * the caller cannot tell which check rejected the URL.
+ */
 function failedToFetchMessage(url: string): string {
   return `Failed to fetch url: ${url}`;
 }
 
 /**
  * Returns `true` for `localhost` and any `*.localhost` name (case-insensitive,
- * ignoring a trailing dot), matching the Python `_is_blocked_hostname` helper.
+ * ignoring a trailing dot).
  */
 function isBlockedHostname(hostname: string): boolean {
   const normalized = hostname.replace(/\.+$/, '').toLowerCase();
@@ -252,7 +254,7 @@ function decodeHtmlEntities(text: string): string {
 /**
  * Extracts readable text from an HTML document. Removes `<script>`/`<style>`
  * blocks and comments, strips remaining tags, decodes common entities, and
- * keeps only lines with more than three words (parity with the Python tool).
+ * keeps only lines with more than three words.
  */
 function htmlToText(html: string): string {
   const withoutCode = html

--- a/core/src/tools/load_web_page.ts
+++ b/core/src/tools/load_web_page.ts
@@ -24,7 +24,10 @@ export interface LoadWebPageOptions {
 /** Default request timeout in milliseconds. */
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-/** Builds the parity failure message for a URL. */
+/**
+ * Builds the single failure message returned for every unsuccessful fetch, so
+ * the caller cannot tell which check rejected the URL.
+ */
 function failedToFetchMessage(url: string): string {
   return `Failed to fetch url: ${url}`;
 }
@@ -67,7 +70,7 @@ function decodeHtmlEntities(text: string): string {
 /**
  * Extracts readable text from an HTML document. Removes `<script>`/`<style>`
  * blocks and comments, strips remaining tags, decodes common entities, and
- * keeps only lines with more than three words (parity with the Python tool).
+ * keeps only lines with more than three words.
  */
 function htmlToText(html: string): string {
   const withoutCode = html

--- a/core/src/tools/long_running_tool.ts
+++ b/core/src/tools/long_running_tool.ts
@@ -21,7 +21,7 @@ NOTE: This is a long-running operation. Do not call this tool again if it has al
  * asynchronously.
  *
  * The framework invokes the user-provided function and delivers the response
- * back to the model once it completes, identified by the `function_call_id`.
+ * back to the model once it completes, matched up by the function call's `id`.
  * The model is also instructed not to re-invoke the tool while a call is
  * already in flight.
  */

--- a/core/src/tools/mcp/mcp_toolset.ts
+++ b/core/src/tools/mcp/mcp_toolset.ts
@@ -37,18 +37,19 @@ import {MCPTool} from './mcp_tool.js';
  * LLM invokes the prefixed tool, this toolset transparently strips the prefix
  * before sending the request to the underlying MCP server.
  *
- * Usage:
- *   import { MCPToolset } from '@google/adk';
- *   import { StreamableHTTPConnectionParamsSchema } from '@google/adk';
+ * @example
+ * ```ts
+ * import {MCPToolset} from '@google/adk';
+ * import type {StreamableHTTPConnectionParams} from '@google/adk';
  *
- *   const connectionParams = StreamableHTTPConnectionParamsSchema.parse({
- *     type: "StreamableHTTPConnectionParams",
- *     url: "http://localhost:8788/mcp"
- *   });
+ * const connectionParams: StreamableHTTPConnectionParams = {
+ *   type: 'StreamableHTTPConnectionParams',
+ *   url: 'http://localhost:8788/mcp',
+ * };
  *
- *   const mcpToolset = new MCPToolset(connectionParams);
- *   const tools = await mcpToolset.getTools();
- *
+ * const mcpToolset = new MCPToolset(connectionParams);
+ * const tools = await mcpToolset.getTools();
+ * ```
  */
 export class MCPToolset extends BaseToolset {
   private readonly mcpSessionManager: MCPSessionManager;

--- a/core/src/tools/openapi_tool/auth/credential_exchangers/auto_auth_credential_exchanger.ts
+++ b/core/src/tools/openapi_tool/auth/credential_exchangers/auto_auth_credential_exchanger.ts
@@ -19,7 +19,6 @@ import {ServiceAccountCredentialExchanger} from './service_account_exchanger.js'
 
 /**
  * Automatically selects the appropriate credential exchanger based on the auth scheme.
- * Ported from Python implementation.
  */
 @experimental
 export class AutoAuthCredentialExchanger implements BaseCredentialExchanger {

--- a/core/src/tools/openapi_tool/auth/credential_exchangers/service_account_exchanger.ts
+++ b/core/src/tools/openapi_tool/auth/credential_exchangers/service_account_exchanger.ts
@@ -22,7 +22,6 @@ const DEFAULT_SCOPES = ['https://www.googleapis.com/auth/cloud-platform'];
 
 /**
  * Fetches credentials for Google Service Account.
- * Ported from Python implementation.
  */
 @experimental
 export class ServiceAccountCredentialExchanger implements BaseCredentialExchanger {

--- a/core/src/tools/openapi_tool/openapi_spec_parser/operation_parser.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/operation_parser.ts
@@ -78,7 +78,7 @@ export class OperationParser {
     }
 
     const content = requestBody.content || {};
-    // Process first mime type only, similar to python
+    // Process the first mime type only.
     const firstMimeType = Object.keys(content)[0];
     if (!firstMimeType) {
       return;

--- a/core/src/tools/preload_memory_tool.ts
+++ b/core/src/tools/preload_memory_tool.ts
@@ -15,7 +15,7 @@ import {
 /**
  * A tool that preloads the memory for the current user.
  *
- * This tool will be automatically executed for each llm_request, and it won't be
+ * This tool is automatically executed for each `LlmRequest`, and it won't be
  * called by the model.
  *
  * NOTE: Currently this tool only uses text part from the memory.
@@ -24,7 +24,7 @@ export class PreloadMemoryTool extends BaseTool {
   constructor() {
     super({
       // Name and description are not used because this tool only
-      // changes llm_request.
+      // changes the LlmRequest.
       name: 'preload_memory',
       description: 'preload_memory',
     });

--- a/core/src/tools/vertex_rag_retrieval_tool.ts
+++ b/core/src/tools/vertex_rag_retrieval_tool.ts
@@ -22,15 +22,20 @@ import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
  *
  * @example
  * ```ts
- * import { VertexRagRetrievalTool } from '@google/adk';
- * import { VertexRagStore } from '@google/genai';
+ * import {LlmAgent, VertexRagRetrievalTool} from '@google/adk';
  *
  * const ragTool = new VertexRagRetrievalTool({
- *   ragResources: [{ragCorpus: 'projects/my-project/locations/us-central1/ragCorpora/my-corpus'}],
+ *   ragResources: [
+ *     {ragCorpus: 'projects/my-project/locations/us-central1/ragCorpora/my-corpus'},
+ *   ],
  *   similarityTopK: 5,
  * });
  *
- * const agent = new LlmAgent({ tools: [ragTool], ... });
+ * const agent = new LlmAgent({
+ *   name: 'rag_agent',
+ *   model: 'gemini-2.5-flash',
+ *   tools: [ragTool],
+ * });
  * ```
  */
 export class VertexRagRetrievalTool extends BaseTool {

--- a/core/src/tools/vertex_rag_retrieval_tool.ts
+++ b/core/src/tools/vertex_rag_retrieval_tool.ts
@@ -23,15 +23,20 @@ import {BuiltInTool} from './built_in_tool.js';
  *
  * @example
  * ```ts
- * import { VertexRagRetrievalTool } from '@google/adk';
- * import { VertexRagStore } from '@google/genai';
+ * import {LlmAgent, VertexRagRetrievalTool} from '@google/adk';
  *
  * const ragTool = new VertexRagRetrievalTool({
- *   ragResources: [{ragCorpus: 'projects/my-project/locations/us-central1/ragCorpora/my-corpus'}],
+ *   ragResources: [
+ *     {ragCorpus: 'projects/my-project/locations/us-central1/ragCorpora/my-corpus'},
+ *   ],
  *   similarityTopK: 5,
  * });
  *
- * const agent = new LlmAgent({ tools: [ragTool], ... });
+ * const agent = new LlmAgent({
+ *   name: 'rag_agent',
+ *   model: 'gemini-2.5-flash',
+ *   tools: [ragTool],
+ * });
  * ```
  */
 export class VertexRagRetrievalTool extends BuiltInTool {

--- a/core/src/utils/error_utils.ts
+++ b/core/src/utils/error_utils.ts
@@ -70,7 +70,7 @@ function baseMessage(err: unknown): string {
  * Extracts synchronously-available HTTP details (status, status text and a
  * truncated response body) from a duck-typed error, or `undefined` when none
  * are present. Several shapes are supported: errors carrying `.status`
- * directly, axios/httpx-style errors nesting them under `.response`, and
+ * directly, axios-style errors nesting them under `.response`, and
  * errors that expose the status as a numeric `.code` (as the MCP SDK's
  * `StreamableHTTPError` does). A body is only read when it is already a
  * string, so no async `Response.text()` is ever invoked.

--- a/core/src/utils/output_schema_utils.ts
+++ b/core/src/utils/output_schema_utils.ts
@@ -15,8 +15,11 @@ import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
  * Early Access Program model names encode no numeric version, so
  * `isGemini2OrAbove` rejects them and this returns `false` for them even on
  * Vertex AI, where they do support the capability. That under-reporting is a
- * known gap in the shared version predicate, not a decision made here: it can
- * only be closed in `isGemini2OrAbove`, which every other caller shares.
+ * known gap rather than a deliberate policy. It could be closed here, with a
+ * case for those names, or in `isGemini2OrAbove` itself — but that predicate
+ * is exported from the package and shared with the URL-context tool, the
+ * built-in code executor and the Runner's CFC check, so widening it there
+ * changes their answers too.
  *
  * @param modelString A simple or path-based model name.
  * @return True if the model supports an output schema alongside tools.

--- a/core/src/utils/output_schema_utils.ts
+++ b/core/src/utils/output_schema_utils.ts
@@ -13,8 +13,8 @@ import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
  * `set_model_response` workaround.
  *
  * Early Access Program model names encode no numeric version, so
- * `isGemini2OrAbove` rejects them even on Vertex AI. The Python
- * implementation accepts them; that gap lives in the shared predicate.
+ * `isGemini2OrAbove` rejects them and this returns `false` for them even on
+ * Vertex AI.
  *
  * @param modelString A simple or path-based model name.
  * @return True if the model supports an output schema alongside tools.

--- a/core/src/utils/output_schema_utils.ts
+++ b/core/src/utils/output_schema_utils.ts
@@ -14,7 +14,9 @@ import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
  *
  * Early Access Program model names encode no numeric version, so
  * `isGemini2OrAbove` rejects them and this returns `false` for them even on
- * Vertex AI.
+ * Vertex AI, where they do support the capability. That under-reporting is a
+ * known gap in the shared version predicate, not a decision made here: it can
+ * only be closed in `isGemini2OrAbove`, which every other caller shares.
  *
  * @param modelString A simple or path-based model name.
  * @return True if the model supports an output schema alongside tools.

--- a/core/src/utils/output_schema_utils.ts
+++ b/core/src/utils/output_schema_utils.ts
@@ -12,14 +12,9 @@ import {getGoogleLlmVariant, GoogleLLMVariant} from './variant_utils.js';
  * time as tools, which is strictly more reliable than the prompt-based
  * `set_model_response` workaround.
  *
- * Early Access Program model names encode no numeric version, so
- * `isGemini2OrAbove` rejects them and this returns `false` for them even on
- * Vertex AI, where they do support the capability. That under-reporting is a
- * known gap rather than a deliberate policy. It could be closed here, with a
- * case for those names, or in `isGemini2OrAbove` itself — but that predicate
- * is exported from the package and shared with the URL-context tool, the
- * built-in code executor and the Runner's CFC check, so widening it there
- * changes their answers too.
+ * Early Access Program model names encode no numeric version, so this returns
+ * `false` for them even on Vertex AI, where they do support the capability.
+ * That under-reporting is a known gap.
  *
  * @param modelString A simple or path-based model name.
  * @return True if the model supports an output schema alongside tools.


### PR DESCRIPTION
A JavaScript developer should not be able to tell from the documentation that this library was ported from Python. Today they can — starting with the most-used API surface in the package.

These comments compile into the public TypeDoc reference at `adk.dev/api-reference/typescript/`, so this is reader-facing text, not internal notes. **Comments only:** the emitted JS was built at `main` and at `HEAD` and diffed across 804 files with comments stripped — **zero non-comment differences**.

## The flagship

`core/src/tools/function_tool.ts` began:

> *"Note: Unlike Python's ADK, JSDoc on the `execute` function is ignored…"*

That sentence encodes a real constraint, expressed as a diff against a library the reader has never used. It now states positively where the model's view of a tool comes from — `name`, `description`, and the `parameters` schema, because types and JSDoc are erased at runtime — with a Zod `.describe()` example that compiles.

An independent reviewer wrote a working tool from that comment alone: `tsc --strict` clean unedited, first try, and a real model called it with the `.describe()` text on the wire.

## Accuracy was the hard part, not tone

Two rounds of review caught **five confidently-worded statements that were false**, three of them introduced by this change. A wrong comment is worse than the awkward one it replaced, so each was reproduced by execution before being rewritten:

- **"the framework validates the arguments"** — false on the plain-`Schema` path. `{n: 'not-a-number', extra: 'x'}` reached `execute` untouched. Validation happens **only** on the Zod path. The comment now says which is which, and tells you to validate inside `execute` otherwise.
- **"everything the model is told comes from these options"** — `LongRunningFunctionTool` appends to the description. Now qualified, and verified to be the only such subclass.
- **`thinkingConfig` "must be configured via `planner`"** — **there is no `planner` in adk-js.** One grep hit repo-wide: that comment. `thinkingConfig` works directly and reaches the request as `{"thinkingBudget":0}`.
- **"Returning `Content` ends the invocation"** — a regression this change introduced. In a `SequentialAgent`, child1's callback returned `Content` and **child2 still ran**. Now correctly scoped.
- **`isGemini2OrAbove` "can only close the gap"** — refuted by closing it elsewhere.

Three earlier deletions were also restored, where removing a Python reference removed real information: a known bug that had started reading as intentional design, the RFC 6890 basis for an SSRF CIDR list, and the note that the on-disk session schema is a stable cross-implementation contract (that last one on a non-exported class, confirmed absent from the published reference).

## Also fixed

`type[BaseLlm]` (Python typing syntax on a public symbol) · `MUST be named 'callbackContext' (enforced)` — a keyword-argument constraint in a language without keyword arguments, and false · `sys.maxsize` where the code checks `Number.MAX_SAFE_INTEGER` · `@param stream bool` and `@yields` · `httpx` · `// TODO: omitted Py LlmAgent features` · and **five `@example` blocks that did not compile**, one importing `StreamableHTTPConnectionParamsSchema`, an identifier that exists nowhere but inside that comment.

## Verification

- TypeDoc regenerated: `Unlike Python` 12→0, `adk-python` 12→0, `Python ADK` 2→0, `sys.maxsize`, `type[`, `MUST be named`, `httpx`, `planner` all **0**. The only surviving `python` is `pythonCommandPath` / `CodeExecutionLanguage.PYTHON`, which genuinely executes Python.
- Every `@example` block in `core/src` containing TypeScript extracted and compiled: **17 blocks, 0 failing** (two were broken before this change).
- Build ✅ · lint ✅ · prettier ✅ · **170 test files / 2440 tests passing**, matching baseline exactly.
- `package-lock.json` unmodified.
- An independent reviewer scored "how likely is a JS developer to detect the Python origin from the published reference" at **8/10 before, 3/10 after**.

Left deliberately: `.py` MIME mappings, `pythonCommandPath`, and the code-executor and skills features, which are genuinely about executing Python; and the snake_case wire-format transforms, where snake_case is the serialization format rather than an API ergonomics leak.

## One root cause, reported not fixed

`CONTRIBUTING.md:94` currently asks that TSDocs be *"usually aligned with adk-python"*. That guidance is what produces this class of comment. Worth revisiting separately — and `README.md:9` and `:102` hotlink their logo and hero screenshot from `raw.githubusercontent.com/google/adk-python/`, which was out of scope here.
