### PR TITLE
ci: type-check the repo in CI

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Build packages
         run: npm run build
 
+      - name: Run type check
+        run: npm run ts:check
+
       - name: Run tests and check code coverage
         run: npm run test:coverage
 

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -12,19 +12,23 @@ env:
 jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/core/src/plugins/security_plugin.ts
+++ b/core/src/plugins/security_plugin.ts
@@ -69,9 +69,10 @@ export class InMemoryPolicyEngine implements BasePolicyEngine {
   /**
    * Always returns {@link PolicyOutcome.ALLOW} for every tool call.
    *
+   * @param _context - The tool and its arguments; ignored.
    * @returns A promise resolving to an ALLOW result.
    */
-  async evaluate(): Promise<PolicyCheckResult> {
+  async evaluate(_context: ToolCallPolicyContext): Promise<PolicyCheckResult> {
     // Default permissive implementation
     return Promise.resolve({
       outcome: PolicyOutcome.ALLOW,

--- a/core/src/sessions/base_session_service.ts
+++ b/core/src/sessions/base_session_service.ts
@@ -49,8 +49,8 @@ export interface GetSessionRequest extends CompositeSessionKey {
 export interface ListSessionsRequest {
   /** The name of the application. */
   appName: string;
-  /** The ID of the user. */
-  userId: string;
+  /** The ID of the user. Sessions of every user are listed if omitted. */
+  userId?: string;
   /** Maximum number of sessions to return. */
   limit?: number;
   /** Zero-based index of the first session to return. Ignored if `page` is set. */

--- a/core/src/sessions/in_memory_session_service.ts
+++ b/core/src/sessions/in_memory_session_service.ts
@@ -151,7 +151,20 @@ export class InMemorySessionService extends BaseSessionService {
     page,
     order,
   }: ListSessionsRequest): Promise<ListSessionsResponse> {
-    if (!this.sessions[appName] || !this.sessions[appName][userId]) {
+    const appSessions = this.sessions[appName];
+    // An omitted `userId` lists every user's sessions, the same as the
+    // filter-less branches in `VertexAiSessionService` and
+    // `DatabaseSessionService`.
+    const sessionsByUser =
+      appSessions === undefined
+        ? []
+        : userId === undefined
+          ? Object.values(appSessions)
+          : appSessions[userId]
+            ? [appSessions[userId]]
+            : [];
+
+    if (sessionsByUser.length === 0) {
       if (limit !== undefined) {
         const effectiveOffset =
           page !== undefined ? (page - 1) * limit : (offset ?? 0);
@@ -178,8 +191,8 @@ export class InMemorySessionService extends BaseSessionService {
       });
     }
 
-    const all: Session[] = Object.values(this.sessions[appName][userId]).map(
-      (session) =>
+    const all: Session[] = sessionsByUser.flatMap((sessionsById) =>
+      Object.values(sessionsById).map((session) =>
         createSession({
           id: session.id,
           appName: session.appName,
@@ -188,6 +201,7 @@ export class InMemorySessionService extends BaseSessionService {
           events: [],
           lastUpdateTime: session.lastUpdateTime,
         }),
+      ),
     );
 
     if (order === 'asc') {

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -709,7 +709,6 @@ describe('getLongRunningFunctionCalls', () => {
         isLongRunning: false,
       }),
     };
-    // @ts-expect-error ts will argue about toolsDict because getLongRunningFunctionCalls is improted from the source and BaseTool is imported from '@google/adk'.
     const result = getLongRunningFunctionCalls(functionCalls, toolsDict);
     expect(result.has('call-1')).toBe(true);
     expect(result.has('call-2')).toBe(false);

--- a/core/test/agents/processors/basic_llm_request_processor_test.ts
+++ b/core/test/agents/processors/basic_llm_request_processor_test.ts
@@ -162,10 +162,10 @@ describe('BasicLlmRequestProcessor', () => {
   });
 
   it('should set outputSchema in config when agent has outputSchema', async () => {
-    const outputSchema = {
-      type: 'object' as const,
+    const outputSchema: Schema = {
+      type: Type.OBJECT,
       properties: {
-        answer: {type: 'string' as const},
+        answer: {type: Type.STRING},
       },
     };
     const agent = new LlmAgent({
@@ -183,10 +183,10 @@ describe('BasicLlmRequestProcessor', () => {
   });
 
   it('should not set outputSchema in config when agent has outputSchema and tools', async () => {
-    const outputSchema = {
-      type: 'object' as const,
+    const outputSchema: Schema = {
+      type: Type.OBJECT,
       properties: {
-        answer: {type: 'string' as const},
+        answer: {type: Type.STRING},
       },
     };
     const agent = new LlmAgent({

--- a/core/test/agents/processors/request_confirmation_llm_request_processor_test.ts
+++ b/core/test/agents/processors/request_confirmation_llm_request_processor_test.ts
@@ -8,7 +8,6 @@ import {
   BaseAgent,
   InvocationContext,
   LlmAgent,
-  LlmRequest,
   PluginManager,
   REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
   createEvent,
@@ -51,22 +50,10 @@ function createMockInvocationContext(
   });
 }
 
-function makeLlmRequest(): LlmRequest {
-  return {
-    contents: [],
-    toolsDict: {},
-    liveConnectConfig: {},
-  };
-}
-
-async function collectEvents(
-  invocationContext: InvocationContext,
-  llmRequest: LlmRequest = makeLlmRequest(),
-) {
+async function collectEvents(invocationContext: InvocationContext) {
   const events = [];
   for await (const event of REQUEST_CONFIRMATION_LLM_REQUEST_PROCESSOR.runAsync(
     invocationContext,
-    llmRequest,
   )) {
     events.push(event);
   }

--- a/core/test/agents/sequential_agent_test.ts
+++ b/core/test/agents/sequential_agent_test.ts
@@ -127,7 +127,7 @@ describe('SequentialAgent', () => {
 
     const context = makeContext(seq);
 
-    const authors: string[] = [];
+    const authors: Array<string | undefined> = [];
     for await (const event of seq.runAsync(context)) {
       authors.push(event.author);
     }

--- a/core/test/apps/app_test.ts
+++ b/core/test/apps/app_test.ts
@@ -6,6 +6,7 @@
 
 import {describe, expect, it} from 'vitest';
 import {BaseAgent} from '../../src/agents/base_agent.js';
+import {InvocationContext} from '../../src/agents/invocation_context.js';
 import {App, isApp, validateAppName} from '../../src/apps/app.js';
 import {createResumabilityConfig} from '../../src/apps/resumability_config.js';
 import {BasePlugin} from '../../src/plugins/base_plugin.js';
@@ -14,6 +15,8 @@ class DummyAgent extends BaseAgent {
   constructor(name = 'dummy_agent') {
     super({name});
   }
+  protected async *runAsyncImpl(_context: InvocationContext) {}
+  protected async *runLiveImpl(_context: InvocationContext) {}
 }
 
 class DummyPlugin extends BasePlugin {
@@ -78,11 +81,19 @@ describe('App', () => {
   });
 
   it('throws if rootAgent is missing or not a BaseAgent', () => {
-    expect(() => new App({name: 'test_app', rootAgent: undefined})).toThrow(
-      'rootAgent must be provided.',
-    );
     expect(
-      () => new App({name: 'test_app', rootAgent: {name: 'fake'}}),
+      () =>
+        new App({
+          name: 'test_app',
+          rootAgent: undefined as unknown as BaseAgent,
+        }),
+    ).toThrow('rootAgent must be provided.');
+    expect(
+      () =>
+        new App({
+          name: 'test_app',
+          rootAgent: {name: 'fake'} as unknown as BaseAgent,
+        }),
     ).toThrow(/rootAgent must be a BaseAgent instance/);
   });
 

--- a/core/test/auth/exchanger/credential_exchanger_test.ts
+++ b/core/test/auth/exchanger/credential_exchanger_test.ts
@@ -6,7 +6,10 @@
 
 import {AuthCredential, AuthCredentialTypes, AuthScheme} from '@google/adk';
 import {describe, expect, it} from 'vitest';
-import {BaseCredentialExchanger} from '../../../src/auth/exchanger/base_credential_exchanger.js';
+import {
+  BaseCredentialExchanger,
+  ExchangeResult,
+} from '../../../src/auth/exchanger/base_credential_exchanger.js';
 import {CredentialExchangerRegistry} from '../../../src/auth/exchanger/credential_exchanger_registry.js';
 
 // Mock credential exchanger for testing
@@ -16,8 +19,8 @@ class MockCredentialExchanger implements BaseCredentialExchanger {
   }: {
     authCredential: AuthCredential;
     authScheme?: AuthScheme;
-  }): Promise<AuthCredential> {
-    return authCredential;
+  }): Promise<ExchangeResult> {
+    return {credential: authCredential, wasExchanged: false};
   }
 }
 

--- a/core/test/code_executors/code_execution_utils_test.ts
+++ b/core/test/code_executors/code_execution_utils_test.ts
@@ -264,17 +264,17 @@ describe('convertCodeExecutionParts', () => {
   });
 
   it('converts last executableCode part to text', () => {
-    const content = {
+    const content: Content = {
       parts: [{executableCode: {code: 'x = 1', language: Language.PYTHON}}],
       role: 'model',
     };
     convertCodeExecutionParts(content, CODE_DELIM, RESULT_DELIM);
-    expect(content.parts[0].text).toBe('```python\nx = 1\n```');
-    expect(content.parts[0].executableCode).toBeUndefined();
+    expect(content.parts![0].text).toBe('```python\nx = 1\n```');
+    expect(content.parts![0].executableCode).toBeUndefined();
   });
 
   it('converts single codeExecutionResult part to text and sets role to user', () => {
-    const content = {
+    const content: Content = {
       parts: [
         {
           codeExecutionResult: {
@@ -286,7 +286,7 @@ describe('convertCodeExecutionParts', () => {
       role: 'model',
     };
     convertCodeExecutionParts(content, CODE_DELIM, RESULT_DELIM);
-    expect(content.parts[0].text).toBe('```tool_output\nhello\n```');
+    expect(content.parts![0].text).toBe('```tool_output\nhello\n```');
     expect(content.role).toBe('user');
   });
 

--- a/core/test/code_executors/code_executor_context_test.ts
+++ b/core/test/code_executors/code_executor_context_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {describe, expect, it} from 'vitest';
+import {File} from '../../src/code_executors/code_execution_utils.js';
 import {CodeExecutorContext} from '../../src/code_executors/code_executor_context.js';
 import {State} from '../../src/sessions/state.js';
 
@@ -77,8 +78,18 @@ describe('CodeExecutorContext', () => {
   });
 
   describe('getInputFiles / addInputFiles / clearInputFiles', () => {
-    const file1 = {name: 'f1.txt', content: 'aGVsbG8=', encoding: undefined};
-    const file2 = {name: 'f2.txt', content: 'd29ybGQ=', encoding: undefined};
+    const file1: File = {
+      name: 'f1.txt',
+      content: 'aGVsbG8=',
+      contentEncoding: undefined,
+      mimeType: 'text/plain',
+    };
+    const file2: File = {
+      name: 'f2.txt',
+      content: 'd29ybGQ=',
+      contentEncoding: undefined,
+      mimeType: 'text/plain',
+    };
 
     it('returns an empty array when no input files have been added', () => {
       const {ctx} = makeContext();

--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -7,6 +7,7 @@
 import {
   CodeExecutionLanguage,
   ExecuteCodeParams,
+  FileContentEncoding,
   InvocationContext,
   LlmAgent,
   PluginManager,
@@ -311,13 +312,13 @@ describe('UnsafeLocalCodeExecutor', () => {
           {
             name: 'test.txt',
             content: Buffer.from('hello file content').toString('base64'),
-            contentEncoding: 'base64',
+            contentEncoding: FileContentEncoding.BASE64,
             mimeType: 'text/plain',
           },
           {
             name: 'subdir/data.json',
             content: '{"key": "value"}',
-            contentEncoding: 'utf8',
+            contentEncoding: FileContentEncoding.UTF8,
             mimeType: 'application/json',
           },
         ],
@@ -341,7 +342,7 @@ describe('UnsafeLocalCodeExecutor', () => {
           {
             name: 'existing_input.txt',
             content: Buffer.from('hello input').toString('base64'),
-            contentEncoding: 'base64',
+            contentEncoding: FileContentEncoding.BASE64,
             mimeType: 'text/plain',
           },
         ],

--- a/core/test/context/anchored_context_compactor_test.ts
+++ b/core/test/context/anchored_context_compactor_test.ts
@@ -26,7 +26,7 @@ class MockSummarizer implements BaseSummarizer {
       actions: {
         stateDelta: {},
         artifactDelta: {},
-        requestedAuthConfigs: [],
+        requestedAuthConfigs: {},
         requestedToolConfirmations: {},
       },
       timestamp: Date.now(),
@@ -38,7 +38,7 @@ class MockSummarizer implements BaseSummarizer {
         role: 'model',
         parts: [{text: `Mock summary of ${events.length} events`}],
       },
-    } as CompactedEvent;
+    };
   }
 }
 
@@ -78,14 +78,15 @@ function createMockScratchpadEvent(
   tokenCount?: number,
   contentStr?: string,
 ): CompactedEvent {
-  const event = createMockEvent(id, tokenCount) as CompactedEvent;
-  event.isCompacted = true;
-  event.isScratchpad = true;
-  event.author = 'system';
-  event.startTime = Date.now() - 10000;
-  event.endTime = Date.now() - 5000;
-  event.compactedContent = contentStr || 'Existing scratchpad content';
-  return event;
+  return {
+    ...createMockEvent(id, tokenCount),
+    isCompacted: true,
+    isScratchpad: true,
+    author: 'system',
+    startTime: Date.now() - 10000,
+    endTime: Date.now() - 5000,
+    compactedContent: contentStr || 'Existing scratchpad content',
+  };
 }
 
 function createMockInvocationContext(events: Event[]): InvocationContext {

--- a/core/test/context/token_based_context_compactor_test.ts
+++ b/core/test/context/token_based_context_compactor_test.ts
@@ -25,7 +25,7 @@ class MockSummarizer implements BaseSummarizer {
       actions: {
         stateDelta: {},
         artifactDelta: {},
-        requestedAuthConfigs: [],
+        requestedAuthConfigs: {},
         requestedToolConfirmations: {},
       },
       timestamp: Date.now(),
@@ -37,7 +37,7 @@ class MockSummarizer implements BaseSummarizer {
         role: 'model',
         parts: [{text: `Mock summary of ${events.length} events`}],
       },
-    } as CompactedEvent;
+    };
   }
 }
 

--- a/core/test/events/event_actions_test.ts
+++ b/core/test/events/event_actions_test.ts
@@ -5,10 +5,18 @@
  */
 
 import {describe, expect, it} from 'vitest';
+import {AuthConfig} from '../../src/auth/auth_tool.js';
 import {
   createEventActions,
   mergeEventActions,
 } from '../../src/events/event_actions.js';
+
+function createTestAuthConfig(credentialKey: string): AuthConfig {
+  return {
+    authScheme: {type: 'apiKey', in: 'header', name: 'X-Api-Key'},
+    credentialKey,
+  };
+}
 
 describe('createEventActions', () => {
   it('creates an EventActions with empty dicts and no scalar fields', () => {
@@ -40,7 +48,7 @@ describe('createEventActions', () => {
   });
 
   it('applies requestedAuthConfigs override', () => {
-    const authConfig = {scheme: 'oauth2'};
+    const authConfig = createTestAuthConfig('key-1');
     const actions = createEventActions({
       requestedAuthConfigs: {'call-1': authConfig},
     });
@@ -108,23 +116,25 @@ describe('mergeEventActions', () => {
   });
 
   it('merges requestedAuthConfigs from multiple sources', () => {
+    const authConfig1 = createTestAuthConfig('key-1');
+    const authConfig2 = createTestAuthConfig('key-2');
     const result = mergeEventActions([
       {
         stateDelta: {},
         artifactDelta: {},
-        requestedAuthConfigs: {'call-1': {scheme: 'oauth2'}},
+        requestedAuthConfigs: {'call-1': authConfig1},
         requestedToolConfirmations: {},
       },
       {
         stateDelta: {},
         artifactDelta: {},
-        requestedAuthConfigs: {'call-2': {scheme: 'apiKey'}},
+        requestedAuthConfigs: {'call-2': authConfig2},
         requestedToolConfirmations: {},
       },
     ]);
     expect(result.requestedAuthConfigs).toEqual({
-      'call-1': {scheme: 'oauth2'},
-      'call-2': {scheme: 'apiKey'},
+      'call-1': authConfig1,
+      'call-2': authConfig2,
     });
   });
 

--- a/core/test/events/structured_events_test.ts
+++ b/core/test/events/structured_events_test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Outcome} from '@google/genai';
+import {Language, Outcome} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {createEvent} from '../../src/events/event.js';
 import {createEventActions} from '../../src/events/event_actions.js';
@@ -92,7 +92,9 @@ describe('toStructuredEvents', () => {
     const event = createEvent({
       partial: true,
       content: {
-        parts: [{executableCode: {code: 'print("hi")', language: 1}}],
+        parts: [
+          {executableCode: {code: 'print("hi")', language: Language.PYTHON}},
+        ],
       },
     });
     const result = toStructuredEvents(event);

--- a/core/test/integrations/agent_registry_test.ts
+++ b/core/test/integrations/agent_registry_test.ts
@@ -6,6 +6,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import {Client, ClientFactory} from '@a2a-js/sdk/client';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   AgentRegistry,
@@ -559,6 +560,9 @@ describe('AgentRegistry', () => {
             preferredTransport: 'JSONRPC',
             protocolVersion: '0.3.0',
             skills: [],
+            capabilities: {},
+            defaultInputModes: [],
+            defaultOutputModes: [],
           },
         },
       };
@@ -694,16 +698,20 @@ describe('AgentRegistry', () => {
           content: {
             name: 'CustomAgentWithOptions',
             description: 'Desc',
+            version: '1.0.0',
             url: 'https://agent.com',
             preferredTransport: 'JSONRPC',
             protocolVersion: '0.3.0',
             skills: [],
+            capabilities: {},
+            defaultInputModes: [],
+            defaultOutputModes: [],
           },
         },
       };
 
-      const dummyClient = {};
-      const dummyClientFactory = () => {};
+      const dummyClient = {} as unknown as Client;
+      const dummyClientFactory = (() => {}) as unknown as ClientFactory;
 
       vi.spyOn(registry, 'getAgentInfo').mockResolvedValue(agentInfo);
       const agent = await registry.getRemoteA2AAgent('agents/agent-1', {

--- a/core/test/memory/vertex_ai_memory_bank_service_test.ts
+++ b/core/test/memory/vertex_ai_memory_bank_service_test.ts
@@ -341,7 +341,7 @@ describe('VertexAiMemoryBankService', () => {
       );
 
       expect(response.memories).toHaveLength(1);
-      expect(response.memories[0].content.parts[0].text).toBe(
+      expect(response.memories[0].content.parts?.[0].text).toBe(
         'user likes blue',
       );
     });

--- a/core/test/models/gemini_llm_connection_test.ts
+++ b/core/test/models/gemini_llm_connection_test.ts
@@ -10,10 +10,12 @@ import {
   GroundingMetadata,
   LiveServerGoAway,
   LiveServerMessage,
+  LiveServerSessionResumptionUpdate,
 } from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {GeminiLlmConnection} from '../../src/models/gemini_llm_connection.js';
 import {AsyncQueue} from '../../src/utils/async_queue.js';
+import {liveServerMessage} from '../utils/live_server_message_test_utils.js';
 
 describe('GeminiLlmConnection', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -278,7 +280,7 @@ describe('GeminiLlmConnection', () => {
         candidatesTokenCount: 20,
         totalTokenCount: 30,
       };
-      messageQueue.push({usageMetadata});
+      messageQueue.push(liveServerMessage({usageMetadata}));
       messageQueue.close();
 
       const res = await generator.next();
@@ -298,25 +300,29 @@ describe('GeminiLlmConnection', () => {
       const generator = connection.receive();
 
       // Chunk 1: partial text
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Hello'}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Hello'}],
+            },
           },
-        },
-      });
+        }),
+      );
 
       // Chunk 2: partial text and turnComplete with interrupted and groundingMetadata
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: ' world!'}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: ' world!'}],
+            },
+            turnComplete: true,
+            interrupted: false,
+            groundingMetadata: {groundingChunks: []} as GroundingMetadata,
           },
-          turnComplete: true,
-          interrupted: false,
-          groundingMetadata: {groundingChunks: []} as GroundingMetadata,
-        },
-      });
+        }),
+      );
 
       const res1 = await generator.next();
       expect(res1.value).toEqual({
@@ -367,28 +373,34 @@ describe('GeminiLlmConnection', () => {
       const generator = connection.receive();
 
       // Chunk 1: thought
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Thinking...', thought: true}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Thinking...', thought: true}],
+            },
           },
-        },
-      });
+        }),
+      );
 
       // Chunk 2: transition to text
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Answer is 42.'}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Answer is 42.'}],
+            },
           },
-        },
-      });
+        }),
+      );
 
-      messageQueue.push({
-        serverContent: {
-          turnComplete: true,
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            turnComplete: true,
+          },
+        }),
+      );
 
       const res1 = await generator.next(); // yields partial thought
       expect(res1.value).toEqual({
@@ -442,17 +454,21 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          inputTranscription: {text: 'hello', finished: false},
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            inputTranscription: {text: 'hello', finished: false},
+          },
+        }),
+      );
 
-      messageQueue.push({
-        serverContent: {
-          inputTranscription: {text: ' world', finished: true},
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            inputTranscription: {text: ' world', finished: true},
+          },
+        }),
+      );
 
       messageQueue.close();
 
@@ -488,20 +504,27 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          inputTranscription: {text: 'hello', finished: false},
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            inputTranscription: {text: 'hello', finished: false},
+          },
+        }),
+      );
 
