### PR TITLE
fix(agents): persist processLlmRequest state changes

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -846,8 +846,18 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
       });
       allTools.push(setModelResponseTool);
     }
+    // Collect turn metadata and event actions
+    // TODO - b/425992518: misleading, this is passing metadata.
+    const modelResponseEvent = createEvent({
+      invocationId: invocationContext.invocationId,
+      author: this.name,
+      branch: invocationContext.branch,
+    });
     for (const toolUnion of allTools) {
-      const toolContext = new Context({invocationContext});
+      const toolContext = new Context({
+        invocationContext,
+        eventActions: modelResponseEvent.actions,
+      });
 
       // process all tools from this tool union
       const tools = (
@@ -888,12 +898,6 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
     // =========================================================================
     // Calls the LLM
     // =========================================================================
-    // TODO - b/425992518: misleading, this is passing metadata.
-    const modelResponseEvent = createEvent({
-      invocationId: invocationContext.invocationId,
-      author: this.name,
-      branch: invocationContext.branch,
-    });
     const span = tracer.startSpan('call_llm');
     const ctx = trace.setSpan(context.active(), span);
     yield* runAsyncGeneratorWithOtelContext<LlmAgent, Event>(

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -19,12 +19,14 @@ import {
   createSession,
   Event,
   FunctionTool,
+  InMemorySessionService,
   InvocationContext,
   LlmAgent,
   LlmRequest,
   LlmResponse,
   PluginManager,
   RunAsyncToolRequest,
+  Runner,
   Session,
   ToolProcessLlmRequest,
 } from '@google/adk';
@@ -977,4 +979,83 @@ describe('LlmAgent outputSchema with tools', () => {
       );
     },
   );
+
+  it('persists state writes made in processLlmRequest across turns', async () => {
+    class StateProbeTool extends BaseTool {
+      constructor() {
+        super({name: 'state_probe_tool', description: 'test probe'});
+      }
+      override _getDeclaration() {
+        return {
+          name: this.name,
+          description: this.description,
+          parameters: {type: Type.OBJECT, properties: {}},
+        };
+      }
+      override async processLlmRequest(
+        request: ToolProcessLlmRequest,
+      ): Promise<void> {
+        await super.processLlmRequest(request);
+        const {toolContext} = request;
+        const current = toolContext.state.get<number>('probe_counter') ?? 0;
+        toolContext.state.set('probe_counter', current + 1);
+      }
+      async runAsync(_request: RunAsyncToolRequest): Promise<unknown> {
+        return Promise.resolve({result: 'ok'});
+      }
+    }
+
+    const tool = new StateProbeTool();
+    const mockLlm = new MockLlm({
+      content: {role: 'model', parts: [{text: 'Done'}]},
+    });
+    const agent = new LlmAgent({
+      name: 'probe_agent',
+      model: mockLlm,
+      tools: [tool],
+    });
+
+    const sessionService = new InMemorySessionService();
+    const runner = new Runner({
+      appName: 'test_app',
+      agent,
+      sessionService,
+    });
+
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'test_user',
+      sessionId: 'test_session',
+    });
+
+    for await (const _event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'Turn 1'}]},
+    })) {
+      // Consume the stream
+    }
+
+    const sessionAfterTurn1 = await sessionService.getSession({
+      appName: 'test_app',
+      userId: 'test_user',
+      sessionId: 'test_session',
+    });
+    expect(sessionAfterTurn1?.state?.['probe_counter']).toBe(1);
+
+    for await (const _event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'Turn 2'}]},
+    })) {
+      // Consume the stream
+    }
+
+    const sessionAfterTurn2 = await sessionService.getSession({
+      appName: 'test_app',
+      userId: 'test_user',
+      sessionId: 'test_session',
+    });
+    expect(sessionAfterTurn2?.state?.['probe_counter']).toBe(2);
+  });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #627

**2. Or, if no issue exists, describe the change:**

**Problem:**
When custom tools perform state writes inside `processLlmRequest()` via `toolContext.state.set()`, the state modifications were silently dropped and never persisted across conversation turns.

This occurred because `toolContext` in `LlmAgent.runAsyncImpl()` was instantiated as `new Context({ invocationContext })` with an unattached `eventActions`. While `toolContext.state.hasDelta()` returned `true` and the state was mutated in-memory on that temporary object, those deltas were never associated with `modelResponseEvent.actions` or saved to the session database via `SessionService.appendEvent()`.

**Solution:**
In `core/src/agents/llm_agent.ts`:
1. Instantiated `modelResponseEvent` prior to the pre-processing `allTools` loop.
2. Passed `eventActions: modelResponseEvent.actions` into `new Context({ invocationContext, eventActions: modelResponseEvent.actions })`.

This ensures all state mutations performed during `processLlmRequest()` are directly captured in `modelResponseEvent.actions.stateDelta` and permanently persisted to `session.state` upon turn completion.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Summary of npm test results:**
- Added test in `core/test/agents/llm_agent_test.ts`: `persists state writes made in processLlmRequest across turns`
- Vitest unit test suite results:
  ```text
  Test Files  217 passed (217)
       Tests  2976 passed (2976)
    Duration  36.66s
  ```
- Formatting & Linting:
  - `npm run format:check` — All matched files use Prettier code style (Passed)
  - `npm run lint` — 0 errors, 0 warnings (Passed)

**Manual End-to-End (E2E) Tests:**

1. **Reproduction Test on Original Code:**
   Ran a multi-turn agent with a tool updating counter state in `processLlmRequest`.
   - *Result on Main:* Turn 1 writes were missing from `session.state`, resetting counter back to 0 on Turn 2.

2. **Verification Test with Fix Applied:**
   Ran the same multi-turn agent with the fix applied:
   - *Turn 1:* `session.state` -> `{"probe_process_llm_request_writes": 2, "probe_run_async_writes": 1}` (Persisted)
   - *Turn 2:* `session.state` -> `{"probe_process_llm_request_writes": 4, "probe_run_async_writes": 2}` (State successfully accumulated across turns)
   - *Multi-Tool Pre-Processing:* Multiple tools writing to different state keys in `processLlmRequest` accumulated without conflict.
   - *Standard Agent Workflow:* Verified standard model conversations and agents without state mutations continue to function with zero regressions.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

- **Root Cause Code Location:** `core/src/agents/llm_agent.ts`
- **Performance Impact:** Zero. This is an $O(1)$ object reference forwarding without any added allocations, async promises, or I/O overhead.
