### PR TITLE
fix(workflow): don't replay a finished run on the next turn

### DIFF
--- a/core/src/workflow/dynamic_node_scheduler.ts
+++ b/core/src/workflow/dynamic_node_scheduler.ts
@@ -16,6 +16,7 @@ import {
   ScheduleDynamicNodeOptions,
 } from './schedule_dynamic_node.js';
 import {
+  eventsForCurrentRun,
   isFastForwardable,
   makeFastForwardResult,
   reconstructNodeStatesByPath,
@@ -61,11 +62,12 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
       return existing.task;
     }
 
-    // Cross-turn resume: rehydrate this dynamic run from prior session events.
+    // Cross-turn resume: rehydrate this dynamic run from the events of the run
+    // still in progress (a run that already completed must not be replayed).
     if (!this.state.runs.has(nodePath)) {
-      const prior = reconstructNodeStatesByPath(ctx.session?.events ?? []).get(
-        nodePath,
-      );
+      const prior = reconstructNodeStatesByPath(
+        eventsForCurrentRun(ctx.session?.events ?? [], ctx.invocationId),
+      ).get(nodePath);
       if (prior && !node.rerunOnResume && isFastForwardable(prior)) {
         // Completed in a prior turn -> return cached output, do not re-execute.
         return this.completeWithoutRunning(

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -16,6 +16,10 @@
 import {Event} from '../../events/event.js';
 import {RouteValue} from '../graph.js';
 import type {NodeContext, NodeResult} from '../node_context.js';
+import {
+  hasAuthRequestFunctionCall,
+  hasRequestInputFunctionCall,
+} from './hitl_utils.js';
 
 const RESULT_KEY = 'result';
 
@@ -33,6 +37,91 @@ export interface RehydratedNode {
   interruptIds: Set<string>;
   /** Resolved interrupt responses, keyed by interrupt id. */
   resolvedResponses: Map<string, unknown>;
+}
+
+/**
+ * Narrows session events to the workflow run still in progress, dropping every
+ * earlier run that already finished.
+ *
+ * Rehydration exists to resume a run that paused, so it must not see a run that
+ * already completed: the finished nodes' cached outputs would be fast-forwarded
+ * into the new run, and the workflow would replay its previous answer instead
+ * of acting on the new input.
+ *
+ * `google/adk-python` scopes this by invocation id, because there a resumed
+ * invocation keeps its id. The TypeScript runner mints a fresh invocation id
+ * for every turn (`Runner.runAsync`), so a run that spans a pause covers
+ * several invocations and an id filter would discard the very outputs resume
+ * needs. Runs are delimited by pausing instead:
+ *
+ *   - An invocation that raised an interrupt ended paused, so it belongs to the
+ *     run still in progress.
+ *   - An invocation that emitted node events without raising one ran to
+ *     completion; it is the boundary, and it and everything before it are
+ *     dropped.
+ *
+ * The current invocation is always kept: it is in progress by definition, and
+ * it carries the user function responses that resolve the pending interrupts.
+ */
+export function eventsForCurrentRun(
+  events: Event[],
+  currentInvocationId: string,
+): Event[] {
+  // Ordered summary of each prior invocation that emitted workflow node events.
+  const priorRuns: Array<{
+    start: number;
+    invocationId?: string;
+    paused: boolean;
+  }> = [];
+  let currentStart = events.length;
+  // Not every node event carries an invocation id: events minted inside the
+  // engine (a RequestInput interrupt, for one) are enriched with author, path
+  // and branch but no id. Such an event belongs to the invocation whose events
+  // it sits among, so carry the last id seen forward rather than let it open a
+  // phantom run of its own — which would put the boundary in the middle of a
+  // paused run and re-execute nodes that had already completed.
+  let lastInvocationId: string | undefined;
+
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    const invocationId = event.invocationId || lastInvocationId;
+    if (event.invocationId) {
+      lastInvocationId = event.invocationId;
+    }
+    if (invocationId === currentInvocationId) {
+      currentStart = Math.min(currentStart, i);
+      continue;
+    }
+    if (!event.nodeInfo?.path) {
+      continue;
+    }
+    let entry = priorRuns[priorRuns.length - 1];
+    if (!entry || entry.invocationId !== invocationId) {
+      entry = {start: i, invocationId, paused: false};
+      priorRuns.push(entry);
+    }
+    if (raisedInterrupt(event)) {
+      entry.paused = true;
+    }
+  }
+
+  // Walk back over the prior invocations that ended paused; the earliest of
+  // them starts the run still in progress.
+  let boundary = currentStart;
+  for (let i = priorRuns.length - 1; i >= 0 && priorRuns[i].paused; i--) {
+    boundary = priorRuns[i].start;
+  }
+
+  return boundary <= 0 ? events : events.slice(boundary);
+}
+
+/** Whether an event raised an interrupt (HITL request-input, or auth). */
+function raisedInterrupt(event: Event): boolean {
+  return (
+    (event.longRunningToolIds?.length ?? 0) > 0 ||
+    hasRequestInputFunctionCall(event) ||
+    hasAuthRequestFunctionCall(event)
+  );
 }
 
 /**

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -13,13 +13,10 @@
  * for deterministic parallel/dynamic replay is a Phase 5b continuation.
  */
 
+import {requiresUserInput} from '../../agents/user_input_request.js';
 import {Event} from '../../events/event.js';
 import {RouteValue} from '../graph.js';
 import type {NodeContext, NodeResult} from '../node_context.js';
-import {
-  hasAuthRequestFunctionCall,
-  hasRequestInputFunctionCall,
-} from './hitl_utils.js';
 
 const RESULT_KEY = 'result';
 
@@ -89,7 +86,9 @@ export function eventsForCurrentRun(
       lastInvocationId = event.invocationId;
     }
     if (invocationId === currentInvocationId) {
-      currentStart = Math.min(currentStart, i);
+      if (currentStart === events.length) {
+        currentStart = i;
+      }
       continue;
     }
     if (!event.nodeInfo?.path) {
@@ -112,16 +111,18 @@ export function eventsForCurrentRun(
     boundary = priorRuns[i].start;
   }
 
-  return boundary <= 0 ? events : events.slice(boundary);
+  return events.slice(boundary);
 }
 
-/** Whether an event raised an interrupt (HITL request-input, or auth). */
+/**
+ * Whether an event paused the run for a human: it carries one of the three
+ * `adk_request_*` calls (input, credential, or tool confirmation).
+ *
+ * Deliberately NOT `longRunningToolIds`, which marks any tool declared
+ * `isLongRunning` — a run that merely used one is not waiting on a person.
+ */
 function raisedInterrupt(event: Event): boolean {
-  return (
-    (event.longRunningToolIds?.length ?? 0) > 0 ||
-    hasRequestInputFunctionCall(event) ||
-    hasAuthRequestFunctionCall(event)
-  );
+  return requiresUserInput(event);
 }
 
 /**

--- a/core/src/workflow/workflow.ts
+++ b/core/src/workflow/workflow.ts
@@ -22,6 +22,7 @@ import {NodeStatus} from './node_status.js';
 import {DynamicNodeState} from './schedule_dynamic_node.js';
 import {Trigger} from './trigger.js';
 import {
+  eventsForCurrentRun,
   isFastForwardable,
   makeFastForwardResult,
   reconstructNodeStates,
@@ -186,11 +187,12 @@ export class Workflow extends BaseNode {
   ): Promise<void> {
     // --- REHYDRATE (resume) ---
     // Reconstruct node state from prior session events and surface resolved
-    // interrupt responses so waiting nodes can resume. Scope to this workflow's
-    // own direct children (by path) so nested workflows with same-named nodes
-    // don't collide.
+    // interrupt responses so waiting nodes can resume. Scope to the run still
+    // in progress (so a run that already completed is not replayed), and to
+    // this workflow's own direct children (by path) so nested workflows with
+    // same-named nodes don't collide.
     const rehydrated = reconstructNodeStates(
-      ctx.session?.events ?? [],
+      eventsForCurrentRun(ctx.session?.events ?? [], ctx.invocationId),
       ctx.nodePath || undefined,
     );
     this.applyResumeInputs(ctx, rehydrated);

--- a/core/src/workflow/workflow_agent.ts
+++ b/core/src/workflow/workflow_agent.ts
@@ -12,7 +12,10 @@ import {AsyncQueue} from '../utils/async_queue.js';
 import {experimental} from '../utils/experimental.js';
 import {isBaseNode, toContent} from './base_node.js';
 import {NodeContext} from './node_context.js';
-import {reconstructNodeStates} from './utils/rehydration_utils.js';
+import {
+  eventsForCurrentRun,
+  reconstructNodeStates,
+} from './utils/rehydration_utils.js';
 import {Workflow, WorkflowConfig} from './workflow.js';
 
 /** Options for a {@link WorkflowAgent}. */
@@ -153,7 +156,10 @@ function resumeInputsFromPlainText(
   const text = parts.map((p) => p.text).join('');
 
   const pending = new Set<string>();
-  for (const node of reconstructNodeStates(ic.session?.events ?? []).values()) {
+  // Scoped to the run still in progress: a pause belonging to a run that
+  // already finished is not resumable, and must not swallow the new message.
+  const events = eventsForCurrentRun(ic.session?.events ?? [], ic.invocationId);
+  for (const node of reconstructNodeStates(events).values()) {
     for (const id of node.interruptIds) {
       if (!node.resolvedResponses.has(id)) {
         pending.add(id);

--- a/core/test/workflow/rehydration_scope_test.ts
+++ b/core/test/workflow/rehydration_scope_test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {createEvent, Event} from '../../src/events/event.js';
+import {Runner} from '../../src/runner/runner.js';
+import {InMemorySessionService} from '../../src/sessions/in_memory_session_service.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
+import {RequestInput} from '../../src/workflow/request_input.js';
+import {hasRequestInputFunctionCall} from '../../src/workflow/utils/hitl_utils.js';
+import {eventsForCurrentRun} from '../../src/workflow/utils/rehydration_utils.js';
+import {WorkflowAgent} from '../../src/workflow/workflow_agent.js';
+
+async function drain(gen: AsyncGenerator<Event>): Promise<Event[]> {
+  const out: Event[] = [];
+  for await (const event of gen) {
+    out.push(event);
+  }
+  return out;
+}
+
+function nodeEvent(
+  invocationId: string,
+  path: string,
+  extra: Partial<Event> = {},
+): Event {
+  return createEvent({
+    author: path.split('.').pop(),
+    invocationId,
+    nodeInfo: {path},
+    ...extra,
+  });
+}
+
+describe('eventsForCurrentRun', () => {
+  it('drops a run that already completed', () => {
+    const events = [
+      createEvent({author: 'user', invocationId: 'a'}),
+      nodeEvent('a', 'wf.n1', {output: 'one'}),
+      nodeEvent('a', 'wf.n2', {output: 'two'}),
+      createEvent({author: 'user', invocationId: 'b'}),
+    ];
+    expect(eventsForCurrentRun(events, 'b')).toEqual([events[3]]);
+  });
+
+  it('keeps a run that paused, so resume still sees its outputs', () => {
+    const events = [
+      createEvent({author: 'user', invocationId: 'a'}),
+      nodeEvent('a', 'wf.n1', {output: 'one'}),
+      nodeEvent('a', 'wf.gate', {longRunningToolIds: ['gate-1']}),
+      createEvent({author: 'user', invocationId: 'b'}),
+    ];
+    expect(eventsForCurrentRun(events, 'b')).toEqual(events.slice(1));
+  });
+
+  it('keeps every invocation of a run that paused more than once', () => {
+    const events = [
+      createEvent({author: 'user', invocationId: 'a'}),
+      nodeEvent('a', 'wf.n1', {output: 'one'}),
+      nodeEvent('a', 'wf.gate1', {longRunningToolIds: ['g1']}),
+      createEvent({author: 'user', invocationId: 'b'}),
+      nodeEvent('b', 'wf.n2', {output: 'two'}),
+      nodeEvent('b', 'wf.gate2', {longRunningToolIds: ['g2']}),
+      createEvent({author: 'user', invocationId: 'c'}),
+    ];
+    expect(eventsForCurrentRun(events, 'c')).toEqual(events.slice(1));
+  });
+
+  it('cuts at the last completed run when a completed run precedes a paused one', () => {
+    const events = [
+      createEvent({author: 'user', invocationId: 'a'}),
+      nodeEvent('a', 'wf.n1', {output: 'stale'}),
+      createEvent({author: 'user', invocationId: 'b'}),
+      nodeEvent('b', 'wf.n1', {output: 'one'}),
+      nodeEvent('b', 'wf.gate', {longRunningToolIds: ['g1']}),
+      createEvent({author: 'user', invocationId: 'c'}),
+    ];
+    // Run `a` finished; only the paused run `b` onward may be rehydrated.
+    expect(eventsForCurrentRun(events, 'c')).toEqual(events.slice(3));
+  });
+
+  it('treats an id-less engine event as part of the surrounding invocation', () => {
+    // A RequestInput interrupt is enriched with author/path/branch but no
+    // invocation id; it must not open a run of its own, or the boundary lands
+    // mid-run and already-completed nodes are re-executed.
+    const events = [
+      createEvent({author: 'user', invocationId: 'a'}),
+      nodeEvent('a', 'wf.n1', {output: 'one'}),
+      nodeEvent('', 'wf.gate', {longRunningToolIds: ['gate-1']}),
+      createEvent({author: 'user', invocationId: 'b'}),
+    ];
+    expect(eventsForCurrentRun(events, 'b')).toEqual(events.slice(1));
+  });
+
+  it('passes through when there is nothing earlier to drop', () => {
+    const events = [createEvent({author: 'user', invocationId: 'a'})];
+    expect(eventsForCurrentRun(events, 'a')).toEqual(events);
+    expect(eventsForCurrentRun([], 'a')).toEqual([]);
+  });
+});
+
+describe('workflow re-invocation after completion', () => {
+  it('runs again on the next turn instead of replaying the previous answer', async () => {
+    const runs: string[] = [];
+    const n1 = new FunctionNode('n1', (_c: NodeContext, input: unknown) => {
+      runs.push(`n1(${input})`);
+      return `n1:${input}`;
+    });
+    const n2 = new FunctionNode('n2', (_c: NodeContext, input: unknown) => {
+      runs.push('n2');
+      return `n2:${input}`;
+    });
+
+    const agent = new WorkflowAgent({name: 'wf', edges: [['START', n1, n2]]});
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'app',
+      userId: 'u',
+    });
+    const runner = new Runner({appName: 'app', agent, sessionService});
+
+    const ask = (text: string) =>
+      drain(
+        runner.runAsync({
+          userId: 'u',
+          sessionId: session.id,
+          newMessage: {role: 'user', parts: [{text}]},
+        }),
+      );
+
+    const turn1 = await ask('first');
+    const turn2 = await ask('second');
+
+    // Both nodes execute on both turns, against that turn's own input.
+    expect(runs).toEqual(['n1(first)', 'n2', 'n1(second)', 'n2']);
+    expect(turn1.some((e) => e.output === 'n2:n1:first')).toBe(true);
+    // The second turn must answer the second question, not replay the first.
+    expect(turn2.some((e) => e.output === 'n2:n1:second')).toBe(true);
+    expect(turn2.some((e) => e.output === 'n2:n1:first')).toBe(false);
+  });
+
+  it('still resumes a pause, then starts clean on the turn after it finishes', async () => {
+    const runs: string[] = [];
+    const ask = new FunctionNode(
+      'ask',
+      (ctx: NodeContext) => {
+        runs.push('ask');
+        const reply = ctx.resumeInputs['q'];
+        return reply === undefined
+          ? new RequestInput({interruptId: 'q', message: 'q?'})
+          : `got:${reply}`;
+      },
+      {rerunOnResume: true},
+    );
+    const after = new FunctionNode(
+      'after',
+      (_c: NodeContext, input: unknown) => {
+        runs.push('after');
+        return `after:${input}`;
+      },
+    );
+
+    const agent = new WorkflowAgent({
+      name: 'wf_hitl',
+      edges: [['START', ask, after]],
+    });
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'app',
+      userId: 'u',
+    });
+    const runner = new Runner({appName: 'app', agent, sessionService});
+    const send = (text: string) =>
+      drain(
+        runner.runAsync({
+          userId: 'u',
+          sessionId: session.id,
+          newMessage: {role: 'user', parts: [{text}]},
+        }),
+      );
+
+    // Turn 1 pauses.
+    const turn1 = await send('go');
+    expect(turn1.some(hasRequestInputFunctionCall)).toBe(true);
+    expect(runs).toEqual(['ask']);
+
+    // Turn 2 resumes the SAME run: `ask` re-runs with the reply, `after` runs.
+    const turn2 = await send('yes');
+    expect(turn2.some((e) => e.output === 'after:got:yes')).toBe(true);
+    expect(runs).toEqual(['ask', 'ask', 'after']);
+
+    // Turn 3 is a NEW run: the finished one must not be replayed.
+    const turn3 = await send('again');
+    expect(runs).toEqual(['ask', 'ask', 'after', 'ask']);
+    expect(turn3.some(hasRequestInputFunctionCall)).toBe(true);
+  });
+});

--- a/core/test/workflow/rehydration_scope_test.ts
+++ b/core/test/workflow/rehydration_scope_test.ts
@@ -36,6 +36,27 @@ function nodeEvent(
   });
 }
 
+/**
+ * A node event that paused for a human, shaped like the engine's own: an
+ * `adk_request_input` call whose id is also a long-running tool id (see
+ * `createRequestInputEvent`).
+ */
+function pauseEvent(
+  invocationId: string,
+  path: string,
+  interruptId: string,
+): Event {
+  return nodeEvent(invocationId, path, {
+    content: {
+      role: 'model',
+      parts: [
+        {functionCall: {name: 'adk_request_input', id: interruptId, args: {}}},
+      ],
+    },
+    longRunningToolIds: [interruptId],
+  });
+}
+
 describe('eventsForCurrentRun', () => {
   it('drops a run that already completed', () => {
     const events = [
@@ -51,7 +72,7 @@ describe('eventsForCurrentRun', () => {
     const events = [
       createEvent({author: 'user', invocationId: 'a'}),
       nodeEvent('a', 'wf.n1', {output: 'one'}),
-      nodeEvent('a', 'wf.gate', {longRunningToolIds: ['gate-1']}),
+      pauseEvent('a', 'wf.gate', 'gate-1'),
       createEvent({author: 'user', invocationId: 'b'}),
     ];
     expect(eventsForCurrentRun(events, 'b')).toEqual(events.slice(1));
@@ -61,10 +82,10 @@ describe('eventsForCurrentRun', () => {
     const events = [
       createEvent({author: 'user', invocationId: 'a'}),
       nodeEvent('a', 'wf.n1', {output: 'one'}),
-      nodeEvent('a', 'wf.gate1', {longRunningToolIds: ['g1']}),
+      pauseEvent('a', 'wf.gate1', 'g1'),
       createEvent({author: 'user', invocationId: 'b'}),
       nodeEvent('b', 'wf.n2', {output: 'two'}),
-      nodeEvent('b', 'wf.gate2', {longRunningToolIds: ['g2']}),
+      pauseEvent('b', 'wf.gate2', 'g2'),
       createEvent({author: 'user', invocationId: 'c'}),
     ];
     expect(eventsForCurrentRun(events, 'c')).toEqual(events.slice(1));
@@ -76,7 +97,7 @@ describe('eventsForCurrentRun', () => {
       nodeEvent('a', 'wf.n1', {output: 'stale'}),
       createEvent({author: 'user', invocationId: 'b'}),
       nodeEvent('b', 'wf.n1', {output: 'one'}),
-      nodeEvent('b', 'wf.gate', {longRunningToolIds: ['g1']}),
+      pauseEvent('b', 'wf.gate', 'g1'),
       createEvent({author: 'user', invocationId: 'c'}),
     ];
     // Run `a` finished; only the paused run `b` onward may be rehydrated.
@@ -90,7 +111,50 @@ describe('eventsForCurrentRun', () => {
     const events = [
       createEvent({author: 'user', invocationId: 'a'}),
       nodeEvent('a', 'wf.n1', {output: 'one'}),
-      nodeEvent('', 'wf.gate', {longRunningToolIds: ['gate-1']}),
+      pauseEvent('', 'wf.gate', 'gate-1'),
+      createEvent({author: 'user', invocationId: 'b'}),
+    ];
+    expect(eventsForCurrentRun(events, 'b')).toEqual(events.slice(1));
+  });
+
+  it('drops a completed run that merely used a long-running tool', () => {
+    // `longRunningToolIds` marks any tool declared `isLongRunning`, not only a
+    // HITL pause. A run that called one and then finished is finished, and must
+    // not be kept and fast-forwarded on the next turn.
+    const events = [
+      createEvent({author: 'user', invocationId: 'a'}),
+      nodeEvent('a', 'wf.n1', {
+        output: 'one',
+        longRunningToolIds: ['poll-job-1'],
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'start_job', id: 'poll-job-1'}}],
+        },
+      }),
+      createEvent({author: 'user', invocationId: 'b'}),
+    ];
+    expect(eventsForCurrentRun(events, 'b')).toEqual([events[2]]);
+  });
+
+  it('keeps a run paused on a tool confirmation', () => {
+    const events = [
+      createEvent({author: 'user', invocationId: 'a'}),
+      nodeEvent('a', 'wf.n1', {output: 'one'}),
+      nodeEvent('a', 'wf.act', {
+        longRunningToolIds: ['c1'],
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'adk_request_confirmation',
+                id: 'c1',
+                args: {},
+              },
+            },
+          ],
+        },
+      }),
       createEvent({author: 'user', invocationId: 'b'}),
     ];
     expect(eventsForCurrentRun(events, 'b')).toEqual(events.slice(1));

--- a/core/test/workflow/workflow_advanced_test.ts
+++ b/core/test/workflow/workflow_advanced_test.ts
@@ -224,12 +224,16 @@ describe('workflow — rerunOnResume', () => {
     });
     const wf = new Workflow({name: 'ff', edges: [['START', node]]});
 
+    const ic = createIc();
+    // Belongs to the run in progress (same invocation), so rehydration sees it.
+    // An event left behind by a run that already FINISHED is deliberately
+    // ignored instead — see rehydration_utils_test.ts.
     const priorEvent: Event = createEvent({
       author: 'once',
+      invocationId: ic.invocationId,
       nodeInfo: {path: 'ff.once'},
       output: 'cached',
     });
-    const ic = createIc();
     ic.session.events.push(priorEvent);
 
     const {output} = await driveNode(wf, 'x', ic);

--- a/core/test/workflow/workflow_agent_test.ts
+++ b/core/test/workflow/workflow_agent_test.ts
@@ -23,6 +23,10 @@ function pendingInterruptEvent(id: string): Event {
     new RequestInput({interruptId: id, message: '?'}),
   );
   event.author = id;
+  // The engine stamps the emitting node's path onto every node event; carry it
+  // here too, since run scoping uses it to tell node events from plain
+  // conversation turns.
+  event.nodeInfo = {path: `capture.${id}`};
   return event;
 }
 


### PR DESCRIPTION
## Summary

Re-invoking a workflow that already completed **does not run it**. Every node is fast-forwarded from the previous turn's cached output, so the workflow re-emits its previous answer and the new user message is silently ignored.

Probe on current `main`, a two-node workflow over two turns:

```
RUNS:          ["n1(first)", "n2(n1:first)"]      <- nothing ran on turn 2
turn 1 output: "n2:n1:first"
turn 2 output: "n2:n1:first"                      <- replayed; "second" ignored
```

Any multi-turn conversational workflow answers the first question forever.

## Root cause

Rehydration exists to resume a run that _paused_, but `reconstructNodeStates` was handed **every** event in the session (`workflow.ts:192`), so a finished run looked identical to one waiting to be resumed — cached outputs present, `isFastForwardable` true, every node skipped.

## Why not upstream's fix

`google/adk-python` scopes this by invocation id:

```python
for event in events:
    if invocation_id and event.invocation_id != invocation_id:
      continue
```

That works there because a resumed invocation keeps its id. The TypeScript runner mints a fresh invocation id on **every** turn (`Runner.runAsync`, `runner.ts:299`) — there is no invocation-level resumption. A run that spans a pause therefore covers several invocations, and an id filter discards exactly the outputs resume needs.

Measured, not assumed — porting the filter verbatim fixes the replay bug but breaks four existing tests:

```
FAIL auth_gate_test         > requests credentials, then runs after they are supplied on resume
FAIL dynamic_resume_test    > dedups a completed dynamic node and resumes a waiting one
FAIL resume_test            > resumes an interrupted workflow without re-running completed nodes
FAIL workflow_advanced_test > fast-forwards a completed node that is NOT rerunOnResume
```

## Fix

Delimit runs by **pausing** rather than by invocation id:

- an invocation that raised an interrupt ended paused → part of the run in progress;
- an invocation that emitted node events without raising one ran to completion → it is the boundary, and it and everything earlier is dropped;
- the current invocation is always kept (in progress by definition, and it carries the function responses that resolve pending interrupts).

A pause is an event carrying one of the three `adk_request_*` calls, tested via `requiresUserInput` (#633). Deliberately not `longRunningToolIds`, which marks any tool declared `isLongRunning`: a run that merely used one is not waiting on a person, and counting it as a pause brings the replay bug straight back for those workflows.

`eventsForCurrentRun` applies that at the three places that scan history:

| site                                  | why                                                                                                                                                  |
| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| `workflow.ts` graph rehydration       | the replay bug itself                                                                                                                                |
| `dynamic_node_scheduler.ts`           | same staleness for `ctx.runNode` children                                                                                                            |
| `workflow_agent.ts` plain-text resume | a plain-text resume never writes a resolving `functionResponse`, so a finished run's interrupt stayed "pending" forever and swallowed later messages |

### One subtlety

Engine-minted events carry no invocation id — `createRequestInputEvent` produces an interrupt event that `enrichEvent` stamps with author, path and branch but no id. Left alone it opens a phantom run and the boundary lands mid-run, re-executing completed nodes. The scan carries the last id seen forward. There is a test for it; arguably the underlying gap is that `enrichEvent` should stamp `invocationId` too — happy to do that separately, since it changes event contents.

## Tests

New `core/test/workflow/rehydration_scope_test.ts`:

- unit coverage of `eventsForCurrentRun`: completed run dropped; paused run kept; multi-pause run kept across all its invocations; a completed run _before_ a paused one cut correctly; id-less engine event attributed to its surrounding invocation; empty/no-op input
- a completed run that merely **used a long-running tool** is dropped, and a run paused on **`adk_request_confirmation`** is kept — the two ends of the pause predicate
- the replay regression end-to-end through the `Runner`
- pause → resume → **new** run on the following turn, asserting the finished run is not replayed

Pauses in the fixtures are built the way the engine builds them (`createRequestInputEvent`: an `adk_request_*` call whose id is also a long-running tool id), not as a bare `longRunningToolIds`, which no real event looks like.

Two other fixtures updated to match how real events look: a hand-built prior event now carries the invocation of the run in progress, and a synthetic pending interrupt now carries the `nodeInfo.path` the engine always stamps.

`unit:core` green: 204 files, 2804 tests.

## Stacking

#635 has landed and is merged in here. Independent of #636 (disjoint files).

