### PR TITLE
fix(tests): keep a prompt change from breaking every workflow sample

### DIFF
--- a/tests/integration/workflows/_harness/record_replay_model.ts
+++ b/tests/integration/workflows/_harness/record_replay_model.ts
@@ -16,12 +16,12 @@
  * - Replay (default): each model call is matched to a recorded response by a
  *   stable fingerprint of its request (contents + config) — exact,
  *   concurrency- and order-independent, so parallel samples need no special
- *   casing. On a miss the match degrades a step at a time (see
- *   {@link installRecordReplay}): a request whose system instruction alone has
- *   changed since it was recorded still matches, but is then served in
- *   recording order and warns. A miss on every key throws with a re-record hint.
+ *   casing. On a miss the match degrades once: a request whose system
+ *   instruction alone has changed since it was recorded still matches, but is
+ *   then served in recording order and warns. A miss on both keys throws with a
+ *   re-record hint.
  * - Record (`RECORD_MODEL_RESPONSES=1`): the call is delegated to a real Gemini
- *   and the raw response is captured under the same fingerprints.
+ *   and the raw response is captured under both fingerprints.
  */
 
 import type {BaseLlmConnection, LlmRequest, LlmResponse} from '@google/adk';
@@ -37,25 +37,15 @@ export interface RecordedCall {
   /**
    * Fallback fingerprint over everything but the system instruction (see
    * {@link instructionAgnosticFingerprint}), used when a prompt change
-   * invalidates {@link key}. Absent on fixtures recorded before it existed.
+   * invalidates {@link key}.
    */
-  instructionAgnosticKey?: string;
+  instructionAgnosticKey: string;
   /**
-   * Last-resort fingerprint over the contents alone (see
-   * {@link contentsFingerprint}). Only consulted for fixtures that predate
-   * {@link instructionAgnosticKey} and so never recorded their `config`; see
-   * {@link installRecordReplay}.
+   * The request both keys were taken over: readable when debugging a fixture,
+   * and enough to re-derive the keys offline should the fingerprints ever have
+   * to change, without a re-record.
    */
-  contentsKey?: string;
-  /**
-   * The request, for debugging the fixture and for deriving keys offline if the
-   * fingerprints ever have to change again (which is how `contentsKey` was
-   * added to existing fixtures without re-recording them).
-   *
-   * `systemInstruction` is the legacy form: fixtures recorded before `config`
-   * was stored kept only that one field of it.
-   */
-  request: {contents: unknown; config?: unknown; systemInstruction?: unknown};
+  request: {contents: unknown; config: unknown};
   /** The raw response to replay. */
   response: RawGenerateContentResponse;
 }
@@ -75,8 +65,6 @@ interface HarnessState {
   exact: Map<string, ReplayEntry>;
   /** Fallback index: everything but the system instruction. */
   byRequest: Map<string, ReplayEntry>;
-  /** Last-resort index: contents only, for fixtures that recorded no config. */
-  byContents: Map<string, ReplayEntry>;
   /** Backend used in record mode (default: a real Gemini). Overridable in tests. */
   liveBackend: (model: string) => BaseLlm;
 }
@@ -132,6 +120,17 @@ function hash(material: unknown): string {
 }
 
 /**
+ * Drops the caller's `AbortSignal`: a live handle rather than request data,
+ * which serializes to `{}` and so tells no two calls apart anyway.
+ */
+function normalizeConfig(
+  config: LlmRequest['config'],
+): Record<string, unknown> {
+  const {abortSignal: _signal, ...rest} = config ?? {};
+  return rest;
+}
+
+/**
  * Exact fingerprint of a model request: contents + config, id-normalized.
  *
  * `config` carries the system instruction, so this is deliberately sensitive to
@@ -142,7 +141,7 @@ function hash(material: unknown): string {
 export function fingerprint(req: LlmRequest): string {
   return hash({
     contents: normalizeContents(req.contents),
-    config: req.config ?? {},
+    config: normalizeConfig(req.config),
   });
 }
 
@@ -163,22 +162,10 @@ export function fingerprint(req: LlmRequest): string {
  * guarantee. Hitting this path warns and asks for a re-record.
  */
 export function instructionAgnosticFingerprint(req: LlmRequest): string {
-  const {systemInstruction: _instruction, ...config} = req.config ?? {};
+  const {systemInstruction: _instruction, ...config} = normalizeConfig(
+    req.config,
+  );
   return hash({contents: normalizeContents(req.contents), config});
-}
-
-/**
- * Last-resort fingerprint over the request's contents alone.
- *
- * For fixtures recorded before {@link instructionAgnosticFingerprint} existed:
- * they stored no `config`, so contents are all that can be matched on once the
- * prompt has moved. Weaker than the key above in exactly the way that key was
- * introduced to avoid — `tools` and `responseSchema` go unchecked, so a
- * regression dropping either still replays green — and the warning says so.
- * This tier retires with the last un-re-recorded fixture.
- */
-export function contentsFingerprint(contents: unknown): string {
-  return hash({contents: normalizeContents(contents)});
 }
 
 /** Reconstructs the raw response shape the fixture stores from an LlmResponse. */
@@ -207,41 +194,29 @@ function toLlmResponse(raw: RawGenerateContentResponse): LlmResponse {
   };
 }
 
-/** How closely a replayed request matched what was recorded. */
-type MatchTier = 'exact' | 'instructionAgnostic' | 'contents';
-
 interface Match {
   entry: ReplayEntry;
-  tier: MatchTier;
-  /** The key that matched, named in the warning for a degraded tier. */
-  matchedKey: string;
+  /**
+   * Set when only the fallback key matched, naming it for the warning; absent
+   * on an exact match.
+   */
+  staleKey?: string;
 }
 
-/**
- * Finds the recorded responses for a request, degrading a tier at a time (see
- * {@link installRecordReplay} for what populates each index).
- */
+/** Finds the recorded responses for a request, exactly or by the fallback key. */
 function lookup(
   s: HarnessState,
-  keys: {key: string; instructionAgnosticKey: string; contentsKey: string},
+  keys: {key: string; instructionAgnosticKey: string},
 ): Match | undefined {
   const exact = s.exact.get(keys.key);
   if (exact) {
-    return {entry: exact, tier: 'exact', matchedKey: keys.key};
+    return {entry: exact};
   }
   // The prompt moved under the fixture: match on everything else, so one
   // instruction edit does not take out every sample at once.
   const byRequest = s.byRequest.get(keys.instructionAgnosticKey);
   if (byRequest) {
-    return {
-      entry: byRequest,
-      tier: 'instructionAgnostic',
-      matchedKey: keys.instructionAgnosticKey,
-    };
-  }
-  const byContents = s.byContents.get(keys.contentsKey);
-  if (byContents) {
-    return {entry: byContents, tier: 'contents', matchedKey: keys.contentsKey};
+    return {entry: byRequest, staleKey: keys.instructionAgnosticKey};
   }
   return undefined;
 }
