### PR TITLE
fix(workflow): resume dynamic HITL children instead of livelocking

### DIFF
--- a/core/src/workflow/dynamic_node_scheduler.ts
+++ b/core/src/workflow/dynamic_node_scheduler.ts
@@ -19,6 +19,7 @@ import {
   isFastForwardable,
   makeFastForwardResult,
   reconstructNodeStatesByPath,
+  type RehydratedNode,
 } from './utils/rehydration_utils.js';
 
 /**
@@ -81,11 +82,63 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
         }
         return makeFastForwardResult(ctx, prior);
       }
+      // Resume with rerunOnResume=false: a child that interrupted last turn
+      // (raised interrupts, produced no output) does NOT re-run its body. It
+      // completes with the resolved resume value(s) as its output, which
+      // `ctx.runNode()` hands back to the caller. Mirrors the static-graph
+      // handoff in `Workflow.scheduleNode`; without it such a child re-runs,
+      // raises a brand-new interrupt, and the workflow can never resume.
+      const handoff = this.resumeHandoff(ctx, node, prior);
+      if (handoff) {
+        this.state.runs.set(nodePath, {
+          state: createNodeState({
+            status: NodeStatus.COMPLETED,
+            runId,
+            parentRunId: ctx.runId,
+          }),
+          output: handoff.output,
+        });
+        if (options.useAsOutput) {
+          ctx.output = handoff.output;
+          ctx.route = handoff.route;
+        }
+        return handoff;
+      }
       // Otherwise (waiting/unresolved): resume inputs were already merged into
       // ctx.resumeInputs by the Workflow; fall through to a fresh run.
     }
 
     return this.runFresh(ctx, node, input, name, runId, nodePath, options);
+  }
+
+  /**
+   * Builds the completion result for a child that interrupted in a prior turn
+   * and whose interrupts are now all resolved, or `undefined` when the child is
+   * not in that state (so the caller falls through to a fresh run).
+   */
+  private resumeHandoff(
+    ctx: NodeContext,
+    node: BaseNode,
+    prior: RehydratedNode | undefined,
+  ): NodeResult | undefined {
+    if (
+      !prior ||
+      node.rerunOnResume ||
+      prior.output !== undefined ||
+      prior.interruptIds.size === 0
+    ) {
+      return undefined;
+    }
+    const values = [...prior.interruptIds].map((id) => ctx.resumeInputs[id]);
+    if (!values.every((value) => value !== undefined)) {
+      return undefined;
+    }
+    return {
+      output: values.length === 1 ? values[0] : values,
+      route: undefined,
+      branch: prior.branch ?? ctx.branch,
+      interruptIds: [],
+    };
   }
 
   private async runFresh(

--- a/core/src/workflow/dynamic_node_scheduler.ts
+++ b/core/src/workflow/dynamic_node_scheduler.ts
@@ -68,19 +68,11 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
       );
       if (prior && !node.rerunOnResume && isFastForwardable(prior)) {
         // Completed in a prior turn -> return cached output, do not re-execute.
-        this.state.runs.set(nodePath, {
-          state: createNodeState({
-            status: NodeStatus.COMPLETED,
-            runId,
-            parentRunId: ctx.runId,
-          }),
-          output: prior.output,
-        });
-        if (options.useAsOutput) {
-          ctx.output = prior.output;
-          ctx.route = prior.route;
-        }
-        return makeFastForwardResult(ctx, prior);
+        return this.completeWithoutRunning(
+          ctx,
+          {nodePath, runId, options},
+          makeFastForwardResult(ctx, prior),
+        );
       }
       // Resume with rerunOnResume=false: a child that interrupted last turn
       // (raised interrupts, produced no output) does NOT re-run its body. It
@@ -90,25 +82,46 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
       // raises a brand-new interrupt, and the workflow can never resume.
       const handoff = this.resumeHandoff(ctx, node, prior);
       if (handoff) {
-        this.state.runs.set(nodePath, {
-          state: createNodeState({
-            status: NodeStatus.COMPLETED,
-            runId,
-            parentRunId: ctx.runId,
-          }),
-          output: handoff.output,
-        });
-        if (options.useAsOutput) {
-          ctx.output = handoff.output;
-          ctx.route = handoff.route;
-        }
-        return handoff;
+        return this.completeWithoutRunning(
+          ctx,
+          {nodePath, runId, options},
+          handoff,
+        );
       }
       // Otherwise (waiting/unresolved): resume inputs were already merged into
       // ctx.resumeInputs by the Workflow; fall through to a fresh run.
     }
 
     return this.runFresh(ctx, node, input, name, runId, nodePath, options);