-      messageQueue.push({
-        serverContent: {
-          interrupted: true,
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            interrupted: true,
+          },
+        }),
+      );
       messageQueue.close();
 
       const res1 = await generator.next(); // partial transcription
+      if (res1.done) {
+        throw new Error('Expected a partial transcription response.');
+      }
       expect(res1.value.inputTranscription).toEqual({
         text: 'hello',
         finished: false,
@@ -531,18 +554,20 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Partial text'}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Partial text'}],
+            },
+            groundingMetadata: {
+              groundingChunks: [
+                {web: {uri: 'https://google.com', title: 'Google'}},
+              ],
+            } as GroundingMetadata,
           },
-          groundingMetadata: {
-            groundingChunks: [
-              {web: {uri: 'https://google.com', title: 'Google'}},
-            ],
-          } as GroundingMetadata,
-        },
-      });
+        }),
+      );
       messageQueue.close();
 
       const res1 = await generator.next();
@@ -568,17 +593,19 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          groundingMetadata: {
-            groundingChunks: [
-              {web: {uri: 'https://google.com', title: 'Google'}},
-            ],
-          } as GroundingMetadata,
-          turnComplete: false,
-          interrupted: false,
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            groundingMetadata: {
+              groundingChunks: [
+                {web: {uri: 'https://google.com', title: 'Google'}},
+              ],
+            } as GroundingMetadata,
+            turnComplete: false,
+            interrupted: false,
+          },
+        }),
+      );
       messageQueue.close();
 
       const res1 = await generator.next();