@@ -268,26 +243,20 @@ class RecordReplayModel extends BaseLlm {
     const instructionAgnosticKey = instructionAgnosticFingerprint(llmRequest);
 
     if (state.mode === 'replay') {
-      const contentsKey = contentsFingerprint(llmRequest.contents);
-      const match = lookup(state, {
-        key,
-        instructionAgnosticKey,
-        contentsKey,
-      });
+      const match = lookup(state, {key, instructionAgnosticKey});
       if (!match) {
         // This throw is easy to lose: the caller can swallow it and the failure
         // then surfaces far away, as a node reading a property of `undefined`.
-        // Say it once on stderr where it happens, with every key that missed.
+        // Say it once on stderr where it happens, with both keys that missed.
         const message =
           `No recorded model response for request ${key} (minus instruction ` +
-          `${instructionAgnosticKey}, contents ${contentsKey}). ` +
-          'Re-record with: npm run record:samples';
+          `${instructionAgnosticKey}). Re-record with: npm run record:samples`;
         console.error(`[sample-harness] ${message}`);
         throw new Error(message);
       }
-      const {entry, tier} = match;
-      if (tier !== 'exact') {
-        warnStaleFixture(tier, match.matchedKey, entry.responses.length);
+      const {entry, staleKey} = match;
+      if (staleKey) {
+        warnStaleFixture(staleKey, entry.responses.length);
       }
       // Deterministic: identical requests reuse the last recorded response.
       const raw =
@@ -298,6 +267,17 @@ class RecordReplayModel extends BaseLlm {
     }
 
     // Record: delegate to a real backend and capture the raw response.
+    //
+    // Snapshot the request first. A backend may edit it on the way out —
+    // `Gemini.preprocessRequest` clears `config.labels` on the Gemini API path
+    // — and a fixture whose stored request is not the one its keys were taken
+    // over could not re-derive them.
+    const request = {
+      contents: normalizeContents(llmRequest.contents),
+      // Kept whole (system instruction included) so both keys can be
+      // re-derived offline should the fingerprints have to change again.
+      config: normalizeConfig(llmRequest.config),
+    };
     const backend = state.liveBackend(this.model);
     for await (const resp of backend.generateContentAsync(
       llmRequest,
@@ -307,12 +287,7 @@ class RecordReplayModel extends BaseLlm {
       state.recorded.push({
         key,
         instructionAgnosticKey,
-        request: {
-          contents: normalizeContents(llmRequest.contents),
-          // Stored whole (system instruction included) so both keys can be
-          // re-derived offline should the fingerprints have to change again.
-          config: llmRequest.config ?? {},
-        },
+        request,
         response: toRaw(resp),
       });
       yield resp;
@@ -328,12 +303,10 @@ class RecordReplayModel extends BaseLlm {
  * Installs the record/replay model into the LLM registry and sets the mode.
  * Call once per test run (before the runner executes).
  *
- * Builds the indexes {@link lookup} consults, in order of decreasing strictness.
- * A call joins the contents-only index *instead of* the instruction-agnostic
- * one, never as well: that last tier is a migration path for fixtures whose
- * `config` was never recorded, and offering it to a fixture that has one would
- * hand back the very coverage — `tools`, `responseSchema` — the middle tier
- * exists to keep.
+ * Builds the two indexes {@link lookup} consults. A fixture written before both
+ * keys existed lands in neither under a key any request can produce, so it
+ * misses and says to re-record — deliberately, rather than matching on
+ * something loose enough to hide a dropped tool or `responseSchema`.
  */
 export function installRecordReplay(opts: {
   mode: Mode;
@@ -342,7 +315,6 @@ export function installRecordReplay(opts: {
 }): void {
   const exact = new Map<string, ReplayEntry>();
   const byRequest = new Map<string, ReplayEntry>();
-  const byContents = new Map<string, ReplayEntry>();
   const index = (map: Map<string, ReplayEntry>, key: string): ReplayEntry => {
     const entry = map.get(key) ?? {responses: [], cursor: 0};
     map.set(key, entry);
@@ -350,17 +322,7 @@ export function installRecordReplay(opts: {
   };
   for (const call of opts.recordedCalls ?? []) {
     index(exact, call.key).responses.push(call.response);
-    if (call.instructionAgnosticKey) {
-      index(byRequest, call.instructionAgnosticKey).responses.push(
-        call.response,
-      );
-    } else {
-      // Recorded before the config was fingerprinted, so the contents are all
-      // that survives a prompt change; recomputed for fixtures older still.
-      const contentsKey =
-        call.contentsKey ?? contentsFingerprint(call.request.contents);
-      index(byContents, contentsKey).responses.push(call.response);
-    }
+    index(byRequest, call.instructionAgnosticKey).responses.push(call.response);
   }
   warnedStaleKeys.clear();
   state = {
@@ -368,7 +330,6 @@ export function installRecordReplay(opts: {
     recorded: [],
     exact,
     byRequest,
-    byContents,
     liveBackend: opts.liveBackend ?? ((model: string) => new Gemini({model})),
   };
   LLMRegistry.register(RecordReplayModel);
@@ -377,11 +338,7 @@ export function installRecordReplay(opts: {
 /** Fallback keys already reported stale this run, so each is warned about once. */
 const warnedStaleKeys = new Set<string>();
 
-function warnStaleFixture(
-  tier: Exclude<MatchTier, 'exact'>,
-  matchedKey: string,
-  candidates: number,
-): void {
+function warnStaleFixture(matchedKey: string, candidates: number): void {
   if (warnedStaleKeys.has(matchedKey)) {
     return;
   }
@@ -391,18 +348,11 @@ function warnStaleFixture(
       ? ` ${candidates} recorded calls share this key, so they are being ` +
         'served in recording order — which a concurrent sample does not guarantee.'
       : '';
-  const what =
-    tier === 'instructionAgnostic'
-      ? `matched request ${matchedKey} on everything but its system ` +
-        'instruction, so the prompt has changed since it was recorded.'
-      : `matched request contents ${matchedKey} but not its config, so the ` +
-        'prompt has changed since it was recorded. This fixture predates ' +
-        'config fingerprinting and stored no config, so its tools and ' +
-        'response schema go unverified here — dropping either would still ' +
-        'replay green.';
   console.warn(
-    `[sample-harness] Stale fixture: ${what} Replaying anyway.${ambiguity} ` +
-      'Refresh with: npm run record:samples',
+    `[sample-harness] Stale fixture: matched request ${matchedKey} on ` +
+      'everything but its system instruction, so the prompt has changed since ' +
+      `it was recorded. Replaying anyway.${ambiguity} Refresh with: ` +
+      'npm run record:samples',
   );
 }
 

--- a/tests/integration/workflows/_harness/record_replay_model.ts
+++ b/tests/integration/workflows/_harness/record_replay_model.ts
@@ -14,10 +14,14 @@
  * closure that static traversal can't reach — resolves to it.
  *
  * - Replay (default): each model call is matched to a recorded response by a
- *   stable fingerprint of its request. Concurrency- and order-independent, so
- *   parallel samples need no special casing. A miss throws with a re-record hint.
+ *   stable fingerprint of its request (contents + config) — exact,
+ *   concurrency- and order-independent, so parallel samples need no special
+ *   casing. On a miss the match degrades a step at a time (see
+ *   {@link installRecordReplay}): a request whose system instruction alone has
+ *   changed since it was recorded still matches, but is then served in
+ *   recording order and warns. A miss on every key throws with a re-record hint.
  * - Record (`RECORD_MODEL_RESPONSES=1`): the call is delegated to a real Gemini
- *   and the raw response is captured keyed by the same fingerprint.
+ *   and the raw response is captured under the same fingerprints.
  */
 
 import type {BaseLlmConnection, LlmRequest, LlmResponse} from '@google/adk';
@@ -31,13 +35,27 @@ export interface RecordedCall {
   /** Exact fingerprint of the request: contents + config (see {@link fingerprint}). */
   key: string;
   /**
-   * Fallback fingerprint over the request's contents alone (see
-   * {@link contentsFingerprint}), used when a prompt change invalidates
-   * {@link key}.
+   * Fallback fingerprint over everything but the system instruction (see
+   * {@link instructionAgnosticFingerprint}), used when a prompt change
+   * invalidates {@link key}. Absent on fixtures recorded before it existed.
+   */
+  instructionAgnosticKey?: string;
+  /**
+   * Last-resort fingerprint over the contents alone (see
+   * {@link contentsFingerprint}). Only consulted for fixtures that predate
+   * {@link instructionAgnosticKey} and so never recorded their `config`; see
+   * {@link installRecordReplay}.
    */
   contentsKey?: string;
-  /** A readable snippet of the request, for debugging the fixture. */
-  request: {contents: unknown; systemInstruction?: unknown};
+  /**
+   * The request, for debugging the fixture and for deriving keys offline if the
+   * fingerprints ever have to change again (which is how `contentsKey` was
+   * added to existing fixtures without re-recording them).
+   *
+   * `systemInstruction` is the legacy form: fixtures recorded before `config`
+   * was stored kept only that one field of it.
+   */
+  request: {contents: unknown; config?: unknown; systemInstruction?: unknown};
   /** The raw response to replay. */
   response: RawGenerateContentResponse;
 }
@@ -54,8 +72,10 @@ interface HarnessState {
   mode: Mode;
   recorded: RecordedCall[];
   /** Exact index: contents + config. */
-  replay: Map<string, ReplayEntry>;
-  /** Fallback index: contents only. */
+  exact: Map<string, ReplayEntry>;
+  /** Fallback index: everything but the system instruction. */
+  byRequest: Map<string, ReplayEntry>;
+  /** Last-resort index: contents only, for fixtures that recorded no config. */
   byContents: Map<string, ReplayEntry>;
   /** Backend used in record mode (default: a real Gemini). Overridable in tests. */
   liveBackend: (model: string) => BaseLlm;
@@ -117,7 +137,7 @@ function hash(material: unknown): string {
  * `config` carries the system instruction, so this is deliberately sensitive to
  * the prompt — two agents that differ only in their instructions are told
  * apart. It is also why it cannot be the only key: see
- * {@link contentsFingerprint}.
+ * {@link instructionAgnosticFingerprint}.
  */
 export function fingerprint(req: LlmRequest): string {
   return hash({
@@ -127,19 +147,35 @@ export function fingerprint(req: LlmRequest): string {
 }
 
 /**
- * Fallback fingerprint over the request's contents alone.
+ * Fallback fingerprint over the request minus its system instruction.
  *
  * Anything that edits a system instruction — a prompt tweak, or a framework
  * change like #616 dropping the identity preamble for transfer-disabled agents
  * — changes {@link fingerprint} for every call in every fixture at once, and
- * the whole sample suite fails with each agent producing nothing. The contents
- * are what actually distinguish one call from another within a sample, and they
- * are unaffected by such a change, so a miss on the exact key retries here.
+ * the whole sample suite fails with each agent producing nothing. Dropping just
+ * that one field absorbs such a change while the rest of `config` still has to
+ * match, so a regression that drops a tool or a `responseSchema` is still a
+ * miss rather than a green replay.
  *
- * This is a degraded match, not an equal one: calls that share contents and
- * differ only in their instructions (a real case — `nested_workflow`) collapse
- * into one bucket and are then served in recording order, which a concurrent
- * sample does not guarantee. Hitting this path warns and asks for a re-record.
+ * This is a degraded match, not an equal one: calls that differ only in their
+ * instructions (a real case — `nested_workflow`) collapse into one bucket and
+ * are then served in recording order, which a concurrent sample does not
+ * guarantee. Hitting this path warns and asks for a re-record.
+ */
+export function instructionAgnosticFingerprint(req: LlmRequest): string {
+  const {systemInstruction: _instruction, ...config} = req.config ?? {};
+  return hash({contents: normalizeContents(req.contents), config});
+}
+
+/**
+ * Last-resort fingerprint over the request's contents alone.
+ *
+ * For fixtures recorded before {@link instructionAgnosticFingerprint} existed:
+ * they stored no `config`, so contents are all that can be matched on once the
+ * prompt has moved. Weaker than the key above in exactly the way that key was
+ * introduced to avoid — `tools` and `responseSchema` go unchecked, so a
+ * regression dropping either still replays green — and the warning says so.
+ * This tier retires with the last un-re-recorded fixture.
  */
 export function contentsFingerprint(contents: unknown): string {
   return hash({contents: normalizeContents(contents)});
@@ -171,6 +207,45 @@ function toLlmResponse(raw: RawGenerateContentResponse): LlmResponse {
   };
 }
 
+/** How closely a replayed request matched what was recorded. */
+type MatchTier = 'exact' | 'instructionAgnostic' | 'contents';
+
+interface Match {
+  entry: ReplayEntry;
+  tier: MatchTier;
+  /** The key that matched, named in the warning for a degraded tier. */
+  matchedKey: string;
+}
+
+/**
+ * Finds the recorded responses for a request, degrading a tier at a time (see
+ * {@link installRecordReplay} for what populates each index).
+ */
+function lookup(
+  s: HarnessState,
+  keys: {key: string; instructionAgnosticKey: string; contentsKey: string},
+): Match | undefined {
+  const exact = s.exact.get(keys.key);
+  if (exact) {
+    return {entry: exact, tier: 'exact', matchedKey: keys.key};
+  }
+  // The prompt moved under the fixture: match on everything else, so one
+  // instruction edit does not take out every sample at once.
+  const byRequest = s.byRequest.get(keys.instructionAgnosticKey);
+  if (byRequest) {
+    return {
+      entry: byRequest,
+      tier: 'instructionAgnostic',
+      matchedKey: keys.instructionAgnosticKey,
+    };
+  }
+  const byContents = s.byContents.get(keys.contentsKey);
+  if (byContents) {
+    return {entry: byContents, tier: 'contents', matchedKey: keys.contentsKey};
+  }
+  return undefined;
+}
+
 /**
  * The model registered for the Gemini regexes during a sample test. It reuses
  * `Gemini.supportedModels` (the same RegExp instances) so registering it
@@ -190,28 +265,29 @@ class RecordReplayModel extends BaseLlm {
       );
     }
     const key = fingerprint(llmRequest);
-    const contentsKey = contentsFingerprint(llmRequest.contents);
+    const instructionAgnosticKey = instructionAgnosticFingerprint(llmRequest);
 
     if (state.mode === 'replay') {
-      let entry = state.replay.get(key);
-      if (!entry) {
-        // The prompt moved under the fixture: fall back to matching on the
-        // contents (see `contentsFingerprint`), so one instruction edit does
-        // not take out every sample at once.
-        entry = state.byContents.get(contentsKey);
-        if (entry) {
-          warnStaleFixture(contentsKey, entry.responses.length);
-        }
-      }
-      if (!entry) {
+      const contentsKey = contentsFingerprint(llmRequest.contents);
+      const match = lookup(state, {
+        key,
+        instructionAgnosticKey,
+        contentsKey,
+      });
+      if (!match) {
         // This throw is easy to lose: the caller can swallow it and the failure
         // then surfaces far away, as a node reading a property of `undefined`.
-        // Say it once on stderr where it happens.
+        // Say it once on stderr where it happens, with every key that missed.
         const message =
-          `No recorded model response for request ${key} (contents ` +
-          `${contentsKey}). Re-record with: npm run record:samples`;
+          `No recorded model response for request ${key} (minus instruction ` +
+          `${instructionAgnosticKey}, contents ${contentsKey}). ` +
+          'Re-record with: npm run record:samples';
         console.error(`[sample-harness] ${message}`);
         throw new Error(message);
+      }
+      const {entry, tier} = match;
+      if (tier !== 'exact') {
+        warnStaleFixture(tier, match.matchedKey, entry.responses.length);
       }
       // Deterministic: identical requests reuse the last recorded response.
       const raw =
@@ -230,10 +306,12 @@ class RecordReplayModel extends BaseLlm {
     )) {
       state.recorded.push({
         key,
-        contentsKey,
+        instructionAgnosticKey,
         request: {
           contents: normalizeContents(llmRequest.contents),
-          systemInstruction: llmRequest.config?.systemInstruction,
+          // Stored whole (system instruction included) so both keys can be
+          // re-derived offline should the fingerprints have to change again.
+          config: llmRequest.config ?? {},
         },
         response: toRaw(resp),
       });
@@ -249,56 +327,82 @@ class RecordReplayModel extends BaseLlm {
 /**
  * Installs the record/replay model into the LLM registry and sets the mode.
  * Call once per test run (before the runner executes).
+ *
+ * Builds the indexes {@link lookup} consults, in order of decreasing strictness.
+ * A call joins the contents-only index *instead of* the instruction-agnostic
+ * one, never as well: that last tier is a migration path for fixtures whose
+ * `config` was never recorded, and offering it to a fixture that has one would
+ * hand back the very coverage — `tools`, `responseSchema` — the middle tier
+ * exists to keep.
  */
 export function installRecordReplay(opts: {
   mode: Mode;
   recordedCalls?: RecordedCall[];
   liveBackend?: (model: string) => BaseLlm;
 }): void {
-  const replay = new Map<string, ReplayEntry>();
+  const exact = new Map<string, ReplayEntry>();
+  const byRequest = new Map<string, ReplayEntry>();
   const byContents = new Map<string, ReplayEntry>();
-  const index = (map: Map<string, ReplayEntry>, key: string | undefined) => {
-    if (!key) return;
+  const index = (map: Map<string, ReplayEntry>, key: string): ReplayEntry => {
     const entry = map.get(key) ?? {responses: [], cursor: 0};
     map.set(key, entry);
     return entry;
   };
   for (const call of opts.recordedCalls ?? []) {
-    index(replay, call.key)?.responses.push(call.response);
-    // Fixtures recorded before `contentsKey` existed fall back on the value
-    // recomputed from the contents they stored.
-    const contentsKey =
-      call.contentsKey ?? contentsFingerprint(call.request.contents);
-    index(byContents, contentsKey)?.responses.push(call.response);
+    index(exact, call.key).responses.push(call.response);
+    if (call.instructionAgnosticKey) {
+      index(byRequest, call.instructionAgnosticKey).responses.push(
+        call.response,
+      );
+    } else {
+      // Recorded before the config was fingerprinted, so the contents are all
+      // that survives a prompt change; recomputed for fixtures older still.
+      const contentsKey =
+        call.contentsKey ?? contentsFingerprint(call.request.contents);
+      index(byContents, contentsKey).responses.push(call.response);
+    }
   }
   warnedStaleKeys.clear();
   state = {
     mode: opts.mode,
     recorded: [],
-    replay,
+    exact,
+    byRequest,
     byContents,
     liveBackend: opts.liveBackend ?? ((model: string) => new Gemini({model})),
   };
   LLMRegistry.register(RecordReplayModel);
 }
 
-/** Contents keys already reported stale this run, so each is warned about once. */
+/** Fallback keys already reported stale this run, so each is warned about once. */
 const warnedStaleKeys = new Set<string>();
 
-function warnStaleFixture(contentsKey: string, candidates: number): void {
-  if (warnedStaleKeys.has(contentsKey)) {
+function warnStaleFixture(
+  tier: Exclude<MatchTier, 'exact'>,
+  matchedKey: string,
+  candidates: number,
+): void {
+  if (warnedStaleKeys.has(matchedKey)) {
     return;
   }
-  warnedStaleKeys.add(contentsKey);
+  warnedStaleKeys.add(matchedKey);
   const ambiguity =
     candidates > 1
-      ? ` ${candidates} recorded calls share these contents, so they are being ` +
+      ? ` ${candidates} recorded calls share this key, so they are being ` +
         'served in recording order — which a concurrent sample does not guarantee.'
       : '';
+  const what =
+    tier === 'instructionAgnostic'
+      ? `matched request ${matchedKey} on everything but its system ` +
+        'instruction, so the prompt has changed since it was recorded.'
+      : `matched request contents ${matchedKey} but not its config, so the ` +
+        'prompt has changed since it was recorded. This fixture predates ' +
+        'config fingerprinting and stored no config, so its tools and ' +
+        'response schema go unverified here — dropping either would still ' +
+        'replay green.';
   console.warn(
-    `[sample-harness] Stale fixture: matched request contents ${contentsKey} ` +
-      'but not its config, so the prompt has changed since it was recorded. ' +
-      `Replaying anyway.${ambiguity} Refresh with: npm run record:samples`,
+    `[sample-harness] Stale fixture: ${what} Replaying anyway.${ambiguity} ` +
+      'Refresh with: npm run record:samples',
   );
 }
 

--- a/tests/integration/workflows/_harness/record_replay_model.ts
+++ b/tests/integration/workflows/_harness/record_replay_model.ts
@@ -26,10 +26,16 @@ import type {Candidate} from '@google/genai';
 import {createHash} from 'node:crypto';
 import type {RawGenerateContentResponse} from '../../test_case_utils.js';
 
-/** A single recorded model call: its request fingerprint and raw response. */
+/** A single recorded model call: its request fingerprints and raw response. */
 export interface RecordedCall {
-  /** Stable fingerprint of the request (see {@link fingerprint}). */
+  /** Exact fingerprint of the request: contents + config (see {@link fingerprint}). */
   key: string;
+  /**
+   * Fallback fingerprint over the request's contents alone (see
+   * {@link contentsFingerprint}), used when a prompt change invalidates
+   * {@link key}.
+   */
+  contentsKey?: string;
   /** A readable snippet of the request, for debugging the fixture. */
   request: {contents: unknown; systemInstruction?: unknown};
   /** The raw response to replay. */
@@ -38,13 +44,19 @@ export interface RecordedCall {
 
 type Mode = 'record' | 'replay';
 
+/** Recorded responses for one fingerprint, served in recording order. */
+interface ReplayEntry {
+  responses: RawGenerateContentResponse[];
+  cursor: number;
+}
+
 interface HarnessState {
   mode: Mode;
   recorded: RecordedCall[];
-  replay: Map<
-    string,
-    {responses: RawGenerateContentResponse[]; cursor: number}
-  >;
+  /** Exact index: contents + config. */
+  replay: Map<string, ReplayEntry>;
+  /** Fallback index: contents only. */
+  byContents: Map<string, ReplayEntry>;
   /** Backend used in record mode (default: a real Gemini). Overridable in tests. */
   liveBackend: (model: string) => BaseLlm;
 }
@@ -92,15 +104,45 @@ function normalizeContents(contents: unknown): unknown {
   return clone;
 }
 
-/** Stable fingerprint of a model request (contents + config, id-normalized). */
+function hash(material: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(sortKeys(material)))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+/**
+ * Exact fingerprint of a model request: contents + config, id-normalized.
+ *
+ * `config` carries the system instruction, so this is deliberately sensitive to
+ * the prompt — two agents that differ only in their instructions are told
+ * apart. It is also why it cannot be the only key: see
+ * {@link contentsFingerprint}.
+ */
 export function fingerprint(req: LlmRequest): string {
-  const material = JSON.stringify(
-    sortKeys({
-      contents: normalizeContents(req.contents),
-      config: req.config ?? {},
-    }),
-  );
-  return createHash('sha256').update(material).digest('hex').slice(0, 16);
+  return hash({
+    contents: normalizeContents(req.contents),
+    config: req.config ?? {},
+  });
+}
+
+/**
+ * Fallback fingerprint over the request's contents alone.
+ *
+ * Anything that edits a system instruction — a prompt tweak, or a framework
+ * change like #616 dropping the identity preamble for transfer-disabled agents
+ * — changes {@link fingerprint} for every call in every fixture at once, and
+ * the whole sample suite fails with each agent producing nothing. The contents
+ * are what actually distinguish one call from another within a sample, and they
+ * are unaffected by such a change, so a miss on the exact key retries here.
+ *
+ * This is a degraded match, not an equal one: calls that share contents and
+ * differ only in their instructions (a real case — `nested_workflow`) collapse
+ * into one bucket and are then served in recording order, which a concurrent
+ * sample does not guarantee. Hitting this path warns and asks for a re-record.
+ */
+export function contentsFingerprint(contents: unknown): string {
+  return hash({contents: normalizeContents(contents)});
 }
 
 /** Reconstructs the raw response shape the fixture stores from an LlmResponse. */
@@ -148,14 +190,28 @@ class RecordReplayModel extends BaseLlm {
       );
     }
     const key = fingerprint(llmRequest);
+    const contentsKey = contentsFingerprint(llmRequest.contents);
 
     if (state.mode === 'replay') {
-      const entry = state.replay.get(key);
+      let entry = state.replay.get(key);
       if (!entry) {
-        throw new Error(
-          `No recorded model response for request fingerprint ${key}. ` +
-            'Re-record with: npm run record:samples',
-        );
+        // The prompt moved under the fixture: fall back to matching on the
+        // contents (see `contentsFingerprint`), so one instruction edit does
+        // not take out every sample at once.
+        entry = state.byContents.get(contentsKey);
+        if (entry) {
+          warnStaleFixture(contentsKey, entry.responses.length);
+        }
+      }
+      if (!entry) {
+        // This throw is easy to lose: the caller can swallow it and the failure
+        // then surfaces far away, as a node reading a property of `undefined`.
+        // Say it once on stderr where it happens.
+        const message =
+          `No recorded model response for request ${key} (contents ` +
+          `${contentsKey}). Re-record with: npm run record:samples`;
+        console.error(`[sample-harness] ${message}`);
+        throw new Error(message);
       }
       // Deterministic: identical requests reuse the last recorded response.
       const raw =
@@ -174,6 +230,7 @@ class RecordReplayModel extends BaseLlm {
     )) {
       state.recorded.push({
         key,
+        contentsKey,
         request: {
           contents: normalizeContents(llmRequest.contents),
           systemInstruction: llmRequest.config?.systemInstruction,
@@ -198,22 +255,51 @@ export function installRecordReplay(opts: {
   recordedCalls?: RecordedCall[];
   liveBackend?: (model: string) => BaseLlm;
 }): void {
-  const replay = new Map<
-    string,
-    {responses: RawGenerateContentResponse[]; cursor: number}
-  >();
+  const replay = new Map<string, ReplayEntry>();
+  const byContents = new Map<string, ReplayEntry>();
+  const index = (map: Map<string, ReplayEntry>, key: string | undefined) => {
+    if (!key) return;
+    const entry = map.get(key) ?? {responses: [], cursor: 0};
+    map.set(key, entry);
+    return entry;
+  };
   for (const call of opts.recordedCalls ?? []) {
-    const entry = replay.get(call.key) ?? {responses: [], cursor: 0};
-    entry.responses.push(call.response);
-    replay.set(call.key, entry);
+    index(replay, call.key)?.responses.push(call.response);
+    // Fixtures recorded before `contentsKey` existed fall back on the value
+    // recomputed from the contents they stored.
+    const contentsKey =
+      call.contentsKey ?? contentsFingerprint(call.request.contents);
+    index(byContents, contentsKey)?.responses.push(call.response);
   }
+  warnedStaleKeys.clear();
   state = {
     mode: opts.mode,
     recorded: [],
     replay,
+    byContents,
     liveBackend: opts.liveBackend ?? ((model: string) => new Gemini({model})),
   };
   LLMRegistry.register(RecordReplayModel);
+}
+
+/** Contents keys already reported stale this run, so each is warned about once. */
+const warnedStaleKeys = new Set<string>();
+
+function warnStaleFixture(contentsKey: string, candidates: number): void {
+  if (warnedStaleKeys.has(contentsKey)) {
+    return;
+  }
+  warnedStaleKeys.add(contentsKey);
+  const ambiguity =
+    candidates > 1
+      ? ` ${candidates} recorded calls share these contents, so they are being ` +
+        'served in recording order — which a concurrent sample does not guarantee.'
+      : '';
+  console.warn(
+    `[sample-harness] Stale fixture: matched request contents ${contentsKey} ` +
+      'but not its config, so the prompt has changed since it was recorded. ' +
+      `Replaying anyway.${ambiguity} Refresh with: npm run record:samples`,
+  );
 }
 
 /** Restores the real Gemini registration and clears harness state. */

--- a/tests/integration/workflows/_harness/record_replay_model_test.ts
+++ b/tests/integration/workflows/_harness/record_replay_model_test.ts
@@ -12,9 +12,10 @@
 
 import type {BaseLlmConnection, LlmRequest, LlmResponse} from '@google/adk';
 import {BaseLlm, LLMRegistry} from '@google/adk';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import {
-  contentsFingerprint,
   drainRecordedCalls,
   fingerprint,
   installRecordReplay,
@@ -46,28 +47,12 @@ function response(answer: string) {
   return {candidates: [{content: {role: 'model', parts: [{text: answer}]}}]};
 }
 
-/** A fixture entry in the current format: both keys, config stored. */
+/** A fixture entry as a record run writes it: both keys, config stored. */
 function recorded(req: LlmRequest, answer: string): RecordedCall {
   return {
     key: fingerprint(req),
     instructionAgnosticKey: instructionAgnosticFingerprint(req),
     request: {contents: req.contents, config: req.config},
-    response: response(answer),
-  };
-}
-
-/**
- * A fixture entry as recorded before the config was fingerprinted: no
- * `instructionAgnosticKey`, and only the system instruction kept of the config.
- */
-function legacyRecorded(req: LlmRequest, answer: string): RecordedCall {
-  return {
-    key: fingerprint(req),
-    contentsKey: contentsFingerprint(req.contents),
-    request: {
-      contents: req.contents,
-      systemInstruction: req.config?.systemInstruction,
-    },
     response: response(answer),
   };
 }
@@ -78,13 +63,20 @@ class StubBackend extends BaseLlm {
     super({model: 'gemini-2.5-flash'});
   }
 
-  override async *generateContentAsync(): AsyncGenerator<LlmResponse, void> {
+  override async *generateContentAsync(
+    _llmRequest?: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void> {
     yield {content: {role: 'model', parts: [{text: this.answer}]}};
   }
 
   override connect(): Promise<BaseLlmConnection> {
     throw new Error('not supported');
   }
+}
+
+/** Reads a sample's fixture off disk, as `runSample` does. */
+function load(file: string): RecordedCall[] {
+  return JSON.parse(readFileSync(file, 'utf8')) as RecordedCall[];
 }
 
 /** Replays (or records) one request through the installed harness model. */
@@ -221,34 +213,26 @@ describe('record/replay matching', () => {
     expect(error).toHaveBeenCalled();
   });
 
-  describe('fixtures recorded before the config was fingerprinted', () => {
-    it('recomputes the fallback key for a fixture recorded without one', async () => {
-      const req = request('legacy fixture', 'old instruction');
-      const legacy = legacyRecorded(req, 'served');
-      delete legacy.contentsKey;
-      vi.spyOn(console, 'warn').mockImplementation(() => {});
-      installRecordReplay({mode: 'replay', recordedCalls: [legacy]});
-
-      expect(await replay(request('legacy fixture', 'new instruction'))).toBe(
-        'served',
-      );
+  it('ignores the caller abort signal, which is a handle and not a request', async () => {
+    // It serializes to `{}`, so it discriminates nothing; a fixture that keyed
+    // on it would still match, but would carry a dead field forever.
+    const withSignal = (): LlmRequest =>
+      ({
+        model: 'gemini-2.5-flash',
+        contents: [{role: 'user', parts: [{text: 'question'}]}],
+        config: {
+          systemInstruction: 'instruction',
+          abortSignal: new AbortController().signal,
+        },
+      }) as unknown as LlmRequest;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    installRecordReplay({
+      mode: 'replay',
+      recordedCalls: [recorded(withSignal(), 'answer')],
     });
 
-    it('says which coverage the contents-only match gives up', async () => {
-      // No config was recorded, so the match cannot check one: say so rather
-      // than let a dropped tool look like a pass.
-      const req = request('use a tool', 'old instruction', ['lookup']);
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      installRecordReplay({
-        mode: 'replay',
-        recordedCalls: [legacyRecorded(req, 'served')],
-      });
-
-      expect(await replay(request('use a tool', 'new instruction'))).toBe(
-        'served',
-      );
-      expect(warn.mock.calls[0][0]).toContain('unverified');
-    });
+    expect(await replay(withSignal())).toBe('answer');
+    expect(warn).not.toHaveBeenCalled();
   });
 
   describe('record mode', () => {
@@ -263,6 +247,54 @@ describe('record/replay matching', () => {
 
       expect(await replay(req)).toBe('live answer');
       expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('stores the config the keys were taken over, minus the abort signal', async () => {
+      // The stored request is what a later fingerprint change re-derives keys
+      // from, so it has to be the normalized one, not the raw call.
+      const req = request('record me', 'You are a recorder.', ['lookup']);
+      (req.config as Record<string, unknown>)['abortSignal'] =
+        new AbortController().signal;
+      const [call] = await record('live answer', req);
+
+      expect(call.request.config).toEqual({
+        systemInstruction: 'You are a recorder.',
+        tools: [{functionDeclarations: [{name: 'lookup'}]}],
+      });
+      expect(call.key).toBe(fingerprint(req));
+      expect(call.instructionAgnosticKey).toBe(
+        instructionAgnosticFingerprint(req),
+      );
+    });
+
+    it('snapshots the request before the backend can edit it', async () => {
+      // `Gemini.preprocessRequest` clears `config.labels` on the Gemini API
+      // path, i.e. after the keys are computed. Storing the request as the
+      // backend left it would make it disagree with its own keys.
+      const req = request('record me', 'You are a recorder.');
+      (req.config as Record<string, unknown>)['labels'] = {
+        adk_agent_name: 'recorder',
+      };
+      installRecordReplay({
+        mode: 'record',
+        liveBackend: () =>
+          new (class extends StubBackend {
+            override async *generateContentAsync(
+              llmRequest: LlmRequest,
+            ): AsyncGenerator<LlmResponse, void> {
+              (llmRequest.config as Record<string, unknown>)['labels'] =
+                undefined;
+              yield* super.generateContentAsync();
+            }
+          })('live answer'),
+      });
+      await replay(req);
+      const [call] = drainRecordedCalls();
+
+      expect(
+        (call.request.config as Record<string, unknown>)['labels'],
+      ).toEqual({adk_agent_name: 'recorder'});
+      expect(fingerprint(call.request as unknown as LlmRequest)).toBe(call.key);
     });
 
     it('writes a fallback key that survives a prompt change', async () => {
@@ -301,4 +333,47 @@ describe('record/replay matching', () => {
       expect(warn).not.toHaveBeenCalled();
     });
   });
+});
+
+describe('the checked-in fixtures', () => {
+  const samples = path.join(import.meta.dirname, '..');
+  const fixtures = readdirSync(samples, {withFileTypes: true})
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(samples, e.name, 'model_responses.json'))
+    .filter((f) => existsSync(f))
+    .sort();
+
+  it('are all present and in the current format', () => {
+    expect(fixtures.length).toBeGreaterThan(0);
+    for (const file of fixtures) {
+      for (const call of load(file)) {
+        expect(Object.keys(call).sort()).toEqual([
+          'instructionAgnosticKey',
+          'key',
+          'request',
+          'response',
+        ]);
+      }
+    }
+  });
+
+  const named: Array<[string, string]> = fixtures.map((f) => [
+    path.basename(path.dirname(f)),
+    f,
+  ]);
+  it.each(named)(
+    'stores in %s the exact request its keys were taken over',
+    (_name, file) => {
+      // The promise the stored request makes: a future fingerprint change can
+      // re-derive keys from it offline, no live model needed. That only holds
+      // while it round-trips to the keys already written beside it.
+      for (const call of load(file)) {
+        const req = call.request as unknown as LlmRequest;
+        expect(fingerprint(req)).toBe(call.key);
+        expect(instructionAgnosticFingerprint(req)).toBe(
+          call.instructionAgnosticKey,
+        );
+      }
+    },
+  );
 });

--- a/tests/integration/workflows/_harness/record_replay_model_test.ts
+++ b/tests/integration/workflows/_harness/record_replay_model_test.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Covers the replay matching in {@link record_replay_model}, in particular that
+ * a fixture survives a system-instruction change instead of every sample
+ * failing at once.
+ */
+
+import type {LlmRequest} from '@google/adk';
+import {LLMRegistry} from '@google/adk';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {
+  contentsFingerprint,
+  fingerprint,
+  installRecordReplay,
+  RecordedCall,
+  restoreRecordReplay,
+} from './record_replay_model.js';
+
+function request(text: string, systemInstruction: string): LlmRequest {
+  return {
+    model: 'gemini-2.5-flash',
+    contents: [{role: 'user', parts: [{text}]}],
+    config: {systemInstruction},
+    // The harness only reads `contents` and `config`; the rest of LlmRequest is
+    // irrelevant to fingerprinting.
+  } as unknown as LlmRequest;
+}
+
+function recorded(req: LlmRequest, answer: string): RecordedCall {
+  return {
+    key: fingerprint(req),
+    contentsKey: contentsFingerprint(req.contents),
+    request: {
+      contents: req.contents,
+      systemInstruction: req.config?.systemInstruction,
+    },
+    response: {
+      candidates: [{content: {role: 'model', parts: [{text: answer}]}}],
+    },
+  };
+}
+
+/** Replays one request through the installed harness model. */
+async function replay(req: LlmRequest): Promise<string | undefined> {
+  const model = LLMRegistry.newLlm('gemini-2.5-flash');
+  for await (const resp of model.generateContentAsync(req)) {
+    return resp.content?.parts?.[0]?.text;
+  }
+  return undefined;
+}
+
+describe('record/replay matching', () => {
+  afterEach(() => {
+    restoreRecordReplay();
+    vi.restoreAllMocks();
+  });
+
+  it('replays on an exact request match', async () => {
+    const req = request('classify: what is ADK?', 'You are a classifier.');
+    installRecordReplay({
+      mode: 'replay',
+      recordedCalls: [recorded(req, 'doc')],
+    });
+
+    expect(await replay(req)).toBe('doc');
+  });
+
+  it('still replays when only the system instruction changed', async () => {
+    // What #616 did to every fixture: same conversation, different preamble.
+    const asRecorded = request('classify: what is ADK?', 'You are classify.');
+    const afterPromptChange = request(
+      'classify: what is ADK?',
+      'You are classify. (preamble dropped)',
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    installRecordReplay({
+      mode: 'replay',
+      recordedCalls: [recorded(asRecorded, 'doc')],
+    });
+
+    expect(await replay(afterPromptChange)).toBe('doc');
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('Stale fixture');
+  });
+
+  it('warns once per stale request, not once per call', async () => {
+    const asRecorded = request('same question', 'old instruction');
+    const afterPromptChange = request('same question', 'new instruction');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    installRecordReplay({
+      mode: 'replay',
+      recordedCalls: [recorded(asRecorded, 'a')],
+    });
+
+    await replay(afterPromptChange);
+    await replay(afterPromptChange);
+
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('flags the ambiguity when a stale match has several candidates', async () => {
+    // Two agents, same conversation, different instructions: the fallback
+    // cannot tell them apart, so it must say so.
+    const first = request('shared prompt', 'instruction A');
+    const second = request('shared prompt', 'instruction B');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    installRecordReplay({
+      mode: 'replay',
+      recordedCalls: [recorded(first, 'A'), recorded(second, 'B')],
+    });
+
+    expect(await replay(request('shared prompt', 'instruction C'))).toBe('A');
+    expect(warn.mock.calls[0][0]).toContain('recording order');
+  });
+
+  it('recomputes the fallback key for a fixture recorded without one', async () => {
+    const req = request('legacy fixture', 'old instruction');
+    const legacy = recorded(req, 'served');
+    delete legacy.contentsKey;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    installRecordReplay({mode: 'replay', recordedCalls: [legacy]});
+
+    expect(await replay(request('legacy fixture', 'new instruction'))).toBe(
+      'served',
+    );
+  });
+
+  it('throws, loudly, when neither key matches', async () => {
+    const req = request('recorded question', 'instruction');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    installRecordReplay({mode: 'replay', recordedCalls: [recorded(req, 'a')]});
+
+    await expect(
+      replay(request('a question never recorded', 'instruction')),
+    ).rejects.toThrow(/No recorded model response/);
+    expect(error).toHaveBeenCalled();
+  });
+
+  it('tells apart two agents that share contents while prompts are unchanged', async () => {
+    const first = request('shared prompt', 'instruction A');
+    const second = request('shared prompt', 'instruction B');
+    installRecordReplay({
+      mode: 'replay',
+      recordedCalls: [recorded(first, 'A'), recorded(second, 'B')],
+    });
+
+    // Exact keys still hit, so contents collisions resolve correctly and in any
+    // order — the property the fallback gives up and warns about.
+    expect(await replay(second)).toBe('B');
+    expect(await replay(first)).toBe('A');
+  });
+});

--- a/tests/integration/workflows/_harness/record_replay_model_test.ts
+++ b/tests/integration/workflows/_harness/record_replay_model_test.ts
@@ -7,31 +7,60 @@
 /**
  * Covers the replay matching in {@link record_replay_model}, in particular that
  * a fixture survives a system-instruction change instead of every sample
- * failing at once.
+ * failing at once — and that nothing weaker than that slips through with it.
  */
 
-import type {LlmRequest} from '@google/adk';
-import {LLMRegistry} from '@google/adk';
+import type {BaseLlmConnection, LlmRequest, LlmResponse} from '@google/adk';
+import {BaseLlm, LLMRegistry} from '@google/adk';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import {
   contentsFingerprint,
+  drainRecordedCalls,
   fingerprint,
   installRecordReplay,
+  instructionAgnosticFingerprint,
   RecordedCall,
   restoreRecordReplay,
 } from './record_replay_model.js';
 
-function request(text: string, systemInstruction: string): LlmRequest {
+function request(
+  text: string,
+  systemInstruction: string,
+  tools?: string[],
+): LlmRequest {
   return {
     model: 'gemini-2.5-flash',
     contents: [{role: 'user', parts: [{text}]}],
-    config: {systemInstruction},
+    config: {
+      systemInstruction,
+      ...(tools
+        ? {tools: [{functionDeclarations: tools.map((name) => ({name}))}]}
+        : {}),
+    },
     // The harness only reads `contents` and `config`; the rest of LlmRequest is
     // irrelevant to fingerprinting.
   } as unknown as LlmRequest;
 }
 
+function response(answer: string) {
+  return {candidates: [{content: {role: 'model', parts: [{text: answer}]}}]};
+}
+
+/** A fixture entry in the current format: both keys, config stored. */
 function recorded(req: LlmRequest, answer: string): RecordedCall {
+  return {
+    key: fingerprint(req),
+    instructionAgnosticKey: instructionAgnosticFingerprint(req),
+    request: {contents: req.contents, config: req.config},
+    response: response(answer),
+  };
+}
+
+/**
+ * A fixture entry as recorded before the config was fingerprinted: no
+ * `instructionAgnosticKey`, and only the system instruction kept of the config.
+ */
+function legacyRecorded(req: LlmRequest, answer: string): RecordedCall {
   return {
     key: fingerprint(req),
     contentsKey: contentsFingerprint(req.contents),
@@ -39,19 +68,50 @@ function recorded(req: LlmRequest, answer: string): RecordedCall {
       contents: req.contents,
       systemInstruction: req.config?.systemInstruction,
     },
-    response: {
-      candidates: [{content: {role: 'model', parts: [{text: answer}]}}],
-    },
+    response: response(answer),
   };
 }
 
-/** Replays one request through the installed harness model. */
+/** Stands in for the live Gemini backend during a record run. */
+class StubBackend extends BaseLlm {
+  constructor(private readonly answer: string) {
+    super({model: 'gemini-2.5-flash'});
+  }
+
+  override async *generateContentAsync(): AsyncGenerator<LlmResponse, void> {
+    yield {content: {role: 'model', parts: [{text: this.answer}]}};
+  }
+
+  override connect(): Promise<BaseLlmConnection> {
+    throw new Error('not supported');
+  }
+}
+
+/** Replays (or records) one request through the installed harness model. */
 async function replay(req: LlmRequest): Promise<string | undefined> {
   const model = LLMRegistry.newLlm('gemini-2.5-flash');
   for await (const resp of model.generateContentAsync(req)) {
     return resp.content?.parts?.[0]?.text;
   }
   return undefined;
+}
+
+/**
+ * Records `reqs` against a stub backend and returns the fixture as a replay run
+ * would read it — through the same JSON round trip `runSample` writes and loads.
+ */
+async function record(
+  answer: string,
+  ...reqs: LlmRequest[]
+): Promise<RecordedCall[]> {
+  installRecordReplay({
+    mode: 'record',
+    liveBackend: () => new StubBackend(answer),
+  });
+  for (const req of reqs) {
+    await replay(req);
+  }
+  return JSON.parse(JSON.stringify(drainRecordedCalls())) as RecordedCall[];
 }
 
 describe('record/replay matching', () => {
@@ -118,18 +178,6 @@ describe('record/replay matching', () => {
     expect(warn.mock.calls[0][0]).toContain('recording order');
   });
 
-  it('recomputes the fallback key for a fixture recorded without one', async () => {
-    const req = request('legacy fixture', 'old instruction');
-    const legacy = recorded(req, 'served');
-    delete legacy.contentsKey;
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    installRecordReplay({mode: 'replay', recordedCalls: [legacy]});
-
-    expect(await replay(request('legacy fixture', 'new instruction'))).toBe(
-      'served',
-    );
-  });
-
   it('throws, loudly, when neither key matches', async () => {
     const req = request('recorded question', 'instruction');
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -153,5 +201,104 @@ describe('record/replay matching', () => {
     // order — the property the fallback gives up and warns about.
     expect(await replay(second)).toBe('B');
     expect(await replay(first)).toBe('A');
+  });
+
+  it('does not let a dropped tool pass as a prompt change', async () => {
+    // The fallback absorbs an edited instruction and nothing else: the rest of
+    // the config, tools included, still has to match.
+    const req = request('use a tool', 'instruction', ['lookup']);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    installRecordReplay({mode: 'replay', recordedCalls: [recorded(req, 'ok')]});
+
+    expect(
+      await replay(request('use a tool', 'new instruction', ['lookup'])),
+    ).toBe('ok');
+    expect(warn).toHaveBeenCalledOnce();
+    await expect(replay(request('use a tool', 'instruction'))).rejects.toThrow(
+      /No recorded model response/,
+    );
+    expect(error).toHaveBeenCalled();
+  });
+
+  describe('fixtures recorded before the config was fingerprinted', () => {
+    it('recomputes the fallback key for a fixture recorded without one', async () => {
+      const req = request('legacy fixture', 'old instruction');
+      const legacy = legacyRecorded(req, 'served');
+      delete legacy.contentsKey;
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      installRecordReplay({mode: 'replay', recordedCalls: [legacy]});
+
+      expect(await replay(request('legacy fixture', 'new instruction'))).toBe(
+        'served',
+      );
+    });
+
+    it('says which coverage the contents-only match gives up', async () => {
+      // No config was recorded, so the match cannot check one: say so rather
+      // than let a dropped tool look like a pass.
+      const req = request('use a tool', 'old instruction', ['lookup']);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      installRecordReplay({
+        mode: 'replay',
+        recordedCalls: [legacyRecorded(req, 'served')],
+      });
+
+      expect(await replay(request('use a tool', 'new instruction'))).toBe(
+        'served',
+      );
+      expect(warn.mock.calls[0][0]).toContain('unverified');
+    });
+  });
+
+  describe('record mode', () => {
+    it('writes keys that a later replay matches exactly', async () => {
+      // The keys are computed once at record time and again at load time, from
+      // a JSON round trip of the request. If those two ever disagreed, every
+      // new fixture would quietly serve from a fallback and CI would stay green.
+      const req = request('record me', 'You are a recorder.', ['lookup']);
+      const fixture = await record('live answer', req);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      installRecordReplay({mode: 'replay', recordedCalls: fixture});
+
+      expect(await replay(req)).toBe('live answer');
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('writes a fallback key that survives a prompt change', async () => {
+      const req = request('record me', 'You are a recorder.', ['lookup']);
+      const fixture = await record('live answer', req);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      installRecordReplay({mode: 'replay', recordedCalls: fixture});
+
+      expect(
+        await replay(
+          request('record me', 'You are a recorder v2.', ['lookup']),
+        ),
+      ).toBe('live answer');
+      expect(warn.mock.calls[0][0]).toContain('Stale fixture');
+    });
+
+    it('normalizes volatile function-call ids the same way on both sides', async () => {
+      // Ids are generated per run, so a recorded key only matches a replayed
+      // one because both sides scrub them.
+      const withId = (id: string): LlmRequest =>
+        ({
+          model: 'gemini-2.5-flash',
+          contents: [
+            {
+              role: 'model',
+              parts: [{functionCall: {id, name: 'lookup', args: {q: 'adk'}}}],
+            },
+          ],
+          config: {systemInstruction: 'You are a caller.'},
+        }) as unknown as LlmRequest;
+      const fixture = await record('live answer', withId('call-1'));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      installRecordReplay({mode: 'replay', recordedCalls: fixture});
+
+      expect(await replay(withId('call-2'))).toBe('live answer');
+      expect(warn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/integration/workflows/agent_in_workflow/model_responses.json
+++ b/tests/integration/workflows/agent_in_workflow/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "58068ee216d63eb1",
+    "contentsKey": "f797905356b308c9",
     "request": {
       "contents": [
         {
@@ -61,6 +62,7 @@
   },
   {
     "key": "4d654d41f3ce18f9",
+    "contentsKey": "a850355740edcae1",
     "request": {
       "contents": [
         {
@@ -151,6 +153,7 @@
   },
   {
     "key": "e21a9474d751f471",
+    "contentsKey": "ab0d3f08e8cccebb",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/agent_in_workflow/model_responses.json
+++ b/tests/integration/workflows/agent_in_workflow/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
-    "key": "58068ee216d63eb1",
-    "contentsKey": "f797905356b308c9",
+    "key": "5859bea69bb556da",
+    "instructionAgnosticKey": "dd892124f5572b7f",
     "request": {
       "contents": [
         {
@@ -21,12 +21,45 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"intake_agent\".\n\nYou are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output."
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phoneNumber": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phoneNumber"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "functionCall": {
@@ -35,34 +68,38 @@
                     "name": "Jane Doe",
                     "phoneNumber": "555-123-4567"
                   },
-                  "id": "adk-ef58a3ea-f2ab-4ace-af69-c611706d22de"
-                },
-                "thoughtSignature": "CuADARFNMg9GT3TBqfAtQkC299opTrVHTOTgRRnuDS2d1rVWaTYKLXtlnYz5gXaQE+zgORiDxCRxNjVilAn9F9/vHx0bNDsQkVSFbxpgTAC/tRQvaSB+YEnEL8pA5SgJlNVQ9zDurfcHo8idZ4VhskYxUIv/8hpuXk19uBXMhDbJcntpty+CwAmeIEMYsUwel450UuAGkQ4rExcjtJSJQmeN9su5zLE3iGE7rU/hPdxgfQb+BJT2GPXkESnAcdvKumMcUrFYUZPU7+1xsCwsn63mhS/v8AW+nLDmZPjHoC6MWYVqHSv6strcTy4G3fGSQtN0nyU5tcwnTDPqtMpyBIrH0g+qqWS7O5yIvdpwhWK3EWvZzhK144vrJ6ZfxIYazHo5G20JTSTQbCnU9Z8tB8OfhW9dwGZECcGtUi/oun77s5Of7KKQqetekHdoqiNXUw+HzV5TRiehLWj3SVCoFyvv3eK7rIwC4ztn+gXv/dBpWweSzTpcykapbE1AaiSQxJv98FwECBqM7VWJ1pwV6hyrDnlsIij8JPu9FPAgGAruirtmXjhdaOFZf6iOSM7BwyhUN231FRxP0PZJEo6v7eqqmYmWP2ujZMACxySoHbea5J8b0PgTxPlJW4wlg0ILVcDy"
+                  "id": "adk-6453bae6-378a-46c3-bea0-149eda8e2788"
+                }
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 266,
-        "candidatesTokenCount": 32,
-        "totalTokenCount": 409,
+        "promptTokenCount": 216,
+        "candidatesTokenCount": 19,
+        "totalTokenCount": 293,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 266
+            "tokenCount": 216
           }
         ],
-        "thoughtsTokenCount": 111,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 19
+          }
+        ],
+        "thoughtsTokenCount": 58
       }
     }
   },
   {
     "key": "4d654d41f3ce18f9",
-    "contentsKey": "a850355740edcae1",
+    "instructionAgnosticKey": "8e897ba6e57b4dc7",
     "request": {
       "contents": [
         {
@@ -115,45 +152,69 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\nYou MUST call the find_orders tool to get the patient's actual\norders. Do not invent orders. After the tool returns, list the orders found and\nthen generate a concise instruction about how to prepare based on those orders."
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\nYou MUST call the find_orders tool to get the patient's actual\norders. Do not invent orders. After the tool returns, list the orders found and\nthen generate a concise instruction about how to prepare based on those orders.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds the patient's lab orders.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "functionCall": {
                   "name": "find_orders",
                   "args": {},
-                  "id": "adk-260437d1-712b-4857-b21d-9a6772944737"
-                },
-                "thoughtSignature": "CpMCARFNMg/GyJi/a3WGeYtBjbQgJGfReCduuU7Aez1tzyYkckkGnDFCpL+2yVS2wzIasyjwXBOFaejPdYWAkOrvUBHH9zB934s32gVjAzBFvasswkRXu7DgS0srvUqgtZQHY0tT81vJERo1xU0fUhV/LPbm2KrQzkgRAWXi8KvT/ERUQt+crjJPoGNWVcshRSjUhA3wC634iL36XWSVJuoRcEmQMXkfFMqBZ6Ngx4+TAL9z0iCKTta2opg8ur/D4VowHrGSU50vQh6Z6iLl13RbvEDpx7EC8uc8MXDWDQzf/Xx1rEoghYni1hkMsH7UdwKYBoSzTfkOkcROA/VKZPir8V3G2pKZ1XstblJvEAAo0nORx3U="
+                  "id": "adk-d98f5307-6330-4235-8fc9-e2f66312d763"
+                }
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 235,
-        "candidatesTokenCount": 10,
-        "totalTokenCount": 296,
+        "promptTokenCount": 212,
+        "candidatesTokenCount": 3,
+        "totalTokenCount": 274,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 235
+            "tokenCount": 212
           }
         ],
-        "thoughtsTokenCount": 51,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 3
+          }
+        ],
+        "thoughtsTokenCount": 59
       }
     }
   },
   {
-    "key": "e21a9474d751f471",
-    "contentsKey": "ab0d3f08e8cccebb",
+    "key": "8de2f3f109b60cc4",
+    "instructionAgnosticKey": "9db7eb5a9e2222a1",
     "request": {
       "contents": [
         {
@@ -206,16 +267,15 @@
           ]
         },
         {
+          "role": "model",
           "parts": [
             {
               "functionCall": {
                 "name": "find_orders",
                 "args": {}
-              },
-              "thoughtSignature": "CpMCARFNMg/GyJi/a3WGeYtBjbQgJGfReCduuU7Aez1tzyYkckkGnDFCpL+2yVS2wzIasyjwXBOFaejPdYWAkOrvUBHH9zB934s32gVjAzBFvasswkRXu7DgS0srvUqgtZQHY0tT81vJERo1xU0fUhV/LPbm2KrQzkgRAWXi8KvT/ERUQt+crjJPoGNWVcshRSjUhA3wC634iL36XWSVJuoRcEmQMXkfFMqBZ6Ngx4+TAL9z0iCKTta2opg8ur/D4VowHrGSU50vQh6Z6iLl13RbvEDpx7EC8uc8MXDWDQzf/Xx1rEoghYni1hkMsH7UdwKYBoSzTfkOkcROA/VKZPir8V3G2pKZ1XstblJvEAAo0nORx3U="
+              }
             }
-          ],
-          "role": "model"
+          ]
         },
         {
           "role": "user",
@@ -237,39 +297,63 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\nYou MUST call the find_orders tool to get the patient's actual\norders. Do not invent orders. After the tool returns, list the orders found and\nthen generate a concise instruction about how to prepare based on those orders."
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\nYou MUST call the find_orders tool to get the patient's actual\norders. Do not invent orders. After the tool returns, list the orders found and\nthen generate a concise instruction about how to prepare based on those orders.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds the patient's lab orders.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "functionCall": {
                   "name": "find_orders",
                   "args": {},
-                  "id": "adk-073f219b-5ff5-4610-9234-953a9582fdd3"
-                },
-                "thoughtSignature": "CosCARFNMg/NlEQswaTxIggapo/vt59KmAsMQN9Z5N0Cio6e7eMj315KCbtJXNtGab6bjfatIDZHnE7ARgOCi+DJ9d4atPj1tA5BI2s2Ms2s444m05pEOFFih7v1JAbBd4S+7hrsaJdR4TvKuRX6sgc8PLfXFl7SbKUfSdLRhW3HaEoBQAgKaJlAFSfgZj/9Vmu7oue5i5Pkcfe+vULjoQAT8q6eUbYiLynwUF5AxyR8/c9gcBI1Y4mhWr/TK+n4mxMmXNlrMAV2NAXR6Kf+PwjIvAPLdYxjbMtsODlDYBpuLEP7Ss28PtTYo/DOAR8O8etNTLUxcPyHtRi85+jTPKcQyMGOpUXI1KQLo3SE"
+                  "id": "adk-0edc0e06-18d6-49aa-86b3-8850e2e3f9bf"
+                }
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 270,
-        "candidatesTokenCount": 10,
-        "totalTokenCount": 331,
+        "promptTokenCount": 237,
+        "candidatesTokenCount": 3,
+        "totalTokenCount": 281,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 270
+            "tokenCount": 237
           }
         ],
-        "thoughtsTokenCount": 51,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 3
+          }
+        ],
+        "thoughtsTokenCount": 41
       }
     }
   }

--- a/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
+++ b/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
@@ -1,135 +1,7 @@
 [
   {
-    "key": "e22d71fa47fcc401",
-    "contentsKey": "b4187b3e3b841660",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "space, oceans, volcanoes"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "oceans"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[orchestrator] said: Processing 3 topics in parallel."
-            }
-          ]
-        }
-      ],
-      "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message."
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "parts": [
-              {
-                "text": "Dive Deep: Unveiling the Ocean's Mysteries."
-              }
-            ],
-            "role": "model"
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 57,
-        "candidatesTokenCount": 12,
-        "totalTokenCount": 84,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 57
-          }
-        ],
-        "thoughtsTokenCount": 15,
-        "serviceTier": "standard"
-      }
-    }
-  },
-  {
-    "key": "4a0fb6899c30134c",
-    "contentsKey": "3ec6e84229e0fc1b",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "space, oceans, volcanoes"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "space"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[orchestrator] said: Processing 3 topics in parallel."
-            }
-          ]
-        }
-      ],
-      "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message."
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "parts": [
-              {
-                "text": "Space, Oceans, Volcanoes: Unveiling the Universe's Most Extreme Stages."
-              }
-            ],
-            "role": "model"
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 56,
-        "candidatesTokenCount": 18,
-        "totalTokenCount": 827,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 56
-          }
-        ],
-        "thoughtsTokenCount": 753,
-        "serviceTier": "standard"
-      }
-    }
-  },
-  {
     "key": "893fe50fb5617951",
-    "contentsKey": "bd48ff5a2508a558",
+    "instructionAgnosticKey": "b07208311518b7db",
     "request": {
       "contents": [
         {
@@ -160,34 +32,195 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message."
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message.",
+        "labels": {
+          "adk_agent_name": "generator"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "**Space, Sea, and Summit: Unveiling the universe's most dramatic frontiers.**"
+                "text": "Deep, Fiery, Infinite: Oceans, Volcanoes, Space."
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 58,
-        "candidatesTokenCount": 19,
-        "totalTokenCount": 874,
+        "promptTokenCount": 54,
+        "candidatesTokenCount": 14,
+        "totalTokenCount": 958,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 58
+            "tokenCount": 54
           }
         ],
-        "thoughtsTokenCount": 797,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 14
+          }
+        ],
+        "thoughtsTokenCount": 890
+      }
+    }
+  },
+  {
+    "key": "4a0fb6899c30134c",
+    "instructionAgnosticKey": "7da08d4d351e7485",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "space, oceans, volcanoes"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "space"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[orchestrator] said: Processing 3 topics in parallel."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message.",
+        "labels": {
+          "adk_agent_name": "generator"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Space, Oceans, Volcanoes: Unearthing the Universe's Wildest Wonders."
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 52,
+        "candidatesTokenCount": 18,
+        "totalTokenCount": 939,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 52
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 18
+          }
+        ],
+        "thoughtsTokenCount": 869
+      }
+    }
+  },
+  {
+    "key": "e22d71fa47fcc401",
+    "instructionAgnosticKey": "5569d5644985d09c",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "space, oceans, volcanoes"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "oceans"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[orchestrator] said: Processing 3 topics in parallel."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message.",
+        "labels": {
+          "adk_agent_name": "generator"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "From Earth's fiery heart to the cosmic expanse: Space, Oceans, Volcanoes."
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 53,
+        "candidatesTokenCount": 18,
+        "totalTokenCount": 1096,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 53
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 18
+          }
+        ],
+        "thoughtsTokenCount": 1025
       }
     }
   }

--- a/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
+++ b/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "e22d71fa47fcc401",
+    "contentsKey": "b4187b3e3b841660",
     "request": {
       "contents": [
         {
@@ -64,6 +65,7 @@
   },
   {
     "key": "4a0fb6899c30134c",
+    "contentsKey": "3ec6e84229e0fc1b",
     "request": {
       "contents": [
         {
@@ -127,6 +129,7 @@
   },
   {
     "key": "893fe50fb5617951",
+    "contentsKey": "bd48ff5a2508a558",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/dynamic_nodes/model_responses.json
+++ b/tests/integration/workflows/dynamic_nodes/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "0112f342bd840a3d",
-    "contentsKey": "91a17c48ecd973f6",
+    "instructionAgnosticKey": "dba6770d80737da2",
     "request": {
       "contents": [
         {
@@ -13,40 +13,51 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"the ocean\".\n    If feedback is provided, take it into account.\n    The feedback: \n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"the ocean\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "The Ocean: A World Beneath the Waves"
+                "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 50,
-        "candidatesTokenCount": 8,
-        "totalTokenCount": 105,
+        "promptTokenCount": 48,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 102,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 50
+            "tokenCount": 48
           }
         ],
-        "thoughtsTokenCount": 47,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 15
+          }
+        ],
+        "thoughtsTokenCount": 39
       }
     }
   },
   {
-    "key": "8e50b204b7bff1d4",
-    "contentsKey": "7acf5ddd402e5854",
+    "key": "b4a7114387b0d365",
+    "instructionAgnosticKey": "fbe12ea2ada9d29d",
     "request": {
       "contents": [
         {
@@ -64,7 +75,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_headline] said: The Ocean: A World Beneath the Waves"
+              "text": "[generate_headline] said: \"Beneath the Surface: Unveiling the Ocean's Secrets\""
             }
           ]
         },
@@ -72,45 +83,76 @@
           "role": "user",
           "parts": [
             {
-              "text": "The Ocean: A World Beneath the Waves"
+              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
             }
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"evaluate_headline\".\n\nGrade whether the headline is related to technology or software engineering."
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ]
+            },
+            "feedback": {
+              "type": "STRING"
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Grade whether the headline is related to technology or software engineering.",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"grade\": \"unrelated\", \"feedback\": \"The headline 'The Ocean: A World Beneath the Waves' is about marine environments and does not contain any terms or concepts related to technology or software engineering.\"}"
+                "text": "{\"grade\": \"unrelated\", \"feedback\": \"The headline is about ocean exploration and discovery, not technology or software engineering.\"}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 59,
-        "candidatesTokenCount": 43,
-        "totalTokenCount": 259,
+        "promptTokenCount": 66,
+        "candidatesTokenCount": 27,
+        "totalTokenCount": 148,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 59
+            "tokenCount": 66
           }
         ],
-        "thoughtsTokenCount": 157,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 27
+          }
+        ],
+        "thoughtsTokenCount": 55
       }
     }
   },
   {
-    "key": "dcc75bb7f3a48697",
-    "contentsKey": "bda38a51d8deceaf",
+    "key": "35f70f2d232d2a3d",
+    "instructionAgnosticKey": "ac107cad3eb60ad5",
     "request": {
       "contents": [
         {
@@ -122,18 +164,18 @@
           ]
         },
         {
+          "role": "model",
           "parts": [
             {
-              "text": "The Ocean: A World Beneath the Waves"
+              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
             }
-          ],
-          "role": "model"
+          ]
         },
         {
           "role": "user",
           "parts": [
             {
-              "text": "The Ocean: A World Beneath the Waves"
+              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
             }
           ]
         },
@@ -144,45 +186,56 @@
               "text": "For context:"
             },
             {
-              "text": "[evaluate_headline] said: {\"grade\": \"unrelated\", \"feedback\": \"The headline 'The Ocean: A World Beneath the Waves' is about marine environments and does not contain any terms or concepts related to technology or software engineering.\"}"
+              "text": "[evaluate_headline] said: {\"grade\": \"unrelated\", \"feedback\": \"The headline is about ocean exploration and discovery, not technology or software engineering.\"}"
             }
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"the ocean\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"The headline 'The Ocean: A World Beneath the Waves' is about marine environments and does not contain any terms or concepts related to technology or software engineering.\"}\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"the ocean\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"The headline is about ocean exploration and discovery, not technology or software engineering.\"}\n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Software for the Seas: Coding the Future of Ocean Discovery"
+                "text": "Deep Dive into Code: Software Engineering for Ocean Innovation"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 161,
-        "candidatesTokenCount": 11,
-        "totalTokenCount": 1369,
+        "promptTokenCount": 138,
+        "candidatesTokenCount": 10,
+        "totalTokenCount": 1282,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 161
+            "tokenCount": 138
           }
         ],
-        "thoughtsTokenCount": 1197,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 10
+          }
+        ],
+        "thoughtsTokenCount": 1134
       }
     }
   },
   {
-    "key": "f44e965e879a66b9",
-    "contentsKey": "0f69e1bc0619b17b",
+    "key": "b426c322f8f0086d",
+    "instructionAgnosticKey": "ad38f7ee02479dc9",
     "request": {
       "contents": [
         {
@@ -200,7 +253,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_headline] said: The Ocean: A World Beneath the Waves"
+              "text": "[generate_headline] said: \"Beneath the Surface: Unveiling the Ocean's Secrets\""
             }
           ]
         },
@@ -208,17 +261,17 @@
           "role": "user",
           "parts": [
             {
-              "text": "The Ocean: A World Beneath the Waves"
+              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
             }
           ]
         },
         {
+          "role": "model",
           "parts": [
             {
-              "text": "{\"grade\": \"unrelated\", \"feedback\": \"The headline 'The Ocean: A World Beneath the Waves' is about marine environments and does not contain any terms or concepts related to technology or software engineering.\"}"
+              "text": "{\"grade\": \"unrelated\", \"feedback\": \"The headline is about ocean exploration and discovery, not technology or software engineering.\"}"
             }
-          ],
-          "role": "model"
+          ]
         },
         {
           "role": "user",
@@ -227,7 +280,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_headline] said: Software for the Seas: Coding the Future of Ocean Discovery"
+              "text": "[generate_headline] said: Deep Dive into Code: Software Engineering for Ocean Innovation"
             }
           ]
         },
@@ -235,39 +288,70 @@
           "role": "user",
           "parts": [
             {
-              "text": "Software for the Seas: Coding the Future of Ocean Discovery"
+              "text": "Deep Dive into Code: Software Engineering for Ocean Innovation"
             }
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"evaluate_headline\".\n\nGrade whether the headline is related to technology or software engineering."
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ]
+            },
+            "feedback": {
+              "type": "STRING"
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Grade whether the headline is related to technology or software engineering.",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"grade\": \"tech-related\", \"feedback\": \"The headline 'Software for the Seas: Coding the Future of Ocean Discovery' explicitly mentions 'Software' and 'Coding', which are core concepts in technology and software engineering.\"}"
+                "text": "{\"grade\": \"tech-related\", \"feedback\": \"The headline explicitly mentions 'Software Engineering' and 'Code,' directly indicating its relevance to technology and software engineering. The 'Ocean Innovation' part describes the application domain, but the core subject remains software engineering.\"}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 137,
-        "candidatesTokenCount": 47,
-        "totalTokenCount": 395,
+        "promptTokenCount": 123,
+        "candidatesTokenCount": 54,
+        "totalTokenCount": 270,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 137
+            "tokenCount": 123
           }
         ],
