### PR TITLE
feat(dev): render graph workflows in the dev UI agent graph

### DIFF
--- a/core/src/a2a/agent_card.ts
+++ b/core/src/a2a/agent_card.ts
@@ -20,6 +20,7 @@ import {isSequentialAgent} from '../agents/sequential_agent.js';
 import {BaseTool, isBaseTool} from '../tools/base_tool.js';
 import {isBaseToolset} from '../tools/base_toolset.js';
 import {logger} from '../utils/logger.js';
+import {isGraphWorkflowAgent} from '../workflow/workflow_agent.js';
 
 /**
  * Resolves the AgentCard from the provided source.
@@ -405,7 +406,7 @@ function getAgentSkillName(agent: BaseAgent): string {
   if (isLlmAgent(agent)) {
     return 'model';
   }
-  if (isWorkflowAgent(agent)) {
+  if (isWorkflowAgent(agent) || isGraphWorkflowAgent(agent)) {
     return 'workflow';
   }
   return 'custom';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -383,6 +383,7 @@ export {
   createNodeErrorEvent,
   createNodeState,
   createSubBranch,
+  isGraphWorkflowAgent,
   isNodeErrorEvent,
   isNodeSchemaValidationError,
   isNodeState,

--- a/core/src/workflow/index.ts
+++ b/core/src/workflow/index.ts
@@ -14,7 +14,7 @@
 // --- Core graph / workflow ---
 export {Workflow} from './workflow.js';
 export type {DynamicEntry, WorkflowConfig} from './workflow.js';
-export {WorkflowAgent} from './workflow_agent.js';
+export {WorkflowAgent, isGraphWorkflowAgent} from './workflow_agent.js';
 export type {WorkflowAgentConfig} from './workflow_agent.js';
 
 // --- Nodes ---

--- a/core/src/workflow/workflow_agent.ts
+++ b/core/src/workflow/workflow_agent.ts
@@ -18,6 +18,10 @@ import {
 } from './utils/rehydration_utils.js';
 import {Workflow, WorkflowConfig} from './workflow.js';
 
+const WORKFLOW_AGENT_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.workflow.workflowAgent',
+);
+
 /** Options for a {@link WorkflowAgent}. */
 export interface WorkflowAgentConfig {
   name?: string;
@@ -35,6 +39,8 @@ export interface WorkflowAgentConfig {
  */
 @experimental
 export class WorkflowAgent extends BaseAgent {
+  readonly [WORKFLOW_AGENT_SIGNATURE_SYMBOL] = true;
+
   readonly workflow: Workflow;
 
   /**
@@ -150,6 +156,15 @@ export class WorkflowAgent extends BaseAgent {
   protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
     throw new Error('WorkflowAgent does not support live mode.');
   }
+}
+
+export function isGraphWorkflowAgent(value: unknown): value is WorkflowAgent {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    WORKFLOW_AGENT_SIGNATURE_SYMBOL in value &&
+    value[WORKFLOW_AGENT_SIGNATURE_SYMBOL] === true
+  );
 }
 
 /**

--- a/core/src/workflow/workflow_agent.ts
+++ b/core/src/workflow/workflow_agent.ts
@@ -158,6 +158,7 @@ export class WorkflowAgent extends BaseAgent {
   }
 }
 
+/** Whether `value` is a graph `WorkflowAgent` (brand check, not `instanceof`). */
 export function isGraphWorkflowAgent(value: unknown): value is WorkflowAgent {
   return (
     typeof value === 'object' &&

--- a/core/test/a2a/agent_card_test.ts
+++ b/core/test/a2a/agent_card_test.ts
@@ -6,6 +6,8 @@
 
 import {describe, expect, it, vi} from 'vitest';
 import {buildAgentSkills} from '../../src/a2a/agent_card.js';
+import {node} from '../../src/workflow/node.js';
+import {WorkflowAgent} from '../../src/workflow/workflow_agent.js';
 
 import {
   BaseAgent,
@@ -218,6 +220,20 @@ describe('Agent Card', () => {
       expect(workflowSkill?.description).toBe(
         'This agent will do A and do B in a loop (max 5 iterations).',
       );
+    });
+
+    it('classifies a graph WorkflowAgent as a workflow, not a custom agent', async () => {
+      const agent = new WorkflowAgent({
+        name: 'graph_workflow',
+        description: 'Runs a graph',
+        edges: [['START', node(() => 'done', {name: 'step'})]],
+      });
+
+      const skills = await buildAgentSkills(agent);
+
+      const workflowSkill = skills.find((s) => s.name === 'workflow');
+      expect(workflowSkill?.description).toBe('Runs a graph');
+      expect(skills.find((s) => s.name === 'custom')).toBeUndefined();
     });
   });
 });

--- a/core/test/workflow/workflow_agent_test.ts
+++ b/core/test/workflow/workflow_agent_test.ts
@@ -6,6 +6,10 @@
 
 import {describe, expect, it} from 'vitest';
 import {InvocationContext} from '../../src/agents/invocation_context.js';
+import {LlmAgent} from '../../src/agents/llm_agent.js';
+import {LoopAgent} from '../../src/agents/loop_agent.js';
+import {ParallelAgent} from '../../src/agents/parallel_agent.js';
+import {SequentialAgent} from '../../src/agents/sequential_agent.js';
 import {Event} from '../../src/events/event.js';
 import {PluginManager} from '../../src/plugins/plugin_manager.js';
 import {createSession} from '../../src/sessions/session.js';
@@ -15,7 +19,10 @@ import {NodeContext} from '../../src/workflow/node_context.js';
 import {RequestInput} from '../../src/workflow/request_input.js';
 import {createRequestInputEvent} from '../../src/workflow/utils/hitl_utils.js';
 import {Workflow} from '../../src/workflow/workflow.js';
-import {WorkflowAgent} from '../../src/workflow/workflow_agent.js';
+import {
+  isGraphWorkflowAgent,
+  WorkflowAgent,
+} from '../../src/workflow/workflow_agent.js';
 
 /** A session event standing in for a node that raised an unresolved interrupt. */
 function pendingInterruptEvent(id: string): Event {
@@ -255,5 +262,62 @@ describe('WorkflowAgent — the workflow output reaches the caller once', () => 
     expect(withOutput).toHaveLength(1);
     expect(withOutput[0].output).toBe('assigned');
     expect(withOutput[0].author).toBe('assigns');
+  });
+});
+
+describe('isGraphWorkflowAgent', () => {
+  const step = node(() => 'done', {name: 'step'});
+
+  it('recognises a graph WorkflowAgent', () => {
+    const agent = new WorkflowAgent(
+      new Workflow({name: 'wf', edges: [['START', step]]}),
+    );
+    expect(isGraphWorkflowAgent(agent)).toBe(true);
+  });
+
+  it('recognises a branded agent from another package copy', () => {
+    const fromOtherCopy = {
+      [Symbol.for('google.adk.workflow.workflowAgent')]: true,
+    };
+    expect(isGraphWorkflowAgent(fromOtherCopy)).toBe(true);
+  });
+
+  it('rejects the v1 workflow agents and a plain LlmAgent', () => {
+    expect(
+      isGraphWorkflowAgent(
+        new SequentialAgent({
+          name: 'seq',
+          subAgents: [new LlmAgent({name: 'sub_seq'})],
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isGraphWorkflowAgent(
+        new ParallelAgent({
+          name: 'par',
+          subAgents: [new LlmAgent({name: 'sub_par'})],
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isGraphWorkflowAgent(
+        new LoopAgent({
+          name: 'loop',
+          subAgents: [new LlmAgent({name: 'sub_loop'})],
+        }),
+      ),
+    ).toBe(false);
+    expect(isGraphWorkflowAgent(new LlmAgent({name: 'llm'}))).toBe(false);
+  });
+
+  it('rejects the wrapped workflow itself and non-objects', () => {
+    expect(
+      isGraphWorkflowAgent(
+        new Workflow({name: 'wf', edges: [['START', step]]}),
+      ),
+    ).toBe(false);
+    expect(isGraphWorkflowAgent(undefined)).toBe(false);
+    expect(isGraphWorkflowAgent(null)).toBe(false);
+    expect(isGraphWorkflowAgent('wf')).toBe(false);
   });
 });

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -41,7 +41,7 @@ import {
   InMemoryExporter,
   setupTelemetry,
 } from '../utils/telemetry_utils.js';
-import {getAgentGraphAsDot} from './agent_graph.js';
+import {getAgentGraphAsDot, getWorkflowHighlights} from './agent_graph.js';
 
 /**
  * Environment variable holding the shared bearer token used to authenticate
@@ -349,6 +349,16 @@ export class AdkApiServer {
           await using agentFile = await this.agentLoader.getAgentFile(appName);
           const loaded = await agentFile.load();
           const rootAgent = isApp(loaded) ? loaded.rootAgent : loaded;
+
+          const workflowHighlights = getWorkflowHighlights(
+            sessionEvents,
+            event,
+          );
+          if (workflowHighlights) {
+            return res.send({
+              dotSrc: await getAgentGraphAsDot(rootAgent, workflowHighlights),
+            });
+          }
 
           if (functionCalls.length > 0) {
             const functionCallHighlights: Array<[string, string]> = [];

--- a/dev/src/server/agent_graph.ts
+++ b/dev/src/server/agent_graph.ts
@@ -5,22 +5,41 @@
  */
 import {
   BaseAgent,
+  BaseNode,
   BaseTool,
+  DEFAULT_ROUTE,
+  Event,
+  RouteValue,
+  Workflow,
+  Graph as WorkflowGraph,
   isAgentTool,
   isBaseAgent,
   isBaseTool,
   isFunctionTool,
+  isGraphWorkflowAgent,
   isLlmAgent,
   isLoopAgent,
   isParallelAgent,
   isSequentialAgent,
 } from '@google/adk';
-import {Digraph, Edge, Node, RootGraph, Subgraph, toDot} from 'ts-graphviz';
+import {
+  Digraph,
+  Edge,
+  Node,
+  NodeAttributesObject,
+  RootGraph,
+  Subgraph,
+  toDot,
+} from 'ts-graphviz';
 
 const DARK_GREEN = '#0F5223';
 const LIGHT_GREEN = '#69CB87';
 const LIGHT_GRAY = '#cccccc';
 const WHITE = '#ffffff';
+
+const WORKFLOW_START_NODE_NAME = '__START__';
+
+const DEFAULT_ROUTE_LABEL = 'default';
 
 export async function buildGraph(
   graph: RootGraph | Subgraph,
@@ -28,6 +47,17 @@ export async function buildGraph(
   highlightsPairs: Array<[string, string]>,
   parentAgent?: BaseAgent,
 ) {
+  if (isGraphWorkflowAgent(rootAgent)) {
+    drawWorkflowCluster(
+      graph,
+      rootAgent.workflow,
+      rootAgent.workflow.name,
+      highlightsPairs,
+    );
+
+    return;
+  }
+
   async function buildCluster(
     subgraph: Subgraph,
     agent: BaseAgent,
@@ -211,6 +241,289 @@ export async function buildGraph(
       drawEdge(rootAgent.name, getNodeName(tool));
     }
   }
+}
+
+function drawWorkflowCluster(
+  container: RootGraph | Subgraph,
+  workflow: Workflow,
+  path: string,
+  highlightsPairs: Array<[string, string]>,
+) {
+  const cluster = new Subgraph(`cluster_${path}`, {
+    label: `🧩 ${workflow.name}`,
+    style: 'rounded',
+    bgcolor: WHITE,
+    fontcolor: LIGHT_GRAY,
+  });
+  container.addSubgraph(cluster);
+
+  const graph = workflow.graph;
+  if (!graph) {
+    cluster.addNode(
+      new Node(path, {
+        label: `⚡ ${workflow.name} (dynamic)`,
+        ...workflowNodeStyle('box', isHighlightedWithin(path, highlightsPairs)),
+      }),
+    );
+
+    return;
+  }
+
+  for (const node of graph.nodes) {
+    drawWorkflowNode(cluster, node, path, highlightsPairs);
+  }
+
+  drawWorkflowEdges(cluster, graph, path, highlightsPairs);
+}
+
+function drawWorkflowNode(
+  cluster: Subgraph,
+  node: BaseNode,
+  path: string,
+  highlightsPairs: Array<[string, string]>,
+) {
+  const id = workflowNodeId(node, path);
+
+  if (node.name === WORKFLOW_START_NODE_NAME) {
+    cluster.addNode(
+      new Node(id, {
+        label: '',
+        shape: 'point',
+        width: 0.15,
+        style: 'filled',
+        color: LIGHT_GRAY,
+        fillcolor: LIGHT_GRAY,
+      }),
+    );
+
+    return;
+  }
+
+  const nested = asWorkflow(node);
+  if (nested) {
+    drawWorkflowCluster(cluster, nested, id, highlightsPairs);
+
+    return;
+  }
+
+  cluster.addNode(
+    new Node(id, {
+      label: getWorkflowNodeCaption(node),
+      ...workflowNodeStyle(
+        getWorkflowNodeShape(node),
+        isHighlightedNode(id, highlightsPairs),
+      ),
+    }),
+  );
+}
+
+function drawWorkflowEdges(
+  cluster: Subgraph,
+  graph: WorkflowGraph,
+  path: string,
+  highlightsPairs: Array<[string, string]>,
+) {
+  for (const edge of graph.edges) {
+    const from = workflowNodeId(edge.fromNode, path);
+    const to = workflowNodeId(edge.toNode, path);
+    const tail = workflowExitAnchorId(edge.fromNode, path);
+    const head = workflowEntryAnchorId(edge.toNode, path);
+    const routes = getRouteLabels(edge.route);
+    const highlighted = isHighlightedEdge(from, to, highlightsPairs);
+    const color = highlighted ? LIGHT_GREEN : LIGHT_GRAY;
+    cluster.addEdge(
+      new Edge([new Node(tail), new Node(head)], {
+        color,
+        fontcolor: color,
+        ...(routes.length > 0 ? {label: routes.join(', ')} : {}),
+      }),
+    );
+  }
+}
+
+function workflowNodeId(node: BaseNode, path: string): string {
+  return `${path}.${node.name}`;
+}
+
+function workflowEntryAnchorId(node: BaseNode, path: string): string {
+  const id = workflowNodeId(node, path);
+  const nested = asWorkflow(node);
+  if (nested?.graph) {
+    return `${id}.${WORKFLOW_START_NODE_NAME}`;
+  }
+
+  return id;
+}
+
+function workflowExitAnchorId(node: BaseNode, path: string): string {
+  const nested = asWorkflow(node);
+  const nestedGraph = nested?.graph;
+  if (nestedGraph) {
+    const id = workflowNodeId(node, path);
+    const terminal = nestedGraph.nodes.find((n) =>
+      nestedGraph.terminalNodeNames.has(n.name),
+    );
+
+    return terminal
+      ? workflowNodeId(terminal, id)
+      : workflowEntryAnchorId(node, path);
+  }
+
+  return workflowNodeId(node, path);
+}
+
+function getRouteLabels(route: RouteValue | RouteValue[] | null): string[] {
+  if (route === null || route === undefined) {
+    return [];
+  }
+
+  const routes = Array.isArray(route) ? route : [route];
+
+  return routes.map((value) =>
+    value === DEFAULT_ROUTE ? DEFAULT_ROUTE_LABEL : String(value),
+  );
+}
+
+function workflowNodeStyle(
+  shape: string,
+  highlighted: boolean,
+): NodeAttributesObject {
+  return {
+    shape,
+    style: highlighted ? 'filled,rounded' : 'rounded',
+    fillcolor: highlighted ? DARK_GREEN : WHITE,
+    color: highlighted ? DARK_GREEN : LIGHT_GRAY,
+    fontcolor: LIGHT_GRAY,
+  };
+}
+
+function isHighlightedNode(
+  name: string,
+  highlightsPairs: Array<[string, string]>,
+): boolean {
+  return (highlightsPairs ?? []).some((pair) => pair.includes(name));
+}
+
+function isHighlightedWithin(
+  path: string,
+  highlightsPairs: Array<[string, string]>,
+): boolean {
+  return (highlightsPairs ?? []).some((pair) =>
+    pair.some((name) => name === path || name.startsWith(`${path}.`)),
+  );
+}
+
+function isHighlightedEdge(
+  fromName: string,
+  toName: string,
+  highlightsPairs: Array<[string, string]>,
+): boolean {
+  return (highlightsPairs ?? []).some(
+    ([from, to]) => from === fromName && to === toName,
+  );
+}
+
+function asWorkflow(node: BaseNode): Workflow | undefined {
+  const graph = getNodeField(node, 'graph');
+  const isWorkflow =
+    isWorkflowGraph(graph) ||
+    typeof getNodeField(node, 'dynamicEntry') === 'function';
+
+  return isWorkflow ? (node as Workflow) : undefined;
+}
+
+function isWorkflowGraph(value: unknown): value is WorkflowGraph {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as WorkflowGraph).nodes) &&
+    Array.isArray((value as WorkflowGraph).edges)
+  );
+}
+
+function getNodeField(node: BaseNode, field: string): unknown {
+  return (node as unknown as Record<string, unknown>)[field];
+}
+
+function getWorkflowNodeCaption(node: BaseNode): string {
+  if (isBaseAgent(getNodeField(node, 'agent'))) {
+    return `🤖 ${node.name}`;
+  }
+
+  if (isBaseTool(getNodeField(node, 'tool'))) {
+    return `🔧 ${node.name}`;
+  }
+
+  if ('maxParallelWorkers' in node) {
+    return `🧵 ${node.name}`;
+  }
+
+  if (node.requiresAllPredecessors) {
+    return `🔗 ${node.name}`;
+  }
+
+  if (typeof getNodeField(node, 'handler') === 'function') {
+    return `⚙️ ${node.name}`;
+  }
+
+  return node.name;
+}
+
+function getWorkflowNodeShape(node: BaseNode): string {
+  if (isBaseAgent(getNodeField(node, 'agent'))) {
+    return 'ellipse';
+  }
+
+  if ('maxParallelWorkers' in node) {
+    return 'box3d';
+  }
+
+  if (node.requiresAllPredecessors) {
+    return 'hexagon';
+  }
+
+  return 'box';
+}
+
+export function getWorkflowHighlights(
+  sessionEvents: Event[],
+  event: Event,
+): Array<[string, string]> | undefined {
+  const path = event.nodeInfo?.path;
+  if (!path) {
+    return undefined;
+  }
+
+  const nodeId = toWorkflowNodeId(path);
+  const index = sessionEvents.findIndex((e) => e.id === event.id);
+
+  for (let i = index - 1; i >= 0; i--) {
+    const previous = sessionEvents[i];
+    if (previous.invocationId !== event.invocationId) {
+      break;
+    }
+
+    const previousPath = previous.nodeInfo?.path;
+    if (!previousPath) {
+      continue;
+    }
+
+    const previousId = toWorkflowNodeId(previousPath);
+    if (previousId === nodeId) {
+      continue;
+    }
+
+    return [[previousId, nodeId]];
+  }
+
+  return [[nodeId, '']];
+}
+
+function toWorkflowNodeId(path: string): string {
+  return path
+    .split('.')
+    .map((segment) => segment.split('@')[0])
+    .join('.');
 }
 
 function getNodeName(toolOrAgent: BaseAgent | BaseTool): string {

--- a/dev/src/server/agent_graph.ts
+++ b/dev/src/server/agent_graph.ts
@@ -306,13 +306,13 @@ function drawWorkflowNode(
     return;
   }
 
+  const {icon, shape} = classifyWorkflowNode(node);
   cluster.addNode(
     new Node(id, {
-      label: getWorkflowNodeCaption(node),
-      ...workflowNodeStyle(
-        getWorkflowNodeShape(node),
-        isHighlightedNode(id, highlightsPairs),
-      ),
+      label: `${icon} ${node.name}`,
+      // Prefix, not exact: a `ParallelWorker` item runs at
+      // `<node path>.<inner name>@<i>`, so its events land below the drawn box.
+      ...workflowNodeStyle(shape, isHighlightedWithin(id, highlightsPairs)),
     }),
   );
 }
@@ -323,6 +323,10 @@ function drawWorkflowEdges(
   path: string,
   highlightsPairs: Array<[string, string]>,
 ) {
+  // No grouping by endpoint pair is needed before emitting into the `strict`
+  // root graph: `validateDuplicateEdges` rejects a second edge with the same
+  // `from`/`to` at construction, so two routes to one node arrive as a single
+  // multi-route `Edge` and are joined by `getRouteLabels`.
   for (const edge of graph.edges) {
     const from = workflowNodeId(edge.fromNode, path);
     const to = workflowNodeId(edge.toNode, path);
@@ -364,8 +368,10 @@ function workflowExitAnchorId(node: BaseNode, path: string): string {
       nestedGraph.terminalNodeNames.has(n.name),
     );
 
+    // Recurse: a terminal node can itself be a nested workflow, and its id is a
+    // cluster id that no drawn node carries.
     return terminal
-      ? workflowNodeId(terminal, id)
+      ? workflowExitAnchorId(terminal, id)
       : workflowEntryAnchorId(node, path);
   }
 
@@ -373,7 +379,7 @@ function workflowExitAnchorId(node: BaseNode, path: string): string {
 }
 
 function getRouteLabels(route: RouteValue | RouteValue[] | null): string[] {
-  if (route === null || route === undefined) {
+  if (route == null) {
     return [];
   }
 
@@ -397,18 +403,15 @@ function workflowNodeStyle(
   };
 }
 
-function isHighlightedNode(
-  name: string,
-  highlightsPairs: Array<[string, string]>,
-): boolean {
-  return (highlightsPairs ?? []).some((pair) => pair.includes(name));
-}
-
+/**
+ * Whether an event highlights `path` itself or anything running below it.
+ * Sibling names differ at every level, so the `.` guard cannot over-match.
+ */
 function isHighlightedWithin(
   path: string,
   highlightsPairs: Array<[string, string]>,
 ): boolean {
-  return (highlightsPairs ?? []).some((pair) =>
+  return highlightsPairs.some((pair) =>
     pair.some((name) => name === path || name.startsWith(`${path}.`)),
   );
 }
@@ -418,7 +421,7 @@ function isHighlightedEdge(
   toName: string,
   highlightsPairs: Array<[string, string]>,
 ): boolean {
-  return (highlightsPairs ?? []).some(
+  return highlightsPairs.some(
     ([from, to]) => from === fromName && to === toName,
   );
 }
@@ -445,44 +448,29 @@ function getNodeField(node: BaseNode, field: string): unknown {
   return (node as unknown as Record<string, unknown>)[field];
 }
 
-function getWorkflowNodeCaption(node: BaseNode): string {
+/**
+ * Detects what a node is, structurally — the dev server loads the user's agent
+ * module, which may resolve its own copy of `@google/adk`, so `instanceof` is
+ * not available. Caption and shape come from one pass so they cannot drift.
+ */
+function classifyWorkflowNode(node: BaseNode): {icon: string; shape: string} {
   if (isBaseAgent(getNodeField(node, 'agent'))) {
-    return `🤖 ${node.name}`;
+    return {icon: '🤖', shape: 'ellipse'};
   }
 
   if (isBaseTool(getNodeField(node, 'tool'))) {
-    return `🔧 ${node.name}`;
+    return {icon: '🔧', shape: 'box'};
   }
 
   if ('maxParallelWorkers' in node) {
-    return `🧵 ${node.name}`;
+    return {icon: '🧵', shape: 'box3d'};
   }
 
   if (node.requiresAllPredecessors) {
-    return `🔗 ${node.name}`;
+    return {icon: '🔗', shape: 'hexagon'};
   }
 
-  if (typeof getNodeField(node, 'handler') === 'function') {
-    return `⚙️ ${node.name}`;
-  }
-
-  return node.name;
-}
-
-function getWorkflowNodeShape(node: BaseNode): string {
-  if (isBaseAgent(getNodeField(node, 'agent'))) {
-    return 'ellipse';
-  }
-
-  if ('maxParallelWorkers' in node) {
-    return 'box3d';
-  }
-
-  if (node.requiresAllPredecessors) {
-    return 'hexagon';
-  }
-
-  return 'box';
+  return {icon: '⚙️', shape: 'box'};
 }
 
 export function getWorkflowHighlights(

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -18,8 +18,10 @@ import {
   InMemorySessionService,
   InvocationContext,
   LlmAgent,
+  node,
   Runner,
   Session,
+  WorkflowAgent,
 } from '@google/adk';
 import {ReadableSpan} from '@opentelemetry/sdk-trace-base';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
@@ -913,6 +915,64 @@ describe('AdkWebServer', () => {
         expect(response.data!.dotSrc).toContain('testAgent');
         expect(response.data!.dotSrc).toContain('foo');
       } finally {
+        sessionService.getSession = originalGetSession;
+      }
+    });
+
+    it('should highlight the workflow node that produced the event', async () => {
+      const originalGetAgentFile = agentLoader.getAgentFile;
+      const originalGetSession = sessionService.getSession;
+      agentLoader.getAgentFile = (() =>
+        Promise.resolve({
+          load: () =>
+            Promise.resolve(
+              new WorkflowAgent({
+                name: 'wf',
+                edges: [
+                  [
+                    'START',
+                    node(async () => 'a', {name: 'one'}),
+                    node(async () => 'b', {name: 'two'}),
+                  ],
+                ],
+              }),
+            ),
+          async [Symbol.asyncDispose](): Promise<void> {
+            return;
+          },
+        })) as unknown as AgentLoader['getAgentFile'];
+      sessionService.getSession = async () =>
+        createSession({
+          id: 'workflowSession',
+          appName: 'testApp',
+          userId: 'testUser',
+          events: [
+            createEvent({
+              id: 'wfEvent1',
+              author: 'one',
+              invocationId: 'inv-1',
+              nodeInfo: {path: 'wf.one'},
+            }),
+            createEvent({
+              id: 'wfEvent2',
+              author: 'two',
+              invocationId: 'inv-1',
+              nodeInfo: {path: 'wf.two'},
+            }),
+          ],
+        });
+
+      try {
+        const response = await client.get<{dotSrc: string}>(
+          '/apps/testApp/users/testUser/sessions/workflowSession/events/wfEvent2/graph',
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data!.dotSrc).toContain('"wf.one" -> "wf.two"');
+        expect(response.data!.dotSrc).toContain('#69CB87');
+        expect(response.data!.dotSrc).toContain('#0F5223');
+      } finally {
+        agentLoader.getAgentFile = originalGetAgentFile;
         sessionService.getSession = originalGetSession;
       }
     });

--- a/dev/test/server/agent_graph_test.ts
+++ b/dev/test/server/agent_graph_test.ts
@@ -344,6 +344,26 @@ describe('AgentGraph — graph WorkflowAgent', () => {
     );
   });
 
+  it('cannot be handed two separate edges with the same endpoints', () => {
+    const classify = node(noopHandler, {name: 'classify'});
+    const send = node(noopHandler, {name: 'send'});
+
+    // The renderer emits one DOT statement per `Edge` into a `strict` graph, so
+    // two edges sharing endpoints would be merged by graphviz and lose a label.
+    // Core forbids that shape, so a routing map with two routes to one node
+    // never reaches the renderer at all.
+    expect(
+      () =>
+        new Workflow({
+          name: 'router',
+          edges: [
+            ['START', classify],
+            [classify, {yes: send, no: send}],
+          ],
+        }),
+    ).toThrow(/Duplicate edge found: from=classify, to=send/);
+  });
+
   it('renders a nested workflow as a recursive cluster', async () => {
     const inner = new Workflow({
       name: 'inner',
@@ -369,6 +389,29 @@ describe('AgentGraph — graph WorkflowAgent', () => {
     expect(nodeBlock(dot, 'outer.inner.step')).toContain('label = "⚙️ step"');
     expect(dot).toContain('"outer.pre" -> "outer.inner.__START__"');
     expect(dot).toContain('"outer.inner.step" -> "outer.post"');
+  });
+
+  it('anchors an edge out of a workflow that ends in another workflow', async () => {
+    const leaf = new Workflow({
+      name: 'leaf',
+      edges: [['START', node(noopHandler, {name: 'deep'})]],
+    });
+    const middle = new Workflow({
+      name: 'middle',
+      edges: [['START', node(noopHandler, {name: 'mid'}), leaf]],
+    });
+    const outer = new Workflow({
+      name: 'outer',
+      edges: [['START', middle, node(noopHandler, {name: 'post'})]],
+    });
+
+    const dot = await renderDot(new WorkflowAgent(outer));
+
+    // The tail is the real leaf node, not the `outer.middle.leaf` cluster id,
+    // which no drawn node carries.
+    expect(dot).toContain('"outer.middle.leaf.deep" -> "outer.post"');
+    expect(dot).not.toContain('"outer.middle.leaf" -> "outer.post"');
+    expect(dot).not.toContain('"outer.middle" -> "outer.post"');
   });
 
   it('shape-codes agent, tool, join and parallel-worker nodes', async () => {
@@ -502,6 +545,23 @@ describe('AgentGraph — workflow execution highlights', () => {
     expect(getWorkflowHighlights(events, events[2])).toEqual([
       ['wf.one', 'wf.two'],
     ]);
+  });
+
+  it('highlights a parallel-worker box for an event from one of its items', async () => {
+    const fanout = node(noopHandler, {name: 'fanout', parallelWorker: true});
+    const parallel = new Workflow({
+      name: 'wf',
+      edges: [['START', fanout]],
+    });
+    // A `ParallelWorker` item runs at `<node path>.<inner name>@<index>`, so the
+    // event path sits one level below the box that is actually drawn.
+    const events = [nodeEvent('inv-1', 'wf.fanout.fanout@0')];
+
+    const highlights = getWorkflowHighlights(events, events[0]);
+    expect(highlights).toEqual([['wf.fanout.fanout', '']]);
+
+    const dot = await renderDot(new WorkflowAgent(parallel), highlights!);
+    expect(nodeBlock(dot, 'wf.fanout')).toContain('fillcolor = "#0F5223"');
   });
 
   it('returns undefined for an event that no workflow node produced', () => {

--- a/dev/test/server/agent_graph_test.ts
+++ b/dev/test/server/agent_graph_test.ts
@@ -5,15 +5,27 @@
  */
 
 import {
+  createEvent,
+  DEFAULT_ROUTE,
+  Edge,
+  Event,
   FunctionTool,
+  JoinNode,
   LlmAgent,
   LoopAgent,
+  node,
   ParallelAgent,
   SequentialAgent,
+  Workflow,
+  WorkflowAgent,
 } from '@google/adk';
+import {parse} from 'ts-graphviz/ast';
 import {describe, expect, it} from 'vitest';
 
-import {getAgentGraphAsDot} from '../../src/server/agent_graph.js';
+import {
+  getAgentGraphAsDot,
+  getWorkflowHighlights,
+} from '../../src/server/agent_graph.js';
 
 describe('AgentGraph', () => {
   it('generates a DOT graph for a simple LlmAgent with a FunctionTool', async () => {
@@ -216,5 +228,285 @@ describe('AgentGraph', () => {
     expect(dotGraph).toContain(
       'label = "cluster_parallelAgent (Parallel Agent)"',
     );
+  });
+});
+
+const noopHandler = async () => 'ok';
+
+async function renderDot(
+  agent: WorkflowAgent | SequentialAgent,
+  highlights: Array<[string, string]> = [],
+): Promise<string> {
+  const dot = await getAgentGraphAsDot(agent, highlights);
+  expect(() => parse(dot)).not.toThrow();
+
+  return dot;
+}
+
+function nodeBlock(dot: string, id: string): string {
+  const start = dot.indexOf(`"${id}" [`);
+  expect(start, `no node statement for "${id}"`).toBeGreaterThanOrEqual(0);
+
+  return dot.slice(start, dot.indexOf('];', start));
+}
+
+function edgeBlock(dot: string, from: string, to: string): string {
+  const start = dot.indexOf(`"${from}" -> "${to}" [`);
+  expect(start, `no edge "${from}" -> "${to}"`).toBeGreaterThanOrEqual(0);
+
+  return dot.slice(start, dot.indexOf('];', start));
+}
+
+describe('AgentGraph — graph WorkflowAgent', () => {
+  it('renders the workflow graph as a cluster of nodes and edges', async () => {
+    const workflow = new Workflow({
+      name: 'wf',
+      edges: [
+        [
+          'START',
+          node(noopHandler, {name: 'one'}),
+          node(noopHandler, {name: 'two'}),
+          node(noopHandler, {name: 'three'}),
+        ],
+      ],
+    });
+
+    const dot = await renderDot(new WorkflowAgent(workflow));
+
+    expect(dot).toContain('subgraph "cluster_wf" {');
+    expect(dot).toContain('label = "🧩 wf"');
+    expect(nodeBlock(dot, 'wf.one')).toContain('label = "⚙️ one"');
+    expect(nodeBlock(dot, 'wf.two')).toContain('label = "⚙️ two"');
+    expect(nodeBlock(dot, 'wf.three')).toContain('label = "⚙️ three"');
+    expect(edgeBlock(dot, 'wf.__START__', 'wf.one')).toContain(
+      'color = "#cccccc"',
+    );
+    expect(dot).toContain('"wf.one" -> "wf.two"');
+    expect(dot).toContain('"wf.two" -> "wf.three"');
+  });
+
+  it('draws the entry sentinel as a point rather than a labelled box', async () => {
+    const workflow = new Workflow({
+      name: 'wf',
+      edges: [['START', node(noopHandler, {name: 'one'})]],
+    });
+
+    const dot = await renderDot(new WorkflowAgent(workflow));
+
+    const start = nodeBlock(dot, 'wf.__START__');
+    expect(start).toContain('shape = "point"');
+    expect(start).toContain('label = ""');
+    expect(dot).not.toContain('label = "__START__"');
+    expect(dot).not.toContain('label = "⚙️ __START__"');
+  });
+
+  it('labels conditional edges with their route values', async () => {
+    const classify = node(noopHandler, {name: 'classify'});
+    const approve = node(noopHandler, {name: 'approve'});
+    const reject = node(noopHandler, {name: 'reject'});
+    const workflow = new Workflow({
+      name: 'router',
+      edges: [
+        ['START', classify],
+        [classify, {yes: approve, [DEFAULT_ROUTE]: reject}],
+      ],
+    });
+
+    const dot = await renderDot(new WorkflowAgent(workflow));
+
+    expect(edgeBlock(dot, 'router.classify', 'router.approve')).toContain(
+      'label = "yes"',
+    );
+    expect(edgeBlock(dot, 'router.classify', 'router.reject')).toContain(
+      'label = "default"',
+    );
+    expect(dot).not.toContain('__DEFAULT__');
+    expect(edgeBlock(dot, 'router.__START__', 'router.classify')).not.toContain(
+      'label',
+    );
+  });
+
+  it('lists every route of a multi-route edge in one label', async () => {
+    const classify = node(noopHandler, {name: 'classify'});
+    const handle = node(noopHandler, {name: 'handle'});
+    const workflow = new Workflow({
+      name: 'router',
+      edges: [
+        ['START', classify],
+        new Edge(classify, handle, ['yes', 'maybe']),
+      ],
+    });
+
+    const dot = await renderDot(new WorkflowAgent(workflow));
+
+    expect(edgeBlock(dot, 'router.classify', 'router.handle')).toContain(
+      'label = "yes, maybe"',
+    );
+  });
+
+  it('renders a nested workflow as a recursive cluster', async () => {
+    const inner = new Workflow({
+      name: 'inner',
+      edges: [['START', node(noopHandler, {name: 'step'})]],
+    });
+    const outer = new Workflow({
+      name: 'outer',
+      edges: [
+        [
+          'START',
+          node(noopHandler, {name: 'pre'}),
+          inner,
+          node(noopHandler, {name: 'post'}),
+        ],
+      ],
+    });
+
+    const dot = await renderDot(new WorkflowAgent(outer));
+
+    expect(dot).toContain('subgraph "cluster_outer" {');
+    expect(dot).toContain('subgraph "cluster_outer.inner" {');
+    expect(dot).toContain('label = "🧩 inner"');
+    expect(nodeBlock(dot, 'outer.inner.step')).toContain('label = "⚙️ step"');
+    expect(dot).toContain('"outer.pre" -> "outer.inner.__START__"');
+    expect(dot).toContain('"outer.inner.step" -> "outer.post"');
+  });
+
+  it('shape-codes agent, tool, join and parallel-worker nodes', async () => {
+    const writer = new LlmAgent({name: 'writer'});
+    const lookup = new FunctionTool({
+      name: 'lookup',
+      description: 'a test tool',
+      execute: async () => 'result',
+    });
+    const join = new JoinNode({name: 'join'});
+    const fanout = node(noopHandler, {name: 'fanout', parallelWorker: true});
+    const workflow = new Workflow({
+      name: 'kinds',
+      edges: [
+        ['START', node(writer), join],
+        ['START', node(lookup), join],
+        [join, fanout],
+      ],
+    });
+
+    const dot = await renderDot(new WorkflowAgent(workflow));
+
+    expect(nodeBlock(dot, 'kinds.writer')).toContain('label = "🤖 writer"');
+    expect(nodeBlock(dot, 'kinds.writer')).toContain('shape = "ellipse"');
+    expect(nodeBlock(dot, 'kinds.lookup')).toContain('label = "🔧 lookup"');
+    expect(nodeBlock(dot, 'kinds.lookup')).toContain('shape = "box"');
+    expect(nodeBlock(dot, 'kinds.join')).toContain('label = "🔗 join"');
+    expect(nodeBlock(dot, 'kinds.join')).toContain('shape = "hexagon"');
+    expect(nodeBlock(dot, 'kinds.fanout')).toContain('label = "🧵 fanout"');
+    expect(nodeBlock(dot, 'kinds.fanout')).toContain('shape = "box3d"');
+  });
+
+  it('renders an imperative dynamicEntry workflow without a static graph', async () => {
+    const workflow = new Workflow({
+      name: 'dyn',
+      dynamicEntry: async () => 'done',
+    });
+
+    const dot = await renderDot(new WorkflowAgent(workflow));
+
+    expect(dot).toContain('subgraph "cluster_dyn" {');
+    expect(nodeBlock(dot, 'dyn')).toContain('label = "⚡ dyn (dynamic)"');
+  });
+
+  it('highlights the dynamic placeholder for an event from one of its nodes', async () => {
+    const workflow = new Workflow({
+      name: 'dyn',
+      dynamicEntry: async () => 'done',
+    });
+
+    const dot = await renderDot(new WorkflowAgent(workflow), [
+      ['dyn.child', ''],
+    ]);
+
+    expect(nodeBlock(dot, 'dyn')).toContain('fillcolor = "#0F5223"');
+  });
+
+  it('renders a workflow agent nested under a v1 workflow agent', async () => {
+    const workflow = new Workflow({
+      name: 'wf',
+      edges: [['START', node(noopHandler, {name: 'one'})]],
+    });
+    const sequential = new SequentialAgent({
+      name: 'seq',
+      subAgents: [new LlmAgent({name: 'first'}), new WorkflowAgent(workflow)],
+    });
+
+    const dot = await renderDot(sequential);
+
+    expect(dot).toContain('subgraph "cluster_seq (Sequential Agent)"');
+    expect(dot).toContain('subgraph "cluster_wf" {');
+    expect(nodeBlock(dot, 'wf.one')).toContain('label = "⚙️ one"');
+  });
+});
+
+describe('AgentGraph — workflow execution highlights', () => {
+  const workflow = () =>
+    new Workflow({
+      name: 'wf',
+      edges: [
+        [
+          'START',
+          node(noopHandler, {name: 'one'}),
+          node(noopHandler, {name: 'two'}),
+        ],
+      ],
+    });
+
+  function nodeEvent(invocationId: string, path: string): Event {
+    return createEvent({
+      invocationId,
+      author: path,
+      nodeInfo: {path},
+    });
+  }
+
+  it('derives the executed node and the traversed edge from nodeInfo.path', async () => {
+    const events = [
+      nodeEvent('inv-1', 'wf.one'),
+      nodeEvent('inv-1', 'wf.two@0'),
+    ];
+
+    const highlights = getWorkflowHighlights(events, events[1]);
+    expect(highlights).toEqual([['wf.one', 'wf.two']]);
+
+    const dot = await renderDot(new WorkflowAgent(workflow()), highlights!);
+    expect(nodeBlock(dot, 'wf.two')).toContain('fillcolor = "#0F5223"');
+    expect(nodeBlock(dot, 'wf.one')).toContain('fillcolor = "#0F5223"');
+    expect(edgeBlock(dot, 'wf.one', 'wf.two')).toContain('color = "#69CB87"');
+  });
+
+  it('highlights only the node when it is the first of the invocation', async () => {
+    const events = [nodeEvent('inv-0', 'wf.two'), nodeEvent('inv-1', 'wf.one')];
+
+    const highlights = getWorkflowHighlights(events, events[1]);
+    expect(highlights).toEqual([['wf.one', '']]);
+
+    const dot = await renderDot(new WorkflowAgent(workflow()), highlights!);
+    expect(nodeBlock(dot, 'wf.one')).toContain('fillcolor = "#0F5223"');
+    expect(nodeBlock(dot, 'wf.two')).toContain('fillcolor = "#ffffff"');
+    expect(edgeBlock(dot, 'wf.one', 'wf.two')).toContain('color = "#cccccc"');
+  });
+
+  it('skips repeated events from the same node when finding the edge', async () => {
+    const events = [
+      nodeEvent('inv-1', 'wf.one'),
+      nodeEvent('inv-1', 'wf.two'),
+      nodeEvent('inv-1', 'wf.two'),
+    ];
+
+    expect(getWorkflowHighlights(events, events[2])).toEqual([
+      ['wf.one', 'wf.two'],
+    ]);
+  });
+
+  it('returns undefined for an event that no workflow node produced', () => {
+    const event = createEvent({invocationId: 'inv-1', author: 'agent'});
+
+    expect(getWorkflowHighlights([event], event)).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`buildGraph` (`dev/src/server/agent_graph.ts`) understood only the v1 composites — `SequentialAgent`, `ParallelAgent`, `LoopAgent` — plus tools. A graph `WorkflowAgent` rendered as **one opaque box**: its nodes, edges and routes were invisible in the dev UI, and there was no indication of which node an event came from.

**Solution:**

The graph endpoint returns a graphviz DOT string (`{dotSrc}`), so this is entirely server-side — no dev-ui bundle change is involved.

**Structure.** A workflow renders as a cluster of its real nodes:

- Node ids are the runtime **node path** (`wf.one`, `wf.sub.leaf`). Rooting them at the workflow's name is what makes highlighting a plain string compare against `nodeInfo.path`, and keeps same-named nodes in different nested workflows distinct.
- Node kinds are shape-coded: agent (ellipse), tool / function (box), parallel worker (box3d), join (hexagon), nested workflow (recursive cluster).
- `__START__` renders as a point, never a labelled box.
- Routes become edge labels; `__DEFAULT__` renders as `default`; multi-route edges join their values.
- An imperative `dynamicEntry` workflow has no static graph — it degrades to a labelled placeholder rather than crashing.

Kinds are detected **structurally**, not with `instanceof`: the dev server loads the user's agent module, which may resolve its own copy of `@google/adk`.

**Execution state.** The endpoint derives its highlight from `event.nodeInfo.path` when present, and colours the traversed edge by looking back for the nearest earlier event of the same `invocationId`. That covers the "visualize execution graph state" item. The check runs *before* the function-call branch so a tool/agent node event highlights the node rather than a tool box that does not exist in a workflow graph. Non-workflow agents fall through to the existing logic untouched.

**Two supporting changes:**

- `isGraphWorkflowAgent` — a brand-based guard (`Symbol.for`, not `instanceof`, per the convention `isBaseNode` documents), exported from core. The name avoids colliding with the private helper at `core/src/a2a/agent_card.ts:414`, which already means "workflow agent" in the **v1** sense.
- That same helper made a graph `WorkflowAgent` fall through to the `custom` skill; it is now classified `workflow`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

16 new dev tests (11 structure + 5 highlight), an endpoint-level test that the highlight arrives through `{dotSrc}`, 4 core tests for the guard, and 1 for the corrected agent-card classification.

**Every DOT string produced in the new tests is run through ts-graphviz's real DOT parser** (`parse` from `ts-graphviz/ast`), so malformed output fails the suite.

```
npx vitest run --project unit:dev
 Test Files  16 passed (16)
      Tests  283 passed (283)

npx vitest run --project unit:core
 Test Files  211 passed (211)
      Tests  2937 passed (2937)
```

`tsc --noEmit`: **0 errors repo-wide** (rebased onto main after #648). eslint and prettier clean on all 10 files.

Note: `dev/test/cli/cli_create_test.ts` fails if `GOOGLE_CLOUD_PROJECT` is set in your environment — pre-existing and unrelated (`cli_create.ts:104` prefers the real env var over the mocked `execSync`). The run above used `env -u GOOGLE_CLOUD_PROJECT -u GOOGLE_CLOUD_LOCATION`.

**Manual End-to-End (E2E) Tests:**

**Not done, and worth a reviewer's eyes.** No graphviz binary or WASM renderer was available, so the DOT was verified as *syntactically* valid but never laid out or rendered. Unverified visually: whether the `point`/`box3d`/`hexagon` shapes and the nested-cluster edge anchoring actually look right, and whether the emoji labels render in the dev UI's font. To check: `adk web`, open a workflow sample from `samples/workflows/`, and view the graph tab.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Judgement calls, flagged for review rather than buried:

- **`compound`/`lhead`/`ltail` deliberately omitted.** Those are graph-level attributes and would change the DOT emitted for plain agents too. Consequence: an edge into a nested workflow anchors on the entry sentinel inside the cluster rather than clipping at the cluster border.
- **A nested workflow's exit anchor is arbitrary** when it has several terminal nodes (first in `graph.nodes` order). It does now recurse correctly when that terminal node is itself a workflow.
- **Nested highlighting is leaf-granular**: a parent-level edge drawn between cluster anchors is never coloured, though both endpoint nodes are.
- **`agent_card.ts` scope**: only `getAgentSkillName` was fixed. `getAgentTypeTag` still tags a graph `WorkflowAgent` as `custom_agent` and `buildAgentDescription` still calls it "A custom agent" — say the word and those can follow.

Drafted by an AI agent (CloudCode session `ses_00c5bebf4ffe0iHeFgiaIe0gYE`) and opened as a draft pending human refinement, per the AI-generated-code policy in CONTRIBUTING.md.

