### PR TITLE
fix(plugins): replay the recorded security decision instead of allowing

### DIFF
--- a/core/src/plugins/security_plugin.ts
+++ b/core/src/plugins/security_plugin.ts
@@ -115,8 +115,11 @@ export class SecurityPlugin extends BasePlugin {
   }): Promise<{[key: string]: unknown} | undefined> {
     const toolCallCheckState = this.getToolCallCheckState(toolContext);
 
-    // We only check the tool call policy ONCE, when the tool call is handled
-    // for the first time.
+    // We only evaluate the tool call policy ONCE, when the tool call is handled
+    // for the first time. Every later evaluation of the same function call id
+    // replays the recorded decision, so each stored decision has to be mapped
+    // back to its own outcome. Anything unrecognised is re-evaluated rather
+    // than allowed, so a decision can never be lost by falling through.
     if (!toolCallCheckState) {
       return this.checkToolCallPolicy({
         tool: tool,
@@ -125,8 +128,34 @@ export class SecurityPlugin extends BasePlugin {
       });
     }
 
-    if (toolCallCheckState !== PolicyOutcome.CONFIRM) {
+    if (toolCallCheckState === PolicyOutcome.ALLOW) {
       return;
+    }
+
+    if (toolCallCheckState === PolicyOutcome.DENY) {
+      return {
+        error: 'This tool call is rejected by policy engine.',
+      };
+    }
+
+    if (isToolConfirmation(toolCallCheckState)) {
+      // The confirmation flow already completed for this call. Replay the
+      // user's answer instead of treating the record as an approval.
+      if (!toolCallCheckState.confirmed) {
+        return {
+          error: 'Tool call rejected from confirmation flow.',
+        };
+      }
+      return;
+    }
+
+    if (toolCallCheckState !== PolicyOutcome.CONFIRM) {
+      // Unrecognised record: re-evaluate rather than proceed on it.
+      return this.checkToolCallPolicy({
+        tool: tool,
+        toolArgs: toolArgs,
+        toolContext: toolContext,
+      });
     }
 
     if (!toolContext.toolConfirmation) {
@@ -211,6 +240,13 @@ export class SecurityPlugin extends BasePlugin {
         return;
     }
   }
+}
+
+/** Narrows a recorded check state to a completed {@link ToolConfirmation}. */
+function isToolConfirmation(
+  state: string | ToolConfirmation,
+): state is ToolConfirmation {
+  return typeof state === 'object' && state !== null && 'confirmed' in state;
 }
 
 /**

--- a/core/test/plugins/security_plugin_replay_test.ts
+++ b/core/test/plugins/security_plugin_replay_test.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseTool} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {Context} from '../../src/agents/context.js';
+import {
+  BasePolicyEngine,
+  PolicyOutcome,
+  SecurityPlugin,
+} from '../../src/plugins/security_plugin.js';
+import {ToolConfirmation} from '../../src/tools/tool_confirmation.js';
+
+function makeToolContext(functionCallId: string) {
+  const stateStore: Record<string, unknown> = {};
+  const toolContext = {
+    functionCallId,
+    state: {
+      get: (key: string) => stateStore[key],
+      set: (key: string, value: unknown) => {
+        stateStore[key] = value;
+      },
+    },
+    toolConfirmation: undefined as ToolConfirmation | undefined,
+    requestConfirmation: () => {},
+  } as unknown as Context;
+  return {toolContext, stateStore};
+}
+
+const tool = {name: 'dangerous_tool'} as BaseTool;
+
+function engine(outcome: string, counter?: {n: number}): BasePolicyEngine {
+  return {
+    evaluate: async () => {
+      if (counter) counter.n++;
+      return {outcome, reason: 'test'};
+    },
+  };
+}
+
+describe('SecurityPlugin — recorded decisions are replayed, not discarded', () => {
+  it('keeps denying a tool call that the policy engine denied', async () => {
+    const calls = {n: 0};
+    const plugin = new SecurityPlugin({
+      policyEngine: engine(PolicyOutcome.DENY, calls),
+    });
+    const {toolContext} = makeToolContext('fc-deny');
+
+    const first = await plugin.beforeToolCallback({
+      tool,
+      toolArgs: {},
+      toolContext,
+    });
+    const second = await plugin.beforeToolCallback({
+      tool,
+      toolArgs: {},
+      toolContext,
+    });
+
+    expect(first).toHaveProperty('error');
+    // Previously the recorded DENY was not CONFIRM, so it fell through to
+    // undefined, which the callback contract treats as "allow execution".
+    expect(second).toHaveProperty('error');
+    expect(calls.n).toBe(1);
+  });
+
+  it('keeps allowing a tool call that the policy engine allowed', async () => {
+    const calls = {n: 0};
+    const plugin = new SecurityPlugin({
+      policyEngine: engine(PolicyOutcome.ALLOW, calls),
+    });
+    const {toolContext} = makeToolContext('fc-allow');
+
+    expect(
+      await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext}),
+    ).toBeUndefined();
+    expect(
+      await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext}),
+    ).toBeUndefined();
+    expect(calls.n).toBe(1);
+  });
+
+  it('keeps rejecting after the user rejected the confirmation', async () => {
+    const plugin = new SecurityPlugin({
+      policyEngine: engine(PolicyOutcome.CONFIRM),
+    });
+    const {toolContext} = makeToolContext('fc-rejected');
+
+    await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext});
+
+    toolContext.toolConfirmation = {confirmed: false} as ToolConfirmation;
+    const rejected = await plugin.beforeToolCallback({
+      tool,
+      toolArgs: {},
+      toolContext,
+    });
+    expect(rejected).toEqual({
+      error: 'Tool call rejected from confirmation flow.',
+    });
+
+    // A later evaluation of the same call must not turn the rejection into an
+    // approval.
+    toolContext.toolConfirmation = undefined;
+    expect(
+      await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext}),
+    ).toEqual({error: 'Tool call rejected from confirmation flow.'});
+  });
+
+  it('stays allowed after the user approved the confirmation', async () => {
+    const plugin = new SecurityPlugin({
+      policyEngine: engine(PolicyOutcome.CONFIRM),
+    });
+    const {toolContext} = makeToolContext('fc-approved');
+
+    await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext});
+
+    toolContext.toolConfirmation = {confirmed: true} as ToolConfirmation;
+    expect(
+      await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext}),
+    ).toBeUndefined();
+
+    toolContext.toolConfirmation = undefined;
+    expect(
+      await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext}),
+    ).toBeUndefined();
+  });
+
+  it('re-evaluates an unrecognised recorded state instead of proceeding on it', async () => {
+    const calls = {n: 0};
+    const plugin = new SecurityPlugin({
+      policyEngine: engine(PolicyOutcome.DENY, calls),
+    });
+    const {toolContext, stateStore} = makeToolContext('fc-garbage');
+
+    stateStore['orcas_tool_call_security_check_states'] = {
+      'fc-garbage': 'NOT_A_REAL_OUTCOME',
+    };
+
+    const result = await plugin.beforeToolCallback({
+      tool,
+      toolArgs: {},
+      toolContext,
+    });
+    expect(result).toHaveProperty('error');
+    expect(calls.n).toBe(1);
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`SecurityPlugin` evaluates the policy engine once per function call id and records
the outcome in session state. Every later evaluation of the same id read that
record with one comparison:

```ts
if (toolCallCheckState !== PolicyOutcome.CONFIRM) {
  return;
}
```

`beforeToolCallback` documents `undefined` as *"allow execution to proceed"*, so
every recorded state other than `CONFIRM` became an allow — including the two
that are refusals:

- a recorded `DENY`, written by `checkToolCallPolicy`, allowed the call;
- a recorded `ToolConfirmation` with `confirmed: false`, written after the user
  **rejected** the confirmation, also allowed the call.

The policy engine is not re-consulted in either case, so the refusal is not just
lost, it is inverted into its opposite. Two details make this reachable rather
than theoretical: the record is stored under a session state key with no `temp:`
prefix, so it persists across turns and is never cleaned up; and the function
call id it is keyed by comes from the model (`functions.ts` reads
`functionCall.id`), so it is not a value the application controls.

Observed with a real `Runner`, `LlmAgent`, `FunctionTool` and a policy engine
that always returns `DENY`, where the tool records each execution:

```
POLICY_EVALUATIONS=1
EXECUTIONS_AFTER_DENIED_TURN1=[]                 # turn 1: denied, tool did not run
EXECUTIONS_AFTER_TURN2=["exfiltrate-secrets"]    # turn 2: same call id, tool ran
```

and for the confirmation path:

```
SECOND_REJECTED={"error":"Tool call rejected from confirmation flow."}
THIRD=undefined                                  # rejection became an allow
```

**Solution:**

Map each recorded state back to its own outcome instead of testing only for
`CONFIRM`:

- `ALLOW` → allow
- `DENY` → deny
- a completed `ToolConfirmation` → replay the user's answer (`confirmed: false`
  denies, `confirmed: true` allows)
- `CONFIRM` → the existing confirmation handling, unchanged
- anything unrecognised → re-evaluate the policy rather than proceed on it, so a
  decision cannot be lost by falling through a comparison again

The happy paths are deliberately untouched: an `ALLOW` still allows without
re-evaluating, and an approved confirmation still proceeds.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
npx vitest run --project unit:core --project unit:dev
Test Files  220 passed (220)
     Tests  3001 passed (3001)
```

New `core/test/plugins/security_plugin_replay_test.ts` covers all five paths: a
denied call stays denied, an allowed call stays allowed, a rejected confirmation
stays rejected, an approved confirmation stays approved, and an unrecognised
record is re-evaluated. The existing `security_plugin_test.ts` passes unchanged.

`npm run ts:check`, `npx eslint` and `npx prettier --check` are clean on both
changed files.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Based on `aee56e07a47df35bece844a91099c8ee760885aa`. Behaviour change worth
flagging for review: a second evaluation of a call id whose recorded state is
`DENY`, or whose confirmation was rejected, now returns the refusal instead of
`undefined`. That is the intended fix, but it is a behaviour change for any
caller that was relying on the previous fall-through.