-        "thoughtsTokenCount": 211,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 54
+          }
+        ],
+        "thoughtsTokenCount": 93
       }
     }
   }

--- a/tests/integration/workflows/dynamic_nodes/model_responses.json
+++ b/tests/integration/workflows/dynamic_nodes/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "0112f342bd840a3d",
+    "contentsKey": "91a17c48ecd973f6",
     "request": {
       "contents": [
         {
@@ -45,6 +46,7 @@
   },
   {
     "key": "8e50b204b7bff1d4",
+    "contentsKey": "7acf5ddd402e5854",
     "request": {
       "contents": [
         {
@@ -108,6 +110,7 @@
   },
   {
     "key": "dcc75bb7f3a48697",
+    "contentsKey": "bda38a51d8deceaf",
     "request": {
       "contents": [
         {
@@ -179,6 +182,7 @@
   },
   {
     "key": "f44e965e879a66b9",
+    "contentsKey": "0f69e1bc0619b17b",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/loop/model_responses.json
+++ b/tests/integration/workflows/loop/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "5fc04152f12fe2c0",
-    "contentsKey": "0be69852f4278c11",
+    "instructionAgnosticKey": "2fc1b852b548f499",
     "request": {
       "contents": [
         {
@@ -13,40 +13,51 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"quantum computing\".\n    If feedback is provided, take it into account.\n    The feedback: \n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"quantum computing\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Quantum Computing: The Next Frontier in Processing Power"
+                "text": "Quantum Computing: The Next Frontier in Technology"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 50,
-        "candidatesTokenCount": 9,
-        "totalTokenCount": 82,
+        "promptTokenCount": 48,
+        "candidatesTokenCount": 8,
+        "totalTokenCount": 75,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 50
+            "tokenCount": 48
           }
         ],
-        "thoughtsTokenCount": 23,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 8
+          }
+        ],
+        "thoughtsTokenCount": 19
       }
     }
   },
   {
-    "key": "2a8cac0388159a84",
-    "contentsKey": "a801d268db063d7b",
+    "key": "9da3434b6aa989f8",
+    "instructionAgnosticKey": "163205064812ed4e",
     "request": {
       "contents": [
         {
@@ -64,7 +75,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_headline] said: Quantum Computing: The Next Frontier in Processing Power"
+              "text": "[generate_headline] said: Quantum Computing: The Next Frontier in Technology"
             }
           ]
         },
@@ -72,39 +83,72 @@
           "role": "user",
           "parts": [
             {
-              "text": "Quantum Computing: The Next Frontier in Processing Power"
+              "text": "Quantum Computing: The Next Frontier in Technology"
             }
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"evaluate_headline\".\n\n\n    Grade whether the headline is related to technology or software engineering.\n    "
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ],
+              "description": "Decide if the headline is related to technology or software engineering."
+            },
+            "feedback": {
+              "type": "STRING",
+              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "text": "{\"grade\": \"tech-related\", \"feedback\": \"\"}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 64,
+        "promptTokenCount": 89,
         "candidatesTokenCount": 12,
-        "totalTokenCount": 184,
+        "totalTokenCount": 286,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 64
+            "tokenCount": 89
           }
         ],
-        "thoughtsTokenCount": 108,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 12
+          }
+        ],
+        "thoughtsTokenCount": 185
       }
     }
   }