@@ -604,22 +631,26 @@ describe('GeminiLlmConnection', () => {
       const generator = connection.receive();
 
       // Push text part
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Hello'}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Hello'}],
+            },
           },
-        },
-      });
+        }),
+      );
 
       // Push non-text part (e.g. functionCall inside modelTurn parts)
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{functionCall: {name: 'tool_a', args: {x: 1}, id: '1'}}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{functionCall: {name: 'tool_a', args: {x: 1}, id: '1'}}],
+            },
           },
-        },
-      });
+        }),
+      );
       messageQueue.close();
 
       // First yield: the partial response for 'Hello'
@@ -661,17 +692,21 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        toolCall: {
-          functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          toolCall: {
+            functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
+          },
+        }),
+      );
 
-      messageQueue.push({
-        serverContent: {
-          turnComplete: true,
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            turnComplete: true,
+          },
+        }),
+      );
 
       // For non-Gemini 3.x, tool call is buffered.
       // So we don't get anything on toolCall message (except if there was text, but there isn't).
@@ -703,11 +738,13 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        toolCall: {
-          functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          toolCall: {
+            functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
+          },
+        }),
+      );
 
       const res1 = await generator.next();
       expect(res1.value).toEqual({
@@ -730,8 +767,12 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      const resumptionUpdate = {resumed: true};
-      messageQueue.push({sessionResumptionUpdate: resumptionUpdate});
+      const resumptionUpdate: LiveServerSessionResumptionUpdate = {
+        resumable: true,
+      };
+      messageQueue.push(
+        liveServerMessage({sessionResumptionUpdate: resumptionUpdate}),
+      );
       messageQueue.close();
 
       const res = await generator.next();
@@ -751,8 +792,8 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      const goAway = {goAway: true}; // mock
-      messageQueue.push({goAway: goAway as LiveServerGoAway});
+      const goAway: LiveServerGoAway = {timeLeft: '10s'};
+      messageQueue.push(liveServerMessage({goAway}));
       messageQueue.close();
 
       const res = await generator.next();
@@ -772,11 +813,13 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        toolCall: {
-          functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          toolCall: {
+            functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
+          },
+        }),
+      );
       messageQueue.close();
 
       const res = await generator.next();
@@ -798,11 +841,13 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        toolCall: {
-          functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          toolCall: {
+            functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
+          },
+        }),
+      );
       messageQueue.close();
 
       const res = await generator.next();
@@ -824,19 +869,23 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Hello'}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Hello'}],
+            },
           },
-        },
-      });
+        }),
+      );
 
-      messageQueue.push({
-        serverContent: {
-          interrupted: true,
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            interrupted: true,
+          },
+        }),
+      );
       messageQueue.close();
 
       const res1 = await generator.next();
@@ -867,19 +916,23 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Hello'}],
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Hello'}],
+            },
           },
-        },
-      });
+        }),
+      );
 
-      messageQueue.push({
-        toolCall: {
-          functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          toolCall: {
+            functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
+          },
+        }),
+      );
       messageQueue.close();
 
       const res1 = await generator.next();
@@ -919,17 +972,21 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          outputTranscription: {text: 'hello', finished: false},
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            outputTranscription: {text: 'hello', finished: false},
+          },
+        }),
+      );
 
-      messageQueue.push({
-        serverContent: {
-          outputTranscription: {text: ' world', finished: true},
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            outputTranscription: {text: ' world', finished: true},
+          },
+        }),
+      );
 
       messageQueue.close();
 
@@ -965,20 +1022,27 @@ describe('GeminiLlmConnection', () => {
       );
       const generator = connection.receive();
 
-      messageQueue.push({
-        serverContent: {
-          outputTranscription: {text: 'hello', finished: false},
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            outputTranscription: {text: 'hello', finished: false},
+          },
+        }),
+      );
 
-      messageQueue.push({
-        serverContent: {
-          interrupted: true,
-        },
-      });
+      messageQueue.push(
+        liveServerMessage({
+          serverContent: {
+            interrupted: true,
+          },
+        }),
+      );
       messageQueue.close();
 
       const res1 = await generator.next();
