### PR TITLE
fix(skills): preserve binary skill assets as Buffer

### DIFF
--- a/core/src/skills/loader.ts
+++ b/core/src/skills/loader.ts
@@ -6,6 +6,7 @@
 
 import AdmZip from 'adm-zip';
 import yaml from 'js-yaml';
+import {isUtf8} from 'node:buffer';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import {logger} from '../utils/logger.js';
@@ -54,6 +55,17 @@ const IGNORED_EXTENSIONS = new Set([
 ]);
 
 /**
+ * Decodes skill resource bytes as UTF-8 text when valid, otherwise keeps the
+ * raw Buffer.
+ *
+ * `Buffer.prototype.toString('utf-8')` never throws on invalid sequences — it
+ * substitutes U+FFFD — so callers must check validity before decoding.
+ */
+function decodeSkillFileContent(data: Buffer): string | Buffer {
+  return isUtf8(data) ? data.toString('utf-8') : data;
+}
+
+/**
  * Recursively loads files from a directory into a dictionary.
  *
  * @param directoryPath - The absolute or relative path of the directory to load.
@@ -82,12 +94,7 @@ async function loadDir(
         }
 
         const fileData = await fs.readFile(fullPath);
-
-        try {
-          files[relativePath] = fileData.toString('utf-8');
-        } catch (_e: unknown) {
-          files[relativePath] = fileData;
-        }
+        files[relativePath] = decodeSkillFileContent(fileData);
       }
     }
   }
@@ -445,11 +452,7 @@ export function loadSkillFromZipBuffer(zipBuffer: Buffer): Skill {
         const relativePath = entry.entryName.substring(normPrefix.length);
         if (!relativePath) continue;
         const data = entry.getData();
-        try {
-          res[relativePath] = data.toString('utf-8');
-        } catch (_e: unknown) {
-          res[relativePath] = data;
-        }
+        res[relativePath] = decodeSkillFileContent(data);
       }
     }
     return res;

--- a/core/test/skills/loader_test.ts
+++ b/core/test/skills/loader_test.ts
@@ -240,8 +240,38 @@ Instructions`,
       expect(skill.resources?.references?.['ref.txt']).toBe(
         'reference content',
       );
+      // File is named .png but contents are valid UTF-8 text, so it stays a string.
       expect(skill.resources?.assets?.['logo.png']).toBe('binary content');
       expect(skill.resources?.scripts?.['run.sh']).toEqual({src: 'echo hello'});
+
+      await fs.rm(tempDir, {recursive: true, force: true});
+    });
+
+    it('keeps non-UTF-8 binary assets as Buffer', async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk-skill-test-'));
+      const skillDir = path.join(tempDir, 'test-skill');
+      await fs.mkdir(skillDir);
+      await fs.mkdir(path.join(skillDir, 'assets'));
+
+      await fs.writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: test-skill
+description: A test skill
+---
+Instructions`,
+      );
+
+      // Minimal PNG signature bytes — invalid UTF-8, must not be stringified.
+      const pngBytes = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xd8,
+      ]);
+      await fs.writeFile(path.join(skillDir, 'assets', 'logo.png'), pngBytes);
+
+      const skill = await loadSkillFromDir(skillDir);
+      const asset = skill.resources?.assets?.['logo.png'];
+      expect(Buffer.isBuffer(asset)).toBe(true);
+      expect(asset).toEqual(pngBytes);
 
       await fs.rm(tempDir, {recursive: true, force: true});
     });
@@ -610,6 +640,20 @@ Instruction body`;
       expect(skill.resources?.references?.['ref1.md']).toBe('ref content');
       expect(skill.resources?.assets?.['a.txt']).toBe('asset content');
       expect(skill.resources?.scripts?.['run.sh']?.src).toBe('echo hello');
+    });
+
+    it('keeps non-UTF-8 binary assets as Buffer', () => {
+      const pngBytes = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xd8,
+      ]);
+      const zip = new AdmZip();
+      zip.addFile('SKILL.md', Buffer.from(validSkillMd, 'utf-8'));
+      zip.addFile('assets/logo.png', pngBytes);
+
+      const skill = loadSkillFromZipBuffer(zip.toBuffer());
+      const asset = skill.resources?.assets?.['logo.png'];
+      expect(Buffer.isBuffer(asset)).toBe(true);
+      expect(asset).toEqual(pngBytes);
     });
 
     it.each([


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #643

**2. Or, if no issue exists, describe the change:**

**Problem:**
`loadDir` / `loadZipDir` tried to keep binary skill resources as `Buffer` via `try { data.toString('utf-8') } catch { data }`. In Node.js, `Buffer.prototype.toString('utf-8')` never throws on invalid sequences — it substitutes `U+FFFD` — so the catch path was dead and binary assets were stored as corrupted strings. That breaks `LoadSkillResourceTool`'s `Buffer.isBuffer` path, which is what injects binary content as `inlineData`.

**Solution:**
Decode with `isUtf8` from `node:buffer`: valid UTF-8 becomes a string; everything else stays a `Buffer`. Shared helper used by both directory and zip loaders. Text skill resources are unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary: `npx vitest run --project unit:core core/test/skills/loader_test.ts` — 49 passed (includes new coverage for PNG-signature bytes via `loadSkillFromDir` and `loadSkillFromZipBuffer`).

Also ran `npx eslint` / `npx prettier --check` on the touched files.

**Manual End-to-End (E2E) Tests:**

1. Create a skill with `assets/logo.png` containing real PNG bytes.
2. `loadSkillFromDir` / `loadSkillFromZipBuffer` — `resources.assets['logo.png']` is a `Buffer`.
3. `load_skill_resource` for that path returns the binary-detected status (not mangled UTF-8 text).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Scoped to the skill loader decode path only. No packaging / CLI / unrelated changes.