--- a/tests/integration/workflows/loop/model_responses.json
+++ b/tests/integration/workflows/loop/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "5fc04152f12fe2c0",
+    "contentsKey": "0be69852f4278c11",
     "request": {
       "contents": [
         {
@@ -45,6 +46,7 @@
   },
   {
     "key": "2a8cac0388159a84",
+    "contentsKey": "a801d268db063d7b",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/nested_workflow/model_responses.json
+++ b/tests/integration/workflows/nested_workflow/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "778e1cce4468601d",
+    "contentsKey": "496a1ff533b8a876",
     "request": {
       "contents": [
         {
@@ -45,6 +46,7 @@
   },
   {
     "key": "228440ecf0c1e553",
+    "contentsKey": "d14d9ef11f08b5bc",
     "request": {
       "contents": [
         {
@@ -108,6 +110,7 @@
   },
   {
     "key": "e15dc3fa645e73fc",
+    "contentsKey": "496a1ff533b8a876",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/nested_workflow/model_responses.json
+++ b/tests/integration/workflows/nested_workflow/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "778e1cce4468601d",
-    "contentsKey": "496a1ff533b8a876",
+    "instructionAgnosticKey": "6f1092c2fdbac9e3",
     "request": {
       "contents": [
         {
@@ -13,40 +13,51 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"find_name\".\n\n\n    Find the name of one famous person who was born in this year: 1955.\n    Return ONLY their name, nothing else.\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"find_name\".\n\n\n    Find the name of one famous person who was born in this year: 1955.\n    Return ONLY their name, nothing else.\n    ",
+        "labels": {
+          "adk_agent_name": "find_name"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "text": "Bill Gates"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 54,
+        "promptTokenCount": 52,
         "candidatesTokenCount": 2,
-        "totalTokenCount": 131,
+        "totalTokenCount": 98,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 54
+            "tokenCount": 52
           }
         ],
-        "thoughtsTokenCount": 75,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 2
+          }
+        ],
+        "thoughtsTokenCount": 44
       }
     }
   },
   {
     "key": "228440ecf0c1e553",
-    "contentsKey": "d14d9ef11f08b5bc",
+    "instructionAgnosticKey": "4969c8b07da28a12",
     "request": {
       "contents": [
         {
@@ -77,40 +88,51 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_bio\".\n\n\n    Write a short, engaging 3-sentence biography for the specified person.\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_bio\".\n\n\n    Write a short, engaging 3-sentence biography for the specified person.\n    ",
+        "labels": {
+          "adk_agent_name": "generate_bio"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Bill Gates co-founded Microsoft, igniting the personal computer revolution and making computing accessible worldwide. His vision transformed industries and everyday life, cementing his legacy as a technology pioneer. Today, he is a leading philanthropist through the Bill & Melinda Gates Foundation, dedicated to global health and poverty eradication."
+                "text": "Bill Gates revolutionized personal computing as the co-founder of Microsoft, turning it into a global software giant that made technology accessible worldwide. His innovative vision and leadership shaped the digital age. Today, he is primarily known for his extensive philanthropic work through the Bill & Melinda Gates Foundation, addressing critical global health and poverty issues."
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 55,
-        "candidatesTokenCount": 58,
-        "totalTokenCount": 229,
+        "promptTokenCount": 51,
+        "candidatesTokenCount": 63,
+        "totalTokenCount": 245,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 55
+            "tokenCount": 51
           }
         ],
-        "thoughtsTokenCount": 116,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 63
+          }
+        ],
+        "thoughtsTokenCount": 131
       }
     }
   },
   {
     "key": "e15dc3fa645e73fc",
-    "contentsKey": "496a1ff533b8a876",
+    "instructionAgnosticKey": "78053afc62938740",
     "request": {
       "contents": [
         {
@@ -122,34 +144,45 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"find_historical_event\".\n\n\n    Describe one highly significant historical event that occurred in this year: 1955.\n    Keep the description to 2 sentences.\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"find_historical_event\".\n\n\n    Describe one highly significant historical event that occurred in this year: 1955.\n    Keep the description to 2 sentences.\n    ",
+        "labels": {
+          "adk_agent_name": "find_historical_event"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "In 1955, the Soviet Union and its Eastern Bloc allies established the Warsaw Pact, a collective defense treaty. This alliance formally solidified the communist military bloc in Europe, directly confronting NATO and intensifying the Cold War."
+                "text": "In 1955, the Montgomery Bus Boycott began after Rosa Parks' refusal to give up her seat on a bus sparked widespread protest against racial segregation. This pivotal act of civil disobedience, led by Martin Luther King Jr., became a foundational event of the American Civil Rights Movement, demonstrating the power of nonviolent resistance."
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 54,
-        "candidatesTokenCount": 45,
-        "totalTokenCount": 727,
+        "promptTokenCount": 52,
+        "candidatesTokenCount": 66,
+        "totalTokenCount": 583,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 54
+            "tokenCount": 52
           }
         ],
-        "thoughtsTokenCount": 628,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 66
+          }
+        ],
+        "thoughtsTokenCount": 465
       }
     }
   }

--- a/tests/integration/workflows/node_as_tool/model_responses.json
+++ b/tests/integration/workflows/node_as_tool/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "5c12572a300d06ce",
+    "contentsKey": "db53386e1fbaa635",
     "request": {
       "contents": [
         {
@@ -52,6 +53,7 @@
   },
   {
     "key": "9198e0671a442787",
+    "contentsKey": "8c0f8f06add6d66b",
     "request": {
       "contents": [
         {
@@ -131,6 +133,7 @@
   },
   {
     "key": "5e0e6625f60e416c",
+    "contentsKey": "7d66ae27391012ae",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/node_as_tool/model_responses.json
+++ b/tests/integration/workflows/node_as_tool/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "5c12572a300d06ce",
-    "contentsKey": "db53386e1fbaa635",
+    "instructionAgnosticKey": "3855f18c9f65f0c3",
     "request": {
       "contents": [
         {
@@ -13,12 +13,56 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "customer_lookup_workflow",
+                "description": "Looks up customer status and tier by user_id.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "userId": {
+                      "type": "STRING",
+                      "description": "The customer's unique identifier."
+                    }
+                  },
+                  "required": [
+                    "userId"
+                  ]
+                }
+              },
+              {
+                "name": "calculate_discount",
+                "description": "Calculates the discount percentage based on the customer tier.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "tier": {
+                      "type": "STRING",
+                      "description": "The customer membership tier (e.g. VIP)."
+                    }
+                  },
+                  "required": [
+                    "tier"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "customer_service_agent"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "functionCall": {
@@ -26,34 +70,38 @@
                   "args": {
                     "userId": "u123"
                   },
-                  "id": "adk-fd285b1d-b631-4b70-af75-2bfbad658de3"
-                },
-                "thoughtSignature": "CrIDARFNMg/l/BhcmHC+A0NSkm0toDFtvveWfCmbIqCqV6BIB1jyhoJjXACDSqNhNU+Z6l6yjtEjePUAeD0aoJG+62oz3vRp0SyOVeMWOZJH3aKDAiL2A6JZ88xW66hNGng41TLnFQSoG7qDmumte00tpF5yCoF167Z3Vo9uhxm/us9H5XAqS94ftuAdKwSRgL/f4i5bB3EJeoIlS75aFoC7hY8vdzNtMq9sT2axfgNlpU0wbp6BGfCEQJXSulUHhW1KffMeoPulnhoQGj0+oCJ3vJ+PiL7qnZ47p61Vy/25MvmOGuPxzgtGcU7BbSPnFfodXBfxWLZKz2m8kqhBuHB9y3bk4pfdc74RIa1eLr8YZ3QynjmRgE4AXr5HsNcRy+NCzkCK4hLNSTLLVCaTL+c32ONu+YppBOUPzxT+LcwYJzsP5W6By2cZejzCC1zpx5Vj64hXWP4aoip7ws8N6pR0tENvb4idzqNx+Vb3mI3Z4RoSaBfNnoVPtiT0smyLpk+eM6RRcCdLovZUYbtzkggchTSbVNA90If26Pm+1COqRA1HT/ibvZqJOPQOk0MkKL6rtlY="
+                  "id": "adk-f58be2e3-f696-4d15-8dee-0cee5c320702"
+                }
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 204,
-        "candidatesTokenCount": 20,
-        "totalTokenCount": 325,
+        "promptTokenCount": 154,
+        "candidatesTokenCount": 10,
+        "totalTokenCount": 271,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 204
+            "tokenCount": 154
           }
         ],
-        "thoughtsTokenCount": 101,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 10
+          }
+        ],
+        "thoughtsTokenCount": 107
       }
     }
   },
   {
-    "key": "9198e0671a442787",
-    "contentsKey": "8c0f8f06add6d66b",
+    "key": "ea80007f6409252c",
+    "instructionAgnosticKey": "0f0a2260e6e894d0",
     "request": {
       "contents": [
         {
@@ -65,6 +113,7 @@
           ]
         },
         {
+          "role": "model",
           "parts": [
             {
               "functionCall": {
@@ -72,11 +121,9 @@
                 "args": {
                   "userId": "u123"
                 }
-              },
-              "thoughtSignature": "CrIDARFNMg/l/BhcmHC+A0NSkm0toDFtvveWfCmbIqCqV6BIB1jyhoJjXACDSqNhNU+Z6l6yjtEjePUAeD0aoJG+62oz3vRp0SyOVeMWOZJH3aKDAiL2A6JZ88xW66hNGng41TLnFQSoG7qDmumte00tpF5yCoF167Z3Vo9uhxm/us9H5XAqS94ftuAdKwSRgL/f4i5bB3EJeoIlS75aFoC7hY8vdzNtMq9sT2axfgNlpU0wbp6BGfCEQJXSulUHhW1KffMeoPulnhoQGj0+oCJ3vJ+PiL7qnZ47p61Vy/25MvmOGuPxzgtGcU7BbSPnFfodXBfxWLZKz2m8kqhBuHB9y3bk4pfdc74RIa1eLr8YZ3QynjmRgE4AXr5HsNcRy+NCzkCK4hLNSTLLVCaTL+c32ONu+YppBOUPzxT+LcwYJzsP5W6By2cZejzCC1zpx5Vj64hXWP4aoip7ws8N6pR0tENvb4idzqNx+Vb3mI3Z4RoSaBfNnoVPtiT0smyLpk+eM6RRcCdLovZUYbtzkggchTSbVNA90If26Pm+1COqRA1HT/ibvZqJOPQOk0MkKL6rtlY="
+              }
             }
-          ],
-          "role": "model"
+          ]
         },
         {
           "role": "user",
@@ -93,12 +140,56 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "customer_lookup_workflow",
+                "description": "Looks up customer status and tier by user_id.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "userId": {
+                      "type": "STRING",
+                      "description": "The customer's unique identifier."
+                    }
+                  },
+                  "required": [
+                    "userId"
+                  ]
+                }
+              },
+              {
+                "name": "calculate_discount",
+                "description": "Calculates the discount percentage based on the customer tier.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "tier": {
+                      "type": "STRING",
+                      "description": "The customer membership tier (e.g. VIP)."
+                    }
+                  },
+                  "required": [
+                    "tier"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "customer_service_agent"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "functionCall": {
@@ -106,34 +197,37 @@
                   "args": {
                     "tier": "Verified VIP Member"
                   },
-                  "id": "adk-ad4e599b-b87b-498a-b85a-fd4d57b287e2"
-                },
-                "thoughtSignature": "CskBARFNMg8w0O19xRklAqwMQk8G8Ofbobo8Cn51FOb0XeQ9tViP4OGaHJQ/NYLS/4C3qrT23M7HEmbY+wdN6Qnsxxt+V7Lz9JgFNJpHLqvNhHlyi44zyNDyX6EhhlfxlRG+ZC11hXkaYqSNHgTwDMOk4VEWrrGsxtwgUA9hVtu8n87INMsCUC73l20FY+fj7iT2zS48LRejcRaDVe6PurVFVgK6R7UHueKsSTqyU1bR/Bsk/Y/8AIqHjNR8SdtCI4Zb55dlX9Wknnwt"
+                  "id": "adk-c050f74b-0a29-4720-86a2-fde8da23cb6b"
+                }
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 252,
-        "candidatesTokenCount": 17,
-        "totalTokenCount": 308,
+        "promptTokenCount": 178,
+        "candidatesTokenCount": 7,
+        "totalTokenCount": 185,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 252
+            "tokenCount": 178
           }
         ],
