### PR TITLE
fix(sessions): keep workflow event fields across the Agent Engine fallback path

### DIFF
--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -13,7 +13,11 @@ import {
   Session as VertexAiSession,
   SessionEvent as VertexAiSessionEvent,
 } from '@google-cloud/vertexai/build/src/genai/types.js';
-import {Content, GenerateContentResponseUsageMetadata} from '@google/genai';
+import {
+  Content,
+  GenerateContentResponseUsageMetadata,
+  GroundingMetadata,
+} from '@google/genai';
 import {isCompactedEvent} from '../events/compacted_event.js';
 import {experimental} from '../utils/experimental.js';
 
@@ -44,6 +48,18 @@ const DEFAULT_MAX_ATTEMPTS = 30;
 const GRPC_NOT_FOUND = 5;
 const HTTP_NOT_FOUND = 404;
 
+/**
+ * `eventMetadata.customMetadata` key carrying the workflow fields of an
+ * {@link Event} that the Agent Engine sessions API does not model: a node's
+ * `output`, `route`, `nodeInfo` and `isolationScope`, plus the
+ * `agentState`/`endOfAgent` actions. It is the same escape hatch this service
+ * already uses for `_compaction` and `_usage_metadata`.
+ *
+ * Workflow resume is driven entirely by these fields — `reconstructNodeStates`
+ * groups prior events by `nodeInfo.path` and replays their `output`/`route`,
+ * and a paused node recovers its input from `actions.agentState` — so an event
+ * rebuilt without them makes a resumed run re-execute completed nodes.
+ */
 const WORKFLOW_CUSTOM_METADATA_KEY = '_workflow';
 
 /**
@@ -651,6 +667,9 @@ function _fromApiEvent(apiEventObj: VertexAiSessionEvent): Event {
     customMetadata,
     longRunningToolIds: eventMetadata['longRunningToolIds'] as
       | string[]
+      | undefined,
+    groundingMetadata: eventMetadata['groundingMetadata'] as
+      | GroundingMetadata
       | undefined,
     usageMetadata:
       usageMetadataData as unknown as GenerateContentResponseUsageMetadata,

--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -18,7 +18,7 @@ import {isCompactedEvent} from '../events/compacted_event.js';
 import {experimental} from '../utils/experimental.js';
 
 import {AuthConfig} from '../auth/auth_tool.js';
-import {Event} from '../events/event.js';
+import {Event, NodeInfo, Route} from '../events/event.js';
 import {EventActions} from '../events/event_actions.js';
 import {ToolConfirmation} from '../tools/tool_confirmation.js';
 import {logger} from '../utils/logger.js';
@@ -43,6 +43,8 @@ import {createSession, Session} from './session.js';
 const DEFAULT_MAX_ATTEMPTS = 30;
 const GRPC_NOT_FOUND = 5;
 const HTTP_NOT_FOUND = 404;
+
+const WORKFLOW_CUSTOM_METADATA_KEY = '_workflow';
 
 /**
  * Checks if the given URI is a Vertex AI session service URI.
@@ -431,6 +433,10 @@ export class VertexAiSessionService extends BaseSessionService {
     if (event.usageMetadata) {
       customMetadata._usage_metadata = event.usageMetadata;
     }
+    const workflowMetadata = toWorkflowMetadata(event);
+    if (workflowMetadata) {
+      customMetadata[WORKFLOW_CUSTOM_METADATA_KEY] = workflowMetadata;
+    }
 
     const config = partialCopy<AppendAgentEngineSessionEventConfig>(event, [
       'content',
@@ -469,7 +475,9 @@ export class VertexAiSessionService extends BaseSessionService {
       await this.sessions.events.append(params);
     } catch (error) {
       logger.warn(
-        'Failed to append event with rawEvent, falling back...',
+        'Failed to append event with rawEvent; retrying without it. The event ' +
+          'will be reconstructed from its structured fields and ' +
+          'customMetadata on read.',
         error,
       );
       delete config.rawEvent;
@@ -483,6 +491,62 @@ export class VertexAiSessionService extends BaseSessionService {
     }
 
     return event;
+  }
+}
+
+interface WorkflowEventMetadata {
+  output?: unknown;
+  route?: Route;
+  nodeInfo?: NodeInfo;
+  isolationScope?: string;
+  agentState?: Record<string, unknown>;
+  endOfAgent?: boolean;
+}
+
+function toWorkflowMetadata(event: Event): WorkflowEventMetadata | undefined {
+  const metadata: WorkflowEventMetadata = {};
+  if (event.output !== undefined) {
+    metadata.output = event.output;
+  }
+  if (event.route !== undefined) {
+    metadata.route = event.route;
+  }
+  if (event.nodeInfo !== undefined) {
+    metadata.nodeInfo = event.nodeInfo;
+  }
+  if (event.isolationScope !== undefined) {
+    metadata.isolationScope = event.isolationScope;
+  }
+  if (event.actions?.agentState !== undefined) {
+    metadata.agentState = event.actions.agentState;
+  }
+  if (event.actions?.endOfAgent !== undefined) {
+    metadata.endOfAgent = event.actions.endOfAgent;
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function applyWorkflowMetadata(
+  event: Event,
+  metadata: WorkflowEventMetadata,
+): void {
+  if (metadata.output !== undefined) {
+    event.output = metadata.output;
+  }
+  if (metadata.route !== undefined) {
+    event.route = metadata.route;
+  }
+  if (metadata.nodeInfo !== undefined) {
+    event.nodeInfo = metadata.nodeInfo;
+  }
+  if (metadata.isolationScope !== undefined) {
+    event.isolationScope = metadata.isolationScope;
+  }
+  if (metadata.agentState !== undefined) {
+    event.actions.agentState = metadata.agentState;
+  }
+  if (metadata.endOfAgent !== undefined) {
+    event.actions.endOfAgent = metadata.endOfAgent;
   }
 }
 
@@ -527,8 +591,10 @@ function _fromApiEvent(apiEventObj: VertexAiSessionEvent): Event {
     compactedContent: string;
   } | null = null;
   let usageMetadataData = null;
+  let workflowData: WorkflowEventMetadata | undefined;
 
   if (customMetadata) {
+    customMetadata = {...customMetadata};
     if (customMetadata._compaction) {
       compactionData = customMetadata._compaction as {
         startTime: number;
@@ -540,6 +606,12 @@ function _fromApiEvent(apiEventObj: VertexAiSessionEvent): Event {
     if (customMetadata._usage_metadata) {
       usageMetadataData = customMetadata._usage_metadata;
       delete customMetadata._usage_metadata;
+    }
+    if (customMetadata[WORKFLOW_CUSTOM_METADATA_KEY]) {
+      workflowData = customMetadata[
+        WORKFLOW_CUSTOM_METADATA_KEY
+      ] as WorkflowEventMetadata;
+      delete customMetadata[WORKFLOW_CUSTOM_METADATA_KEY];
     }
     if (Object.keys(customMetadata).length === 0) {
       customMetadata = undefined;
@@ -589,6 +661,10 @@ function _fromApiEvent(apiEventObj: VertexAiSessionEvent): Event {
     event.startTime = compactionData.startTime;
     event.endTime = compactionData.endTime;
     event.compactedContent = compactionData.compactedContent;
+  }
+
+  if (workflowData) {
+    applyWorkflowMetadata(event, workflowData);
   }
 
   return event;

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -14,6 +14,10 @@ import {
 import {Session} from '@google/adk/sessions/session.js';
 import {ApiError} from '@google/genai';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  isFastForwardable,
+  reconstructNodeStates,
+} from '../../src/workflow/utils/rehydration_utils.js';
 
 // Mock the unreleased nodejs-vertexai package so the import resolves
 vi.mock('nodejs-vertexai', () => ({
@@ -1252,6 +1256,202 @@ describe('VertexAiSessionService', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('workflow event fields', () => {
+    const appendSession = () =>
+      ({
+        id: 'wf-session',
+        appName: '12345',
+        userId: 'testUser',
+        events: [],
+        lastUpdateTime: Date.now(),
+      }) as unknown as Session;
+
+    const readBackWithoutRawEvent = async () => {
+      const sent = mockClient.events.append.mock.calls.at(-1)![0];
+      const apiEvent = {
+        name: 'reasoningEngines/12345/sessions/wf-session/events/e1',
+        author: sent.author,
+        invocationId: sent.invocationId,
+        timestamp: sent.timestamp,
+        content: sent.config.content,
+        actions: sent.config.actions,
+        eventMetadata: sent.config.eventMetadata,
+      };
+      mockClient.events.listInternal.mockResolvedValue({
+        sessionEvents: [apiEvent],
+      });
+      const session = await service.getSession({
+        appName: '12345',
+        userId: 'testUser',
+        sessionId: 'wf-session',
+      });
+      return {apiEvent, event: session!.events[0]};
+    };
+
+    it('writes workflow fields into customMetadata', async () => {
+      const event = createEvent({
+        timestamp: 1620000000000,
+        author: 'reviewer',
+        invocationId: 'inv-1',
+        output: {score: 7},
+        route: 'approved',
+        nodeInfo: {path: 'wf.reviewer', messageAsOutput: true},
+        isolationScope: 'wf:evt_1',
+        actions: {agentState: {input: 'draft'}, endOfAgent: true},
+      });
+
+      await service.appendEvent({session: appendSession(), event});
+
+      expect(mockClient.events.append).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            eventMetadata: expect.objectContaining({
+              customMetadata: expect.objectContaining({
+                _workflow: {
+                  output: {score: 7},
+                  route: 'approved',
+                  nodeInfo: {path: 'wf.reviewer', messageAsOutput: true},
+                  isolationScope: 'wf:evt_1',
+                  agentState: {input: 'draft'},
+                  endOfAgent: true,
+                },
+              }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('writes no workflow metadata for a plain event', async () => {
+      const event = createEvent({
+        timestamp: 1620000000000,
+        author: 'agent',
+        invocationId: 'inv-1',
+        content: {role: 'model', parts: [{text: 'hi'}]},
+      });
+
+      await service.appendEvent({session: appendSession(), event});
+
+      const sent = mockClient.events.append.mock.calls.at(-1)![0];
+      expect(sent.config.eventMetadata.customMetadata).toBeUndefined();
+    });
+
+    it('restores workflow fields when rawEvent is absent', async () => {
+      const original = createEvent({
+        timestamp: 1620000000000,
+        author: 'reviewer',
+        invocationId: 'inv-1',
+        output: {score: 7},
+        route: 'approved',
+        nodeInfo: {path: 'wf.reviewer', outputFor: '1'},
+        isolationScope: 'wf:evt_1',
+        actions: {agentState: {input: 'draft'}, endOfAgent: true},
+      });
+
+      await service.appendEvent({session: appendSession(), event: original});
+      const {event} = await readBackWithoutRawEvent();
+
+      expect(event.output).toEqual({score: 7});
+      expect(event.route).toBe('approved');
+      expect(event.nodeInfo).toEqual({path: 'wf.reviewer', outputFor: '1'});
+      expect(event.isolationScope).toBe('wf:evt_1');
+      expect(event.actions.agentState).toEqual({input: 'draft'});
+      expect(event.actions.endOfAgent).toBe(true);
+    });
+
+    it('round-trips a falsy output rather than dropping it', async () => {
+      for (const output of [false, 0, '', null]) {
+        mockClient.events.append.mockClear();
+        const event = createEvent({
+          timestamp: 1620000000000,
+          author: 'gate',
+          invocationId: 'inv-1',
+          nodeInfo: {path: 'wf.gate'},
+          output,
+        });
+
+        await service.appendEvent({session: appendSession(), event});
+        const {event: readBack} = await readBackWithoutRawEvent();
+
+        expect(readBack.output).toBe(output);
+      }
+    });
+
+    it('keeps the workflow key out of user-visible customMetadata', async () => {
+      const event = createEvent({
+        timestamp: 1620000000000,
+        author: 'reviewer',
+        invocationId: 'inv-1',
+        output: 'done',
+        nodeInfo: {path: 'wf.reviewer'},
+        customMetadata: {tenant: 'acme'},
+      });
+
+      await service.appendEvent({session: appendSession(), event});
+      const {apiEvent, event: readBack} = await readBackWithoutRawEvent();
+
+      expect(readBack.customMetadata).toEqual({tenant: 'acme'});
+      expect(readBack.output).toBe('done');
+      expect(
+        (apiEvent.eventMetadata.customMetadata as Record<string, unknown>)
+          ._workflow,
+      ).toBeDefined();
+    });
+
+    it('lets a resumed workflow rehydrate from reconstructed events', async () => {
+      const completed = createEvent({
+        timestamp: 1620000000000,
+        author: 'fetch',
+        invocationId: 'inv-1',
+        nodeInfo: {path: 'wf.fetch'},
+        output: 'A(x)',
+      });
+      const paused = createEvent({
+        timestamp: 1620000001000,
+        author: 'gate',
+        invocationId: 'inv-1',
+        nodeInfo: {path: 'wf.gate'},
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'adk_request_input', id: 'gate-1'}}],
+        },
+        longRunningToolIds: ['gate-1'],
+        actions: {agentState: {input: 'A(x)'}},
+      });
+
+      const apiEvents = [];
+      for (const event of [completed, paused]) {
+        mockClient.events.append.mockClear();
+        await service.appendEvent({session: appendSession(), event});
+        const sent = mockClient.events.append.mock.calls.at(-1)![0];
+        apiEvents.push({
+          name: `reasoningEngines/12345/sessions/wf-session/events/${apiEvents.length}`,
+          author: sent.author,
+          invocationId: sent.invocationId,
+          timestamp: sent.timestamp,
+          content: sent.config.content,
+          actions: sent.config.actions,
+          eventMetadata: sent.config.eventMetadata,
+        });
+      }
+      mockClient.events.listInternal.mockResolvedValue({
+        sessionEvents: apiEvents,
+      });
+
+      const session = await service.getSession({
+        appName: '12345',
+        userId: 'testUser',
+        sessionId: 'wf-session',
+      });
+
+      const states = reconstructNodeStates(session!.events, 'wf');
+      expect(states.get('fetch')?.output).toBe('A(x)');
+      expect(isFastForwardable(states.get('fetch')!)).toBe(true);
+      expect([...states.get('gate')!.interruptIds]).toEqual(['gate-1']);
+      expect(states.get('gate')?.input).toBe('A(x)');
     });
   });
 });

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -502,6 +502,35 @@ describe('VertexAiSessionService', () => {
       expect(parsedEvent?.usageMetadata).toEqual({promptTokens: 10});
     });
 
+    it('restores groundingMetadata when rawEvent is absent', async () => {
+      const groundingMetadata = {
+        webSearchQueries: ['adk js sessions'],
+        groundingChunks: [
+          {web: {uri: 'https://example.com', title: 'Example'}},
+        ],
+      };
+      mockClient.events.listInternal.mockResolvedValue({
+        sessionEvents: [
+          {
+            name: 'projects/p/locations/l/sessions/s/events/e1',
+            invocationId: 'inv-1',
+            author: 'agent',
+            content: {role: 'model', parts: [{text: 'grounded'}]},
+            timestamp: '2026-04-09T13:00:00Z',
+            eventMetadata: {groundingMetadata},
+          },
+        ],
+      });
+
+      const session = await service.getSession({
+        appName: '12345',
+        userId: 'testUser',
+        sessionId: 'my-session-id',
+      });
+
+      expect(session?.events[0].groundingMetadata).toEqual(groundingMetadata);
+    });
+
     it('slices events based on numRecentEvents', async () => {
       mockClient.events.listInternal.mockResolvedValue({
         sessionEvents: [
@@ -1269,9 +1298,18 @@ describe('VertexAiSessionService', () => {
         lastUpdateTime: Date.now(),
       }) as unknown as Session;
 
+    /**
+     * Replays an API event the way the real service sees it: the request is
+     * serialized on the wire, so anything that survives only by object
+     * identity (a `Date`, `Map` or `Set` inside `output`) must not survive
+     * here either.
+     */
+    const overTheWire = <T>(value: T): T =>
+      JSON.parse(JSON.stringify(value)) as T;
+
     const readBackWithoutRawEvent = async () => {
       const sent = mockClient.events.append.mock.calls.at(-1)![0];
-      const apiEvent = {
+      const apiEvent = overTheWire({
         name: 'reasoningEngines/12345/sessions/wf-session/events/e1',
         author: sent.author,
         invocationId: sent.invocationId,
@@ -1279,7 +1317,7 @@ describe('VertexAiSessionService', () => {
         content: sent.config.content,
         actions: sent.config.actions,
         eventMetadata: sent.config.eventMetadata,
-      };
+      });
       mockClient.events.listInternal.mockResolvedValue({
         sessionEvents: [apiEvent],
       });
@@ -1427,15 +1465,17 @@ describe('VertexAiSessionService', () => {
         mockClient.events.append.mockClear();
         await service.appendEvent({session: appendSession(), event});
         const sent = mockClient.events.append.mock.calls.at(-1)![0];
-        apiEvents.push({
-          name: `reasoningEngines/12345/sessions/wf-session/events/${apiEvents.length}`,
-          author: sent.author,
-          invocationId: sent.invocationId,
-          timestamp: sent.timestamp,
-          content: sent.config.content,
-          actions: sent.config.actions,
-          eventMetadata: sent.config.eventMetadata,
-        });
+        apiEvents.push(
+          overTheWire({
+            name: `reasoningEngines/12345/sessions/wf-session/events/${apiEvents.length}`,
+            author: sent.author,
+            invocationId: sent.invocationId,
+            timestamp: sent.timestamp,
+            content: sent.config.content,
+            actions: sent.config.actions,
+            eventMetadata: sent.config.eventMetadata,
+          }),
+        );
       }
       mockClient.events.listInternal.mockResolvedValue({
         sessionEvents: apiEvents,


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`VertexAiSessionService.appendEvent` sends the whole event as `rawEvent`, and `_fromApiEvent` restores from it when present. But **any** append failure retries with `rawEvent` deleted ([`vertex_ai_session_service.ts#L471-L479`](https://github.com/google/adk-js/blob/main/core/src/sessions/vertex_ai_session_service.ts#L471-L479)), and the field-by-field reconstruction that runs on read never mapped `output`, `route`, `nodeInfo`, `isolationScope`, or `actions.agentState`.

Those five are exactly what workflow resume runs on: `reconstructNodeStates` groups prior events by `nodeInfo.path` and replays their `output`/`route`, and a paused node recovers its original input from `actions.agentState`. An event written through the fallback came back stripped, so on Agent Engine a resumed workflow **silently re-executed nodes that had already completed** instead of fast-forwarding them, losing pending HITL replies with them.

This only affects `VertexAiSessionService`. `InMemorySessionService` keeps live objects, and `DatabaseSessionService` JSON-blobs the whole event with `output`/`route`/`actions.agentState` already in `PRESERVE_KEYS_*`, so both were already correct.

**Solution:**

Carry the fields in `eventMetadata.customMetadata._workflow` — the escape hatch this service already uses for `_compaction` and `_usage_metadata`. The API cannot hold them natively: its `EventActions` has no `agent_state` (adk-python carries the same `TODO: add ... agent_state once they are available in the API` in its own append path) and `EventMetadata` has no `output`.

`output` is compared against `undefined` rather than tested for truthiness, so a node that legitimately outputs `false`/`0`/`''`/`null` round-trips as itself instead of collapsing into "this node never completed".

Two smaller fixes in the same code path:

- `_fromApiEvent` stripped its internal keys with `delete` on the API response object, mutating data it does not own. It copies first now, matching Python.
- The fallback logged `"falling back..."` without saying to what; it now names the degraded path, so a lossy write is not mistaken for a clean one.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

6 new cases in `core/test/sessions/vertex_ai_session_service_test.ts`, under `describe('workflow event fields')`. They exercise the real fallback path: capture what `appendEvent` sent, replay it back through `listInternal` **without** `rawEvent`, and read via `getSession`.

**5 of the 6 fail without the source change** — verified by reverting it and re-running. The end-to-end one is the point of the PR:

```
AssertionError: expected undefined to be 'A(x)'
 ❯ core/test/sessions/vertex_ai_session_service_test.ts:1462
     expect(states.get('fetch')?.output).toBe('A(x)');
```

The sixth pins that a plain non-workflow event still writes no metadata at all.

Results:

```
npx vitest run --project unit:core
 Test Files  207 passed (207)
      Tests  2849 passed (2849)
```

`npx eslint` and `npx prettier --check` clean on both files. `tsc --noEmit` adds no new errors (300 pre-existing on `main` at the time of writing, none in the touched file).

**Manual End-to-End (E2E) Tests:**

Not run: exercising the real path needs a live Agent Engine session plus an induced `events.append` failure to trigger the no-`rawEvent` retry. The unit tests simulate that failure mode directly instead. Reviewers with a Vertex project can reproduce by running any HITL workflow sample against `vertexai://` and resuming it across turns.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Found while here, deliberately left out of this PR:** the write path sends `actions.transferToAgent`, but the API schema field is `transferAgent` — which is what `_fromApiEvent` reads back at `vertex_ai_session_service.ts:559`. adk-python maps this explicitly (`'transfer_agent': event.actions.transfer_to_agent`). So agent transfers do not round-trip on the no-`rawEvent` path either. It is a one-line fix in the same function, but it affects all users rather than just workflows, so it deserves its own PR.