+      if (res1.done) {
+        throw new Error('Expected a partial transcription response.');
+      }
       expect(res1.value.outputTranscription).toEqual({
         text: 'hello',
         finished: false,

--- a/core/test/models/google_llm_test.ts
+++ b/core/test/models/google_llm_test.ts
@@ -12,7 +12,13 @@ import {
   geminiInitParams,
   version,
 } from '@google/adk';
-import {GenerateContentResponse, GoogleGenAI, HttpOptions} from '@google/genai';
+import {
+  GenerateContentResponse,
+  GoogleGenAI,
+  HttpOptions,
+  Modality,
+  Part,
+} from '@google/genai';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 vi.mock('@google/genai', async (importOriginal) => {
@@ -148,8 +154,7 @@ describe('GoogleLlm', () => {
         {
           content: {
             role: 'model',
-            parts:
-              parts as GenerateContentResponse['candidates'][0]['content']['parts'],
+            parts: parts as Part[],
           },
         },
       ];
@@ -622,8 +627,9 @@ describe('GoogleLlm', () => {
 
       const request: LlmRequest = {
         model: 'gemini-2.5-flash',
+        contents: [],
         liveConnectConfig: {
-          generationConfig: {responseModalities: ['audio']},
+          generationConfig: {responseModalities: [Modality.AUDIO]},
         },
         config: {
           systemInstruction: 'You are a helpful assistant.',
@@ -642,7 +648,7 @@ describe('GoogleLlm', () => {
         expect.objectContaining({
           model: 'gemini-2.5-flash',
           config: expect.objectContaining({
-            generationConfig: {responseModalities: ['audio']},
+            generationConfig: {responseModalities: [Modality.AUDIO]},
             systemInstruction: {
               role: 'system',
               parts: [{text: 'You are a helpful assistant.'}],

--- a/core/test/models/llm_response_test.ts
+++ b/core/test/models/llm_response_test.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {FinishReason, GenerateContentResponse} from '@google/genai';
+import {
+  BlockedReason,
+  FinishReason,
+  GenerateContentResponse,
+} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {createLlmResponse} from '../../src/models/llm_response.js';
 
@@ -143,7 +147,7 @@ describe('createLlmResponse', () => {
     it('returns blockReason as errorCode', () => {
       const response = makeResponse({
         promptFeedback: {
-          blockReason: 'SAFETY',
+          blockReason: BlockedReason.SAFETY,
           blockReasonMessage: 'blocked by safety',
         },
       });
@@ -154,7 +158,7 @@ describe('createLlmResponse', () => {
     it('returns blockReasonMessage as errorMessage', () => {
       const response = makeResponse({
         promptFeedback: {
-          blockReason: 'OTHER',
+          blockReason: BlockedReason.OTHER,
           blockReasonMessage: 'other reason',
         },
       });
@@ -165,7 +169,10 @@ describe('createLlmResponse', () => {
     it('includes usageMetadata in the prompt feedback response', () => {
       const usageMetadata = {totalTokenCount: 5};
       const response = makeResponse({
-        promptFeedback: {blockReason: 'SAFETY', blockReasonMessage: ''},
+        promptFeedback: {
+          blockReason: BlockedReason.SAFETY,
+          blockReasonMessage: '',
+        },
         usageMetadata,
       });
       const result = createLlmResponse(response);
@@ -174,7 +181,10 @@ describe('createLlmResponse', () => {
 
     it('does not set content', () => {
       const response = makeResponse({
-        promptFeedback: {blockReason: 'SAFETY', blockReasonMessage: ''},
+        promptFeedback: {
+          blockReason: BlockedReason.SAFETY,
+          blockReasonMessage: '',
+        },
       });
       const result = createLlmResponse(response);
       expect(result.content).toBeUndefined();

--- a/core/test/plugins/global_instruction_plugin_test.ts
+++ b/core/test/plugins/global_instruction_plugin_test.ts
@@ -6,6 +6,7 @@
 
 import {
   BaseLlm,
+  BaseLlmConnection,
   Context,
   GlobalInstructionPlugin,
   InMemoryRunner,
@@ -31,6 +32,10 @@ class MockLlm extends BaseLlm {
     yield {
       content: {parts: [{text: 'Hello from mock LLM'}]},
     };
+  }
+
+  async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    throw new Error('Method not implemented.');
   }
 }
 

--- a/core/test/plugins/security_plugin_test.ts
+++ b/core/test/plugins/security_plugin_test.ts
@@ -269,7 +269,7 @@ describe('SecurityPlugin', () => {
 
   describe('InMemoryPolicyEngine', () => {
     it('should always return ALLOW', async () => {
-      const engine = new InMemoryPolicyEngine();
+      const engine: BasePolicyEngine = new InMemoryPolicyEngine();
       const result: PolicyCheckResult = await engine.evaluate({
         tool: mockTool,
         toolArgs: {},

--- a/core/test/plugins/security_plugin_test.ts
+++ b/core/test/plugins/security_plugin_test.ts
@@ -269,7 +269,7 @@ describe('SecurityPlugin', () => {
 
   describe('InMemoryPolicyEngine', () => {
     it('should always return ALLOW', async () => {
-      const engine: BasePolicyEngine = new InMemoryPolicyEngine();
+      const engine = new InMemoryPolicyEngine();
       const result: PolicyCheckResult = await engine.evaluate({
         tool: mockTool,
         toolArgs: {},

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -744,7 +744,9 @@ describe('Runner error handling', () => {
 
   it('should throw clear error when appName is not configured in runner', async () => {
     const agent = new MockLlmAgent('test_agent');
-    // @ts-expect-error - Intentionally omitting appName to test error handling
+    // Intentionally omitting appName to test error handling. `appName` is
+    // optional on RunnerConfig (it can come from `app.name`), so this is only
+    // reported at runtime, when the session lookup fails.
     const runner = new Runner({
       agent: agent,
       sessionService,
@@ -939,7 +941,7 @@ describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
             data: 'JVBERi0xLjQ...',
             displayName: 'file.pdf',
           },
-        } as unknown as Content['parts']![0],
+        },
       ],
     };
 
@@ -994,7 +996,7 @@ describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
             data: 'JVBERi0xLjQ...',
             displayName: 'file.pdf',
           },
-        } as unknown as Content['parts']![0],
+        },
       ],
     };
 
@@ -1037,7 +1039,7 @@ describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
       parts: [
         {
           inlineData: inlineDataObj,
-        } as unknown as Content['parts']![0],
+        },
       ],
     };
 
@@ -1077,7 +1079,7 @@ describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
             data: 'JVBERi0xLjQ...',
             displayName: 'named_doc.pdf',
           },
-        } as unknown as Content['parts']![0],
+        },
         {
           inlineData: {
             mimeType: 'image/png',
@@ -1135,14 +1137,14 @@ describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
             data: 'JVBERi0xLjQ...',
             displayName: 'good.pdf',
           },
-        } as unknown as Content['parts']![0],
+        },
         {
           inlineData: {
             mimeType: 'image/png',
             data: 'bad_data',
             displayName: 'bad.png',
           },
-        } as unknown as Content['parts']![0],
+        },
       ],
     };
 
@@ -1191,7 +1193,7 @@ describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
             data: 'data',
             displayName: 'file1.pdf',
           },
-        } as unknown as Content['parts']![0],
+        },
       ],
     };
 
@@ -1228,7 +1230,7 @@ describe('Runner artifact saving (`saveInputBlobsAsArtifacts`)', () => {
             data: 'data',
             displayName: 'file2.pdf',
           },
-        } as unknown as Content['parts']![0],
+        },
       ],
     };
 

--- a/core/test/sessions/in_memory_session_service_test.ts
+++ b/core/test/sessions/in_memory_session_service_test.ts
@@ -229,6 +229,22 @@ describe('InMemorySessionService', () => {
       expect(response.sessions[1].events).toEqual([]);
     });
 
+    it('lists every user of the app when userId is omitted', async () => {
+      const appName = 'app';
+      await service.createSession({appName, userId: 'user1'});
+      await service.createSession({appName, userId: 'user2'});
+      await service.createSession({appName: 'other-app', userId: 'user1'});
+
+      const response = await service.listSessions({appName});
+
+      expect(response.sessions).toHaveLength(2);
+      expect(response.sessions.map((s) => s.userId).sort()).toEqual([
+        'user1',
+        'user2',
+      ]);
+      expect(response.totalItems).toBe(2);
+    });
+
     it('limit on empty result → returns pagination metadata with zeros', async () => {
       const response = await service.listSessions({
         appName: 'app',

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -10,7 +10,6 @@ import {
   isCompactedEvent,
   State,
   VertexAiSessionService,
-  type ListSessionsRequest,
 } from '@google/adk';
 import {Session} from '@google/adk/sessions/session.js';
 import {ApiError} from '@google/genai';
@@ -679,11 +678,6 @@ describe('VertexAiSessionService', () => {
   });
 
   describe('listSessions', () => {
-    // `ListSessionsRequest` declares `userId` as required, but `listSessions`
-    // handles its absence by listing without a `user_id` filter. The cast keeps
-    // the tests that cover that path calling the service with no `userId`.
-    const requestWithoutUserId = {appName: '12345'} as ListSessionsRequest;
-
     it('returns list of sessions parsing name extracts', async () => {
       mockClient.listInternal.mockResolvedValue({
         sessions: [
@@ -727,7 +721,9 @@ describe('VertexAiSessionService', () => {
     });
 
     it('lists sessions without filter if userId is missing', async () => {
-      await service.listSessions(requestWithoutUserId);
+      await service.listSessions({
+        appName: '12345',
+      });
 
       expect(mockClient.listInternal).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -741,7 +737,9 @@ describe('VertexAiSessionService', () => {
         sessions: [{name: 'projects/p/locations/l/sessions/s1', userId: 'u1'}],
       });
 
-      const result = await service.listSessions(requestWithoutUserId);
+      const result = await service.listSessions({
+        appName: '12345',
+      });
 
       expect(result.sessions[0].state).toEqual({});
       expect(result.sessions[0].lastUpdateTime).toBeGreaterThan(0);
@@ -750,7 +748,9 @@ describe('VertexAiSessionService', () => {
     it('returns empty list if no sessions found in listSessions', async () => {
       mockClient.listInternal.mockResolvedValue({}); // No sessions!
 
-      const result = await service.listSessions(requestWithoutUserId);
+      const result = await service.listSessions({
+        appName: '12345',
+      });
 
       expect(result.sessions).toEqual([]);
     });
@@ -767,7 +767,9 @@ describe('VertexAiSessionService', () => {
         ],
       });
 
-      const result = await service.listSessions(requestWithoutUserId);
+      const result = await service.listSessions({
+        appName: '12345',
+      });
 
       expect(result.sessions[0].state).toEqual({foo: 'bar'});
       expect(result.sessions[0].lastUpdateTime).toBe(

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -5,7 +5,13 @@
  */
 
 import {Sessions} from '@google-cloud/vertexai/build/src/genai/sessions.js';
-import {createEvent, State, VertexAiSessionService} from '@google/adk';
+import {
+  createEvent,
+  isCompactedEvent,
+  State,
+  VertexAiSessionService,
+  type ListSessionsRequest,
+} from '@google/adk';
 import {Session} from '@google/adk/sessions/session.js';
 import {ApiError} from '@google/genai';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
@@ -484,7 +490,12 @@ describe('VertexAiSessionService', () => {
 
       expect(session?.events).toHaveLength(1);
       const parsedEvent = session?.events[0];
-      expect(parsedEvent?.isCompacted).toBe(true);
+      // `isCompacted` is declared on `CompactedEvent`, a refinement of `Event`,
+      // so it is only readable after narrowing with the exported type guard
+      // (which checks exactly `isCompacted === true`).
+      expect(parsedEvent !== undefined && isCompactedEvent(parsedEvent)).toBe(
+        true,
+      );
       expect(parsedEvent?.usageMetadata).toEqual({promptTokens: 10});
     });
 
@@ -668,6 +679,11 @@ describe('VertexAiSessionService', () => {
   });
 
   describe('listSessions', () => {
+    // `ListSessionsRequest` declares `userId` as required, but `listSessions`
+    // handles its absence by listing without a `user_id` filter. The cast keeps
+    // the tests that cover that path calling the service with no `userId`.
+    const requestWithoutUserId = {appName: '12345'} as ListSessionsRequest;
+
     it('returns list of sessions parsing name extracts', async () => {
       mockClient.listInternal.mockResolvedValue({
         sessions: [
@@ -711,9 +727,7 @@ describe('VertexAiSessionService', () => {
     });
 
     it('lists sessions without filter if userId is missing', async () => {
-      await service.listSessions({
-        appName: '12345',
-      });
+      await service.listSessions(requestWithoutUserId);
 
       expect(mockClient.listInternal).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -727,9 +741,7 @@ describe('VertexAiSessionService', () => {
         sessions: [{name: 'projects/p/locations/l/sessions/s1', userId: 'u1'}],
       });
 
-      const result = await service.listSessions({
-        appName: '12345',
-      });
+      const result = await service.listSessions(requestWithoutUserId);
 
       expect(result.sessions[0].state).toEqual({});
       expect(result.sessions[0].lastUpdateTime).toBeGreaterThan(0);
@@ -738,9 +750,7 @@ describe('VertexAiSessionService', () => {
     it('returns empty list if no sessions found in listSessions', async () => {
       mockClient.listInternal.mockResolvedValue({}); // No sessions!
 
-      const result = await service.listSessions({
-        appName: '12345',
-      });
+      const result = await service.listSessions(requestWithoutUserId);
 
       expect(result.sessions).toEqual([]);
     });
@@ -757,9 +767,7 @@ describe('VertexAiSessionService', () => {
         ],
       });
 
-      const result = await service.listSessions({
-        appName: '12345',
-      });
+      const result = await service.listSessions(requestWithoutUserId);
 
       expect(result.sessions[0].state).toEqual({foo: 'bar'});
       expect(result.sessions[0].lastUpdateTime).toBe(

--- a/core/test/tools/google_search_tool_test.ts
+++ b/core/test/tools/google_search_tool_test.ts
@@ -5,16 +5,17 @@
  */
 
 import {GOOGLE_SEARCH, GoogleSearchTool, LlmRequest} from '@google/adk';
+import {Tool} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 
-function makeRequest(model?: string, tools = []): LlmRequest {
+function makeRequest(model?: string, tools: Tool[] = []): LlmRequest {
   return {
     model,
     config: {tools},
     contents: [],
     toolsDict: {},
     liveConnectConfig: {},
-  } as unknown as LlmRequest;
+  };
 }
 
 describe('GoogleSearchTool', () => {
@@ -83,7 +84,7 @@ describe('GoogleSearchTool', () => {
         contents: [],
         toolsDict: {},
         liveConnectConfig: {},
-      } as unknown as LlmRequest;
+      };
       await tool.processLlmRequest({
         llmRequest: req,
         toolContext: {} as never,

--- a/core/test/tools/openapi_tool/auth_helpers_test.ts
+++ b/core/test/tools/openapi_tool/auth_helpers_test.ts
@@ -6,7 +6,10 @@
 
 import {OpenAPIV3} from 'openapi-types';
 import {describe, expect, it} from 'vitest';
-import {AuthCredential} from '../../../src/auth/auth_credential.js';
+import {
+  AuthCredential,
+  AuthCredentialTypes,
+} from '../../../src/auth/auth_credential.js';
 import {
   applyCredential,
   createApiKeyScheme,
@@ -26,7 +29,10 @@ describe('auth_helpers', () => {
     it('should apply API key in header', () => {
       const url = 'http://example.com';
       const headers: Record<string, string> = {};
-      const credential: AuthCredential = {apiKey: 'secret_key'};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.API_KEY,
+        apiKey: 'secret_key',
+      };
       const authScheme: OpenAPIV3.SecuritySchemeObject = {
         type: 'apiKey',
         name: 'X-API-Key',
@@ -42,7 +48,10 @@ describe('auth_helpers', () => {
     it('should apply API key in query', () => {
       const url = 'http://example.com';
       const headers: Record<string, string> = {};
-      const credential: AuthCredential = {apiKey: 'secret_key'};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.API_KEY,
+        apiKey: 'secret_key',
+      };
       const authScheme: OpenAPIV3.SecuritySchemeObject = {
         type: 'apiKey',
         name: 'api_key',
@@ -58,7 +67,10 @@ describe('auth_helpers', () => {
     it('should apply API key in query with existing params', () => {
       const url = 'http://example.com?foo=bar';
       const headers: Record<string, string> = {};
-      const credential: AuthCredential = {apiKey: 'secret_key'};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.API_KEY,
+        apiKey: 'secret_key',
+      };
       const authScheme: OpenAPIV3.SecuritySchemeObject = {
         type: 'apiKey',
         name: 'api_key',
@@ -73,7 +85,10 @@ describe('auth_helpers', () => {
     it('should fallback to Authorization header for API key if location is not specified', () => {
       const url = 'http://example.com';
       const headers: Record<string, string> = {};
-      const credential: AuthCredential = {apiKey: 'secret_key'};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.API_KEY,
+        apiKey: 'secret_key',
+      };
 
       const result = applyCredential(url, headers, credential);
 
@@ -85,7 +100,9 @@ describe('auth_helpers', () => {
       const url = 'http://example.com';
       const headers: Record<string, string> = {};
       const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
         http: {
+          scheme: 'bearer',
           credentials: {
             token: 'my_token',
           },

--- a/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
+++ b/core/test/tools/openapi_tool/openapi_spec_parser_test.ts
@@ -133,7 +133,9 @@ describe('OpenApiSpecParser', () => {
   });
 
   it('should sanitize schema types', () => {
-    const spec: OpenAPIV3.Document = {
+    // Declares schema types the OpenAPI typings reject, because normalizing
+    // exactly those is what is under test.
+    const spec = {
       openapi: '3.0.0',
       info: {title: 'Sanitize API', version: '1.0.0'},
       paths: {
@@ -157,7 +159,7 @@ describe('OpenApiSpecParser', () => {
           },
         },
       },
-    };
+    } as unknown as OpenAPIV3.Document;
 
     const parser = new OpenApiSpecParser();
     const parsed = parser.parse(spec);
@@ -168,7 +170,9 @@ describe('OpenApiSpecParser', () => {
     const schema = body.content['application/json']
       .schema as OpenAPIV3.SchemaObject;
     expect(schema.type).toBe('object');
-    expect(schema.properties?.age?.type).toBe('integer');
+    expect(
+      (schema.properties?.age as OpenAPIV3.SchemaObject | undefined)?.type,
+    ).toBe('integer');
     expect(
       (schema.properties?.invalid as OpenAPIV3.SchemaObject).type,
     ).toBeUndefined();

--- a/core/test/tools/openapi_tool/openapi_toolset_integration_test.ts
+++ b/core/test/tools/openapi_tool/openapi_toolset_integration_test.ts
@@ -52,11 +52,11 @@ describe('OpenAPIToolset Integration', () => {
     expect(getProfileTool).toBeTruthy();
 
     const mockResponse = {status: 'success', data: {confirmed: true}};
-    vi.mocked(globalThis.fetch).mockResolvedValue({
-      ok: true,
-      headers: {get: () => 'application/json'},
-      json: async () => mockResponse,
-    });
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), {
+        headers: {'content-type': 'application/json'},
+      }),
+    );
 
     // Mock context
     const mockContext = {
@@ -87,11 +87,11 @@ describe('OpenAPIToolset Integration', () => {
     const tools = await toolset.getTools();
     const getProfileTool = tools.find((t) => t.name === 'get_profile');
 
-    vi.mocked(globalThis.fetch).mockResolvedValue({
-      ok: true,
-      headers: {get: () => 'text/plain'},
-      text: async () => 'plain text response',
-    });
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response('plain text response', {
+        headers: {'content-type': 'text/plain'},
+      }),
+    );
 
     const mockContext = {
       getAuthResponse: vi.fn().mockReturnValue(undefined),

--- a/core/test/tools/openapi_tool/openapi_toolset_test.ts
+++ b/core/test/tools/openapi_tool/openapi_toolset_test.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {OpenApiSpecParser, OpenAPIToolset, ReadonlyContext} from '@google/adk';
+import {
+  AuthCredentialTypes,
+  OpenApiSpecParser,
+  OpenAPIToolset,
+  ReadonlyContext,
+} from '@google/adk';
 import {OpenAPIV3} from 'openapi-types';
 import {describe, expect, it} from 'vitest';
 
@@ -112,7 +117,7 @@ describe('OpenAPIToolset', () => {
     const toolset = new OpenAPIToolset({
       specDict: mockSpec,
       authScheme: {type: 'apiKey', name: 'key', in: 'header'},
-      authCredential: {api_key: 'my-key'},
+      authCredential: {authType: AuthCredentialTypes.API_KEY, apiKey: 'my-key'},
     });
     const tools = await toolset.getTools();
 
@@ -122,7 +127,7 @@ describe('OpenAPIToolset', () => {
     );
     expect(
       (tools[0] as unknown as Record<string, unknown>).authCredential,
-    ).toEqual({api_key: 'my-key'});
+    ).toEqual({authType: AuthCredentialTypes.API_KEY, apiKey: 'my-key'});
   });
 
   it('should return all tools when no toolFilter is set and a context is provided', async () => {
@@ -381,9 +386,11 @@ describe('OpenApiSpecParser', () => {
     const operations = parser.parse(specWithInvalidType);
 
     expect(operations.length).toBe(1);
-    const schema = operations[0].operation.responses?.['200']?.content?.[
-      'application/json'
-    ]?.schema as OpenAPIV3.SchemaObject;
+    const response = operations[0].operation.responses?.['200'] as
+      | OpenAPIV3.ResponseObject
+      | undefined;
+    const schema = response?.content?.['application/json']
+      ?.schema as OpenAPIV3.SchemaObject;
     const invalidPropSchema = schema.properties?.[
       'invalidProp'
     ] as OpenAPIV3.SchemaObject;
@@ -426,9 +433,11 @@ describe('OpenApiSpecParser', () => {
     const operations = parser.parse(specWithInvalidArrayType);
 
     expect(operations.length).toBe(1);
-    const schema = operations[0].operation.responses?.['200']?.content?.[
-      'application/json'
-    ]?.schema as OpenAPIV3.SchemaObject;
+    const response = operations[0].operation.responses?.['200'] as
+      | OpenAPIV3.ResponseObject
+      | undefined;
+    const schema = response?.content?.['application/json']
+      ?.schema as OpenAPIV3.SchemaObject;
     const multiPropSchema = schema.properties?.[
       'multiProp'
     ] as OpenAPIV3.SchemaObject;

--- a/core/test/tools/openapi_tool/tool_auth_handler_test.ts
+++ b/core/test/tools/openapi_tool/tool_auth_handler_test.ts
@@ -52,7 +52,11 @@ describe('ToolAuthHandler', () => {
       }),
     } as unknown as Context;
 
-    const handler = new ToolAuthHandler(mockContext, {type: 'apiKey'});
+    const handler = new ToolAuthHandler(mockContext, {
+      type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
+    });
 
     const result = await handler.prepareAuthCredentials();
 
@@ -69,7 +73,11 @@ describe('ToolAuthHandler', () => {
       requestCredential: vi.fn(),
     } as unknown as Context;
 
-    const handler = new ToolAuthHandler(mockContext, {type: 'apiKey'});
+    const handler = new ToolAuthHandler(mockContext, {
+      type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
+    });
 
     const result = await handler.prepareAuthCredentials();
 
@@ -87,7 +95,11 @@ describe('ToolAuthHandler', () => {
       }),
     } as unknown as Context;
 
-    const handler = new ToolAuthHandler(mockContext, {type: 'apiKey'});
+    const handler = new ToolAuthHandler(mockContext, {
+      type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
+    });
 
     const result = await handler.prepareAuthCredentials();
 
@@ -105,7 +117,11 @@ describe('ToolAuthHandler', () => {
       }),
     } as unknown as Context;
 
-    const handler = new ToolAuthHandler(mockContext, {type: 'apiKey'});
+    const handler = new ToolAuthHandler(mockContext, {
+      type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
+    });
 
     const result = await handler.prepareAuthCredentials();
 
@@ -132,6 +148,8 @@ describe('ToolAuthHandler', () => {
     } as unknown as Context;
     await new ToolAuthHandler(firstContext, {
       type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
     }).prepareAuthCredentials();
 
     // Each tool call gets a fresh Context whose State is rebuilt from the
@@ -144,6 +162,8 @@ describe('ToolAuthHandler', () => {
     } as unknown as Context;
     const result = await new ToolAuthHandler(secondContext, {
       type: 'apiKey',
+      name: 'X-API-Key',
+      in: 'header',
     }).prepareAuthCredentials();
 
     expect(result.state).toBe('done');

--- a/core/test/tools/skills/run_skill_script_tool_test.ts
+++ b/core/test/tools/skills/run_skill_script_tool_test.ts
@@ -11,6 +11,7 @@ import {
   Context,
   ExecuteCodeParams,
   File,
+  FileContentEncoding,
   InvocationContext,
   LlmAgent,
   RunSkillScriptTool,
@@ -206,12 +207,12 @@ describe('RunSkillScriptTool', () => {
 
   it('calls materializeFiles with output files from executor', async () => {
     const mockExecutor = new MockCodeExecutor();
-    const testFile = {
+    const testFile: File = {
       name: 'output.txt',
       content: 'hello',
-      contentEncoding: 'utf8',
+      contentEncoding: FileContentEncoding.UTF8,
       mimeType: 'text/plain',
-    } as File;
+    };
     mockExecutor.mockResult = {
       stdout: '',
       stderr: '',

--- a/core/test/tools/vertex_ai_search_tool_test.ts
+++ b/core/test/tools/vertex_ai_search_tool_test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {GenerateContentConfig} from '@google/genai';
 import {afterEach, describe, expect, it} from 'vitest';
 import {Context} from '../../src/agents/context.js';
 import {LlmRequest} from '../../src/models/llm_request.js';
@@ -40,6 +41,13 @@ function invalidParams(
   params: LooseVertexAiSearchToolParams,
 ): VertexAiSearchToolParams {
   return params as unknown as VertexAiSearchToolParams;
+}
+
+function makeLlmRequest(
+  model: string,
+  config?: GenerateContentConfig,
+): LlmRequest {
+  return {model, contents: [], toolsDict: {}, liveConnectConfig: {}, config};
 }
 
 describe('VertexAiSearchTool', () => {
@@ -93,12 +101,7 @@ describe('VertexAiSearchTool', () => {
       filter: 'f',
       maxResults: 10,
     });
-    const llmRequest: LlmRequest = {
-      model: 'gemini-2.0-flash',
-      contents: [],
-      toolsDict: {},
-      liveConnectConfig: {},
-    };
+    const llmRequest = makeLlmRequest('gemini-2.0-flash');
     const toolContext = {} as Context;
 
     await tool.processLlmRequest({toolContext, llmRequest});
@@ -118,15 +121,9 @@ describe('VertexAiSearchTool', () => {
 
   it('should throw error for Gemini 1.x if other tools are present and bypass is false', async () => {
     const tool = new VertexAiSearchTool({dataStoreId: 'ds'});
-    const llmRequest: LlmRequest = {
-      model: 'gemini-1.5-pro',
-      contents: [],
-      toolsDict: {},
-      liveConnectConfig: {},
-      config: {
-        tools: [{functionDeclarations: []}],
-      },
-    };
+    const llmRequest = makeLlmRequest('gemini-1.5-pro', {
+      tools: [{functionDeclarations: []}],
+    });
     const toolContext = {} as Context;
 
     await expect(
@@ -141,15 +138,9 @@ describe('VertexAiSearchTool', () => {
       dataStoreId: 'ds',
       bypassMultiToolsLimit: true,
     });
-    const llmRequest: LlmRequest = {
-      model: 'gemini-1.5-pro',
-      contents: [],
-      toolsDict: {},
-      liveConnectConfig: {},
-      config: {
-        tools: [{functionDeclarations: []}],
-      },
-    };
+    const llmRequest = makeLlmRequest('gemini-1.5-pro', {
+      tools: [{functionDeclarations: []}],
+    });
     const toolContext = {} as Context;
 
     await tool.processLlmRequest({toolContext, llmRequest});
@@ -159,12 +150,7 @@ describe('VertexAiSearchTool', () => {
 
   it('should throw error for non-Gemini model', async () => {
     const tool = new VertexAiSearchTool({dataStoreId: 'ds'});
-    const llmRequest: LlmRequest = {
-      model: 'claude-3',
-      contents: [],
-      toolsDict: {},
-      liveConnectConfig: {},
-    };
+    const llmRequest = makeLlmRequest('claude-3');
     const toolContext = {} as Context;
 
     await expect(
@@ -188,12 +174,7 @@ describe('VertexAiSearchTool', () => {
     it('should bypass model check if ADK_DISABLE_GEMINI_MODEL_ID_CHECK is true', async () => {
       process.env.ADK_DISABLE_GEMINI_MODEL_ID_CHECK = 'true';
       const tool = new VertexAiSearchTool({dataStoreId: 'ds'});
-      const llmRequest: LlmRequest = {
-        model: 'claude-3',
-        contents: [],
-        toolsDict: {},
-        liveConnectConfig: {},
-      };
+      const llmRequest = makeLlmRequest('claude-3');
       const toolContext = {} as Context;
 
       await tool.processLlmRequest({toolContext, llmRequest});

--- a/core/test/tools/vertex_ai_search_tool_test.ts
+++ b/core/test/tools/vertex_ai_search_tool_test.ts
@@ -7,7 +7,10 @@
 import {afterEach, describe, expect, it} from 'vitest';
 import {Context} from '../../src/agents/context.js';
 import {LlmRequest} from '../../src/models/llm_request.js';
-import {VertexAiSearchTool} from '../../src/tools/vertex_ai_search_tool.js';
+import {
+  VertexAiSearchTool,
+  VertexAiSearchToolParams,
+} from '../../src/tools/vertex_ai_search_tool.js';
 
 interface TestTool {
   retrieval?: {
@@ -21,9 +24,27 @@ interface TestTool {
   };
 }
 
+/** The param combinations the constructor rejects at runtime. */
+interface LooseVertexAiSearchToolParams {
+  dataStoreId?: string;
+  searchEngineId?: string;
+  dataStoreSpecs?: Array<{dataStore?: string}>;
+}
+
+/**
+ * `VertexAiSearchToolParams` is a discriminated union that makes the invalid
+ * combinations below unrepresentable, but the constructor still validates them
+ * at runtime, so these tests deliberately pass params the type would reject.
+ */
+function invalidParams(
+  params: LooseVertexAiSearchToolParams,
+): VertexAiSearchToolParams {
+  return params as unknown as VertexAiSearchToolParams;
+}
+
 describe('VertexAiSearchTool', () => {
   it('should throw error if neither dataStoreId nor searchEngineId is specified', () => {
-    expect(() => new VertexAiSearchTool({})).toThrowError(
+    expect(() => new VertexAiSearchTool(invalidParams({}))).toThrowError(
       'Either dataStoreId or searchEngineId must be specified.',
     );
   });
@@ -31,20 +52,24 @@ describe('VertexAiSearchTool', () => {
   it('should throw error if both dataStoreId and searchEngineId are specified', () => {
     expect(
       () =>
-        new VertexAiSearchTool({
-          dataStoreId: 'ds',
-          searchEngineId: 'se',
-        }),
+        new VertexAiSearchTool(
+          invalidParams({
+            dataStoreId: 'ds',
+            searchEngineId: 'se',
+          }),
+        ),
     ).toThrowError('Either dataStoreId or searchEngineId must be specified.');
   });
 
   it('should throw error if dataStoreSpecs is specified without searchEngineId', () => {
     expect(
       () =>
-        new VertexAiSearchTool({
-          dataStoreId: 'ds',
-          dataStoreSpecs: [{dataStore: 'ds1'}],
-        }),
+        new VertexAiSearchTool(
+          invalidParams({
+            dataStoreId: 'ds',
+            dataStoreSpecs: [{dataStore: 'ds1'}],
+          }),
+        ),
     ).toThrowError(
       'searchEngineId must be specified if dataStoreSpecs is specified.',
     );
@@ -70,7 +95,9 @@ describe('VertexAiSearchTool', () => {
     });
     const llmRequest: LlmRequest = {
       model: 'gemini-2.0-flash',
+      contents: [],
       toolsDict: {},
+      liveConnectConfig: {},
     };
     const toolContext = {} as Context;
 
@@ -93,7 +120,9 @@ describe('VertexAiSearchTool', () => {
     const tool = new VertexAiSearchTool({dataStoreId: 'ds'});
     const llmRequest: LlmRequest = {
       model: 'gemini-1.5-pro',
+      contents: [],
       toolsDict: {},
+      liveConnectConfig: {},
       config: {
         tools: [{functionDeclarations: []}],
       },
@@ -114,7 +143,9 @@ describe('VertexAiSearchTool', () => {
     });
     const llmRequest: LlmRequest = {
       model: 'gemini-1.5-pro',
+      contents: [],
       toolsDict: {},
+      liveConnectConfig: {},
       config: {
         tools: [{functionDeclarations: []}],
       },
@@ -130,7 +161,9 @@ describe('VertexAiSearchTool', () => {
     const tool = new VertexAiSearchTool({dataStoreId: 'ds'});
     const llmRequest: LlmRequest = {
       model: 'claude-3',
+      contents: [],
       toolsDict: {},
+      liveConnectConfig: {},
     };
     const toolContext = {} as Context;
 
@@ -157,7 +190,9 @@ describe('VertexAiSearchTool', () => {
       const tool = new VertexAiSearchTool({dataStoreId: 'ds'});
       const llmRequest: LlmRequest = {
         model: 'claude-3',
+        contents: [],
         toolsDict: {},
+        liveConnectConfig: {},
       };
       const toolContext = {} as Context;
 

--- a/core/test/tools/vertex_rag_retrieval_tool_test.ts
+++ b/core/test/tools/vertex_rag_retrieval_tool_test.ts
@@ -4,19 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {VertexRagRetrievalTool} from '@google/adk';
+import {Context, LlmRequest, VertexRagRetrievalTool} from '@google/adk';
+import {GenerateContentConfig, Tool} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 
 const RAG_CORPUS =
   'projects/my-project/locations/us-central1/ragCorpora/my-corpus';
 
-function makeLlmRequest(model = 'gemini-2.0-flash') {
+/** An `LlmRequest` whose `config` is guaranteed present, so tests can index it. */
+type LlmRequestWithConfig = LlmRequest & {config: GenerateContentConfig};
+
+function makeLlmRequest(model = 'gemini-2.0-flash'): LlmRequestWithConfig {
   return {
     model,
     config: {},
     contents: [],
-    systemInstruction: undefined,
+    toolsDict: {},
+    liveConnectConfig: {},
   };
+}
+
+// The tool only reads `llmRequest`; the context is never touched, so an empty
+// stand-in is enough.
+function makeToolContext(): Context {
+  return {} as Context;
+}
+
+/**
+ * `config.tools` is a `ToolUnion[]` (`Tool | CallableTool`); the tool under test
+ * only ever pushes plain declarative `Tool`s, so narrow to that member.
+ */
+function toolAt(llmRequest: LlmRequestWithConfig, index: number): Tool {
+  return llmRequest.config.tools![index] as Tool;
 }
 
 describe('VertexRagRetrievalTool', () => {
@@ -27,7 +46,10 @@ describe('VertexRagRetrievalTool', () => {
       });
       const llmRequest = makeLlmRequest();
 
-      await tool.processLlmRequest({llmRequest} as never);
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: makeToolContext(),
+      });
 
       expect(llmRequest.config.tools).toHaveLength(1);
       expect(llmRequest.config.tools![0]).toEqual({
@@ -46,10 +68,12 @@ describe('VertexRagRetrievalTool', () => {
       });
       const llmRequest = makeLlmRequest();
 
-      await tool.processLlmRequest({llmRequest} as never);
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: makeToolContext(),
+      });
 
-      const vertexRagStore =
-        llmRequest.config.tools![0].retrieval!.vertexRagStore!;
+      const vertexRagStore = toolAt(llmRequest, 0).retrieval!.vertexRagStore!;
       expect(vertexRagStore.similarityTopK).toBe(10);
     });
 
@@ -60,10 +84,12 @@ describe('VertexRagRetrievalTool', () => {
       });
       const llmRequest = makeLlmRequest();
 
-      await tool.processLlmRequest({llmRequest} as never);
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: makeToolContext(),
+      });
 
-      const vertexRagStore =
-        llmRequest.config.tools![0].retrieval!.vertexRagStore!;
+      const vertexRagStore = toolAt(llmRequest, 0).retrieval!.vertexRagStore!;
       expect(
         vertexRagStore.ragRetrievalConfig?.filter?.vectorDistanceThreshold,
       ).toBe(0.5);
@@ -75,10 +101,12 @@ describe('VertexRagRetrievalTool', () => {
       });
       const llmRequest = makeLlmRequest();
 
-      await tool.processLlmRequest({llmRequest} as never);
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: makeToolContext(),
+      });
 
-      const vertexRagStore =
-        llmRequest.config.tools![0].retrieval!.vertexRagStore!;
+      const vertexRagStore = toolAt(llmRequest, 0).retrieval!.vertexRagStore!;
       expect(vertexRagStore.similarityTopK).toBeUndefined();
       expect(vertexRagStore.ragRetrievalConfig).toBeUndefined();
     });
@@ -87,13 +115,19 @@ describe('VertexRagRetrievalTool', () => {
       const tool = new VertexRagRetrievalTool({
         ragResources: [{ragCorpus: RAG_CORPUS}],
       });
-      const llmRequest = {model: 'gemini-2.0-flash', contents: []} as never;
+      const llmRequest: LlmRequest = {
+        model: 'gemini-2.0-flash',
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
 
-      await tool.processLlmRequest({llmRequest} as never);
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: makeToolContext(),
+      });
 
-      expect(
-        (llmRequest as never as {config: {tools: unknown[]}}).config.tools,
-      ).toHaveLength(1);
+      expect(llmRequest.config?.tools).toHaveLength(1);
     });
 
     it('appends to existing tools without removing them', async () => {
@@ -101,12 +135,15 @@ describe('VertexRagRetrievalTool', () => {
         ragResources: [{ragCorpus: RAG_CORPUS}],
       });
       const llmRequest = makeLlmRequest();
-      llmRequest.config.tools = [{googleSearch: {}}] as never;
+      llmRequest.config.tools = [{googleSearch: {}}];
 
-      await tool.processLlmRequest({llmRequest} as never);
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: makeToolContext(),
+      });
 
       expect(llmRequest.config.tools).toHaveLength(2);
-      expect(llmRequest.config.tools![1].retrieval).toBeDefined();
+      expect(toolAt(llmRequest, 1).retrieval).toBeDefined();
     });
   });
 
@@ -115,7 +152,7 @@ describe('VertexRagRetrievalTool', () => {
       const tool = new VertexRagRetrievalTool({
         ragResources: [{ragCorpus: RAG_CORPUS}],
       });
-      const result = await tool.runAsync({} as never);
+      const result = await tool.runAsync();
       expect(result).toBeUndefined();
     });
   });

--- a/core/test/utils/live_connection_utils_test.ts
+++ b/core/test/utils/live_connection_utils_test.ts
@@ -7,6 +7,7 @@
 import {GroundingMetadata, LiveServerGoAway} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {LiveResponseAggregator} from '../../src/utils/live_connection_utils.js';
+import {liveServerMessage} from './live_server_message_test_utils.js';
 
 describe('LiveResponseAggregator', () => {
   it('should yield usage metadata', () => {
@@ -17,7 +18,9 @@ describe('LiveResponseAggregator', () => {
       totalTokenCount: 30,
     };
 
-    const generator = aggregator.processMessage({usageMetadata});
+    const generator = aggregator.processMessage(
+      liveServerMessage({usageMetadata}),
+    );
     const results = Array.from(generator);
 
     expect(results).toEqual([
@@ -32,13 +35,15 @@ describe('LiveResponseAggregator', () => {
     const aggregator = new LiveResponseAggregator('gemini-2.5-flash');
 
     // Message 1: partial text
-    const gen1 = aggregator.processMessage({
-      serverContent: {
-        modelTurn: {
-          parts: [{text: 'Hello'}],
+    const gen1 = aggregator.processMessage(
+      liveServerMessage({
+        serverContent: {
+          modelTurn: {
+            parts: [{text: 'Hello'}],
+          },
         },
-      },
-    });
+      }),
+    );
     const res1 = Array.from(gen1);
     expect(res1).toEqual([
       {
@@ -49,16 +54,18 @@ describe('LiveResponseAggregator', () => {
     ]);
 
     // Message 2: partial text and turnComplete
-    const gen2 = aggregator.processMessage({
-      serverContent: {
-        modelTurn: {
-          parts: [{text: ' world!'}],
+    const gen2 = aggregator.processMessage(
+      liveServerMessage({
+        serverContent: {
+          modelTurn: {
+            parts: [{text: ' world!'}],
+          },
+          turnComplete: true,
+          interrupted: false,
+          groundingMetadata: {groundingChunks: []} as GroundingMetadata,
         },
-        turnComplete: true,
-        interrupted: false,
-        groundingMetadata: {groundingChunks: []} as GroundingMetadata,
-      },
-    });
+      }),
+    );
     const res2 = Array.from(gen2);
     expect(res2).toEqual([
       {
@@ -90,13 +97,15 @@ describe('LiveResponseAggregator', () => {
 
     // Message 1: thought
     const res1 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Thinking...', thought: true}],
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Thinking...', thought: true}],
+            },
           },
-        },
-      }),
+        }),
+      ),
     );
     expect(res1).toEqual([
       {
@@ -108,13 +117,15 @@ describe('LiveResponseAggregator', () => {
 
     // Message 2: transition to text
     const res2 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Answer is 42.'}],
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Answer is 42.'}],
+            },
           },
-        },
-      }),
+        }),
+      ),
     );
     expect(res2).toEqual([
       {
@@ -134,11 +145,13 @@ describe('LiveResponseAggregator', () => {
 
     // Message 3: turn complete
     const res3 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          turnComplete: true,
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            turnComplete: true,
+          },
+        }),
+      ),
     );
     expect(res3).toEqual([
       {
@@ -160,11 +173,13 @@ describe('LiveResponseAggregator', () => {
     const aggregator = new LiveResponseAggregator('gemini-2.5-flash');
 
     const res1 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          inputTranscription: {text: 'hello', finished: false},
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            inputTranscription: {text: 'hello', finished: false},
+          },
+        }),
+      ),
     );
     expect(res1).toEqual([
       {
@@ -175,11 +190,13 @@ describe('LiveResponseAggregator', () => {
     ]);
 
     const res2 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          inputTranscription: {text: ' world', finished: true},
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            inputTranscription: {text: ' world', finished: true},
+          },
+        }),
+      ),
     );
     expect(res2).toEqual([
       {
@@ -199,11 +216,13 @@ describe('LiveResponseAggregator', () => {
     const aggregator = new LiveResponseAggregator('gemini-2.5-flash');
 
     const res1 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          inputTranscription: {text: 'hello', finished: false},
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            inputTranscription: {text: 'hello', finished: false},
+          },
+        }),
+      ),
     );
     expect(res1[0].inputTranscription).toEqual({
       text: 'hello',
@@ -211,11 +230,13 @@ describe('LiveResponseAggregator', () => {
     });
 
     const res2 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          interrupted: true,
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            interrupted: true,
+          },
+        }),
+      ),
     );
     expect(res2).toEqual([
       {
@@ -234,18 +255,20 @@ describe('LiveResponseAggregator', () => {
     const aggregator = new LiveResponseAggregator('gemini-2.5-flash');
 
     const res1 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          modelTurn: {
-            parts: [{text: 'Partial text'}],
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            modelTurn: {
+              parts: [{text: 'Partial text'}],
+            },
+            groundingMetadata: {
+              groundingChunks: [
+                {web: {uri: 'https://google.com', title: 'Google'}},
+              ],
+            } as GroundingMetadata,
           },
-          groundingMetadata: {
-            groundingChunks: [
-              {web: {uri: 'https://google.com', title: 'Google'}},
-            ],
-          } as GroundingMetadata,
-        },
-      }),
+        }),
+      ),
     );
     expect(res1).toEqual([
       {
@@ -265,20 +288,24 @@ describe('LiveResponseAggregator', () => {
     const aggregator = new LiveResponseAggregator('gemini-2.5-flash');
 
     const res1 = Array.from(
-      aggregator.processMessage({
-        toolCall: {
-          functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          toolCall: {
+            functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
+          },
+        }),
+      ),
     );
     expect(res1).toEqual([]); // Buffered
 
     const res2 = Array.from(
-      aggregator.processMessage({
-        serverContent: {
-          turnComplete: true,
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          serverContent: {
+            turnComplete: true,
+          },
+        }),
+      ),
     );
     expect(res2).toEqual([
       {
@@ -299,11 +326,13 @@ describe('LiveResponseAggregator', () => {
     const aggregator = new LiveResponseAggregator('gemini-3.1-flash-live');
 
     const res1 = Array.from(
-      aggregator.processMessage({
-        toolCall: {
-          functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
-        },
-      }),
+      aggregator.processMessage(
+        liveServerMessage({
+          toolCall: {
+            functionCalls: [{name: 'tool_a', args: {x: 1}, id: '1'}],
+          },
+        }),
+      ),
     );
     expect(res1).toEqual([
       {
@@ -318,10 +347,12 @@ describe('LiveResponseAggregator', () => {
 
   it('should yield session resumption update', () => {
     const aggregator = new LiveResponseAggregator('gemini-2.5-flash');
-    const resumptionUpdate = {resumed: true};
+    const resumptionUpdate = {resumable: true};
 
     const res = Array.from(
-      aggregator.processMessage({sessionResumptionUpdate: resumptionUpdate}),
+      aggregator.processMessage(
+        liveServerMessage({sessionResumptionUpdate: resumptionUpdate}),
+      ),
     );
     expect(res).toEqual([
       {
@@ -333,10 +364,10 @@ describe('LiveResponseAggregator', () => {
 
   it('should yield go away', () => {
     const aggregator = new LiveResponseAggregator('gemini-2.5-flash');
-    const goAway = {goAway: true};
+    const goAway: LiveServerGoAway = {timeLeft: '10s'};
 
     const res = Array.from(
-      aggregator.processMessage({goAway: goAway as LiveServerGoAway}),
+      aggregator.processMessage(liveServerMessage({goAway})),
     );
     expect(res).toEqual([
       {

--- a/core/test/utils/live_server_message_test_utils.ts
+++ b/core/test/utils/live_server_message_test_utils.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LiveServerMessage} from '@google/genai';
+
+/**
+ * Builds a `LiveServerMessage` for a test.
+ *
+ * `LiveServerMessage` is a class, not an interface: `text` and `data` are
+ * getters over `serverContent`, so a plain object literal is not assignable to
+ * it. Those two are excluded from `init` because they have no setter --
+ * assigning to one throws at runtime.
+ */
+export function liveServerMessage(
+  init: Partial<Omit<LiveServerMessage, 'text' | 'data'>>,
+): LiveServerMessage {
+  return Object.assign(new LiveServerMessage(), init);
+}

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist/types"
+    "outDir": "dist/types",
+    // Reset the root config's test-only path aliases: a published build must
+    // resolve @google/adk through node_modules, not the sibling sources.
+    "paths": {}
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/dev/src/conformance/conformance_integrations.ts
+++ b/dev/src/conformance/conformance_integrations.ts
@@ -13,7 +13,10 @@ import {
 } from '@google/adk';
 import {Content} from '@google/genai';
 import {z} from 'zod';
-import {IntegrationRegistry} from '../integration/integration_registry.js';
+import {
+  AnyFunctionTool,
+  IntegrationRegistry,
+} from '../integration/integration_registry.js';
 
 export function registerConformanceIntegrations(registry: IntegrationRegistry) {
   // Plugins
@@ -57,7 +60,7 @@ export function registerConformanceIntegrations(registry: IntegrationRegistry) {
   }
 
   // Tools
-  const tools: {name: string; tool: FunctionTool}[] = [
+  const tools: {name: string; tool: AnyFunctionTool}[] = [
     {name: 'tools_agent_009.tools.reimburse', tool: reimburse},
     {name: 'tools_agent_009.tools.ask_for_approval', tool: askForApproval},
     {name: 'tools_agent_004.tools.search_flights', tool: searchFlights},

--- a/dev/src/integration/agent_registry.ts
+++ b/dev/src/integration/agent_registry.ts
@@ -7,7 +7,6 @@
 import {
   AgentTool,
   BaseAgent,
-  FunctionTool,
   LlmAgent,
   LoopAgent,
   MCPToolset,
@@ -21,7 +20,7 @@ import {
   McpToolsetArgs,
   YamlAgentConfig,
 } from './agent_types.js';
-import {IntegrationRegistry} from './integration_registry.js';
+import {AnyFunctionTool, IntegrationRegistry} from './integration_registry.js';
 
 const BUILTIN_TOOLS = [
   'exit_loop',
@@ -73,7 +72,7 @@ export class AgentRegistry {
     this.configs.set(name, config);
   }
 
-  private findToolOrThrow(name: string): FunctionTool<undefined> {
+  private findToolOrThrow(name: string): AnyFunctionTool {
     const tool = this.integrationRegistry.getTool(name);
     if (!tool) {
       console.log('Tool not found in registry', name);

--- a/dev/src/integration/integration_registry.ts
+++ b/dev/src/integration/integration_registry.ts
@@ -4,10 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {BasePlugin, FunctionTool, SingleAgentCallback} from '@google/adk';
+import {
+  BasePlugin,
+  FunctionTool,
+  SingleAgentCallback,
+  ToolInputParameters,
+} from '@google/adk';
+
+/**
+ * A function tool of any parameter shape.
+ *
+ * Bare `FunctionTool` means `FunctionTool<undefined>` — a tool that takes no
+ * arguments — so it cannot hold the schema-carrying tools this registry is
+ * given.
+ */
+export type AnyFunctionTool = FunctionTool<ToolInputParameters>;
 
 export class IntegrationRegistry {
-  private tools = new Map<string, FunctionTool>();
+  private tools = new Map<string, AnyFunctionTool>();
   private beforeAgentCallbacks = new Map<string, SingleAgentCallback>();
   private afterAgentCallbacks = new Map<string, SingleAgentCallback>();
   private plugins = new Map<string, BasePlugin>();
@@ -21,11 +35,11 @@ export class IntegrationRegistry {
     );
   }
 
-  registerTool(name: string, tool: FunctionTool) {
+  registerTool(name: string, tool: AnyFunctionTool) {
     this.tools.set(name, tool);
   }
 
-  getTool(name: string): FunctionTool | undefined {
+  getTool(name: string): AnyFunctionTool | undefined {
     return this.tools.get(name);
   }
 

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist/types"
+    "outDir": "dist/types",
+    // Reset the root config's test-only path aliases: a published build must
+    // resolve @google/adk through node_modules, not the sibling sources.
+    "paths": {}
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/integrations/tsconfig.json
+++ b/integrations/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist/types"
+    "outDir": "dist/types",
+    // Reset the root config's test-only path aliases: a published build must
+    // resolve @google/adk through node_modules, not the sibling sources.
+    "paths": {}
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/tests/integration/sessions/vertex_ai_session_service_test.ts
+++ b/tests/integration/sessions/vertex_ai_session_service_test.ts
@@ -21,6 +21,23 @@ import {afterAll, beforeAll, beforeEach, describe, expect, it} from 'vitest';
 const AGENT_ENGINE_ID = '12345';
 
 /**
+ * Builds the Agent Engine `Sessions` client from an `ApiClient`.
+ *
+ * `@google-cloud/vertexai` bundles its own nested copy of `@google/genai`
+ * (1.52.0) while the repo root resolves `@google/genai` to 2.9.0, so the
+ * `ApiClient` this test constructs is a structurally distinct class (its
+ * private fields make the two nominally incompatible) from the one `Sessions`
+ * declares. The instances are interchangeable at runtime -- the mismatch is a
+ * duplicate-dependency artifact, not a real API difference -- so the cast is
+ * confined to this one boundary.
+ */
+function createSessionsClient(apiClient: ApiClient): Sessions {
+  return new Sessions(
+    apiClient as unknown as ConstructorParameters<typeof Sessions>[0],
+  );
+}
+
+/**
  * Exercises `getSession`'s NOT_FOUND handling against an error the SDK builds
  * itself: a loopback HTTP server answers 404 in place of the Agent Engine
  * Sessions API, and the response travels back through the real
@@ -56,7 +73,7 @@ describe('VertexAiSessionService over the real Sessions HTTP client', () => {
     });
     service = new VertexAiSessionService({
       agentEngineId: AGENT_ENGINE_ID,
-      sessions: new Sessions(apiClient),
+      sessions: createSessionsClient(apiClient),
     });
   });
 
@@ -121,7 +138,7 @@ describe('VertexAiSessionService session expiration over the wire', () => {
     });
     service = new VertexAiSessionService({
       agentEngineId: AGENT_ENGINE_ID,
-      sessions: new Sessions(apiClient),
+      sessions: createSessionsClient(apiClient),
     });
   });
 

--- a/tests/integration/workflows/advanced_workflows/advanced_workflows_test.ts
+++ b/tests/integration/workflows/advanced_workflows/advanced_workflows_test.ts
@@ -138,7 +138,7 @@ describe('workflow integration — mid-graph HITL resume', () => {
 
 describe('workflow integration — multi-trigger fan-in with JoinNode', () => {
   it('joins three parallel branches produced from START', async () => {
-    const mk = (name: string): FunctionNode =>
+    const mk = (name: string) =>
       new FunctionNode(name, (_c, i: string) => `${name}:${i}`);
     const join = new JoinNode({name: 'join'});
     const wf = new Workflow({
@@ -155,7 +155,7 @@ describe('workflow integration — multi-trigger fan-in with JoinNode', () => {
 
 describe('workflow integration — parallel branches emit independent events', () => {
   it('streams events from all parallel branches', async () => {
-    const mk = (name: string): FunctionNode =>
+    const mk = (name: string) =>
       new FunctionNode(name, (_c, i: string) => `${name}(${i})`);
     const join = new JoinNode({name: 'join'});
     const wf = new Workflow({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,11 @@
       "@google/adk-integrations": ["./integrations/src/index.ts"],
       "@google/adk-integrations/*": ["./integrations/src/*"]
     }
-  }
+  },
+  // gts' `exclude` resolves relative to gts itself, so it excludes nothing
+  // here. Without this, the check picks up every `*/dist/**/*.d.ts` emitted by
+  // the preceding build step, so CI and a fresh clone check different files.
+  // The three workspace configs set their own `exclude`, so this does not
+  // reach them.
+  "exclude": ["node_modules", "**/dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,18 @@
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    // Mirrors the aliases in vitest.config.ts so that a test importing
+    // `@google/adk` type-checks against the same sources it runs against.
+    // Without this, a file mixing `@google/adk` and `../../src/...` imports
+    // gets two distinct identities for the same class. The per-workspace
+    // configs reset this to `{}` so that a published build still resolves
+    // through node_modules.
+    "paths": {
+      "@google/adk": ["./core/src/index.ts"],
+      "@google/adk/*": ["./core/src/*"],
+      "@google/adk-integrations": ["./integrations/src/index.ts"],
+      "@google/adk-integrations/*": ["./integrations/src/*"]
+    }
   }
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`npm run ts:check` (`tsc --noEmit`) exists in `package.json` and is wired into
nothing. `validation.yaml` runs secretlint, build, tests, lint, format and
docs:

- **build** only compiles the three workspaces' `src/` — `core/test/**`,
  `dev/test/**`, `tests/**` are in no tsconfig's `include`;
- **lint** reaches those files, but `eslint.config.js` uses
  `tseslint.configs.recommended`, which is not type-aware;
- **tests** run through vitest, which strips types rather than checking them.

So no job compiles a single test file. Running `tsc --noEmit` on `main` today:

```
Found 287 errors in 44 files.
```

A renamed type, a changed signature or a removed export can land green. This
came out of review on #634, where the same hole was noticed for `samples/`.

**Solution:**

Get to zero, then add the step so it stays there.

#### Two thirds of it was one bug, not 200

A test that imports both `@google/adk` and `../../src/...` got **two distinct
identities for the same class** — vitest aliases `@google/adk` to `core/src`,
while tsc resolved it through `node_modules` to the built `core/dist/types`:

```
Type 'core/dist/types/agents/invocation_context'.InvocationContext
  is not assignable to type
     'core/src/agents/invocation_context'.InvocationContext
```

That is not a test bug; it is the type-checker disagreeing with the test
runner. Mirroring the vitest aliases as `paths` in the root `tsconfig.json`
takes it from 287 to 164 without touching a line of test code, and makes the
IDE agree with CI too.

The three per-workspace configs reset `paths` to `{}`, so a **published build
still resolves `@google/adk` through `node_modules`** rather than the sibling
sources. Verified rather than assumed: `core/dist/types` and `dev/dist/types`
are byte-identical before and after (`diff -rq`).

#### The rest was real drift, fixed rather than suppressed

No `@ts-ignore`, no `as any`, no test skipped, no assertion weakened —
**22 casts removed against 15 added**. The recurring ones:

| Pattern                                                                                                                       | Count | Fix                                                                                                                                                                         |
| :---------------------------------------------------------------------------------------------------------------------------- | :---- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `LiveServerMessage` is a class with `text`/`data` getters, so object literals were never assignable                           | ~45   | one shared `liveServerMessage()` helper that builds a real instance                                                                                                         |
| String literal where a genai enum member is required (`Modality`, `BlockedReason`, `Type`, `Language`, `FileContentEncoding`) | ~12   | use the enum member; values are the same strings, so assertions are untouched                                                                                               |
| Partial mocks missing required properties                                                                                     | ~40   | complete the object, or a typed factory where a partial mock is genuinely intended                                                                                          |
| Mock signatures drifted from the type they implement                                                                          | 3     | `MockCredentialExchanger.exchange` still returned a bare `AuthCredential` instead of `ExchangeResult`; `DummyAgent` and `MockLlm` were missing abstract members added since |
| `Content['parts']![0]` — `!` is not valid inside a type                                                                       | 8     | the literals type-check as `Part` with no cast at all now                                                                                                                   |
| Stale `@ts-expect-error` for an error that no longer occurs                                                                   | 2     | directive deleted, test and assertions kept                                                                                                                                 |

#### One genuine source bug it surfaced

`dev`'s integration registry declared its tools as bare `FunctionTool` — which
means `FunctionTool<undefined>`, a tool that takes **no arguments** — so it
could not actually hold any of the seven schema-carrying tools it is handed.
Now `FunctionTool<ToolInputParameters>`.

#### Two more source bugs, from review

Both started as documented casts in the tests, and review was right that the
type was the wrong part:

- `ListSessionsRequest.userId` was declared required, but all three
  implementations branch on its absence — and a test named _"lists sessions
  without filter if userId is missing"_ covers exactly that. It is `userId?:
  string` now, so the cast and the four call sites go back to their original
  form. `InMemorySessionService` was the one site that indexed on it
  (`this.sessions[appName][userId]`); it now lists across every user of the app
  when `userId` is omitted, the same as the filter-less branches in
  `VertexAiSessionService` and `DatabaseSessionService`. That path is new
  behaviour, so it gets a test.
- `InMemoryPolicyEngine.evaluate()` declared no parameter while
  `BasePolicyEngine.evaluate` declares one, so
  `new InMemoryPolicyEngine().evaluate(context)` did not compile for a user of
  the exported class. The parameter is declared now.

#### One thing deliberately left as a documented cast

`@google-cloud/vertexai` bundles its own `@google/genai@1.52.0` alongside the
root `@google/genai@2.9.0`, so the two `ApiClient` classes are nominally
distinct (private `customBaseUrl`). Deduping is a dependency decision, not a
CI one.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

One new test, for the one new behaviour: `InMemorySessionService.listSessions`
with no `userId` (see above). Everything else changes no runtime behaviour —
each remaining touched test file keeps its assertions and its test count, and
no `.skip`/`.only`/`.todo` was added.

```
npx tsc --noEmit                    -> 0 errors (was 287)
npm run test:unit                   -> 219 files, 3054 tests
npm run lint                        -> clean
npm run format:check                -> clean
npm run build                       -> clean
zizmor --no-ignores --offline       -> no findings (was exit 14)
```

The emitted `.d.ts` are byte-identical except for the two intended public-type
changes above: `userId` becomes optional on `ListSessionsRequest`, and
`InMemoryPolicyEngine.evaluate` gains its parameter. Both widen what callers may
pass, so neither breaks a caller.

One pre-existing failure, unrelated and not a regression:
`dev/test/cli/cli_create_test.ts` reads the machine's gcloud project and fails
the same way on a clean `main` (verified with `git stash`).

**Manual End-to-End (E2E) Tests:**

The touched integration tests were run directly:

```
tests/integration/sessions/vertex_ai_session_service_test.ts        3 passed
tests/integration/workflows/advanced_workflows/..._test.ts          5 passed
```

Both run offline (loopback HTTP server / recorded model responses).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Cost.** One `tsc --noEmit` pass, after `Build packages`, on each of the three
matrix OSes.

**Why `paths` in the root config rather than a separate `tsconfig.check.json`.**
A check-only config would fix CI but leave every editor showing the same 287
phantom errors on test files, which is how they accumulated. Putting the
aliases in the config the IDE actually loads fixes both; the `"paths": {}`
reset keeps the published builds honest. The root config also gains an
`exclude`: the one it inherits from gts resolves relative to gts, so without it
the check compiles the 270 `*/dist/**/*.d.ts` the preceding `Build packages`
step emits (939 files down to 669), and CI checks a different file set than a
fresh clone.

**Action pinning.** The three actions in `validation.yaml` are now pinned to
commit SHAs with `permissions: contents: read` and `persist-credentials: false`,
matching #634 — zizmor scans the workflow files a PR touches, and this PR
touches that one.

**Relationship to #634.** That PR adds a samples-scoped
`npm run ts:check:samples` step, because the repo-wide check could not pass at
the time. Once this lands, that step is redundant — `samples/**` is already
covered by the root config, so the repo-wide `Run type check` step subsumes it.
Happy to land this first and drop the scoped step from #634.

