### PR TITLE
docs(workflow): present the graph-workflow samples as TypeScript, and track gemini-flash-latest

### DIFF
--- a/samples/workflows/README.md
+++ b/samples/workflows/README.md
@@ -1,16 +1,15 @@
 # Graph workflow samples
 
-Runnable TypeScript ports of the **Python** code snippets in the ADK
-[Graph Workflows docs](https://adk.dev/graphs/). One directory per snippet,
-grouped by the docs page it comes from, so a sample directory maps 1:1 to a
-section anchor on adk.dev.
+Runnable TypeScript workflows for each section of the ADK
+[Graph Workflows docs](https://adk.dev/graphs/). One directory per section,
+grouped by the page it belongs to, so a sample directory maps 1:1 to a section
+anchor on adk.dev.
 
-Each directory exports a `rootAgent` that runs with the ADK CLI. The docs
-snippets are fragments — they reference helpers they never define (`condition()`,
-`task_A_node`, …) — so each port fills those in with the smallest plausible
-implementation and says so in its header comment. Everything else follows the
-Python source as closely as the TypeScript API allows; where the two genuinely
-differ, the file comments say why.
+Each directory exports a `rootAgent` that runs with the ADK CLI. The code on
+the docs pages is written to illustrate one idea at a time, so it leaves
+helpers undefined (`condition()`, `task_A_node`, …); each sample fills those in
+with the smallest plausible implementation and says so in its header comment,
+which also links the section it covers.
 
 ## Running
 
@@ -119,24 +118,24 @@ interactively.
 | `data_handling`  | [Data handling](https://adk.dev/graphs/dynamic/#data-handling)                                         | `editorial_workflow`: agent → function, no state keys              | ✅  |
 | `sequence_route` | [Sequence route](https://adk.dev/graphs/dynamic/#sequence-route)                                       | `city_workflow`: sequential `runNode` calls + schemas              | ✅  |
 | `loop_route`     | [Loop route](https://adk.dev/graphs/dynamic/#loop-route)                                               | A real `while` loop (generate → lint → fix), bounded               | ✅  |
-| `parallel_route` | [Parallel execution routes](https://adk.dev/graphs/dynamic/#parallel-execution-routes)                 | `Promise.all` fan-out (the `asyncio.gather` equivalent)            | —   |
+| `parallel_route` | [Parallel execution routes](https://adk.dev/graphs/dynamic/#parallel-execution-routes)                 | `Promise.all` fan-out over a list of items                         | —   |
 | `human_input`    | [Human input](https://adk.dev/graphs/dynamic/#human-input)                                             | HITL inside an orchestrator; the leaf keeps `rerunOnResume: false` | —   |
 | `custom_run_ids` | [Custom execution IDs](https://adk.dev/graphs/dynamic/#custom-execution-ids)                           | `ctx.runNode(..., {runId})` for a reorderable collection           | —   |
 
-## Python → TypeScript differences
+## Worth knowing
 
-The ports are faithful in structure; these are the places where the API itself
-differs, all called out again in the affected sample's header comment.
+Behaviour that is easy to get wrong, each called out again in the affected
+sample's header comment.
 
-- **No `@node` decorator.** `node(fn, options)` is the factory form; the
+- **Two ways to build a node.** `node(fn, options)` is the factory form; the
   explicit `new FunctionNode(name, fn, config)` constructor is also public.
-- **No `Event.message`.** Python's `Event(message=...)` becomes an event with
-  `content` — rendered to the user, and NOT passed to the next node.
-- **No `Event(state=...)`.** Write through `ctx.state`; the accumulated delta is
-  attached to the node's events.
-- **No signature-based injection.** Python binds `node_input`/state values to
-  named parameters by introspection. TypeScript handlers always take
-  `(ctx, input)` and read state explicitly via `ctx.state`.
+- **A user-facing message is the event's `content`,** which the runtime renders
+  and the graph does NOT pass to the next node. Data for the next node goes in
+  `output`.
+- **State is written through `ctx.state`,** not returned; the accumulated delta
+  is attached to the node's events.
+- **A handler always takes `(ctx, input)`** and reads state explicitly through
+  `ctx.state`. Nothing is injected by parameter name.
 - **A workflow's input is a `string` only for a text-only turn** — for anything
   else the entry node is handed the raw `Content`. Every entry node here
   declares `nodeInput: string` and calls string methods on it directly, so a
@@ -147,24 +146,21 @@ differs, all called out again in the affected sample's header comment.
 - **`ctx.runNode()` resolves to a node _result_,** not the output directly — read
   `.output`. It also does not throw when a child interrupts: check
   `.interruptIds` and bail out (see `dynamic/human_input`).
-- **A second `output` event overwrites the first, silently.** The Python page
-  gives two accounts of emitting `output` more than once from a node — each
-  `yield` "adds to a list of data objects on the Event", and two yields carrying
-  `Event.output` are "a runtime error". Neither is what happens here: there is
-  no list and no error, the last event to set `output` wins, and the successor
-  never sees the rest. Emit it once (see `data_handling/node_output`).
+- **A second `output` event overwrites the first, silently.** A node may emit
+  any number of events carrying `output`; nothing throws, the last one wins,
+  and the successor never sees the rest. Emit it once
+  (see `data_handling/node_output`).
 - **`LlmAgent.inputSchema` is not the node's input contract.** It is only used
   when the agent is exposed as a tool. Inside a graph, put the validating schema
   on the node: `node(agent, {inputSchema})`.
-- **Schemas are Zod objects** (or a genai `Schema`) rather than pydantic models.
-- **`{Class.field}` and `<Class.field from source_node>` work verbatim** — the
-  Python data-selection syntax is supported (see `data_handling/structured_access`).
+- **Schemas are Zod objects,** or a genai `Schema`.
+- **`{Class.field}` and `<Class.field from source_node>`** select a field off
+  this node's input, or off a named predecessor's output, inside an agent
+  instruction (see `data_handling/structured_access`).
 
 ## See also
 
 The `tests/integration/workflows/*/agent.ts` files are a second, larger set of
-workflow examples — TypeScript ports of Python's
-[`contributing/samples/workflows`](https://github.com/google/adk-python/tree/main/contributing/samples/workflows),
-each paired with a record/replay integration test. They cover surface these
-docs snippets do not: retries, parallel workers, auth (API key and OAuth),
-node-as-tool, `task` mode, and multi-trigger nodes.
+workflow examples, each paired with a record/replay integration test. They
+cover surface these docs sections do not: retries, parallel workers, auth (API
+key and OAuth), node-as-tool, `task` mode, and multi-trigger nodes.

--- a/samples/workflows/data_handling/node_output/agent.ts
+++ b/samples/workflows/data_handling/node_output/agent.ts
@@ -5,29 +5,21 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Node output
  * https://adk.dev/graphs/data-handling/#node-output
- *
- *   def my_function_node(node_input: str):
- *       output_value = node_input.upper()
- *       return Event(output=output_value)   # "THE RESULT"
  *
  * A node hands data to its successor through the event's `output` field. Three
  * equivalent ways to produce it:
  *
- *   1. return a bare value            — boxed into `Event(output=value)` for you
+ *   1. return a bare value            — boxed into an event's `output` for you
  *   2. return `createEvent({output})` — the explicit form, when you also need
  *                                       `route`, `content`, or `actions`
  *   3. yield from a generator         — to stream progress alongside the result
  *
- * Caution: emit `output` from ONE event per execution — but nothing enforces
- * that here, so getting it wrong is silent. A node may yield any number of
- * events carrying `output`; each one overwrites the last, and the successor
- * receives only the final value. The Python page describes two other
- * behaviours, and neither holds in TypeScript: it says each `yield` "adds to a
- * list of data objects on the Event", and then cautions that two yields
- * carrying `Event.output` are "a runtime error". There is no list and no
- * error — just last-write-wins. Carry progress on `content` instead.
+ * Caution: emit `output` from ONE event per execution. Nothing enforces that,
+ * so getting it wrong is silent — a node may yield any number of events
+ * carrying `output`, each overwrites the last, and the successor receives only
+ * the final value. Carry progress on `content` instead.
  *
  * Run (offline, no API key):
  *   npm run sample -- samples/workflows/data_handling/node_output/agent.ts

--- a/samples/workflows/data_handling/routing_output/agent.ts
+++ b/samples/workflows/data_handling/routing_output/agent.ts
@@ -5,11 +5,8 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Routing output
  * https://adk.dev/graphs/data-handling/#routing-output
- *
- *   def router(node_input: str):
- *       return Event(route="BUG")
  *
  * `route` is the event field that drives conditional edge dispatch — it is
  * independent of `output`, so a router can select a branch AND forward a payload

--- a/samples/workflows/data_handling/schemas/agent.ts
+++ b/samples/workflows/data_handling/schemas/agent.ts
@@ -5,20 +5,11 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Constrain node data with schemas
  * https://adk.dev/graphs/data-handling/#constrain-node-data-with-schemas
  *
- *   flight_searcher = Agent(
- *       name="flight_searcher",
- *       instruction="Search for available flights.",
- *       input_schema=FlightSearchInput,
- *       output_schema=FlightSearchOutput,
- *       tools=[search_flights_api],
- *       mode="single_turn",
- *   )
- *
- * Schemas constrain what a node accepts and produces. Python uses pydantic
- * `BaseModel`s; TypeScript uses Zod objects (a genai `Schema` also works).
+ * Schemas constrain what a node accepts and produces. Use a Zod object, or a
+ * genai `Schema`.
  *
  * Where the schema goes:
  *   - `LlmAgent.outputSchema` forces the model to answer in that shape.

--- a/samples/workflows/data_handling/schemas/agent.ts
+++ b/samples/workflows/data_handling/schemas/agent.ts
@@ -93,7 +93,7 @@ const parseRequest = node(
 
 const flightSearcher = new LlmAgent({
   name: 'flight_searcher',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   mode: 'single_turn',
   instruction:
     'Search for available flights with the search_flights_api tool and report ' +

--- a/samples/workflows/data_handling/session_state/agent.ts
+++ b/samples/workflows/data_handling/session_state/agent.ts
@@ -5,24 +5,13 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Session state and state scopes
  * https://adk.dev/graphs/data-handling/#session-state-and-state-scopes
  *
- *   async def init_state_node(attempts: int = 0):
- *     yield Event(state={"attempts": attempts})
- *
- *   async def task_attempt_node(node_input: Content, attempts: int):
- *     yield Event(state={"attempts": attempts + 1})
- *
- *   async def read_state_node(ctx: Context):
- *     print(f"attempts state: {ctx.state}")   # attempts state: attempts: 1
- *
- * Python binds state values to named function parameters by signature
- * introspection. TypeScript nodes take an explicit `(ctx, input)` pair instead,
- * so you read and write the same session state through `ctx.state`. A write is
- * visible to every later node in the same run, and is committed with the
- * writing node's events — so `attempts` can be incremented by one node and read
- * back by another, exactly as the snippet does.
+ * A node takes an explicit `(ctx, input)` pair and reads and writes session
+ * state through `ctx.state`. A write is visible to every later node in the same
+ * run, and is committed with the writing node's events — so `attempts` below is
+ * initialized by one node, incremented by a second and read back by a third.
  *
  * State-key prefixes control lifetime and scope:
  *   "app:<key>"   shared across all users and sessions of the app

--- a/samples/workflows/data_handling/structured_access/agent.ts
+++ b/samples/workflows/data_handling/structured_access/agent.ts
@@ -33,7 +33,7 @@ type CityTime = z.infer<typeof cityTimeSchema>;
 
 const cityGeneratorAgent = new LlmAgent({
   name: 'city_generator_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   instruction: 'Return the name of a random city. Return only the name.',
 });
 
@@ -48,7 +48,7 @@ const lookupTimeFunction = node(
 
 const cityReportAgent = new LlmAgent({
   name: 'city_report_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
 
   // Data selection based on class and parameter — reads this node's own input:
   // instruction: `Return a sentence in the following format:

--- a/samples/workflows/data_handling/structured_access/agent.ts
+++ b/samples/workflows/data_handling/structured_access/agent.ts
@@ -5,17 +5,10 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Access structured data in agents
  * https://adk.dev/graphs/data-handling/#access-structured-data-in-agents
  *
- *   instruction="""
- *       Return a sentence in the following format:
- *       It is <CityTime.time_info from lookup_time_function> in
- *       <CityTime.city from lookup_time_function> right now.
- *   """
- *
- * adk-js supports Python's data-selection syntax verbatim in agent
- * instructions:
+ * Two data-selection forms are available inside an agent instruction:
  *
  *   {Class.field}                    reads a field off THIS node's input
  *   <Class.field from source_node>   reads a field off a named predecessor's

--- a/samples/workflows/data_handling/structured_output/agent.ts
+++ b/samples/workflows/data_handling/structured_output/agent.ts
@@ -5,11 +5,8 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Node output: passing structured data
  * https://adk.dev/graphs/data-handling/#node-output-passing-structured-data
- *
- *   def my_function_node_3():
- *       yield Event(output={"city_name": "Paris", "city_time": "10:10 AM"})
  *
  * `output` is not limited to text — any serializable value flows to the next
  * node, which receives it as a typed object. Attaching an `outputSchema` to the

--- a/samples/workflows/data_handling/user_message/agent.ts
+++ b/samples/workflows/data_handling/user_message/agent.ts
@@ -5,19 +5,15 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * User-facing messages
  * https://adk.dev/graphs/data-handling/#user-facing-messages
  *
- *   async def user_message(node_input: str):
- *     yield Event(message="Beginning research process...")
- *
- * `message` is for the human, `output` is for the next node. TypeScript events
- * have no `message` field: a user-facing message is the event's `content`, which
- * the runtime renders but the graph does NOT forward as node input.
+ * A message for the human is the event's `content`: the runtime renders it, and
+ * the graph does NOT forward it as node input. `content` is for the user,
+ * `output` is for the next node.
  *
  * Because the first node below emits content only, the next node's input is
- * `undefined` — exactly the Python behaviour of a node that yields a message
- * and no output.
+ * `undefined`.
  *
  * Run (offline, no API key):
  *   npm run sample -- samples/workflows/data_handling/user_message/agent.ts
@@ -25,7 +21,7 @@
 
 import {createEvent, node, NodeContext, WorkflowAgent} from '@google/adk';
 
-/** Emits a user-facing message (Python's `Event(message=...)`). */
+/** Emits a user-facing message: `content`, with no `output`. */
 const message = (text: string) =>
   createEvent({content: {role: 'model', parts: [{text}]}});
 

--- a/samples/workflows/dynamic/custom_run_ids/agent.ts
+++ b/samples/workflows/dynamic/custom_run_ids/agent.ts
@@ -5,10 +5,8 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Custom execution IDs
  * https://adk.dev/graphs/dynamic/#custom-execution-ids
- *
- *   task = ctx.run_node(process_order, order, run_id=f"order-{order.order_id}")
  *
  * ADK gives every child execution a deterministic id derived from the parent id
  * and a per-node-name counter ("1", "2", "3", ...). Those ids are how a resumed

--- a/samples/workflows/dynamic/data_handling/agent.ts
+++ b/samples/workflows/dynamic/data_handling/agent.ts
@@ -5,22 +5,15 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Data handling in a dynamic workflow
  * https://adk.dev/graphs/dynamic/#data-handling
- *
- *   @node(rerun_on_resume=True)
- *   async def editorial_workflow(ctx: Context, user_request: str):
- *       raw_draft = await ctx.run_node(draft_agent, user_request)
- *       formatted_text = await ctx.run_node(format_function_node, raw_draft)
- *       return formatted_text
  *
  * Passing data in a dynamic workflow is simpler than in a graph: `ctx.runNode()`
  * hands you the child's result directly, so there are no session-state keys to
- * read and write just to move a value one step downstream.
+ * read and write just to move a value one step downstream. It resolves to a
+ * node result, so read `.output`.
  *
- * In TypeScript `ctx.runNode()` resolves to a node result — read `.output`.
- *
- * REQUIRES an API key (draft_agent calls a live model). Set GEMINI_API_KEY:
+ * REQUIRES an API key (the draft agent calls a live model). Set GEMINI_API_KEY:
  *   npm run sample -- samples/workflows/dynamic/data_handling/agent.ts
  * Try "a short paragraph about why graphs beat long prompts".
  */

--- a/samples/workflows/dynamic/data_handling/agent.ts
+++ b/samples/workflows/dynamic/data_handling/agent.ts
@@ -23,7 +23,7 @@ import {LlmAgent, node, NodeContext, WorkflowAgent} from '@google/adk';
 const draftAgent = node(
   new LlmAgent({
     name: 'draft_agent',
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     instruction: 'Write a short draft for the user request.',
   }),
 );

--- a/samples/workflows/dynamic/get_started/agent.ts
+++ b/samples/workflows/dynamic/get_started/agent.ts
@@ -5,28 +5,15 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Dynamic workflows: get started
  * https://adk.dev/graphs/dynamic/#get-started
- *
- *   @node(name="hello_node")
- *   def my_node(node_input: Any):
- *       return "Hello World"
- *
- *   @node(rerun_on_resume=True)
- *   async def my_workflow(ctx: Context, node_input: str) -> str:
- *       result = await ctx.run_node(my_node, node_input="hello")
- *       return result
- *
- *   root_agent = Workflow(name="root_agent", edges=[("START", my_workflow)])
  *
  * A dynamic workflow drops the static edge graph and orchestrates in plain
  * code: an outer node calls `ctx.runNode(child, input)` to execute children in
  * whatever order your loops and conditionals dictate.
  *
- * TypeScript differences from Python:
- *   - There is no `@node` decorator. `node(fn, options)` is the factory form.
- *   - `ctx.runNode()` resolves to a node RESULT, so read `.output` (Python
- *     returns the output directly).
+ * Two things to know going in:
+ *   - `ctx.runNode()` resolves to a node RESULT, so read `.output`.
  *   - An orchestrator that calls `ctx.runNode` must set `rerunOnResume: true`,
  *     so its body re-runs on resume and already-finished children are replayed
  *     from their checkpoints rather than executed again.

--- a/samples/workflows/dynamic/human_input/agent.ts
+++ b/samples/workflows/dynamic/human_input/agent.ts
@@ -5,27 +5,14 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Human input in a dynamic workflow
  * https://adk.dev/graphs/dynamic/#human-input
- *
- *   @node(rerun_on_resume=False)
- *   async def get_user_approval(ctx: Context, node_input: Any):
- *       yield RequestInput(message="Please approve this request (Yes/No)")
- *
- *   @node(rerun_on_resume=True)
- *   async def handle_process(ctx: Context, node_input: Any):
- *       user_response = await ctx.run_node(get_user_approval)
- *       if user_response.lower() == "yes":
- *           return "Approved"
- *       return "Denied"
  *
  * Important: a parent node that calls `ctx.runNode` must set
  * `rerunOnResume: true`, or it cannot handle an interrupt raised by a child.
- * The leaf keeps the snippet's `rerun_on_resume=False`: on resume it does not
- * re-run its body, it completes with the human's reply as its output, and
- * `ctx.runNode()` hands that back to the caller.
- *
- * !! One TypeScript difference from the Python snippet. !!
+ * The leaf keeps `rerunOnResume: false`: on resume it does not re-run its body,
+ * it completes with the human's reply as its output, and `ctx.runNode()` hands
+ * that back to the caller.
  *
  * `ctx.runNode()` does NOT throw when a child interrupts. It resolves with a
  * result whose `interruptIds` are populated and whose `output` is still
@@ -42,9 +29,9 @@ import {node, NodeContext, RequestInput, WorkflowAgent} from '@google/adk';
 /**
  * Pauses the workflow and waits for user input.
  *
- * `rerunOnResume: false` (the default, explicit here to mirror the decorator)
- * is what makes this a one-liner: the reply is handed to the node as its
- * output instead of the body running a second time to collect it.
+ * `rerunOnResume: false` (the default, spelled out here because it is the
+ * point) is what makes this a one-liner: the reply is handed to the node as
+ * its output instead of the body running a second time to collect it.
  */
 const getUserApproval = node(
   () => new RequestInput({message: 'Please approve this request (Yes/No)'}),

--- a/samples/workflows/dynamic/loop_route/agent.ts
+++ b/samples/workflows/dynamic/loop_route/agent.ts
@@ -29,7 +29,7 @@ const MAX_FIX_ROUNDS = 3;
 const coderAgent = node(
   new LlmAgent({
     name: 'generator_agent',
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     instruction:
       'Write TypeScript code for the user request. Output code only.',
   }),
@@ -53,7 +53,7 @@ const compileLintCheck = node(
 const fixerAgent = node(
   new LlmAgent({
     name: 'fixer_agent',
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     instruction: `Refactor current code {code}.
         Based on compile & lint review: {findings}
         Output code only.`,

--- a/samples/workflows/dynamic/loop_route/agent.ts
+++ b/samples/workflows/dynamic/loop_route/agent.ts
@@ -5,20 +5,8 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Loop route
  * https://adk.dev/graphs/dynamic/#loop-route
- *
- *   @node # workflow node
- *   async def code_workflow(ctx: Context, user_request: str):
- *     code = await ctx.run_node(coder_agent, user_request)
- *     check_resp = await ctx.run_node(compile_lint_check, code)
- *
- *     while check_resp.findings:
- *       yield Event(state={"code": code, "findings": check_resp.findings})
- *       code = await ctx.run_node(fixer_agent, {"code": code, "findings": ...})
- *       check_resp = await ctx.run_node(compile_lint_check, code)
- *
- *     return code
  *
  * This is where dynamic workflows earn their keep: the iteration is an ordinary
  * `while` loop, not a back-edge you have to reason about. Values live in local
@@ -42,7 +30,8 @@ const coderAgent = node(
   new LlmAgent({
     name: 'generator_agent',
     model: 'gemini-2.5-flash',
-    instruction: 'Write python code for the user request. Output code only.',
+    instruction:
+      'Write TypeScript code for the user request. Output code only.',
   }),
 );
 
@@ -50,10 +39,10 @@ const coderAgent = node(
 const compileLintCheck = node(
   (_ctx: NodeContext, code: string) => {
     const findings: string[] = [];
-    if (!/"""/.test(code)) {
-      findings.push('every function needs a docstring');
+    if (!/\/\*\*/.test(code)) {
+      findings.push('every function needs a JSDoc comment');
     }
-    if (!/->/.test(code)) {
+    if (!/\)\s*:\s*\w/.test(code)) {
       findings.push('add return type annotations');
     }
     return {findings: findings.join('; ')};

--- a/samples/workflows/dynamic/nodes/agent.ts
+++ b/samples/workflows/dynamic/nodes/agent.ts
@@ -5,21 +5,13 @@
  */
 
 /**
- * TypeScript port of the Python snippets in
- * https://adk.dev/graphs/dynamic/#node and
+ * Nodes, and the workflows that compose them
+ * https://adk.dev/graphs/dynamic/#node
  * https://adk.dev/graphs/dynamic/#workflows
  *
- *   @node(name="hello_node")
- *   def my_function_node(node_input: Any):
- *       return "Hello World"
+ * The two ways to build a node:
  *
- *   # ...the same thing without the decorator:
- *   success_node = FunctionNode(my_function_node, name="hello",
- *                               rerun_on_resume=True)
- *
- * The two ways to build a node, and how an orchestrator composes them.
- *
- *   node(fn, options)                     the factory — Python's `@node`
+ *   node(fn, options)                     the factory form
  *   new FunctionNode(name, fn, config)    the explicit constructor
  *
  * Reach for the explicit constructor when you are wrapping a function from
@@ -37,7 +29,7 @@ function myFunctionNode(_ctx: NodeContext, nodeInput: unknown): string {
   return `Hello ${nodeInput ?? 'World'}`;
 }
 
-// Form 1 — the `node()` factory (Python's `@node(name="hello_node")`).
+// Form 1 — the `node()` factory.
 const helloNode = node(myFunctionNode, {name: 'hello_node'});
 
 // Form 2 — the explicit constructor, same function, different configuration.

--- a/samples/workflows/dynamic/parallel_route/agent.ts
+++ b/samples/workflows/dynamic/parallel_route/agent.ts
@@ -5,22 +5,13 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Parallel execution routes
  * https://adk.dev/graphs/dynamic/#parallel-execution-routes
  *
- *   @node(rerun_on_resume=True)
- *   async def parallel_supervisor(ctx, node_input: list[Any], real_node):
- *       tasks = []
- *       for item in node_input:
- *           # ctx.run_node returns a future. Append instead of awaiting.
- *           tasks.append(ctx.run_node(real_node, item))
- *       results = await asyncio.gather(*tasks)
- *       return results
- *
  * `ctx.runNode()` returns a promise, so starting every child before awaiting any
- * of them runs them concurrently — `Promise.all` is the `asyncio.gather`
- * equivalent. Run ids are assigned in CALL order, so kick the children off in a
- * synchronous loop to keep them deterministic across a resume.
+ * of them runs them concurrently, and `Promise.all` gathers the results. Run
+ * ids are assigned in CALL order, so kick the children off in a synchronous
+ * loop to keep them deterministic across a resume.
  *
  * Resuming parallel nodes: on resume only the failed or interrupted workers
  * re-execute; children that already completed are replayed from their

--- a/samples/workflows/dynamic/sequence_route/agent.ts
+++ b/samples/workflows/dynamic/sequence_route/agent.ts
@@ -29,7 +29,7 @@ type CityTime = z.infer<typeof cityTimeSchema>;
 const cityGeneratorAgent = node(
   new LlmAgent({
     name: 'city_generator_agent',
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     instruction: 'Return the name of a random city. Return only the name.',
   }),
 );
@@ -46,7 +46,7 @@ const cityTimeFunction = node(
 const cityReportAgent = node(
   new LlmAgent({
     name: 'city_report_agent',
-    model: 'gemini-2.5-flash',
+    model: 'gemini-flash-latest',
     instruction: 'Output the data provided by the previous node as a sentence.',
   }),
   {inputSchema: cityTimeSchema},

--- a/samples/workflows/dynamic/sequence_route/agent.ts
+++ b/samples/workflows/dynamic/sequence_route/agent.ts
@@ -5,16 +5,9 @@
  */
 
 /**
- * TypeScript port of the Python snippets in
- * https://adk.dev/graphs/dynamic/#data-handling (the `CityTime` variant) and
+ * Sequence route
  * https://adk.dev/graphs/dynamic/#sequence-route
- *
- *   @node # workflow node
- *   async def city_workflow(ctx: Context):
- *       city = await ctx.run_node(city_generator_agent)
- *       city_time = await ctx.run_node(city_time_function, city)
- *       report_text = await ctx.run_node(city_report_agent, city_time)
- *       return report_text
+ * https://adk.dev/graphs/dynamic/#data-handling (the `CityTime` variant)
  *
  * A sequential route in a dynamic workflow is just awaiting `ctx.runNode()`
  * calls one after another — each finishes before the next starts. Schemas work

--- a/samples/workflows/graphs/get_started/agent.ts
+++ b/samples/workflows/graphs/get_started/agent.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Graph workflows: get started
  * https://adk.dev/graphs/#get-started
  *
  * A sequential graph workflow that alternates between AI reasoning and plain
@@ -32,7 +32,7 @@ const cityGeneratorAgent = new LlmAgent({
       Return only the name, nothing else.`,
 });
 
-/** Python: `class CityTime(BaseModel)`. */
+/** The structured payload handed from the lookup node to the report agent. */
 const cityTimeSchema = z.object({
   timeInfo: z.string().describe('Time information.'),
   city: z.string().describe('City name.'),
@@ -47,17 +47,15 @@ function lookupTimeFunction(_ctx: NodeContext, nodeInput: string): CityTime {
 const cityReportAgent = new LlmAgent({
   name: 'city_report_agent',
   model: 'gemini-2.5-flash',
-  // `{CityTime.<field>}` selects a field off THIS node's input. adk-js supports
-  // Python's data-selection syntax verbatim; the `CityTime.` prefix is
-  // documentation, only the field name after the dot is resolved.
+  // `{CityTime.<field>}` selects a field off THIS node's input. The `CityTime.`
+  // prefix is documentation, only the field name after the dot is resolved.
   instruction: `Output the following line:
     It is {CityTime.timeInfo} in {CityTime.city} right now.`,
 });
 
 function completedMessageFunction(_ctx: NodeContext, nodeInput: string) {
-  // Python's `Event(message=...)`. TypeScript events have no `message` field —
-  // a user-facing message is the event's `content` (and, unlike `output`, it is
-  // not handed to the next node).
+  // A user-facing message is the event's `content` which, unlike `output`, is
+  // not handed to the next node.
   return createEvent({
     content: {
       role: 'model',
@@ -76,8 +74,7 @@ export const rootAgent = new WorkflowAgent({
         name: 'lookup_time_function',
         outputSchema: cityTimeSchema,
       }),
-      // Python declares `input_schema=CityTime` on the Agent. In a graph the
-      // validating schema belongs to the node wrapping the agent — an
+      // The validating schema belongs to the node wrapping the agent — an
       // `LlmAgent.inputSchema` is only used when the agent is exposed as a tool.
       node(cityReportAgent, {inputSchema: cityTimeSchema}),
       node(completedMessageFunction, {name: 'completed_message_function'}),

--- a/samples/workflows/graphs/get_started/agent.ts
+++ b/samples/workflows/graphs/get_started/agent.ts
@@ -27,7 +27,7 @@ import {z} from 'zod';
 
 const cityGeneratorAgent = new LlmAgent({
   name: 'city_generator_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   instruction: `Return the name of a random city.
       Return only the name, nothing else.`,
 });
@@ -46,7 +46,7 @@ function lookupTimeFunction(_ctx: NodeContext, nodeInput: string): CityTime {
 
 const cityReportAgent = new LlmAgent({
   name: 'city_report_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   // `{CityTime.<field>}` selects a field off THIS node's input. The `CityTime.`
   // prefix is documentation, only the field name after the dot is resolved.
   instruction: `Output the following line:

--- a/samples/workflows/graphs/process_pipeline/agent.ts
+++ b/samples/workflows/graphs/process_pipeline/agent.ts
@@ -28,7 +28,7 @@ import {
 
 const processMessage = new LlmAgent({
   name: 'process_message',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   instruction: `Classify user message into either "BUG", "CUSTOMER_SUPPORT",
       or "LOGISTICS". If you think a message applies to more than one category,
       reply with a comma separated list of categories.

--- a/samples/workflows/graphs/process_pipeline/agent.ts
+++ b/samples/workflows/graphs/process_pipeline/agent.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Build processes with graphs
  * https://adk.dev/graphs/#build-processes-with-graphs
  *
  * A prompt-based agent turned into a graph: one agent classifies the message,
@@ -35,8 +35,8 @@ const processMessage = new LlmAgent({
       Reply with the categories only, nothing else.`,
 });
 
-// Python: `return Event(route=routes)`. A route array fires EVERY branch whose
-// route key matches one of the listed values (multi-route dispatch).
+// A route ARRAY fires every branch whose route key matches one of the listed
+// values (multi-route dispatch), rather than just the first match.
 const router = node(
   (_ctx: NodeContext, nodeInput: string) =>
     createEvent({
@@ -48,7 +48,7 @@ const router = node(
   {name: 'router'},
 );
 
-/** Emits a user-facing message (Python's `Event(message=...)`). */
+/** Emits a user-facing message: `content`, with no `output`. */
 const message = (text: string) =>
   createEvent({content: {role: 'model', parts: [{text}]}});
 

--- a/samples/workflows/human_input/get_started/agent.ts
+++ b/samples/workflows/human_input/get_started/agent.ts
@@ -5,22 +5,13 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Human input: get started
  * https://adk.dev/graphs/human-input/#get-started
- *
- *   def step1():                              # Human input step
- *     yield RequestInput(message="Enter a number:")
- *
- *   def step2(node_input):
- *     return node_input * 2
- *
- *   root_agent = Workflow(name="root_agent", edges=[('START', step1, step2)])
  *
  * `step1` pauses the workflow until the user replies; the reply is then handed
  * to the next node as its input. This is the default `rerunOnResume: false`
  * handoff: the interrupted node does NOT re-run — it completes with the user's
- * reply as its output. (For the re-entry variant, where the paused node itself
- * re-runs and receives the reply, see samples/workflows/dynamic/human_input.)
+ * reply as its output.
  *
  * A HITL node needs no model, which makes the pause fully deterministic.
  *

--- a/samples/workflows/human_input/initial_prompt/agent.ts
+++ b/samples/workflows/human_input/initial_prompt/agent.ts
@@ -5,19 +5,14 @@
  */
 
 /**
- * TypeScript port of the Python `initial_prompt` snippet in
+ * A human-input node as the FIRST step of a workflow
  * https://adk.dev/graphs/human-input/#tool-confirmation-approval-prompts-in-llm-agents
  *
- *   async def initial_prompt(ctx: Context):
- *      yield RequestInput(message=input_message, response_schema=str)
+ * Instead of guessing what the user wants, the graph opens by asking, pauses,
+ * and then routes the reply into the rest of the process.
  *
- * A HITL node as the FIRST step of a workflow: instead of guessing what the
- * user wants, the graph opens by asking, pauses, and then routes the reply into
- * the rest of the process.
- *
- * `response_schema=str` becomes `responseSchema: z.string()` — a plain text
- * reply. Nothing coerces the human's answer into that shape; the schema tells a
- * client what to collect.
+ * `responseSchema: z.string()` asks for a plain text reply. Nothing coerces the
+ * human's answer into that shape; the schema tells a client what to collect.
  *
  * (The same docs section also covers tool-confirmation, an LlmAgent-level
  * mechanism rather than a graph node: set `requireConfirmation: true` on a

--- a/samples/workflows/human_input/payload_and_schema/agent.ts
+++ b/samples/workflows/human_input/payload_and_schema/agent.ts
@@ -5,14 +5,8 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Request input with a message and payload
  * https://adk.dev/graphs/human-input/#request-input-with-a-message-and-payload
- *
- *   yield RequestInput(
- *       message=message,
- *       payload=node_input,
- *       response_schema=UserFeedback,
- *   )
  *
  * `RequestInput` takes three configuration options:
  *   message         text shown to the user explaining what is being asked

--- a/samples/workflows/routes/branches/agent.ts
+++ b/samples/workflows/routes/branches/agent.ts
@@ -49,7 +49,7 @@ const router = node(
 // An agent to execute node B.
 const taskBNode = new LlmAgent({
   name: 'task_B_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   instruction: 'Answer the user in a single short sentence.',
 });
 

--- a/samples/workflows/routes/branches/agent.ts
+++ b/samples/workflows/routes/branches/agent.ts
@@ -5,14 +5,14 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Route branches and conditional execution
  * https://adk.dev/graphs/routes/#route-branches-and-conditional-execution
  *
  * Branching is a node that emits a `route`, plus an edge row mapping each route
  * value to the node that handles it. A branch target can be anything node-like:
  * `task_B_node` here is an `LlmAgent`, `task_C_node` a plain function.
  *
- * The docs snippet leaves `task_A_node` and `condition()` undefined; this port
+ * The docs page leaves `task_A_node` and `condition()` undefined; this sample
  * defines them (the condition is "the input mentions a number").
  *
  * REQUIRES an API key when the RUN_TASK_B branch is taken (it calls a live

--- a/samples/workflows/routes/fan_out_join/agent.ts
+++ b/samples/workflows/routes/fan_out_join/agent.ts
@@ -5,16 +5,8 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Parallel tasks: fan out and join paths
  * https://adk.dev/graphs/routes/#parallel-tasks-fan-out-and-join-paths
- *
- *   my_join_node = JoinNode(name="my_join_node")
- *   edges=[
- *       ("START", parallel_task_A, my_join_node),
- *       ("START", parallel_task_B, my_join_node),
- *       ("START", parallel_task_C, my_join_node),
- *       (my_join_node, final_task_D),
- *   ]
  *
  * A `JoinNode` is a fan-in barrier: it waits for EVERY predecessor to finish and
  * then hands the next node an object keyed by predecessor node name.
@@ -58,8 +50,8 @@ const finalTaskD = node(
 
 export const rootAgent = new WorkflowAgent({
   name: 'fan_out_workflow',
-  // One edge row per parallel path, exactly as in the Python snippet. The
-  // equivalent TypeScript shorthand nests the parallel nodes in an array:
+  // One edge row per parallel path. The equivalent shorthand nests the
+  // parallel nodes in an array:
   //   [['START', [parallelTaskA, parallelTaskB, parallelTaskC], myJoinNode,
   //     finalTaskD]]
   edges: [

--- a/samples/workflows/routes/function_node/agent.ts
+++ b/samples/workflows/routes/function_node/agent.ts
@@ -5,16 +5,15 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Nodes
  * https://adk.dev/graphs/routes/#nodes
  *
  * The simplest node type: a plain function wrapped as a FunctionNode. It takes
  * text in, returns text out, and the framework hands that value to the next
  * node as its input — no session-state writes needed.
  *
- * Python returns `Event(output=...)` explicitly; in TypeScript a bare return
- * value is boxed into an `Event` with that `output` for you, so both forms
- * below are equivalent.
+ * A bare return value is boxed into an `Event` carrying that `output` for you,
+ * so both forms below are equivalent.
  *
  * Run (offline, no API key):
  *   npm run sample -- samples/workflows/routes/function_node/agent.ts
@@ -28,7 +27,7 @@ import {
   type FunctionNodeHandler,
 } from '@google/adk';
 
-/** Python: `return Event(output=node_input.upper())`. */
+/** A bare return value: boxed into an event's `output` for you. */
 const myFunctionNode: FunctionNodeHandler<string, string> = (
   _ctx: NodeContext,
   nodeInput: string,

--- a/samples/workflows/routes/loop_escalation/agent.ts
+++ b/samples/workflows/routes/loop_escalation/agent.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * TypeScript port of
+ * Loop and escalation exit
  * https://adk.dev/graphs/routes/#loop-and-escalation-exit
  *
  * A loop is a BACK-EDGE in the graph: a downstream node routes back to an
@@ -18,9 +18,9 @@
  *                             +----------------------------------+
  *                                        router --DONE--> finalize
  *
- * The docs page shows the generic router snippet for this section; this port
+ * The docs page shows only the generic router for this section; this sample
  * adds the back-edge that actually makes it a loop, and keeps the exit
- * condition deterministic so the sample terminates.
+ * condition deterministic so it terminates.
  *
  * Note: a graph cycle is NOT capped by the framework. Make sure your exit
  * condition always becomes true (here the draft gains a bullet each pass), or

--- a/samples/workflows/routes/nested_workflow/agent.ts
+++ b/samples/workflows/routes/nested_workflow/agent.ts
@@ -5,16 +5,8 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Nested workflows
  * https://adk.dev/graphs/routes/#nested-workflows
- *
- *   root_agent = Workflow(
- *       name="parent_workflow",
- *       edges=[
- *          ("START", task_A1, router),
- *          (router, {"RUN_WORKFLOW_B": workflow_B, "RUN_WORKFLOW_C": workflow_C}),
- *       ],
- *   )
  *
  * A `Workflow` is itself a node, so it can be dropped straight into another
  * workflow's edges to encapsulate a reusable sub-process.

--- a/samples/workflows/routes/sequence/agent.ts
+++ b/samples/workflows/routes/sequence/agent.ts
@@ -5,14 +5,14 @@
  */
 
 /**
- * TypeScript port of the Python snippet in
+ * Route sequences
  * https://adk.dev/graphs/routes/#route-sequences
- *
- *   edges=[("START", task_A_node)]                              # single node
- *   edges=[("START", task_A_node, task_B_node, task_C_node)]    # 3 in order
  *
  * A sequential route runs each node once, in the listed order. Each node's
  * return value is delivered to the next node as its input.
+ *
+ *   edges: [['START', taskANode]]                        // a single node
+ *   edges: [['START', taskANode, taskBNode, taskCNode]]  // three, in order
  *
  * Run (offline, no API key):
  *   npm run sample -- samples/workflows/routes/sequence/agent.ts


### PR DESCRIPTION
### Link to Issue or Description of Change

Follow-up to #634, which merged while these two commits were in flight.

**Problem:**

Two things about the samples #634 added:

1. **They read as derivative of the Python docs rather than as TypeScript.**
   Every header opened `TypeScript port of the Python snippet in <url>`, 21 of
   the 26 embedded the Python source as a comment block, and the README framed
   the whole set as ports and closed with a "Python → TypeScript differences"
   section. A TypeScript reader arriving at a TypeScript sample should not have
   to read Python first to find out what the file does.

2. **The model was pinned to `gemini-2.5-flash`** in all 12 places, so the
   samples age out from under a reader as the current flash model moves.

**Solution:**

Each header now names the concept and links the docs section it covers:

```ts
/**
 * Route sequences
 * https://adk.dev/graphs/routes/#route-sequences
 *
 * A sequential route runs each node once, in the listed order. Each node's
 * return value is delivered to the next node as its input.
 * ...
 */
```

Nothing is lost by dropping the embedded snippets — the link goes to the page
that has them. The behaviour notes that were phrased as a contrast ("Python
binds state by signature introspection, TypeScript takes `(ctx, input)`") are
restated as plain facts about this API, which is what a reader needed from them
anyway. The README's differences section is now "Worth knowing".

The 12 model references become `gemini-flash-latest`, the alias the adk.dev
graph-workflow pages themselves use. Only the 8 model-backed samples are
affected; the other 18 declare no model.

Two things fell out while going through them:

- `human_input/get_started` pointed at `dynamic/human_input` as the "re-entry
  variant" of the resume handoff. That cross-reference died in #634's review,
  which gave the dynamic leaf the same `rerunOnResume: false` handoff — both
  samples show the one form now, so the pointer is gone.
- `dynamic/loop_route` asked its agent for Python code, and its stub linter
  checked for `"""` docstrings and `->` return annotations. In a TypeScript
  sample set that is incongruous, so it generates TypeScript and the linter
  looks for JSDoc and `): T`. It was the one place `python` still appeared
  after the rest of the pass.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

No new tests: this is comment and README prose plus a model-id swap. The
execution coverage #634 added (`tests/integration/docs_samples/`) already
constructs all 26 samples and runs the 18 offline ones, and it stays green.

```
npm run ts:check              -> 0 errors
npm run ts:check:samples      -> 0 errors
npm run lint                  -> clean
npm run format:check          -> clean
scripts/check_license.sh      -> clean
npx vitest run --project integration \
  tests/integration/docs_samples tests/integration/workflows
                              -> 38 files, 111 tests, all passing
```

`tests/integration/build_setup` is excluded from that command only because it
runs real `npm install`s and is network-bound; it is untouched here and CI
covers it.

**Manual End-to-End (E2E) Tests:**

The de-Pythoning is comment-only for 24 of the 26 files, so the risk is
concentrated in the two that changed code — both verified:

- `dynamic/loop_route` (model-backed): constructs, and the reworked linter
  returns findings for code with no JSDoc and no return annotations, none for
  code with both.
- The `gemini-flash-latest` swap: all 8 model-backed samples still construct.

A grep over `samples/` for `python`, `pydantic` and `asyncio` returns nothing.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