-        "thoughtsTokenCount": 39,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 7
+          }
+        ]
       }
     }
   },
   {
-    "key": "5e0e6625f60e416c",
-    "contentsKey": "7d66ae27391012ae",
+    "key": "028f0c7b0f0252ef",
+    "instructionAgnosticKey": "a7d31ef585c10ae6",
     "request": {
       "contents": [
         {
@@ -145,6 +239,7 @@
           ]
         },
         {
+          "role": "model",
           "parts": [
             {
               "functionCall": {
@@ -152,11 +247,9 @@
                 "args": {
                   "userId": "u123"
                 }
-              },
-              "thoughtSignature": "CrIDARFNMg/l/BhcmHC+A0NSkm0toDFtvveWfCmbIqCqV6BIB1jyhoJjXACDSqNhNU+Z6l6yjtEjePUAeD0aoJG+62oz3vRp0SyOVeMWOZJH3aKDAiL2A6JZ88xW66hNGng41TLnFQSoG7qDmumte00tpF5yCoF167Z3Vo9uhxm/us9H5XAqS94ftuAdKwSRgL/f4i5bB3EJeoIlS75aFoC7hY8vdzNtMq9sT2axfgNlpU0wbp6BGfCEQJXSulUHhW1KffMeoPulnhoQGj0+oCJ3vJ+PiL7qnZ47p61Vy/25MvmOGuPxzgtGcU7BbSPnFfodXBfxWLZKz2m8kqhBuHB9y3bk4pfdc74RIa1eLr8YZ3QynjmRgE4AXr5HsNcRy+NCzkCK4hLNSTLLVCaTL+c32ONu+YppBOUPzxT+LcwYJzsP5W6By2cZejzCC1zpx5Vj64hXWP4aoip7ws8N6pR0tENvb4idzqNx+Vb3mI3Z4RoSaBfNnoVPtiT0smyLpk+eM6RRcCdLovZUYbtzkggchTSbVNA90If26Pm+1COqRA1HT/ibvZqJOPQOk0MkKL6rtlY="
+              }
             }
-          ],
-          "role": "model"
+          ]
         },
         {
           "role": "user",
@@ -184,6 +277,7 @@
           ]
         },
         {
+          "role": "model",
           "parts": [
             {
               "functionCall": {
@@ -191,11 +285,9 @@
                 "args": {
                   "tier": "Verified VIP Member"
                 }
-              },
-              "thoughtSignature": "CskBARFNMg8w0O19xRklAqwMQk8G8Ofbobo8Cn51FOb0XeQ9tViP4OGaHJQ/NYLS/4C3qrT23M7HEmbY+wdN6Qnsxxt+V7Lz9JgFNJpHLqvNhHlyi44zyNDyX6EhhlfxlRG+ZC11hXkaYqSNHgTwDMOk4VEWrrGsxtwgUA9hVtu8n87INMsCUC73l20FY+fj7iT2zS48LRejcRaDVe6PurVFVgK6R7UHueKsSTqyU1bR/Bsk/Y/8AIqHjNR8SdtCI4Zb55dlX9Wknnwt"
+              }
             }
-          ],
-          "role": "model"
+          ]
         },
         {
           "role": "user",
@@ -211,35 +303,83 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "customer_lookup_workflow",
+                "description": "Looks up customer status and tier by user_id.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "userId": {
+                      "type": "STRING",
+                      "description": "The customer's unique identifier."
+                    }
+                  },
+                  "required": [
+                    "userId"
+                  ]
+                }
+              },
+              {
+                "name": "calculate_discount",
+                "description": "Calculates the discount percentage based on the customer tier.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "tier": {
+                      "type": "STRING",
+                      "description": "The customer membership tier (e.g. VIP)."
+                    }
+                  },
+                  "required": [
+                    "tier"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "customer_service_agent"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Your membership tier is \"Verified VIP Member\" and you get a 20% discount.",
-                "thoughtSignature": "CpUCARFNMg9D6HOPkkiMGyyxIENysDhYK+G4QMIaNTCQepr/de3zwVjrrT2WGdxDnvWOkDGFGn7s8eBoIGikoLBpYskhZ9lBE5qO3Dm1paFK5+iHECq6QYf5udHpCpzYcyih7kwFbg6u62NJCHV+HVzKgEG4HdSvnzS/9mRQYqzktIhueiGhwVvDJE9zLeNefJsOY1qGrV1XTd3BNOXD5noz5rdOz9azywcidw02CY6FBL4HCtWOtQ7U+eCza4ftTj9we7zbkaySQh5cW+7ifb9QldT+u5kAzWqUjTh8YTXwRQsT8RZr2zdtJ0uZFXvSpwWUNCH2PYRqoiG+yMZOKGwBeI27BlJEAUFfsNkZcCdjeobSR7TAfQ=="
+                "text": "Your membership tier is \"Verified VIP Member\" and your discount is 20% off."
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 314,
+        "promptTokenCount": 219,
         "candidatesTokenCount": 19,
-        "totalTokenCount": 396,
+        "totalTokenCount": 291,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 314
+            "tokenCount": 219
           }
         ],
