### PR TITLE
Fix: encode and validate OpenAPI path parameters in RestApiTool

### DIFF
--- a/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
@@ -217,28 +217,17 @@ function sanitizeSchemaTypes(
  * @throws {Error} If a placeholder has no variable declaring a value for it.
  */
 function resolveServerUrl(server: OpenAPIV3.ServerObject): string {
-  const unresolved: string[] = [];
-  const url = server.url.replace(
-    SERVER_VARIABLE_PATTERN,
-    (placeholder, name: string) => {
-      const variable = server.variables?.[name];
-      const value = variable?.default || variable?.enum?.[0];
-      if (!value) {
-        unresolved.push(name);
-        return placeholder;
-      }
-      return value;
-    },
-  );
-
-  if (unresolved.length > 0) {
-    throw new Error(
-      `Unresolved server URL variable(s) in '${server.url}': ` +
-        `${unresolved.join(', ')}. Declare a default for each under ` +
-        `servers[].variables.`,
-    );
-  }
-  return url;
+  return server.url.replace(SERVER_VARIABLE_PATTERN, (_, name: string) => {
+    const variable = server.variables?.[name];
+    const value = variable?.default || variable?.enum?.[0];
+    if (!value) {
+      throw new Error(
+        `Unresolved server URL variable '${name}' in '${server.url}'. ` +
+          `Declare a default under servers[].variables.`,
+      );
+    }
+    return value;
+  });
 }
 
 /**

--- a/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
@@ -205,6 +205,23 @@ function sanitizeSchemaTypes(
 }
 
 /**
+ * Resolves OpenAPI Server Object variables (`{name}`) in a server URL using
+ * their declared `default` values.
+ *
+ * Placeholders with no matching variable are left as-is so an incomplete spec
+ * still parses; they can no longer be filled in by a path parameter.
+ */
+function resolveServerUrl(server: OpenAPIV3.ServerObject | undefined): string {
+  if (!server?.url) return '';
+  const variables = server.variables;
+  if (!variables) return server.url;
+  return server.url.replace(
+    /\{([^{}]+)\}/g,
+    (placeholder, name: string) => variables[name]?.default ?? placeholder,
+  );
+}
+
+/**
  * Collects and parses all operations defined in the OpenAPI spec document.
  */
 function collectOperations(
@@ -213,7 +230,7 @@ function collectOperations(
 ): ParsedOperation[] {
   const preservePropertyNames = options.preservePropertyNames ?? false;
   const operations: ParsedOperation[] = [];
-  const baseUrl = spec.servers?.[0]?.url || '';
+  const baseUrl = resolveServerUrl(spec.servers?.[0]);
 
   const globalSecurity = spec.security || [];
   let globalSchemeName: string | undefined;

--- a/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
@@ -213,8 +213,7 @@ function sanitizeSchemaTypes(
  */
 function resolveServerUrl(server: OpenAPIV3.ServerObject | undefined): string {
   if (!server?.url) return '';
-  const variables = server.variables;
-  if (!variables) return server.url;
+  const variables = server.variables ?? {};
   return server.url.replace(
     /\{([^{}]+)\}/g,
     (placeholder, name: string) => variables[name]?.default ?? placeholder,

--- a/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
@@ -8,6 +8,9 @@ import {OpenAPIV3} from 'openapi-types';
 import {experimental} from '../../../utils/experimental.js';
 import {ApiParameter, OperationParser} from './operation_parser.js';
 
+/** Matches a `{name}` OpenAPI Server Object variable placeholder. */
+const SERVER_VARIABLE_PATTERN = /\{([^{}]+)\}/g;
+
 const VALID_SCHEMA_TYPES = new Set([
   'array',
   'boolean',
@@ -205,19 +208,37 @@ function sanitizeSchemaTypes(
 }
 
 /**
- * Resolves OpenAPI Server Object variables (`{name}`) in a server URL using
- * their declared `default` values.
+ * Resolves OpenAPI Server Object variables (`{name}`) in a server URL from
+ * their declared `default`, falling back to the first `enum` entry.
  *
- * Placeholders with no matching variable are left as-is so an incomplete spec
- * still parses; they can no longer be filled in by a path parameter.
+ * A placeholder with no declared variable is a spec error: left in place it
+ * becomes a literal `{name}` in the request host.
+ *
+ * @throws {Error} If a placeholder has no variable declaring a value for it.
  */
-function resolveServerUrl(server: OpenAPIV3.ServerObject | undefined): string {
-  if (!server?.url) return '';
-  const variables = server.variables ?? {};
-  return server.url.replace(
-    /\{([^{}]+)\}/g,
-    (placeholder, name: string) => variables[name]?.default ?? placeholder,
+function resolveServerUrl(server: OpenAPIV3.ServerObject): string {
+  const unresolved: string[] = [];
+  const url = server.url.replace(
+    SERVER_VARIABLE_PATTERN,
+    (placeholder, name: string) => {
+      const variable = server.variables?.[name];
+      const value = variable?.default || variable?.enum?.[0];
+      if (!value) {
+        unresolved.push(name);
+        return placeholder;
+      }
+      return value;
+    },
   );
+
+  if (unresolved.length > 0) {
+    throw new Error(
+      `Unresolved server URL variable(s) in '${server.url}': ` +
+        `${unresolved.join(', ')}. Declare a default for each under ` +
+        `servers[].variables.`,
+    );
+  }
+  return url;
 }
 
 /**
@@ -229,7 +250,8 @@ function collectOperations(
 ): ParsedOperation[] {
   const preservePropertyNames = options.preservePropertyNames ?? false;
   const operations: ParsedOperation[] = [];
-  const baseUrl = resolveServerUrl(spec.servers?.[0]);
+  const server = spec.servers?.[0];
+  const baseUrl = server ? resolveServerUrl(server) : '';
 
   const globalSecurity = spec.security || [];
   let globalSchemeName: string | undefined;

--- a/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts
@@ -8,9 +8,6 @@ import {OpenAPIV3} from 'openapi-types';
 import {experimental} from '../../../utils/experimental.js';
 import {ApiParameter, OperationParser} from './operation_parser.js';
 
-/** Matches a `{name}` OpenAPI Server Object variable placeholder. */
-const SERVER_VARIABLE_PATTERN = /\{([^{}]+)\}/g;
-
 const VALID_SCHEMA_TYPES = new Set([
   'array',
   'boolean',
@@ -217,7 +214,7 @@ function sanitizeSchemaTypes(
  * @throws {Error} If a placeholder has no variable declaring a value for it.
  */
 function resolveServerUrl(server: OpenAPIV3.ServerObject): string {
-  return server.url.replace(SERVER_VARIABLE_PATTERN, (_, name: string) => {
+  return server.url.replace(/\{([^{}]+)\}/g, (_, name: string) => {
     const variable = server.variables?.[name];
     const value = variable?.default || variable?.enum?.[0];
     if (!value) {

--- a/core/src/tools/openapi_tool/rest_api_tool.ts
+++ b/core/src/tools/openapi_tool/rest_api_tool.ts
@@ -159,6 +159,28 @@ export interface PreparedParams {
   bodyData: Record<string, unknown>;
 }
 
+/**
+ * Percent-encodes a model-supplied value for substitution into a single URL
+ * path segment.
+ *
+ * Path parameter values come from the LLM and are therefore untrusted. Left
+ * raw, a `/`, `?` or `#` lets the value escape the segment, and the endpoint,
+ * declared by the OpenAPI spec. Values that are exactly `.` or `..` are
+ * rejected rather than encoded, because URL normalization resolves a
+ * percent-encoded dot-segment (`%2E%2E`) exactly like a literal one.
+ *
+ * @throws {Error} If the value is a relative path segment.
+ */
+function encodePathParamValue(name: string, value: string): string {
+  if (value === '.' || value === '..') {
+    throw new Error(
+      `Invalid value for path parameter '${name}': relative path segments ` +
+        `('.' and '..') are not allowed.`,
+    );
+  }
+  return encodeURIComponent(value);
+}
+
 export function prepareRequestParams(
   endpoint: OperationEndpoint,
   parameters: ApiParameter[],
@@ -169,7 +191,10 @@ export function prepareRequestParams(
   let body: unknown = undefined;
 
   const paramsMap = new Map(parameters.map((p) => [p.name, p]));
-  const pathParams: Record<string, string> = {};
+  // A Map, not a plain object: placeholder names come from the spec's path
+  // template, and an object lookup would resolve `{constructor}` against
+  // Object.prototype.
+  const pathParams = new Map<string, string>();
   const bodyData: Record<string, unknown> = {};
 
   for (const [argName, argValue] of Object.entries(args)) {
@@ -180,7 +205,10 @@ export function prepareRequestParams(
     const location = param.paramLocation;
 
     if (location === 'path') {
-      pathParams[originalName] = String(argValue);
+      pathParams.set(
+        originalName,
+        encodePathParamValue(originalName, String(argValue)),
+      );
     } else if (location === 'query') {
       queryParams.append(originalName, String(argValue));
     } else if (location === 'header') {
@@ -198,12 +226,13 @@ export function prepareRequestParams(
     }
   }
 
-  let url = `${endpoint.baseUrl}${endpoint.path}`;
-
-  // Replace path parameters
-  for (const [key, value] of Object.entries(pathParams)) {
-    url = url.replace(`{${key}}`, value);
-  }
+  // Placeholders are resolved against the path only, so a path parameter can
+  // never reach the host.
+  const resolvedPath = endpoint.path.replace(
+    /\{([^{}]+)\}/g,
+    (placeholder, name: string) => pathParams.get(name) ?? placeholder,
+  );
+  let url = `${endpoint.baseUrl}${resolvedPath}`;
 
   // Extract query parameters from path if any
   const urlParts = url.split('?');

--- a/core/src/tools/openapi_tool/rest_api_tool.ts
+++ b/core/src/tools/openapi_tool/rest_api_tool.ts
@@ -191,10 +191,7 @@ export function prepareRequestParams(
   let body: unknown = undefined;
 
   const paramsMap = new Map(parameters.map((p) => [p.name, p]));
-  // A Map, not a plain object: placeholder names come from the spec's path
-  // template, and an object lookup would resolve `{constructor}` against
-  // Object.prototype.
-  const pathParams = new Map<string, string>();
+  const pathParams: Record<string, string> = {};
   const bodyData: Record<string, unknown> = {};
 
   for (const [argName, argValue] of Object.entries(args)) {
@@ -205,9 +202,9 @@ export function prepareRequestParams(
     const location = param.paramLocation;
 
     if (location === 'path') {
-      pathParams.set(
+      pathParams[originalName] = encodePathParamValue(
         originalName,
-        encodePathParamValue(originalName, String(argValue)),
+        String(argValue),
       );
     } else if (location === 'query') {
       queryParams.append(originalName, String(argValue));
@@ -227,10 +224,12 @@ export function prepareRequestParams(
   }
 
   // Placeholders are resolved against the path only, so a path parameter can
-  // never reach the host.
+  // never reach the host. `hasOwn`, because a spec may name a path parameter
+  // `constructor`, which a bare lookup would resolve off Object.prototype.
   const resolvedPath = endpoint.path.replace(
     /\{([^{}]+)\}/g,
-    (placeholder, name: string) => pathParams.get(name) ?? placeholder,
+    (placeholder, name: string) =>
+      Object.hasOwn(pathParams, name) ? pathParams[name] : placeholder,
   );
   let url = `${endpoint.baseUrl}${resolvedPath}`;
 

--- a/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
+++ b/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
@@ -254,4 +254,64 @@ describe('OpenApiSpecParser', () => {
     expect(postOp).toBeDefined();
     expect(postOp?.authScheme?.type).toBe('oauth2');
   });
+
+  describe('server URL resolution', () => {
+    function parseBaseUrl(servers?: OpenAPIV3.ServerObject[]): string {
+      const spec: OpenAPIV3.Document = {
+        openapi: '3.0.0',
+        info: {title: 'Server API', version: '1.0.0'},
+        ...(servers ? {servers} : {}),
+        paths: {
+          '/v1/data': {
+            get: {operationId: 'getData', responses: {}},
+          },
+        },
+      };
+
+      const parsed = new OpenApiSpecParser().parse(spec);
+      expect(parsed.length).toBe(1);
+      return parsed[0].endpoint.baseUrl;
+    }
+
+    it('should resolve server variables from their default values', () => {
+      const baseUrl = parseBaseUrl([
+        {
+          url: 'https://{region}.api.example.com/{version}',
+          variables: {
+            region: {default: 'us-central1'},
+            version: {default: 'v1'},
+          },
+        },
+      ]);
+
+      expect(baseUrl).toBe('https://us-central1.api.example.com/v1');
+    });
+
+    it('should leave a server placeholder literal when no variable is declared', () => {
+      const baseUrl = parseBaseUrl([{url: 'https://{region}.api.example.com'}]);
+
+      expect(baseUrl).toBe('https://{region}.api.example.com');
+    });
+
+    it('should leave an undeclared placeholder literal when other variables resolve', () => {
+      const baseUrl = parseBaseUrl([
+        {
+          url: 'https://{region}.api.{tld}',
+          variables: {region: {default: 'us'}},
+        },
+      ]);
+
+      expect(baseUrl).toBe('https://us.api.{tld}');
+    });
+
+    it('should default the base URL to an empty string when the spec has no servers', () => {
+      expect(parseBaseUrl()).toBe('');
+    });
+
+    it('should use a plain server URL unchanged', () => {
+      expect(parseBaseUrl([{url: 'https://api.example.com'}])).toBe(
+        'https://api.example.com',
+      );
+    });
+  });
 });

--- a/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
+++ b/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
@@ -7,6 +7,7 @@
 import {OpenApiSpecParser} from '@google/adk';
 import {OpenAPIV3} from 'openapi-types';
 import {describe, expect, it} from 'vitest';
+import {prepareRequestParams} from '../../../src/tools/openapi_tool/rest_api_tool.js';
 
 describe('OpenApiSpecParser', () => {
   it('should resolve internal references', () => {
@@ -256,19 +257,34 @@ describe('OpenApiSpecParser', () => {
   });
 
   describe('server URL resolution', () => {
-    function parseBaseUrl(servers?: OpenAPIV3.ServerObject[]): string {
-      const spec: OpenAPIV3.Document = {
+    function serverSpec(
+      servers?: OpenAPIV3.ServerObject[],
+    ): OpenAPIV3.Document {
+      return {
         openapi: '3.0.0',
         info: {title: 'Server API', version: '1.0.0'},
         ...(servers ? {servers} : {}),
         paths: {
           '/v1/data': {
-            get: {operationId: 'getData', responses: {}},
+            get: {
+              operationId: 'getData',
+              parameters: [
+                {
+                  name: 'region',
+                  in: 'path',
+                  required: true,
+                  schema: {type: 'string'},
+                },
+              ],
+              responses: {},
+            },
           },
         },
       };
+    }
 
-      const parsed = new OpenApiSpecParser().parse(spec);
+    function parseBaseUrl(servers?: OpenAPIV3.ServerObject[]): string {
+      const parsed = new OpenApiSpecParser().parse(serverSpec(servers));
       expect(parsed.length).toBe(1);
       return parsed[0].endpoint.baseUrl;
     }
@@ -287,21 +303,68 @@ describe('OpenApiSpecParser', () => {
       expect(baseUrl).toBe('https://us-central1.api.example.com/v1');
     });
 
-    it('should leave a server placeholder literal when no variable is declared', () => {
-      const baseUrl = parseBaseUrl([{url: 'https://{region}.api.example.com'}]);
-
-      expect(baseUrl).toBe('https://{region}.api.example.com');
-    });
-
-    it('should leave an undeclared placeholder literal when other variables resolve', () => {
+    it('should fall back to the first enum entry when the default is empty', () => {
       const baseUrl = parseBaseUrl([
         {
-          url: 'https://{region}.api.{tld}',
-          variables: {region: {default: 'us'}},
+          url: 'https://{region}.api.example.com',
+          variables: {
+            region: {default: '', enum: ['us-central1', 'europe-west1']},
+          },
         },
       ]);
 
-      expect(baseUrl).toBe('https://us.api.{tld}');
+      expect(baseUrl).toBe('https://us-central1.api.example.com');
+    });
+
+    it('should throw naming a placeholder that has no declared variable', () => {
+      expect(() =>
+        parseBaseUrl([{url: 'https://{region}.api.example.com'}]),
+      ).toThrow(/region/);
+    });
+
+    it('should throw when a declared variable supplies no default or enum', () => {
+      expect(() =>
+        parseBaseUrl([
+          {
+            url: 'https://{region}.api.example.com',
+            variables: {region: {default: ''}},
+          },
+        ]),
+      ).toThrow(/region/);
+    });
+
+    it('should throw naming the unresolved placeholder when others resolve', () => {
+      expect(() =>
+        parseBaseUrl([
+          {
+            url: 'https://{region}.api.{tld}',
+            variables: {region: {default: 'us'}},
+          },
+        ]),
+      ).toThrow(
+        "Unresolved server URL variable(s) in 'https://{region}.api.{tld}': " +
+          'tld. Declare a default for each under servers[].variables.',
+      );
+    });
+
+    it('should keep a path parameter off the resolved server host', () => {
+      const parsed = new OpenApiSpecParser().parse(
+        serverSpec([
+          {
+            url: 'https://{region}.api.example.com',
+            variables: {region: {default: 'us-central1'}},
+          },
+        ]),
+      );
+
+      const result = prepareRequestParams(
+        parsed[0].endpoint,
+        parsed[0].parameters,
+        {region: 'evil.attacker.com/'},
+      );
+
+      expect(new URL(result.url).host).toBe('us-central1.api.example.com');
+      expect(result.url).toBe('https://us-central1.api.example.com/v1/data');
     });
 
     it('should default the base URL to an empty string when the spec has no servers', () => {

--- a/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
+++ b/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
@@ -342,8 +342,8 @@ describe('OpenApiSpecParser', () => {
           },
         ]),
       ).toThrow(
-        "Unresolved server URL variable(s) in 'https://{region}.api.{tld}': " +
-          'tld. Declare a default for each under servers[].variables.',
+        "Unresolved server URL variable 'tld' in 'https://{region}.api.{tld}'. " +
+          'Declare a default under servers[].variables.',
       );
     });
 

--- a/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
+++ b/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
@@ -7,7 +7,6 @@
 import {OpenApiSpecParser} from '@google/adk';
 import {OpenAPIV3} from 'openapi-types';
 import {describe, expect, it} from 'vitest';
-import {prepareRequestParams} from '../../../src/tools/openapi_tool/rest_api_tool.js';
 
 describe('OpenApiSpecParser', () => {
   it('should resolve internal references', () => {
@@ -257,34 +256,17 @@ describe('OpenApiSpecParser', () => {
   });
 
   describe('server URL resolution', () => {
-    function serverSpec(
-      servers?: OpenAPIV3.ServerObject[],
-    ): OpenAPIV3.Document {
-      return {
+    function parseBaseUrl(servers?: OpenAPIV3.ServerObject[]): string {
+      const spec: OpenAPIV3.Document = {
         openapi: '3.0.0',
         info: {title: 'Server API', version: '1.0.0'},
         ...(servers ? {servers} : {}),
         paths: {
-          '/v1/data': {
-            get: {
-              operationId: 'getData',
-              parameters: [
-                {
-                  name: 'region',
-                  in: 'path',
-                  required: true,
-                  schema: {type: 'string'},
-                },
-              ],
-              responses: {},
-            },
-          },
+          '/v1/data': {get: {operationId: 'getData', responses: {}}},
         },
       };
-    }
 
-    function parseBaseUrl(servers?: OpenAPIV3.ServerObject[]): string {
-      const parsed = new OpenApiSpecParser().parse(serverSpec(servers));
+      const parsed = new OpenApiSpecParser().parse(spec);
       expect(parsed.length).toBe(1);
       return parsed[0].endpoint.baseUrl;
     }
@@ -345,26 +327,6 @@ describe('OpenApiSpecParser', () => {
         "Unresolved server URL variable 'tld' in 'https://{region}.api.{tld}'. " +
           'Declare a default under servers[].variables.',
       );
-    });
-
-    it('should keep a path parameter off the resolved server host', () => {
-      const parsed = new OpenApiSpecParser().parse(
-        serverSpec([
-          {
-            url: 'https://{region}.api.example.com',
-            variables: {region: {default: 'us-central1'}},
-          },
-        ]),
-      );
-
-      const result = prepareRequestParams(
-        parsed[0].endpoint,
-        parsed[0].parameters,
-        {region: 'evil.attacker.com/'},
-      );
-
-      expect(new URL(result.url).host).toBe('us-central1.api.example.com');
-      expect(result.url).toBe('https://us-central1.api.example.com/v1/data');
     });
 
     it('should default the base URL to an empty string when the spec has no servers', () => {

--- a/core/test/tools/openapi_tool/openapi_toolset_integration_test.ts
+++ b/core/test/tools/openapi_tool/openapi_toolset_integration_test.ts
@@ -4,8 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Context, OpenAPIToolset} from '@google/adk';
+import {
+  AuthCredentialTypes,
+  Context,
+  createSession,
+  InvocationContext,
+  LlmAgent,
+  OpenAPIToolset,
+  PluginManager,
+} from '@google/adk';
 import * as fs from 'fs';
+import {OpenAPIV3} from 'openapi-types';
 import * as path from 'path';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
@@ -122,5 +131,73 @@ describe('OpenAPIToolset Integration', () => {
     expect(result).toEqual({
       error: 'Failed to execute API call: Network error',
     });
+  });
+
+  it('should keep a malicious path argument inside the declared endpoint', async () => {
+    const apiKeyScheme: OpenAPIV3.ApiKeySecurityScheme = {
+      type: 'apiKey',
+      in: 'query',
+      name: 'key',
+    };
+    const spec: OpenAPIV3.Document = {
+      openapi: '3.0.3',
+      info: {title: 'Users API', version: '1.0.0'},
+      servers: [{url: 'https://api.example.com'}],
+      security: [{ApiKeyAuth: []}],
+      paths: {
+        '/v1/users/{user_id}': {
+          get: {
+            operationId: 'getUser',
+            parameters: [
+              {
+                name: 'user_id',
+                in: 'path',
+                required: true,
+                schema: {type: 'string'},
+              },
+            ],
+            responses: {'200': {description: 'ok'}},
+          },
+        },
+      },
+      components: {securitySchemes: {ApiKeyAuth: apiKeyScheme}},
+    };
+    const toolset = new OpenAPIToolset({
+      specStr: JSON.stringify(spec),
+      specType: 'json',
+      authScheme: apiKeyScheme,
+      authCredential: {
+        authType: AuthCredentialTypes.API_KEY,
+        apiKey: 'test-api-key',
+      },
+    });
+    const tools = await toolset.getTools();
+    const getUserTool = tools.find((t) => t.name === 'get_user');
+    if (!getUserTool) expect.fail('get_user tool was not created');
+
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response('{}', {headers: {'content-type': 'application/json'}}),
+    );
+
+    await getUserTool.runAsync({
+      args: {user_id: '../../admin/export'},
+      toolContext: new Context({
+        invocationContext: new InvocationContext({
+          invocationId: 'invocation-1',
+          agent: new LlmAgent({name: 'test_agent'}),
+          session: createSession({id: 'session-1', appName: 'test_app'}),
+          pluginManager: new PluginManager(),
+        }),
+      }),
+    });
+
+    const [calledUrl] = vi.mocked(globalThis.fetch).mock.calls[0];
+    if (typeof calledUrl !== 'string') {
+      expect.fail('fetch was not called with a URL string');
+    }
+    const requestUrl = new URL(calledUrl);
+    expect(requestUrl.host).toBe('api.example.com');
+    expect(requestUrl.pathname).toBe('/v1/users/..%2F..%2Fadmin%2Fexport');
+    expect(requestUrl.searchParams.get('key')).toBe('test-api-key');
   });
 });

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -7,6 +7,7 @@
 import {
   ApiParameter,
   AuthCredential,
+  AuthCredentialTypes,
   Context,
   createRestApiTool,
   RestApiTool,
@@ -14,6 +15,10 @@ import {
 } from '@google/adk';
 import {OpenAPIV3} from 'openapi-types';
 import {afterEach, describe, expect, it, vi} from 'vitest';
+import {
+  applyCredential,
+  createApiKeyScheme,
+} from '../../../src/tools/openapi_tool/auth/auth_helpers.js';
 import {
   prepareRequestBody,
   prepareRequestParams,
@@ -784,6 +789,48 @@ describe('RestApiTool Utilities', () => {
           'http://api.example.com/v1/users/x%3Frole%3Dadmin%26debug%3Dtrue',
         );
         expect(new URL(result.url).searchParams.get('role')).toBeNull();
+        expect([...new URL(result.url).searchParams.keys()]).toEqual([]);
+      });
+
+      it('should not attach the credential to a traversed path', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: '../../admin/export',
+        });
+
+        const withKey = applyCredential(
+          result.url,
+          {},
+          {authType: AuthCredentialTypes.API_KEY, apiKey: 'test-api-key'},
+          createApiKeyScheme('key', 'query'),
+        );
+
+        expect(new URL(withKey).pathname).toBe(
+          '/v1/users/..%2F..%2Fadmin%2Fexport',
+        );
+        expect(new URL(withKey).searchParams.get('key')).toBe('test-api-key');
+      });
+
+      it('should merge declared query parameters with an encoded path value', () => {
+        const parameters: ApiParameter[] = [
+          ...userIdParameters,
+          {
+            name: 'q',
+            originalName: 'q',
+            paramLocation: 'query',
+            paramSchema: {},
+            required: false,
+          },
+        ];
+
+        const result = prepareRequestParams(usersEndpoint, parameters, {
+          user_id: 'a/b',
+          q: 'search term',
+        });
+
+        expect(result.url).toBe(
+          'http://api.example.com/v1/users/a%2Fb?q=search+term',
+        );
+        expect(new URL(result.url).searchParams.get('q')).toBe('search term');
       });
 
       it('should reject a path parameter value that is a relative path segment', () => {
@@ -845,6 +892,49 @@ describe('RestApiTool Utilities', () => {
         });
 
         expect(result.url).toBe('http://api.example.com/v1/users/a%24%26b');
+      });
+
+      it('should encode a space in a path parameter value', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: 'John Doe',
+        });
+
+        expect(result.url).toBe('http://api.example.com/v1/users/John%20Doe');
+      });
+
+      it('should encode non-ASCII characters in a path parameter value', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: 'café',
+        });
+
+        expect(result.url).toBe('http://api.example.com/v1/users/caf%C3%A9');
+      });
+
+      it('should round-trip a value made of reserved characters', () => {
+        const value = "a/b?c#d&e=f%g$&h'i";
+
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: value,
+        });
+
+        expect(result.url).toBe(
+          'http://api.example.com/v1/users/' +
+            "a%2Fb%3Fc%23d%26e%3Df%25g%24%26h'i",
+        );
+        const segment = new URL(result.url).pathname.split('/').pop();
+        if (segment === undefined) expect.fail('the URL had no path segment');
+        expect(decodeURIComponent(segment)).toBe(value);
+      });
+
+      it('should stringify non-string path parameter values', () => {
+        expect(
+          prepareRequestParams(usersEndpoint, userIdParameters, {user_id: 123})
+            .url,
+        ).toBe('http://api.example.com/v1/users/123');
+        expect(
+          prepareRequestParams(usersEndpoint, userIdParameters, {user_id: true})
+            .url,
+        ).toBe('http://api.example.com/v1/users/true');
       });
 
       it('should substitute every occurrence of a repeated path placeholder', () => {

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  ApiParameter,
   AuthCredential,
   Context,
   createRestApiTool,
@@ -743,6 +744,162 @@ describe('RestApiTool Utilities', () => {
 
       expect(result.url).toBe('http://api.example.com/users/123/posts');
       expect(result.headers).toEqual({});
+    });
+
+    describe('path parameter encoding', () => {
+      const usersEndpoint = {
+        baseUrl: 'http://api.example.com',
+        path: '/v1/users/{user_id}',
+        method: 'GET',
+      };
+      const userIdParameters: ApiParameter[] = [
+        {
+          name: 'user_id',
+          originalName: 'user_id',
+          paramLocation: 'path',
+          paramSchema: {},
+          required: true,
+        },
+      ];
+
+      it('should percent-encode path traversal sequences in path parameter values', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: '../../admin/export',
+        });
+
+        expect(result.url).toBe(
+          'http://api.example.com/v1/users/..%2F..%2Fadmin%2Fexport',
+        );
+        expect(new URL(result.url).pathname).toBe(
+          '/v1/users/..%2F..%2Fadmin%2Fexport',
+        );
+      });
+
+      it('should not let a path parameter value smuggle query parameters', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: 'x?role=admin&debug=true',
+        });
+
+        expect(result.url).toBe(
+          'http://api.example.com/v1/users/x%3Frole%3Dadmin%26debug%3Dtrue',
+        );
+        expect(new URL(result.url).searchParams.get('role')).toBeNull();
+      });
+
+      it('should reject a path parameter value that is a relative path segment', () => {
+        expect(() =>
+          prepareRequestParams(usersEndpoint, userIdParameters, {
+            user_id: '..',
+          }),
+        ).toThrow(/relative path segments/);
+      });
+
+      it('should reject a single-dot path parameter value', () => {
+        expect(() =>
+          prepareRequestParams(usersEndpoint, userIdParameters, {
+            user_id: '.',
+          }),
+        ).toThrow(
+          "Invalid value for path parameter 'user_id': relative path " +
+            "segments ('.' and '..') are not allowed.",
+        );
+      });
+
+      it('should not substitute a path parameter into the base URL host', () => {
+        const endpoint = {
+          baseUrl: 'https://{region}.api.example.com',
+          path: '/v1/data',
+          method: 'GET',
+        };
+        const parameters: ApiParameter[] = [
+          {
+            name: 'region',
+            originalName: 'region',
+            paramLocation: 'path',
+            paramSchema: {},
+            required: true,
+          },
+        ];
+
+        const result = prepareRequestParams(endpoint, parameters, {
+          region: 'evil.attacker.com/',
+        });
+
+        expect(result.url).toBe('https://{region}.api.example.com/v1/data');
+        expect(result.url).not.toContain('evil.attacker.com');
+      });
+
+      it('should encode reserved characters in path parameter values', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: 'a b#c&d=e',
+        });
+
+        expect(result.url).toBe(
+          'http://api.example.com/v1/users/a%20b%23c%26d%3De',
+        );
+      });
+
+      it('should not expand dollar patterns from a path parameter value', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: 'a$&b',
+        });
+
+        expect(result.url).toBe('http://api.example.com/v1/users/a%24%26b');
+      });
+
+      it('should substitute every occurrence of a repeated path placeholder', () => {
+        const endpoint = {
+          baseUrl: 'http://api.example.com',
+          path: '/a/{id}/b/{id}',
+          method: 'GET',
+        };
+        const parameters: ApiParameter[] = [
+          {
+            name: 'id',
+            originalName: 'id',
+            paramLocation: 'path',
+            paramSchema: {},
+            required: true,
+          },
+        ];
+
+        const result = prepareRequestParams(endpoint, parameters, {id: '7'});
+
+        expect(result.url).toBe('http://api.example.com/a/7/b/7');
+      });
+
+      it('should leave a path placeholder literal when no argument is supplied', () => {
+        const endpoint = {
+          baseUrl: 'http://api.example.com',
+          path: '/users/{userId}',
+          method: 'GET',
+        };
+
+        const result = prepareRequestParams(endpoint, userIdParameters, {});
+
+        expect(result.url).toBe('http://api.example.com/users/{userId}');
+      });
+
+      it('should not resolve a placeholder from Object.prototype', () => {
+        const endpoint = {
+          baseUrl: 'http://api.example.com',
+          path: '/v1/{constructor}',
+          method: 'GET',
+        };
+
+        const result = prepareRequestParams(endpoint, userIdParameters, {});
+
+        expect(result.url).toBe('http://api.example.com/v1/{constructor}');
+      });
+
+      it('should percent-encode a percent sign in a path parameter value', () => {
+        const result = prepareRequestParams(usersEndpoint, userIdParameters, {
+          user_id: '%2e%2e',
+        });
+
+        expect(result.url).toBe('http://api.example.com/v1/users/%252e%252e');
+        expect(new URL(result.url).pathname).toBe('/v1/users/%252e%252e');
+      });
     });
   });
 

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -10,6 +10,7 @@ import {
   AuthCredentialTypes,
   Context,
   createRestApiTool,
+  OpenApiSpecParser,
   RestApiTool,
   ToolAuthHandler,
 } from '@google/adk';
@@ -874,6 +875,45 @@ describe('RestApiTool Utilities', () => {
 
         expect(result.url).toBe('https://{region}.api.example.com/v1/data');
         expect(result.url).not.toContain('evil.attacker.com');
+      });
+
+      it('should keep a path parameter off a parsed spec\u2019s resolved host', () => {
+        const spec: OpenAPIV3.Document = {
+          openapi: '3.0.0',
+          info: {title: 'Server API', version: '1.0.0'},
+          servers: [
+            {
+              url: 'https://{region}.api.example.com',
+              variables: {region: {default: 'us-central1'}},
+            },
+          ],
+          paths: {
+            '/v1/data': {
+              get: {
+                operationId: 'getData',
+                parameters: [
+                  {
+                    name: 'region',
+                    in: 'path',
+                    required: true,
+                    schema: {type: 'string'},
+                  },
+                ],
+                responses: {},
+              },
+            },
+          },
+        };
+        const parsed = new OpenApiSpecParser().parse(spec);
+
+        const result = prepareRequestParams(
+          parsed[0].endpoint,
+          parsed[0].parameters,
+          {region: 'evil.attacker.com/'},
+        );
+
+        expect(new URL(result.url).host).toBe('us-central1.api.example.com');
+        expect(result.url).toBe('https://us-central1.api.example.com/v1/data');
       });
 
       it('should encode reserved characters in path parameter values', () => {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Fixes: #597

**Problem:**

Values bound to OpenAPI `path` parameters were substituted into the request URL verbatim, with no percent-encoding (`core/src/tools/openapi_tool/rest_api_tool.ts`):

```ts
if (location === 'path') {
  pathParams[originalName] = String(argValue); // no encoding
}
let url = `${endpoint.baseUrl}${endpoint.path}`; // includes the host
for (const [key, value] of Object.entries(pathParams)) {
  url = url.replace(`{${key}}`, value); // raw string substitution
}
```

Those values come from the LLM, and `applyCredential` attaches the application's API key / bearer token to the assembled URL immediately afterwards. This is a defense asymmetry inside a single function: query values in the same loop go through `URLSearchParams`, and the API key goes through `encodeURIComponent` — only path values were raw. The three defects reported in #597 followed, plus a fourth smaller one:

| #   | variant                                                                                                                                    | url before this change                                                                                                                                                                                                          |
| --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | path traversal — `user_id: '../../admin/export'` on `/v1/users/{user_id}`                                                                  | `https://api.example.com/v1/users/../../admin/export`, which `fetch`'s URL parse resolves to `https://api.example.com/admin/export?key=SECRET`                                                                                  |
| 2   | query smuggling — `user_id: 'x?role=admin&debug=true'`                                                                                     | `https://api.example.com/v1/users/x?role=admin&debug=true`; `role`/`debug` are adopted as real query parameters by the `?`-splitting block                                                                                      |
| 3   | SSRF + credential exfiltration — `baseUrl: 'https://{region}.api.example.com'`, `region: 'evil.attacker.com/'`                             | `https://evil.attacker.com/.api.example.com/v1/data?key=SECRET_API_KEY` — the substitution loop ran over the host, and `collectOperations` never resolved OpenAPI Server Object variables, so `{region}` survived into `baseUrl` |
| 4   | `String.replace` with a **string** pattern replaces only the first occurrence and expands `$&` / `` $` `` / `$'` / `$1` in the replacement | a repeated placeholder stayed unsubstituted; a value containing `$&` was corrupted                                                                                                                                              |

**Honest scope statement**: exploiting this requires the model to be steered into emitting the malicious argument, i.e. there is a prompt-injection precondition. This is a defense-in-depth / hardening fix, not a directly-exploitable remote vulnerability. It is nonetheless a concrete encoding gap in a boundary the spec is expected to enforce. #597 records that this was reported to the Google OSS VRP (538901535), that the team declined to track it as a security bug, and that public disclosure was authorized — so there is no embargo on the description above.

**Solution:**

Two source files change (+75 lines of `src`).

`core/src/tools/openapi_tool/rest_api_tool.ts`

- New module-level `encodePathParamValue(name, value)`: `encodeURIComponent` the value, and **reject** a value that is exactly `.` or `..`. Encoding alone is not sufficient for a dot-segment — measured, not assumed: `encodeURIComponent('..')` returns `'..'` unchanged (dots are unreserved), and even a hand-written `%2E%2E` is normalized by the WHATWG URL parser, so `new URL('https://a.com/v1/users/%2E%2E/x').pathname` is `/v1/x`. Conversely a raw `%` becomes `%25` under `encodeURIComponent` (`'%2e%2e'` -> `'%252e%252e'`), so the two exact-string comparisons are complete: no input other than the literal `.`/`..` can re-form a dot-segment. This is deliberately **not** a `../` blocklist — `'../../admin/export'` and `'..%2F'` are accepted and encoded; only the two exact strings a URL parser treats as dot-segments are rejected. The error names the parameter but never echoes the value, which is attacker-influenced and reaches the model and the logs.
- Placeholders are resolved against `endpoint.path` **only**, then concatenated with an untouched `baseUrl`, so a path parameter is structurally incapable of reaching the host. The single regex pass with a **function** replacement also fixes defect 4.
- `pathParams` becomes a `Map`, not a plain object. This is required, not cosmetic: placeholder names come from the spec's path template, and an object lookup would resolve `{constructor}` against `Object.prototype` and substitute a function into the URL.

`core/src/tools/openapi_tool/openapi_spec_parser/openapi_spec_parser.ts`

- New module-level `resolveServerUrl(server)` substitutes Server Object `{name}` variables from their declared `default`, falling back to the first `enum` entry when the default is the empty string. `collectOperations` uses it instead of reading `servers[0].url` verbatim. A placeholder that no declared variable can fill throws from inside the replacer, naming the offending variable and the `servers[].variables` field. It reports the **first** unresolved variable rather than aggregating every one: collecting them all needs an accumulator, a `return placeholder` branch and a trailing check (24 lines against 13) to buy a marginally kinder message in a case no test pins, and a spec author fixing them one re-run at a time reaches the same place.

This second file is **not** separable scope: confining substitution to `endpoint.path` is what fixes variant 3, but on its own it would leave a literal `{region}` in the host for exactly the specs that previously had it filled in by a same-named path parameter — turning a steerable request into a broken one. Resolving the variable from its declared `default` is the spec-compliant way to fill that placeholder, so the two changes have to land together for variant 3 to end up at a working, non-steerable request rather than a malformed URL.

Post-fix results for the three variants from #597:

| variant         | url after                                                                                                                                                                                                                                            |
| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1               | `https://api.example.com/v1/users/..%2F..%2Fadmin%2Fexport` (`new URL(url).pathname === '/v1/users/..%2F..%2Fadmin%2Fexport'`)                                                                                                                       |
| 2               | `https://api.example.com/v1/users/x%3Frole%3Dadmin%26debug%3Dtrue` (`[...new URL(url).searchParams.keys()]` is empty)                                                                                                                                |
| 3               | with `variables: {region: {default: 'us-central1'}}` the parser yields `https://us-central1.api.example.com` and the request stays there; an `endpoint` whose `baseUrl` still holds a literal `{region}` keeps it — `evil.attacker.com` never appears |
| `user_id: '..'` | throws `Error`, no request is sent                                                                                                                                                                                                                   |

**Two intentional behavior changes, both without an opt-out.**

1. _Reserved and sub-delimiter characters in path values are now encoded._ A spec that binds a multi-segment resource name (`projects/p/locations/l`) to a single `{name}` path parameter now produces `projects%2Fp%2Flocations%2Fl` instead of multiple path segments. That is the conformant encoding for a `style: simple` path parameter (`allowReserved` is defined only for `in: query`), and a value that can add path segments is precisely the vulnerability — the spec-side fix is to declare the segments as separate path parameters. This package implements no parameter serialization styles at all today (`String(argValue)` for every type), so no working feature regresses. There is deliberately **no flag to disable the encoding**: a knob that turns it off is a knob that restores the vulnerability. Everything in this package is `@experimental`.
2. _A templated `servers[0].url` with an undeclared variable now throws at toolset construction_ instead of silently issuing a request to a literal `{region}.api.example.com` host. OpenAPI requires every server variable to be declared, so only invalid specs are affected, and those specs were already sending broken requests. Verified that nothing existing starts throwing: no fixture or test in the repo uses a templated server URL (`core/test/tools/openapi_tool/fixtures/petstore.yaml`, `fixtures/truanon.yaml` and `openapi_toolset_test.ts` all use plain hosts), and the full `core/test/tools/openapi_tool/` suite passes.

**Deliberate omission.** _No post-substitution `new URL(...)` host allowlist check_, which is the third remediation bullet in #597. Once placeholders can only land in `endpoint.path` and every value is percent-encoded, a value cannot reach the authority component at all, so such a check would be unreachable defensive code that invites the reader to think the structural guarantee is weaker than it is.

**Not a parity change.** `adk-python` has the identical gap (`_prepare_request_params` uses a plain `str.format`, and its `OpenApiSpecParser` reads `servers[0]['url']` verbatim), so this is net-new behavior relative to Python and no parity claim is made. `adk-python` is untouched here.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

26 new test cases, all additive — no pre-existing test was edited, renamed, skipped or deleted.

- `core/test/tools/openapi_tool/rest_api_tool_test.ts` — new nested `describe('path parameter encoding')` with 17 cases: traversal encoding, query smuggling (asserting the assembled URL carries zero query parameters), the credential still landing on a contained path via `applyCredential` + `createApiKeyScheme`, declared query parameters merging alongside an encoded path value, `..` rejection, `.` rejection (exact message), no substitution into the host, reserved characters, `$&` non-expansion, repeated placeholder, unsupplied placeholder left literal, `{constructor}` not resolved from `Object.prototype`, `%2e%2e` double-encoding, and the positive round-trips — space, non-ASCII (`café` -> `caf%C3%A9`), a value of pure reserved characters asserted to `decodeURIComponent` back verbatim, and non-string (`123`, `true`) values.
- `core/test/tools/openapi_tool/openapi_spec_parser_test.ts` — new `describe('server URL resolution')` with 8 cases: variables resolved from defaults (including two placeholders in one URL), `enum[0]` fallback when the default is empty, a throw naming an undeclared variable, a throw when a declared variable supplies neither default nor enum, a throw naming the unresolved variable when a sibling resolves (exact message), no `servers`, plain URL unchanged, and an end-to-end containment case that parses a templated spec and feeds `parsed[0].endpoint` straight into `prepareRequestParams` with `region: 'evil.attacker.com/'`, asserting `new URL(result.url).host === 'us-central1.api.example.com'`. That case lives here rather than in the integration test because the property it pins is a property of the parser's _output_ — that the `baseUrl` this parser produces cannot be steered by a later path argument — so it reads as `parse` -> `parsed[0].endpoint` -> `prepareRequestParams` with nothing mocked in between.
- `core/test/tools/openapi_tool/openapi_toolset_integration_test.ts` — one case driving spec -> `OpenAPIToolset` -> `RestApiTool.runAsync` -> mocked `fetch`, the only place the encoding, `applyCredential` and the final URL are observed together. It builds a real `Context`/`InvocationContext`/`Session` rather than a cast mock.

Commands run:

```
npx vitest run --project unit:core core/test/tools/openapi_tool/   # 8 files, 108 tests passed
npm run build                                                      # clean
npm run lint                                                       # clean
npm run format:check                                               # clean
npm run docs:check                                                 # clean
npm run test                                                       # full suite, see below
```

`npm run ts:check` is **not** green in this repo and was not made so by this change: it reports 287 errors on `main`, all from test files resolving `@google/adk` to `core/dist/types` after a local build while also importing `core/src` relatively. Every such error in a file this PR touches (`openapi_spec_parser_test.ts:141`, `:172`, `openapi_toolset_integration_test.ts:57`, `:92`) `git blame`s to #385 / #386, not to this branch, and no error references either `src` file this PR changes. `.github/workflows/validation.yaml` does not run `ts:check`.

**Coverage.** `core/src/tools/openapi_tool/rest_api_tool.ts` measures **100% statements / branches / functions / lines**. In `openapi_spec_parser.ts` every statement and branch of the new `resolveServerUrl` and of its `collectOperations` call site is covered (checked per-branch against `coverage-final.json`, not just the file total); the file's only remaining gaps — the `delete schemaDict['type']` line in `sanitizeSchemaTypes` and the `options.preservePropertyNames ?? false` default — are pre-existing and untouched.

**Mutation proof.** Every new test is killed by at least one mutation. Each source hunk was mutated in turn, the suite re-run, and the tree restored (baseline: 108 passed):

| mutation                                                       | result                                                                                                                                                                                                             |
| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| a. `return encodeURIComponent(value)` -> `return value`        | **11 failed** / 97 passed. `expected 'http://api.example.com/v1/users/a b#c…' to be 'http://api.example.com/v1/users/a%20b…'`, and end to end `expected '/admin/export' to be '/v1/users/..%2F..%2Fadmin%2Fexport'` |
| b. substitute over `baseUrl + path` again                      | **1 failed** / 107 passed. `expected 'https://evil.attacker.com%2F.api.exam…' to be 'https://{region}.api.example.com/v1/d…'`                                                                                       |
| c. `resolveServerUrl(...)` -> `spec.servers?.[0]?.url \|\| ''` | **6 failed** / 102 passed. `expected '{region}.api.example.com' to be 'us-central1.api.example.com'`; `expected [Function] to throw an error`                                                                       |
| d. delete the `.`/`..` guard, keep `encodeURIComponent`        | **2 failed** / 106 passed. `expected [Function] to throw an error`                                                                                                                                                 |
| e. drop the `enum` fallback                                    | **1 failed** / 107 passed. `Unresolved server URL variable 'region' in 'https://{region}.api.example.com'.`                                                                                                        |
| f. never throw on an unresolved placeholder                    | **3 failed** / 105 passed. `expected [Function] to throw an error`                                                                                                                                                 |
| g. `Map` -> plain object lookup                                | **1 failed** / 107 passed. `expected 'http://api.example.com/v1/function Ob…' to be 'http://api.example.com/v1/{constructo…'`                                                                                       |
| h. drop the `/g` regex flag                                    | **1 failed** / 107 passed. `expected 'http://api.example.com/a/7/b/{id}' to be 'http://api.example.com/a/7/b/7'`                                                                                                    |

**Manual End-to-End (E2E) Tests:**

No new e2e test: `tests/e2e/tools/rest_api_tool_auth_e2e_test.ts` uses `path: '/test'` with no path parameters, so it is unaffected by this change. It was run and fails at `new Gemini(...)` with `API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable` — it needs live model credentials, which this environment does not have. That failure is environmental and was confirmed to reproduce identically on an unmodified tree.

To reproduce the fix by hand against a real endpoint:

1. Register an `OpenAPIToolset` whose spec declares `servers: [{url: 'https://api.example.com'}]` and a path `/v1/users/{user_id}` with an `apiKey` security scheme.
2. Invoke the generated tool with `user_id = '../../admin/export'`.
3. Before this change the request went to `https://api.example.com/admin/export?key=<your key>`. After it, the request goes to `https://api.example.com/v1/users/..%2F..%2Fadmin%2Fexport?key=<your key>` — still authenticated, still inside the declared endpoint.
4. Invoke it with `user_id = '..'`: the tool now rejects with `Invalid value for path parameter 'user_id': relative path segments ('.' and '..') are not allowed.` and no request is sent. The throw propagates out of `runAsync` and the tool-calling flow converts it into the function-response error the model sees (and fires the plugin `onToolError` hook), so no new try/catch was added.
5. To see change 2, give the spec `servers: [{url: 'https://{region}.api.example.com'}]` with no `variables`: the `OpenAPIToolset` constructor now throws `Unresolved server URL variable 'region' in 'https://{region}.api.example.com'. Declare a default under servers[].variables.` Adding `variables: {region: {default: 'us-central1'}}` resolves it.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