+  }
+
+  /**
+   * Books a dynamic run that completed WITHOUT executing its body — either
+   * fast-forwarded from a cached output or handed the resolved resume value —
+   * and returns `result` for `ctx.runNode()` to give back to the caller.
+   */
+  private completeWithoutRunning(
+    ctx: NodeContext,
+    run: {
+      nodePath: string;
+      runId: string;
+      options: ScheduleDynamicNodeOptions;
+    },
+    result: NodeResult,
+  ): NodeResult {
+    this.state.runs.set(run.nodePath, {
+      state: createNodeState({
+        status: NodeStatus.COMPLETED,
+        runId: run.runId,
+        parentRunId: ctx.runId,
+      }),
+      output: result.output,
+    });
+    if (run.options.useAsOutput) {
+      ctx.output = result.output;
+      ctx.route = result.route;
+    }
+    return result;
   }
 
   /**

--- a/core/test/workflow/dynamic_resume_test.ts
+++ b/core/test/workflow/dynamic_resume_test.ts
@@ -32,14 +32,26 @@ describe('Phase 5b-cont — dynamic (ctx.runNode) resume via the Runner', () => 
       stepRuns++;
       return `step(${input})`;
     });
-    const ask = new FunctionNode('ask', (ctx: NodeContext) => {
-      askRuns++;
-      const answer = ctx.resumeInputs['confirm'];
-      if (answer === undefined) {
-        return new RequestInput({interruptId: 'confirm', message: 'confirm?'});
-      }
-      return `confirmed:${answer}`;
-    });
+    // Re-entry HITL node: it re-runs on resume and consumes the reply itself,
+    // so it must declare `rerunOnResume: true`. With the default (false) the
+    // scheduler completes it with the raw reply as its output instead (the
+    // handoff form), exactly like a static graph node — see the handoff test
+    // below.
+    const ask = new FunctionNode(
+      'ask',
+      (ctx: NodeContext) => {
+        askRuns++;
+        const answer = ctx.resumeInputs['confirm'];
+        if (answer === undefined) {
+          return new RequestInput({
+            interruptId: 'confirm',
+            message: 'confirm?',
+          });
+        }
+        return `confirmed:${answer}`;
+      },
+      {rerunOnResume: true},
+    );
 
     // Imperative workflow: run `step` (completes), then `ask` (interrupts).
     const wf = new Workflow({
@@ -96,5 +108,67 @@ describe('Phase 5b-cont — dynamic (ctx.runNode) resume via the Runner', () => 
     expect(askRuns).toBe(2);
     expect(turn2.some((e) => e.output === 'step(x)')).toBe(false);
     expect(turn2.some((e) => e.output === 'confirmed:yes')).toBe(true);
+  });
+
+  it('hands the resume value to a rerunOnResume=false child without re-running it', async () => {
+    let askRuns = 0;
+
+    // Handoff HITL node: it just raises the interrupt (with a framework-issued
+    // id) and relies on `rerunOnResume: false` to be completed with the reply
+    // as its output. Before the handoff existed this re-ran on every turn,
+    // minting a fresh interrupt id each time, so the workflow never resumed.
+    const ask = new FunctionNode(
+      'ask',
+      async function* () {
+        askRuns++;
+        yield new RequestInput({message: 'confirm?'});
+      },
+      {rerunOnResume: false},
+    );
+
+    const wf = new Workflow({
+      name: 'dyn_handoff_wf',
+      dynamicEntry: async (ctx, input) => {
+        const a = await ctx.runNode(ask, input);
+        // `ctx.runNode()` resolves (rather than throwing) while the child is
+        // still interrupted, so the caller must check before using `output`.
+        if (a.interruptIds.length > 0) {
+          return undefined;
+        }
+        return `decided:${String(a.output).trim().toLowerCase()}`;
+      },
+    });
+
+    const agent = new WorkflowAgent(wf);
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'u1',
+    });
+    const runner = new Runner({appName: 'test_app', agent, sessionService});
+
+    const turn1 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {role: 'user', parts: [{text: 'ship it'}]},
+      }),
+    );
+    expect(askRuns).toBe(1);
+    expect(turn1.some(hasRequestInputFunctionCall)).toBe(true);
+
+    // Reply in plain text: the single pending interrupt is unambiguous.
+    const turn2 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {role: 'user', parts: [{text: 'yes'}]},
+      }),
+    );
+
+    // The child did NOT re-run, and no second interrupt was raised.
+    expect(askRuns).toBe(1);
+    expect(turn2.some(hasRequestInputFunctionCall)).toBe(false);
+    expect(turn2.some((e) => e.output === 'decided:yes')).toBe(true);
   });
 });

--- a/core/test/workflow/hitl_flow_test.ts
+++ b/core/test/workflow/hitl_flow_test.ts
@@ -103,13 +103,27 @@ describe('Phase 5 — HITL (pause / resume)', () => {
   });
 
   it('supports HITL in an imperative dynamicEntry workflow', async () => {
-    const ask = new FunctionNode('ask', (ctx) => {
-      const answer = ctx.resumeInputs['name'];
-      if (answer === undefined) {
-        return new RequestInput({interruptId: 'name', message: 'Your name?'});
-      }
-      return answer;
-    });
+    // Re-entry HITL node: it re-runs on resume and reads the reply itself, so
+    // it declares `rerunOnResume: true`. Under the default the dynamic
+    // scheduler completes such a child with the raw reply as its output
+    // instead of re-running it (the handoff form) — see
+    // `dynamic_resume_test.ts` for both shapes driven through the Runner.
+    //
+    // Note this harness builds a fresh session per `drive()` call, so there
+    // are no prior events to rehydrate from and neither cross-turn branch is
+    // reached here; the flag is what the node means, not what this test
+    // exercises.
+    const ask = new FunctionNode(
+      'ask',
+      (ctx) => {
+        const answer = ctx.resumeInputs['name'];
+        if (answer === undefined) {
+          return new RequestInput({interruptId: 'name', message: 'Your name?'});
+        }
+        return answer;
+      },
+      {rerunOnResume: true},
+    );
     const wf = new Workflow({
       name: 'dyn_hitl',
       dynamicEntry: async (ctx) => {


### PR DESCRIPTION
## Summary

A node run via `ctx.runNode()` that raises a `RequestInput` can never be answered — the workflow pauses forever, silently.

`Workflow.scheduleNode` implements the `rerunOnResume: false` **handoff**: a node that interrupted last turn does not re-run, it completes with the human's reply as its output (`core/src/workflow/workflow.ts:385-411`). `DynamicNodeScheduler.schedule` had no equivalent and fell straight through to a fresh run.

So the child re-ran from the top and raised a **brand-new** interrupt. With a framework-issued id the reply could never match it. Traced over four turns:

```
[user]: ship it
  >> leaf ran: raising interruptId=eb4a1cab…
  >> resumeInputs available: []
[user]: yes
  >> leaf ran: raising interruptId=60410882…       ← new id
  >> resumeInputs available: [eb4a1cab…]           ← the reply IS here
[user]: yes
  >> leaf ran: raising interruptId=92126087…
  >> resumeInputs available: []                    ← permanently wedged
```

It degrades: each turn orphans another pending interrupt, and once two are outstanding `resumeInputsFromPlainText` stops disambiguating, so plain-text replies never resolve again. No error is raised — the workflow just produces nothing, forever.

This is the pattern the docs show for [dynamic human input](https://adk.dev/graphs/dynamic/#human-input), so the documented Python snippet does not work in TypeScript today.

## Fix

Port the handoff branch to the dynamic scheduler. `rerunOnResume` now means the same thing in both schedulers:

| | behaviour on resume |
| --- | --- |
| `rerunOnResume: false` | do not re-run; complete with the reply as the child's output |
| `rerunOnResume: true` | re-run the body so it consumes the reply via `ctx.resumeInputs` |

## Breaking change

A dynamic `ctx.runNode()` child that raises an interrupt and re-reads `ctx.resumeInputs` on re-run must now declare `rerunOnResume: true`. With the default it is completed with the raw reply as its output instead of re-running.

`Workflow` is still `@experimental`. The one in-tree case was `dynamic_resume_test.ts`, updated here — its `ask` node used the re-entry style with the default flag, which the old dynamic path happened to allow.

The alternative considered was leaving the semantics alone and only throwing on the livelock. That keeps the flag meaning two different things depending on scheduler, and leaves the documented pattern unsupported, so aligning seemed better — happy to switch if you'd rather not take the break.

## Tests

- `dynamic_resume_test.ts` — existing re-entry test updated to declare `rerunOnResume: true`, with a comment explaining the distinction.
- New: `hands the resume value to a rerunOnResume=false child without re-running it` — asserts the child runs exactly once across both turns, no second interrupt is raised, and the reply reaches the caller.

Full `unit:core` suite green: 201 files, 2732 tests.

## Note for reviewers

`ctx.runNode()` resolves (rather than throwing) while a child is still interrupted, returning `interruptIds` set and `output` undefined. Callers must check before using `output` or they will act on an answer the human never gave — an approval gate written straight from the docs auto-denies on turn 1. Not changed here since it is arguably intentional, but it is an easy footgun; say the word and I'll open a follow-up.