-        "thoughtsTokenCount": 63,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 19
+          }
+        ],
+        "thoughtsTokenCount": 53
       }
     }
   }

--- a/tests/integration/workflows/node_output/model_responses.json
+++ b/tests/integration/workflows/node_output/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "c22ca69dcb15fada",
+    "contentsKey": "c07c2d146c9cf5a8",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/node_output/model_responses.json
+++ b/tests/integration/workflows/node_output/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
-    "key": "c22ca69dcb15fada",
-    "contentsKey": "c07c2d146c9cf5a8",
+    "key": "9770890d07d83c14",
+    "instructionAgnosticKey": "5583ad5423f13dc1",
     "request": {
       "contents": [
         {
@@ -32,34 +32,68 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_pydantic_output\".\n\nGenerate a creative topic based on the following input."
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "title": {
+              "type": "STRING",
+              "description": "The title of the generated topic."
+            },
+            "description": {
+              "type": "STRING",
+              "description": "A short description of the topic."
+            },
+            "category": {
+              "type": "STRING",
+              "description": "The broad category of the topic."
+            }
+          },
+          "required": [
+            "title",
+            "description",
+            "category"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Generate a creative topic based on the following input.",
+        "labels": {
+          "adk_agent_name": "generate_pydantic_output"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"title\": \"Abyssal Pioneers: Unveiling the Ocean's Deepest Secrets with Autonomous Fleets\", \"description\": \"Explore the next frontier of ocean exploration, focusing on the development and deployment of advanced autonomous underwater vehicles (AUVs) and robotic fleets to map, analyze, and discover the mysteries of the deep sea, from unexplored trenches to hydrothermal vents and their unique ecosystems.\", \"category\": \"Future Technology & Marine Science\"}"
+                "text": "{\n  \"title\": \"Abyssal Archives: Unearthing the Ocean's Hidden History and Future Secrets\",\n  \"description\": \"Explore how cutting-edge ocean exploration technologies are not only discovering new life forms and geological wonders in the deep sea, but also revealing forgotten histories and providing critical insights into the future of Earth's climate and biodiversity.\",\n  \"category\": \"Marine Science & Future Discovery\"\n}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 63,
-        "candidatesTokenCount": 89,
-        "totalTokenCount": 393,
+        "promptTokenCount": 71,
+        "candidatesTokenCount": 88,
+        "totalTokenCount": 443,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 63
+            "tokenCount": 71
           }
         ],
-        "thoughtsTokenCount": 241,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 88
+          }
+        ],
+        "thoughtsTokenCount": 284
       }
     }
   }

