### PR TITLE
fix(agents): keep usage metadata from content-less streaming responses

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -971,11 +971,28 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
     // =========================================================================
     // Builds the merged model response event
     // =========================================================================
+    // A response with NO content that carries usageMetadata is the stream
+    // aggregator's end-of-turn usage report, not an absent model response. In
+    // SSE streaming, close() reports a turn's token counts this way whenever the
+    // turn's parts were already yielded (i.e. any turn ending in a tool call),
+    // so skipping it loses that turn's usage entirely -- silently, because
+    // downstream "no usage reported" and "zero tokens used" are the same value.
+    //
+    // Deliberately narrow: this covers `content === undefined` ONLY. A response
+    // with an empty PARTS ARRAY stays suppressed, because emitting one puts
+    // `content: {parts: []}` into session history and Vertex then rejects the
+    // NEXT request with HTTP 400 (#21, #22). A content-less event carries no
+    // such content, and buildContents() skips events without `content.role`, so
+    // it never enters history at all.
+    const isUsageOnlyReport =
+      !llmResponse.content && !!llmResponse.usageMetadata;
+
     // If no model response, skip.
     if (
       (!llmResponse.content || llmResponse.content.parts?.length === 0) &&
       !llmResponse.errorCode &&
-      !llmResponse.interrupted
+      !llmResponse.interrupted &&
+      !isUsageOnlyReport
     ) {
       return;
     }

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -1059,3 +1059,87 @@ describe('LlmAgent outputSchema with tools', () => {
     expect(sessionAfterTurn2?.state?.['probe_counter']).toBe(2);
   });
 });
+
+describe('LlmAgent usage metadata on content-less responses', () => {
+  let agent: LlmAgent;
+  let invocationContext: InvocationContext;
+
+  beforeEach(() => {
+    agent = new LlmAgent({name: 'usage_test_agent'});
+    const mockState = {
+      hasDelta: () => false,
+      get: () => undefined,
+      set: () => {},
+    };
+    invocationContext = new InvocationContext({
+      invocationId: 'inv_usage',
+      session: {
+        id: 'sess_usage',
+        state: mockState,
+        events: [],
+      } as unknown as Session,
+      agent,
+      pluginManager: new PluginManager(),
+    });
+  });
+
+  async function runAndCollect(): Promise<Event[]> {
+    const events: Event[] = [];
+    for await (const event of agent.runAsync(invocationContext)) {
+      events.push(event);
+    }
+    return events;
+  }
+
+  // In SSE streaming, StreamingResponseAggregator.close() reports a turn's
+  // token counts on a response with no content, because the turn's parts were
+  // already yielded. Skipping it loses that turn's usage entirely, and the loss
+  // is silent: downstream, "no usage reported" and "zero tokens used" are the
+  // same value.
+  it('emits an event for a response that carries only usage metadata', async () => {
+    const response: LlmResponse = {
+      usageMetadata: {
+        promptTokenCount: 1234,
+        candidatesTokenCount: 56,
+        totalTokenCount: 1290,
+      },
+    };
+    agent.model = new MockLlm(response);
+
+    const events = await runAndCollect();
+
+    expect(events.length).toBeGreaterThan(0);
+    const usageEvent = events.find((e) => e.usageMetadata);
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent!.usageMetadata?.promptTokenCount).toEqual(1234);
+    expect(usageEvent!.usageMetadata?.candidatesTokenCount).toEqual(56);
+  });
+
+  // The event must NOT carry an empty parts array. That is what poisoned
+  // session history and made Vertex reject the following request with HTTP 400
+  // (#21, #22); buildContents() skips events without `content.role`, so an
+  // undefined content keeps the usage out of history while still delivering it.
+  it('does not emit empty-parts content alongside the usage', async () => {
+    const response: LlmResponse = {
+      usageMetadata: {promptTokenCount: 10, totalTokenCount: 10},
+    };
+    agent.model = new MockLlm(response);
+
+    const events = await runAndCollect();
+
+    const usageEvent = events.find((e) => e.usageMetadata);
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent!.content?.parts).toBeUndefined();
+    expect(usageEvent!.content?.role).toBeUndefined();
+  });
+
+  // Control: without usage metadata the guard must still skip, or the fix would
+  // start emitting events for genuinely empty responses.
+  it('still skips a response with neither content nor usage metadata', async () => {
+    agent.model = new MockLlm({} as LlmResponse);
+
+    const events = await runAndCollect();
+
+    expect(events.find((e) => e.usageMetadata)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #645.

## Problem

In SSE streaming, `usageMetadata` never reaches an `Event` for any turn that **ends in a function call**. Token counts read as zero, so cost tracking, budget enforcement and quota accounting all see a free run.

`StreamingResponseAggregator.close()` reports a turn's token counts on a response with **no content**, because the turn's parts were already yielded. `postprocess()` then skips any response lacking content, and the usage goes with it.

It fails silently by construction: downstream, "no usage reported" and "zero tokens used" are the same value once a number reaches a cost gate.

Observed on a production pipeline over 60 days — `gemini-3.5-flash` reported 0 input, 0 output and $0.00 on **7/7 sessions** including every one that succeeded, while `gemini-2.5-pro` on the identical code path reported correctly on **202/202** successful sessions. 2.5-pro is unaffected because it carries usage on a parts-bearing chunk rather than a trailing usage-only one.

## The fix, and why it is narrow

```ts
const isUsageOnlyReport = !llmResponse.content && !!llmResponse.usageMetadata;
```

It covers **`content === undefined` only**. A response with an empty *parts array* stays suppressed.

That distinction is the whole safety argument. Emitting an empty-parts content object puts `content: {parts: []}` into session history, and Vertex then rejects the **next** request with HTTP 400 — the regression #450 and #485 exist to prevent (#21, #22). A content-less event carries no such content, and `buildContents()` already skips events without `content.role`, so it never enters history at all.

I first tried the broader form (`!llmResponse.usageMetadata` on the guard) and it **broke #450's test** — correctly. That failure is what identified the narrower boundary.

## Testing

- **Full `unit:core` suite: 2748/2748 pass.**
- **`should not yield an event when LLM response has empty parts array` (#450) passes unchanged** — the guard on the boundary above.
- Three tests added:
  - emits an event for a usage-only response *(fails without the fix)*
  - does not emit empty-parts content alongside the usage *(fails without the fix)*
  - control: a response with neither content nor usage is still skipped *(passes either way — it pins behaviour that must not change)*
- Verified by reverting the one-line change and rebuilding: the two new tests fail, the control does not.
- `eslint` clean.

## Context

Three individually-correct changes compose into this, all first shipped in 1.4.0:

| PR | effect |
|---|---|
| #426 | added the empty-STOP-chunk early return; its description correctly noted metadata was *still* delivered via `close()` — true when written |
| #450 | added `\|\| llmResponse.content.parts?.length === 0` to this guard |
| #485 | made `close()` emit `content: undefined`, so the `!llmResponse.content` arm now matches |

Disclosure: #485 is mine. This is a follow-up to it, not a criticism of it — it fixed a real and more serious bug, and the interaction was genuinely hard to see.

## Related, not included here

`streaming_utils.ts` has an unguarded `this.usageMetadata = llmResponse.usageMetadata` (the sibling assignment on the early-return path *is* guarded), so a later chunk carrying no usage erases usage from an earlier one. `adk-python` fixed exactly this in `aebb2a13b`. Left out of this PR to keep it to one change; happy to send it separately if wanted.