--- a/tests/integration/workflows/parallel_worker/model_responses.json
+++ b/tests/integration/workflows/parallel_worker/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
-    "key": "af9498818db98c17",
-    "contentsKey": "8c3b368028e18bba",
+    "key": "cd9270015161d3d2",
+    "instructionAgnosticKey": "4264aed4e3cdf2d9",
     "request": {
       "contents": [
         {
@@ -13,40 +13,58 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"find_related_topics\".\n\nGiven the specific topic \"databases\", generate a list of 3 related topics."
+      "config": {
+        "responseSchema": {
+          "type": "ARRAY",
+          "items": {
+            "type": "STRING"
+          }
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Given the specific topic \"databases\", generate a list of 3 related topics.",
+        "labels": {
+          "adk_agent_name": "find_related_topics"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "[\"SQL\", \"Data Warehousing\", \"Cloud Computing\"]"
+                "text": "[\n  \"SQL\",\n  \"data modeling\",\n  \"database administration\"\n]"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 36,
-        "candidatesTokenCount": 12,
-        "totalTokenCount": 188,
+        "promptTokenCount": 19,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 64,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 36
+            "tokenCount": 19
           }
         ],
-        "thoughtsTokenCount": 140,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 20
+          }
+        ],
+        "thoughtsTokenCount": 25
       }
     }
   },
   {
-    "key": "725400919553bd3a",
-    "contentsKey": "529ad20ad9ecabab",
+    "key": "4be471efd03ca099",
+    "instructionAgnosticKey": "41c6a4874736a99c",
     "request": {
       "contents": [
         {
@@ -64,7 +82,7 @@
               "text": "For context:"
             },
             {
-              "text": "[find_related_topics] said: [\"SQL\", \"Data Warehousing\", \"Cloud Computing\"]"
+              "text": "[find_related_topics] said: [\n  \"SQL\",\n  \"data modeling\",\n  \"database administration\"\n]"
             }
           ]
         },
@@ -77,40 +95,67 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"explain_topic\".\n\nExplain how the following topic relates to the original topic: \"databases\"."
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "topic": {
+              "type": "STRING"
+            },
+            "explanation": {
+              "type": "STRING"
+            }
+          },
+          "required": [
+            "topic",
+            "explanation"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Explain how the following topic relates to the original topic: \"databases\".",
+        "labels": {
+          "adk_agent_name": "explain_topic"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"topic\":\"SQL\",\"explanation\":\"SQL (Structured Query Language) is the primary language used to define, manipulate, and query data in relational databases. It's the standard way to interact with and manage the vast majority of database systems, allowing users to create tables, insert data, retrieve specific information, and update records.\"}"
+                "text": "{\n  \"topic\": \"SQL\",\n  \"explanation\": \"SQL (Structured Query Language) is the standard language used for managing and manipulating relational databases. It allows users to create, retrieve, update, and delete data, as well as define database schemas and manage access permissions. Without SQL, interacting with most traditional 'databases' would be significantly more complex, as it provides the core functionality for data operations and database management.\"\n}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 59,
-        "candidatesTokenCount": 66,
-        "totalTokenCount": 245,
+        "promptTokenCount": 55,
+        "candidatesTokenCount": 89,
+        "totalTokenCount": 178,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 59
+            "tokenCount": 55
           }
         ],
-        "thoughtsTokenCount": 120,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 89
+          }
+        ],
+        "thoughtsTokenCount": 34
       }
     }
   },
   {
-    "key": "4413514f9a6e442e",
-    "contentsKey": "a6e4a0baf522f12b",
+    "key": "ea16caa379152d83",
+    "instructionAgnosticKey": "f74803db885b14a0",
     "request": {
       "contents": [
         {
@@ -128,7 +173,7 @@
               "text": "For context:"
             },
             {
-              "text": "[find_related_topics] said: [\"SQL\", \"Data Warehousing\", \"Cloud Computing\"]"
+              "text": "[find_related_topics] said: [\n  \"SQL\",\n  \"data modeling\",\n  \"database administration\"\n]"
             }
           ]
         },
@@ -136,45 +181,72 @@
           "role": "user",
           "parts": [
             {
-              "text": "DATA WAREHOUSING"
+              "text": "DATA MODELING"
             }
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"explain_topic\".\n\nExplain how the following topic relates to the original topic: \"databases\"."
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "topic": {
+              "type": "STRING"
+            },
+            "explanation": {
+              "type": "STRING"
+            }
+          },
+          "required": [
+            "topic",
+            "explanation"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Explain how the following topic relates to the original topic: \"databases\".",
+        "labels": {
+          "adk_agent_name": "explain_topic"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"topic\":\"DATA WAREHOUSING\",\"explanation\":\"Data Warehousing is a specific type of database system designed for analytical reporting and data analysis. While traditional databases (often called OLTP - Online Transaction Processing) are optimized for transactional operations like inserting, updating, and deleting small amounts of data quickly, data warehouses (OLAP - Online Analytical Processing) are optimized for complex queries that involve reading and aggregating large volumes of historical data. Data warehouses typically collect and consolidate data from multiple operational databases and other sources, transforming it into a format suitable for business intelligence and decision-making. Therefore, data warehousing heavily relies on databases as its foundational technology, but with a distinct architectural and usage pattern focused on analytical workloads rather than real-time transactions.\"}"
+                "text": "{\n  \"topic\": \"DATA MODELING\",\n  \"explanation\": \"Data modeling is a fundamental and crucial step in the design and implementation of databases. It involves creating a visual or conceptual representation of the data that an organization needs to store and manage. This process defines the structure of the data, the relationships between different data elements, and the constraints that govern the data's integrity. Essentially, data modeling provides the blueprint for building a database, determining how tables will be organized, what attributes they will contain, and how they will connect to each other. Without effective data modeling, a database would lack structure, consistency, and efficiency in storing and retrieving information.\"\n}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 63,
-        "candidatesTokenCount": 148,
-        "totalTokenCount": 347,
+        "promptTokenCount": 57,
+        "candidatesTokenCount": 137,
+        "totalTokenCount": 252,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 63
+            "tokenCount": 57
           }
         ],
-        "thoughtsTokenCount": 136,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 137
+          }
+        ],
+        "thoughtsTokenCount": 58
       }
     }
   },
   {
-    "key": "40da01e7376bf978",
-    "contentsKey": "ebb11c9521a2771b",
+    "key": "21a12fc32ed4924b",
+    "instructionAgnosticKey": "831e9fdf435ed2b5",
     "request": {
       "contents": [
         {
@@ -192,7 +264,7 @@
               "text": "For context:"
             },
             {
-              "text": "[find_related_topics] said: [\"SQL\", \"Data Warehousing\", \"Cloud Computing\"]"
+              "text": "[find_related_topics] said: [\n  \"SQL\",\n  \"data modeling\",\n  \"database administration\"\n]"
             }
           ]
         },
@@ -206,10 +278,10 @@
               "text": "[make_upper_case] said: SQL"
             },
             {
-              "text": "[make_upper_case] said: DATA WAREHOUSING"
+              "text": "[make_upper_case] said: DATA MODELING"
             },
             {
-              "text": "[make_upper_case] said: CLOUD COMPUTING"
+              "text": "[make_upper_case] said: DATABASE ADMINISTRATION"
             }
           ]
         },
@@ -217,39 +289,66 @@
           "role": "user",
           "parts": [
             {
-              "text": "CLOUD COMPUTING"
+              "text": "DATABASE ADMINISTRATION"
             }
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"explain_topic\".\n\nExplain how the following topic relates to the original topic: \"databases\"."
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "topic": {
+              "type": "STRING"
+            },
+            "explanation": {
+              "type": "STRING"
+            }
+          },
+          "required": [
+            "topic",
+            "explanation"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Explain how the following topic relates to the original topic: \"databases\".",
+        "labels": {
+          "adk_agent_name": "explain_topic"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"topic\": \"CLOUD COMPUTING\", \"explanation\": \"Cloud Computing relates directly to databases by providing the infrastructure, platforms, and services necessary to host, manage, and scale databases. Cloud providers offer 'Database as a Service' (DBaaS) solutions, enabling users to deploy and operate various types of databases (relational, NoSQL, data warehouses) without the need for extensive on-premise hardware or software management. This allows for increased scalability, reliability, cost-efficiency, and global accessibility of database systems.\"}"
+                "text": "{\n  \"topic\": \"DATABASE ADMINISTRATION\",\n  \"explanation\": \"DATABASE ADMINISTRATION is the practice of managing and maintaining databases to ensure their optimal performance, security, and availability. This involves tasks such as installation, configuration, backup and recovery, security management, performance tuning, and troubleshooting. It is directly related to databases as it encompasses all the necessary activities to keep a database system operational, secure, and efficient for the organizations that rely on them.\"\n}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 102,
-        "candidatesTokenCount": 106,
-        "totalTokenCount": 393,
+        "promptTokenCount": 92,
+        "candidatesTokenCount": 93,
+        "totalTokenCount": 219,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 102
+            "tokenCount": 92
           }
         ],
-        "thoughtsTokenCount": 185,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 93
+          }
+        ],
+        "thoughtsTokenCount": 34
       }
     }
   }

--- a/tests/integration/workflows/parallel_worker/model_responses.json
+++ b/tests/integration/workflows/parallel_worker/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "af9498818db98c17",
+    "contentsKey": "8c3b368028e18bba",
     "request": {
       "contents": [
         {
@@ -45,6 +46,7 @@
   },
   {
     "key": "725400919553bd3a",
+    "contentsKey": "529ad20ad9ecabab",
     "request": {
       "contents": [
         {
@@ -108,6 +110,7 @@
   },
   {
     "key": "4413514f9a6e442e",
+    "contentsKey": "a6e4a0baf522f12b",
     "request": {
       "contents": [
         {
@@ -171,6 +174,7 @@
   },
   {
     "key": "40da01e7376bf978",
+    "contentsKey": "ebb11c9521a2771b",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/request_input/model_responses.json
+++ b/tests/integration/workflows/request_input/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "2286e7d95f2f2225",
+    "contentsKey": "55a88d3803f13c46",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/request_input/model_responses.json
+++ b/tests/integration/workflows/request_input/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "2286e7d95f2f2225",
-    "contentsKey": "55a88d3803f13c46",
+    "instructionAgnosticKey": "dc9308db164b54da",
     "request": {
       "contents": [
         {
@@ -13,34 +13,45 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"The product I bought broke after a day.\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"The product I bought broke after a day.\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Subject: We're Sorry to Hear About Your Product Issue - How Can We Help?\n\nDear Valued Customer,\n\nThank you for reaching out to us. I'm truly sorry to hear that the product you purchased broke after just one day. That is certainly not the experience we want our customers to have, and I understand how frustrating this must be.\n\nWe pride ourselves on the quality of our products, and we want to make this right for you.\n\nTo help us resolve this swiftly, could you please provide us with a few more details?\n\n*   Your order number (if you have it)\n*   The exact name of the product that broke\n*   A brief description of what happened when it broke\n\nOnce we have this information, we can promptly guide you through our [replacement/return/warranty] process to ensure you either receive a working replacement or a full refund.\n\nPlease reply to this email with the details, or feel free to call our customer service team directly at [Your Phone Number] if you prefer to speak with someone. We're available [Your Customer Service Hours, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nThank you for your patience and for bringing this to our attention. We look forward to assisting you and ensuring your satisfaction.\n\nSincerely,\n\nThe [Your Company Name] Team"
+                "text": "Subject: We're Sorry to Hear About Your Product Issue - Let's Make It Right\n\nDear [Customer Name],\n\nThank you for reaching out to us. I am truly sorry to hear that the product you purchased broke after just one day. We understand how frustrating and disappointing this must be, and it's certainly not the experience we want our customers to have with our products.\n\nWe are committed to providing high-quality items, and we want to help resolve this for you as quickly as possible.\n\nTo assist you efficiently, could you please provide us with the following information?\n\n*   Your order number or proof of purchase\n*   The name of the product you purchased\n*   A brief description of how the product broke (e.g., what happened, what part broke)\n*   Any photos or videos of the damaged product, if available (this can often help us understand the issue faster)\n\nOnce we have this information, we will be able to review your case and discuss the best resolution, whether that's a replacement, a refund, or a repair, according to our warranty policy.\n\nWe genuinely appreciate your patience and cooperation as we work to resolve this for you. Please reply to this email with the details requested, and we'll get right on it.\n\nSincerely,\n\nThe [Your Company Name] Team"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 73,
-        "candidatesTokenCount": 280,
-        "totalTokenCount": 833,
+        "promptTokenCount": 71,
+        "candidatesTokenCount": 276,
+        "totalTokenCount": 810,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 73
+            "tokenCount": 71
           }
         ],
-        "thoughtsTokenCount": 480,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 276
+          }
+        ],
+        "thoughtsTokenCount": 463
       }
     }
   }

--- a/tests/integration/workflows/request_input_advanced/model_responses.json
+++ b/tests/integration/workflows/request_input_advanced/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "57df526204e44e91",
+    "contentsKey": "d09f131d2a442dae",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/request_input_advanced/model_responses.json
+++ b/tests/integration/workflows/request_input_advanced/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
-    "key": "57df526204e44e91",
-    "contentsKey": "d09f131d2a442dae",
+    "key": "cd00e10c2b9ea2c8",
+    "instructionAgnosticKey": "a6cfda2775c1b821",
     "request": {
       "contents": [
         {
@@ -21,34 +21,63 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"process_request\".\n\nExtract the number of days and the reason from the user's natural language time off request."
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "days": {
+              "type": "NUMBER",
+              "description": "Number of days requested."
+            },
+            "reason": {
+              "type": "STRING",
+              "description": "Reason for the time off."
+            }
+          },
+          "required": [
+            "days",
+            "reason"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Extract the number of days and the reason from the user's natural language time off request.",
+        "labels": {
+          "adk_agent_name": "process_request"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"days\":3,\"reason\":\"family trip\"}"
+                "text": "{\"days\": 3, \"reason\": \"family trip\"}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
         "promptTokenCount": 63,
-        "candidatesTokenCount": 10,
-        "totalTokenCount": 134,
+        "candidatesTokenCount": 13,
+        "totalTokenCount": 115,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
             "tokenCount": 63
           }
         ],
-        "thoughtsTokenCount": 61,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 13
+          }
+        ],
+        "thoughtsTokenCount": 39
       }
     }
   }

--- a/tests/integration/workflows/request_input_rerun/model_responses.json
+++ b/tests/integration/workflows/request_input_rerun/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "98b25193a6c2de82",
-    "contentsKey": "f49b0f809166b0b9",
+    "instructionAgnosticKey": "684e2888794c2394",
     "request": {
       "contents": [
         {
@@ -13,34 +13,45 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"My order never arrived and support is ignoring me.\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    "
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"My order never arrived and support is ignoring me.\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Subject: We're so sorry – Let's get your order sorted out immediately!\n\nDear Customer,\n\nPlease accept our sincere apologies for the trouble you've experienced with your order not arriving, and even more so for feeling ignored by our support team. That is absolutely not the experience we want you to have, and we understand how frustrating this must be.\n\nWe are truly sorry for this lapse in service.\n\nI want to personally assure you that we are taking this seriously and will get to the bottom of it. To help us locate your order and investigate what went wrong with your previous support requests, could you please provide us with your **order number**?\n\nOnce we have that, I will personally look into your shipment status and review the communication history with support. We will work to resolve this for you as quickly as possible, whether that means arranging a replacement shipment or a full refund, based on your preference.\n\nYou can expect to hear back from us with an update within [mention a realistic timeframe, e.g., 24 business hours] of receiving your order number.\n\nThank you for your patience as we rectify this.\n\nSincerely,\n\n[Your Name/Customer Service Manager]\n[Your Company Name]"
+                "text": "Subject: We're so sorry about your order and the lack of response - Let's fix this immediately\n\nDear Customer,\n\nPlease accept my sincerest apologies for the frustration and inconvenience you've experienced. It is completely unacceptable that your order has not arrived, and I am truly sorry to hear that you feel ignored by our support team. That is not the level of service we aim to provide, and I understand how disheartening that must be.\n\nI want to assure you that I am personally looking into this right away. To help me investigate your order status and resolve this for you as quickly as possible, could you please provide me with your:\n\n*   **Order Number:**\n*   **Email Address used for the order:**\n*   **(Optional, but helpful) Date of Purchase:**\n\nOnce I have this information, I will immediately:\n1.  Trace your shipment.\n2.  Review all previous support interactions.\n3.  Work directly with our logistics and support teams to find out exactly what happened and why your previous inquiries went unanswered.\n\nYou can expect to hear back from me within [e.g., 4-8 business hours / 24 hours] with a full update and a proposed resolution. My priority is to get this resolved for you quickly and to ensure you receive your order or a full refund, along with a proper explanation.\n\nThank you for your patience as we rectify this. Please feel free to reply directly to this email with the requested details or any further questions you may have.\n\nSincerely,\n\n[Your Name/Customer Service Manager]\n[Your Title]\n[Your Company]"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 75,
-        "candidatesTokenCount": 252,
-        "totalTokenCount": 526,
+        "promptTokenCount": 73,
+        "candidatesTokenCount": 337,
+        "totalTokenCount": 615,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 75
+            "tokenCount": 73
           }
         ],
-        "thoughtsTokenCount": 199,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 337
+          }
+        ],
+        "thoughtsTokenCount": 205
       }
     }
   }

--- a/tests/integration/workflows/request_input_rerun/model_responses.json
+++ b/tests/integration/workflows/request_input_rerun/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "98b25193a6c2de82",
+    "contentsKey": "f49b0f809166b0b9",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/route/model_responses.json
+++ b/tests/integration/workflows/route/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "04cfafaecb1a4f23",
+    "contentsKey": "c5c786dc0d117b74",
     "request": {
       "contents": [
         {
@@ -45,6 +46,7 @@
   },
   {
     "key": "d1fcb02355443296",
+    "contentsKey": "80a6a4c9a2e07a69",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/route/model_responses.json
+++ b/tests/integration/workflows/route/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
-    "key": "04cfafaecb1a4f23",
-    "contentsKey": "c5c786dc0d117b74",
+    "key": "e2ef67caafcbd841",
+    "instructionAgnosticKey": "c115d001eab3ef66",
     "request": {
       "contents": [
         {
@@ -13,40 +13,68 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"classify_input\".\n\nBased on this input, decide which category it belongs to: What is ADK?"
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "category": {
+              "type": "STRING",
+              "enum": [
+                "question",
+                "statement",
+                "other"
+              ]
+            }
+          },
+          "required": [
+            "category"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Based on this input, decide which category it belongs to: What is ADK?",
+        "labels": {
+          "adk_agent_name": "classify_input"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
                 "text": "{\"category\": \"question\"}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 39,
+        "promptTokenCount": 29,
         "candidatesTokenCount": 6,
-        "totalTokenCount": 80,
+        "totalTokenCount": 67,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 39
+            "tokenCount": 29
           }
         ],
-        "thoughtsTokenCount": 35,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 6
+          }
+        ],
+        "thoughtsTokenCount": 32
       }
     }
   },
   {
     "key": "d1fcb02355443296",
-    "contentsKey": "80a6a4c9a2e07a69",
+    "instructionAgnosticKey": "468125998cc36437",
     "request": {
       "contents": [
         {
@@ -69,34 +97,45 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"answer_question\".\n\nAnswer the question: What is ADK?"
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"answer_question\".\n\nAnswer the question: What is ADK?",
+        "labels": {
+          "adk_agent_name": "answer_question"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "ADK most commonly refers to the **Windows Assessment and Deployment Kit**.\n\nIt is a collection of tools from Microsoft designed for:\n\n1.  **Assessment:** Evaluating the performance and quality of Windows systems, components, and software.\n2.  **Deployment:** Customizing, assessing, and deploying Windows operating systems to new computers.\n\nThe ADK is primarily used by OEMs (Original Equipment Manufacturers), IT professionals, and developers to prepare, install, and customize Windows images for large-scale deployments or specific hardware configurations.\n\nKey components often included in the ADK are:\n\n*   **Deployment Tools:** Includes DISM (Deployment Image Servicing and Management) and OSCDImg.\n*   **Windows Preinstallation Environment (WinPE):** A light version of Windows used for installing, deploying, and repairing Windows.\n*   **User State Migration Tool (USMT):** Migrates user files and settings during a deployment.\n*   **Volume Activation Management Tool (VAMT):** Manages Windows and Office activation.\n*   **Performance Toolkit:** Tools like Windows Performance Recorder and Analyzer.\n*   **Application Compatibility Toolkit (ACT):** Helps identify and mitigate application compatibility issues."
+                "text": "\"ADK\" can stand for several different things, depending on the context. Here are the most common interpretations:\n\n1.  **Application Development Kit (ADK):** This is a generic term referring to a set of software development tools that allows for the creation of applications for a certain software package, platform, hardware device, or operating system. It's very similar to an SDK (Software Development Kit) and often includes compilers, debuggers, libraries, APIs, documentation, and sample code.\n2.  **Android Development Kit:** While the official term is usually **Android SDK (Software Development Kit)**, \"ADK\" might sometimes be informally used to refer to the tools and resources for developing applications for the Android platform. There was also a specific \"Android ADK\" (Android Open Accessory Development Kit) for connecting hardware accessories to Android devices.\n3.  **Adirondack Park / Mountains:** Often abbreviated as \"ADK,\" this refers to a large protected area in northeastern New York State, known for its mountains, lakes, and forests. People might use \"ADK\" when talking about hiking, camping, or the region in general.\n4.  **Appliance Development Kit:** In the context of embedded systems or IoT (Internet of Things), an ADK might refer to tools used to develop software for specific smart appliances or connected devices.\n\nTo know exactly what \"ADK\" means in a specific situation, you usually need more context."
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 48,
-        "candidatesTokenCount": 245,
-        "totalTokenCount": 798,
+        "promptTokenCount": 45,
+        "candidatesTokenCount": 300,
+        "totalTokenCount": 648,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 48
+            "tokenCount": 45
           }
         ],
-        "thoughtsTokenCount": 505,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 300
+          }
+        ],
+        "thoughtsTokenCount": 303
       }
     }
   }

--- a/tests/integration/workflows/sequence/model_responses.json
+++ b/tests/integration/workflows/sequence/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "fe3c05c052fff445",
-    "contentsKey": "64ce92e663f23e5b",
+    "instructionAgnosticKey": "e2299668e57ebcb1",
     "request": {
       "contents": [
         {
@@ -21,40 +21,51 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_fruit_agent\".\n\nReturn the name of a random fruit.\n      Return only the name, nothing else."
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_fruit_agent\".\n\nReturn the name of a random fruit.\n      Return only the name, nothing else.",
+        "labels": {
+          "adk_agent_name": "generate_fruit_agent"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Apple"
+                "text": "I cannot provide a fruit fact. I can only provide the name of a random fruit."
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 48,
-        "candidatesTokenCount": 1,
-        "totalTokenCount": 129,
+        "promptTokenCount": 45,
+        "candidatesTokenCount": 18,
+        "totalTokenCount": 103,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 48
+            "tokenCount": 45
           }
         ],
-        "thoughtsTokenCount": 80,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 18
+          }
+        ],
+        "thoughtsTokenCount": 40
       }
     }
   },
   {
-    "key": "3c06842da841d90e",
-    "contentsKey": "30a2979a67c32bbb",
+    "key": "6fee2a727c1ea777",
+    "instructionAgnosticKey": "3506ab9a2bab86b7",
     "request": {
       "contents": [
         {
@@ -80,7 +91,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_fruit_agent] said: Apple"
+              "text": "[generate_fruit_agent] said: I cannot provide a fruit fact. I can only provide the name of a random fruit."
             }
           ]
         },
@@ -88,39 +99,50 @@
           "role": "user",
           "parts": [
             {
-              "text": "Apple"
+              "text": "I cannot provide a fruit fact. I can only provide the name of a random fruit."
             }
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"generate_benefit_agent\".\n\nTell me a health benefit about the specified fruit."
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_benefit_agent\".\n\nTell me a health benefit about the specified fruit.",
+        "labels": {
+          "adk_agent_name": "generate_benefit_agent"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "Apples are a good source of dietary fiber, which can help promote healthy digestion and regulate blood sugar levels."
+                "text": "Here's a health benefit about an apple:\n\n**Apples are a good source of dietary fiber, which can help promote healthy digestion and regulate blood sugar levels.**"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 56,
-        "candidatesTokenCount": 22,
-        "totalTokenCount": 102,
+        "promptTokenCount": 85,
+        "candidatesTokenCount": 34,
+        "totalTokenCount": 212,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 56
+            "tokenCount": 85
           }
         ],
-        "thoughtsTokenCount": 24,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 34
+          }
+        ],
+        "thoughtsTokenCount": 93
       }
     }
   }

--- a/tests/integration/workflows/sequence/model_responses.json
+++ b/tests/integration/workflows/sequence/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "fe3c05c052fff445",
+    "contentsKey": "64ce92e663f23e5b",
     "request": {
       "contents": [
         {
@@ -53,6 +54,7 @@
   },
   {
     "key": "3c06842da841d90e",
+    "contentsKey": "30a2979a67c32bbb",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/use_as_output/model_responses.json
+++ b/tests/integration/workflows/use_as_output/model_responses.json
@@ -1,6 +1,7 @@
 [
   {
     "key": "8069171463b0c7a3",
+    "contentsKey": "7b8b4dab54972a75",
     "request": {
       "contents": [
         {

--- a/tests/integration/workflows/use_as_output/model_responses.json
+++ b/tests/integration/workflows/use_as_output/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "8069171463b0c7a3",
-    "contentsKey": "7b8b4dab54972a75",
+    "instructionAgnosticKey": "28b9e67bda5ca5eb",
     "request": {
       "contents": [
         {
@@ -21,34 +21,45 @@
           ]
         }
       ],
-      "systemInstruction": "You are an agent. Your internal name is \"summarizer\".\n\nSummarize the following text in one sentence."
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"summarizer\".\n\nSummarize the following text in one sentence.",
+        "labels": {
+          "adk_agent_name": "summarizer"
+        }
+      }
     },
     "response": {
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "A quick brown fox repeatedly jumps over a lazy dog throughout the entire day."
+                "text": "The quick brown fox repeatedly jumps over the lazy dog throughout the day."
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 56,
-        "candidatesTokenCount": 15,
-        "totalTokenCount": 177,
+        "promptTokenCount": 53,
+        "candidatesTokenCount": 14,
+        "totalTokenCount": 96,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 56
+            "tokenCount": 53
           }
         ],
-        "thoughtsTokenCount": 106,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 14
+          }
+        ],
+        "thoughtsTokenCount": 29
       }
     }
   }


### PR DESCRIPTION
## Summary

`main` is red. Seven workflow-sample integration tests fail on its own push run, and every open PR inherits it.

- `main` @ `1961d2c` (#635) — [green](https://github.com/google/adk-js/actions/runs/31433624015)
- `main` @ `09e2375` (#616) — [red](https://github.com/google/adk-js/actions/runs/31435412938), 7 failures

```
agent_in_workflow  dynamic_nodes  loop  node_output
parallel_worker    request_input_advanced  route
```

Bisected: `1961d2c` passes those tests, `09e2375` fails them.

## Root cause

The harness fingerprints a model call over `contents` + `config`, and `config` carries the system instruction. #616 stops emitting the identity preamble for transfer-disabled agents — which is every agent in these samples (`Invalid config for agent classify_input: outputSchema cannot co-exist with agent transfer configurations. Setting disallowTransferToParent=true...`). Every recorded response therefore misses its lookup at once.

Nothing about the failure said so. The harness throws `No recorded model response`, the caller swallows it, the agent yields nothing, and the test fails several nodes later on `Cannot read properties of undefined (reading 'category' | 'grade' | 'title' | 'days')`.

This is not a one-off. Any future edit to a system instruction breaks all of them again, in the same undiagnosable way.

## Fix

Two things: a match that survives a prompt change, and fixtures that are no longer stale.

**Matching** degrades once instead of failing outright.

1. **Exact** — contents + config, as before. Two agents differing only in their instructions are still told apart, in any order, under concurrency.
2. **Minus the system instruction** — on a miss, match the request with that one field dropped. A prompt edit is absorbed; the rest of `config` still has to agree, so a regression that drops a `tool` or a `responseSchema` is a miss, not a green replay. Replays with a warning naming the drift.

There is no third, looser tier. A fixture that matches neither key fails loudly:

```
[sample-harness] No recorded model response for request 5fc04152f12fe2c0
(minus instruction 2fc1b852b548f499). Re-record with: npm run record:samples
```

That now prints to stderr at the point of the miss, so the next one is not diagnosed from a TypeError three nodes away.

The fallback is a degraded match and says so: calls that differ only by instruction collapse into one bucket and are served in recording order, which a concurrent sample does not guarantee. `nested_workflow` has such a pair, so the warning is explicit about it. While prompts are unchanged the exact key resolves that pair correctly; only a prompt edit costs the discrimination, and then it is announced rather than silent.

**Fixtures** are all 14 re-recorded against a live model. Every call matches on its exact key again — the suite replays with zero stale-fixture warnings — and each fixture now stores the `config` its keys were taken over, so a future fingerprint change can re-derive them offline without a re-record. That is not hypothetical: it is how this PR migrated the fixtures at its first revision.

Two smaller corrections that a full re-write of every key made cheap:

- The caller's `AbortSignal` is out of the key and out of the fixture. A live handle that serializes to `{}`, it discriminated nothing and stored a dead field.
- The request is snapshotted _before_ the backend runs. `Gemini.preprocessRequest` clears `config.labels` on the Gemini API path, so a fixture recorded with an API key used to store a request that no longer derived its own keys.

## Tests

`tests/integration/workflows/_harness/record_replay_model_test.ts`, 28 tests.

Matching: exact hit; instruction-changed hit via the fallback; **a dropped tool failing rather than passing on a stale match**; one warning per stale request rather than per call; the ambiguity warning; a hard, loud failure when neither key matches; two agents sharing contents still resolved exactly; the abort signal ignored.

Record mode, through the `liveBackend` seam — previously untested, though the whole design rests on its keys agreeing with the ones computed at load: a run recorded against a stub and replayed through the same JSON round trip `runSample` performs must hit the _exact_ key with `console.warn` never called. Plus id normalization across that boundary, and a backend that mutates the request mid-call to pin the snapshot ordering.

The checked-in fixtures, one case each: every stored request must re-derive both of its own keys, and every fixture must be in the current format. The offline-re-derivation promise is machine-checked rather than asserted in a comment.

`integration tests/integration/workflows`: **37 files, 84 tests green**, the 7 above included, with no harness warnings.

(The remaining `--project integration` failures — `app_loader`, `build_setup`, `a2a`, `adk_web` — are unrelated and reproduce on the base commit; they need `npm run build` output that a fresh worktree lacks.)
