### PR TITLE
feat(workflow): make isolationScope real by filtering LLM contents on it

### DIFF
--- a/core/src/agents/invocation_context.ts
+++ b/core/src/agents/invocation_context.ts
@@ -54,6 +54,7 @@ export interface InvocationContextParams {
   pluginManager: PluginManager;
   abortSignal?: AbortSignal;
   workflowInstructionScope?: WorkflowInstructionScope;
+  isolationScope?: string;
   /** Nesting depth of node-as-tool executions; used to bound recursion. */
   nodeToolDepth?: number;
 }
@@ -219,6 +220,12 @@ export class InvocationContext {
   workflowInstructionScope?: WorkflowInstructionScope;
 
   /**
+   * Workflow: the isolation scope of the node this context runs in. Events
+   * carrying a different scope are withheld from this agent's LLM request.
+   */
+  isolationScope?: string;
+
+  /**
    * Nesting depth of node-as-tool ({@link NodeTool}) executions in this
    * invocation. Incremented each time a node runs as a tool (via a depth+1
    * clone), so `NodeTool` can bound `node -> tool -> node` recursion.
@@ -244,6 +251,7 @@ export class InvocationContext {
     this.pluginManager = params.pluginManager;
     this.abortSignal = params.abortSignal;
     this.workflowInstructionScope = params.workflowInstructionScope;
+    this.isolationScope = params.isolationScope;
     this.nodeToolDepth = params.nodeToolDepth ?? 0;
     // Inherit the parent invocation's cost manager when one is available.
 

--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -48,6 +48,7 @@ export function removeClientFunctionCallId(content: Content): void {
  * @param events: A list of all session events.
  * @param agentName: The name of the agent.
  * @param currentBranch: The current branch of the agent.
+ * @param currentIsolationScope: The isolation scope of the current node, if any.
  *
  * @returns A list of processed contents.
  */
@@ -55,6 +56,7 @@ export function getContents(
   events: Event[],
   agentName: string,
   currentBranch?: string,
+  currentIsolationScope?: string,
 ): Content[] {
   const filteredEvents: Event[] = [];
 
@@ -77,6 +79,10 @@ export function getContents(
       event.branch &&
       !isSegmentPrefix(currentBranch, event.branch)
     ) {
+      continue;
+    }
+
+    if (isOutsideIsolationScope(event, currentIsolationScope)) {
       continue;
     }
 
@@ -129,16 +135,43 @@ export function getCurrentTurnContents(
   events: Event[],
   agentName: string,
   currentBranch?: string,
+  currentIsolationScope?: string,
 ): Content[] {
   // Find the latest event that starts the current turn and process from there.
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i];
+    if (isOutsideIsolationScope(event, currentIsolationScope)) {
+      continue;
+    }
     if (event.author === 'user' || isEventFromAnotherAgent(agentName, event)) {
-      return getContents(events.slice(i), agentName, currentBranch);
+      return getContents(
+        events.slice(i),
+        agentName,
+        currentBranch,
+        currentIsolationScope,
+      );
     }
   }
 
   return [];
+}
+
+/**
+ * Whether an event belongs to a different isolation scope than the one asking
+ * for it, and so must be withheld.
+ *
+ * A tagged event is visible only within its own scope; an untagged event is
+ * shared history and visible everywhere. So an isolated node sees the ambient
+ * conversation plus its own turns, while its peers never see those turns.
+ */
+function isOutsideIsolationScope(
+  event: Event,
+  currentIsolationScope?: string,
+): boolean {
+  return (
+    event.isolationScope !== undefined &&
+    event.isolationScope !== currentIsolationScope
+  );
 }
 
 /**

--- a/core/src/agents/processors/content_request_processor.ts
+++ b/core/src/agents/processors/content_request_processor.ts
@@ -50,6 +50,7 @@ export class ContentRequestProcessor implements BaseLlmRequestProcessor {
         events,
         agent.name,
         invocationContext.branch,
+        invocationContext.isolationScope,
       );
     } else {
       // Include current turn context only (no conversation history).
@@ -57,6 +58,7 @@ export class ContentRequestProcessor implements BaseLlmRequestProcessor {
         events,
         agent.name,
         invocationContext.branch,
+        invocationContext.isolationScope,
       );
     }
 

--- a/core/src/workflow/base_node.ts
+++ b/core/src/workflow/base_node.ts
@@ -65,6 +65,13 @@ export interface BaseNodeConfig {
 
   /** Optional schema validating relevant session state (Zod v3/v4 or genai `Schema`). */
   stateSchema?: SchemaLike;
+
+  /**
+   * Runs this node's subtree in an isolated conversation scope: an agent inside
+   * it sees only session events carrying the same scope, plus untagged ones.
+   * `true` derives a scope per node run; a string is an explicit shared tag.
+   */
+  isolationScope?: string | true;
 }
 
 /**
@@ -94,6 +101,7 @@ export abstract class BaseNode<TInput = unknown, TOutput = unknown> {
   readonly inputSchema?: SchemaLike;
   readonly outputSchema?: SchemaLike;
   readonly stateSchema?: SchemaLike;
+  readonly isolationScope?: string | true;
 
   constructor(config: BaseNodeConfig) {
     if (
@@ -115,6 +123,7 @@ export abstract class BaseNode<TInput = unknown, TOutput = unknown> {
     this.inputSchema = config.inputSchema;
     this.outputSchema = config.outputSchema;
     this.stateSchema = config.stateSchema;
+    this.isolationScope = config.isolationScope;
   }
 
   /**

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -99,8 +99,10 @@ export async function executeChildNode({
     });
   }
 
+  const declaredScope =
+    node.isolationScope === true ? `${nodePath}@${runId}` : node.isolationScope;
   const isolationScope =
-    options.overrideIsolationScope ?? parent.isolationScope;
+    options.overrideIsolationScope ?? declaredScope ?? parent.isolationScope;
 
   // The child observes the engine-supplied abort signal when given (a Workflow
   // uses it to cancel siblings on failure), otherwise the parent invocation's.
@@ -109,12 +111,14 @@ export async function executeChildNode({
 
   const childIc =
     branch === parent.invocationContext.branch &&
-    effectiveAbortSignal === parent.invocationContext.abortSignal
+    effectiveAbortSignal === parent.invocationContext.abortSignal &&
+    isolationScope === parent.invocationContext.isolationScope
       ? parent.invocationContext
       : new InvocationContext({
           ...parent.invocationContext,
           branch,
           abortSignal: effectiveAbortSignal,
+          isolationScope,
         });
 
   const child = new NodeContext({

--- a/core/src/workflow/utils/workflow_graph_utils.ts
+++ b/core/src/workflow/utils/workflow_graph_utils.ts
@@ -24,6 +24,8 @@ export interface BuildNodeOptions {
   outputSchema?: SchemaLike;
   stateSchema?: SchemaLike;
   authConfig?: AuthConfig;
+  /** Runs the node's subtree in an isolated conversation scope. */
+  isolationScope?: string | true;
   /** If true, wrap the built node in a parallel worker. */
   parallelWorker?: boolean;
   /** Concurrency limit for the parallel worker (requires `parallelWorker`). */

--- a/core/test/workflow/isolation_scope_test.ts
+++ b/core/test/workflow/isolation_scope_test.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  CONTENT_REQUEST_PROCESSOR,
+  InvocationContext,
+  LlmAgent,
+  LlmRequest,
+  PluginManager,
+  Session,
+} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {
+  getContents,
+  getCurrentTurnContents,
+} from '../../src/agents/processors/content_processor_utils.js';
+import {createEvent, Event} from '../../src/events/event.js';
+import {node} from '../../src/workflow/node.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {JoinNode} from '../../src/workflow/nodes/join_node.js';
+import {Workflow} from '../../src/workflow/workflow.js';
+import {driveNode} from './test_helpers.js';
+
+function userEvent(text: string, isolationScope?: string): Event {
+  return createEvent({
+    author: 'user',
+    invocationId: 'inv-1',
+    content: {role: 'user', parts: [{text}]},
+    isolationScope,
+  });
+}
+
+function textsOf(contents: Array<{parts?: Array<{text?: string}>}>): string[] {
+  return contents.flatMap((c) => (c.parts ?? []).map((p) => p.text ?? ''));
+}
+
+describe('isolation scope — content filtering', () => {
+  const events = [
+    userEvent('shared'),
+    userEvent('mine', 'scope-a'),
+    userEvent('theirs', 'scope-b'),
+  ];
+
+  it('shows an unscoped reader only untagged events', () => {
+    expect(textsOf(getContents(events, 'agent'))).toEqual(['shared']);
+  });
+
+  it('shows a scoped reader its own events plus untagged ones', () => {
+    expect(textsOf(getContents(events, 'agent', undefined, 'scope-a'))).toEqual(
+      ['shared', 'mine'],
+    );
+    expect(textsOf(getContents(events, 'agent', undefined, 'scope-b'))).toEqual(
+      ['shared', 'theirs'],
+    );
+  });
+
+  it('applies the same rule to current-turn contents', () => {
+    const turn = getCurrentTurnContents(events, 'agent', undefined, 'scope-a');
+    expect(textsOf(turn)).toEqual(['mine']);
+  });
+});
+
+describe('isolation scope — node plumbing', () => {
+  it('derives a per-run scope when a node declares isolationScope: true', async () => {
+    const isolated = node(() => 'done', {
+      name: 'isolated',
+      isolationScope: true,
+    });
+
+    const {events} = await driveNode(isolated, 'in');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].isolationScope).toBe('isolated@isolated');
+  });
+
+  it('stamps an explicit scope tag verbatim', async () => {
+    const tagged = node(() => 'done', {
+      name: 'tagged',
+      isolationScope: 'review-thread',
+    });
+
+    const {events} = await driveNode(tagged, 'in');
+
+    expect(events[0].isolationScope).toBe('review-thread');
+  });
+
+  it('leaves events untagged by default', async () => {
+    const plain = node(() => 'done', {name: 'plain'});
+
+    const {events} = await driveNode(plain, 'in');
+
+    expect(events[0].isolationScope).toBeUndefined();
+  });
+
+  it('propagates the scope to the running agent invocation context and to children', async () => {
+    const seen: Array<string | undefined> = [];
+    const child = node(
+      async (ctx: NodeContext) => {
+        seen.push(ctx.invocationContext.isolationScope);
+        return 'child';
+      },
+      {name: 'child'},
+    );
+    const parent = node(
+      async (ctx: NodeContext) => {
+        seen.push(ctx.invocationContext.isolationScope);
+        await ctx.runNode(child, 'x');
+        return 'parent';
+      },
+      {name: 'parent', isolationScope: 'shared-tag'},
+    );
+
+    await driveNode(parent, 'in');
+
+    expect(seen).toEqual(['shared-tag', 'shared-tag']);
+  });
+
+  it('keeps sibling nodes in separate scopes', async () => {
+    const a = node(() => 'a', {name: 'a', isolationScope: true});
+    const b = node(() => 'b', {name: 'b', isolationScope: true});
+    const join = new JoinNode({name: 'join'});
+    const wf = new Workflow({
+      name: 'wf',
+      edges: [
+        ['START', a, join],
+        ['START', b, join],
+      ],
+    });
+
+    const {events} = await driveNode(wf, 'in');
+
+    const scopes = events
+      .filter((e) => e.author === 'a' || e.author === 'b')
+      .map((e) => e.isolationScope);
+    expect(new Set(scopes).size).toBe(2);
+    expect(scopes).toContain('wf.a@1');
+    expect(scopes).toContain('wf.b@1');
+  });
+});
+
+describe('isolation scope — end to end through the content processor', () => {
+  async function contentsFor(
+    events: Event[],
+    isolationScope?: string,
+  ): Promise<string[]> {
+    const session = {
+      id: 's',
+      events,
+      appName: 'app',
+      userId: 'u',
+    } as unknown as Session;
+    const ic = new InvocationContext({
+      invocationId: 'inv-1',
+      agent: new LlmAgent({
+        name: 'reviewer',
+        model: 'gemini-2.5-flash',
+      }) as BaseAgent,
+      session,
+      pluginManager: new PluginManager([]),
+      isolationScope,
+    });
+    const request: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+    for await (const _ of CONTENT_REQUEST_PROCESSOR.runAsync(ic, request)) {
+      // drain
+    }
+    return textsOf(request.contents);
+  }
+
+  it('withholds another node conversation from an isolated agent', async () => {
+    const events = [
+      userEvent('the original question'),
+      userEvent('draft the summary', 'wf.writer@1'),
+      userEvent('critique the summary', 'wf.critic@1'),
+    ];
+
+    expect(await contentsFor(events, 'wf.critic@1')).toEqual([
+      'the original question',
+      'critique the summary',
+    ]);
+  });
+
+  it('leaves an agent outside any scope seeing only shared history', async () => {
+    const events = [
+      userEvent('the original question'),
+      userEvent('draft the summary', 'wf.writer@1'),
+    ];
+
+    expect(await contentsFor(events)).toEqual(['the original question']);
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`Event.isolationScope` existed and was plumbed through `NodeContext`, `Trigger` and the node runner — but it was **inert**. Nothing ever assigned it, so `node_runner` never stamped an event and the `llm_agent_wrapper.ts:70` branch that reads it never fired. Nothing consumed it either. The only non-`undefined` values anywhere in the repo were in a unit test, which is exactly what made the field look implemented.

**Solution:**

Give it both halves — a writer and a consumer.

A node can declare `isolationScope`, and an agent running inside that node gets a filtered conversation: events tagged with a **different** scope are withheld from its LLM request, while **untagged** events remain shared history. So an isolated node sees the ambient conversation plus its own turns, and its peers never see those turns.

That is deliberately distinct from `branch`, whose segment-prefix check separates graph *paths*; this separates *conversations*.

Filtering lands next to the existing branch check in `getContents` / `getCurrentTurnContents`. Those are reached from `ContentRequestProcessor`, which only has an `InvocationContext` — so the scope had to become visible there. `NodeContext.isolationScope` is now carried onto the child `InvocationContext` the node runner builds, and the runner's reuse-the-parent-context shortcut compares the scope too. Without that last detail an isolated node silently borrows its parent's context and reads the wrong history.

**Opt-in, defaults to off**, so no existing workflow changes behaviour:

| Value | Effect |
| --- | --- |
| `isolationScope: true` | derives a per-run tag, `<nodePath>@<runId>` |
| `isolationScope: 'tag'` | explicit tag, so several nodes can deliberately share one scope |
| omitted | inherits the parent's scope — today's behaviour |

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New `core/test/workflow/isolation_scope_test.ts`, 10 tests in three layers: the filtering rules on `getContents`/`getCurrentTurnContents`, the node plumbing (derived tag, explicit tag, untagged by default, inheritance by children, siblings landing in separate scopes), and an end-to-end pass through the **real** `CONTENT_REQUEST_PROCESSOR` asserting an isolated agent's request excludes a peer node's turns.

**Mutation-checked:** stubbing the scope filter to `return false` fails 5 of the 10.

```
npx vitest run --project unit:core
 Test Files  207 passed (207)
      Tests  2854 passed (2854)
```

2844 of those pass unchanged before this change too — the default-off design means nothing existing shifts.

`tsc --noEmit`: 0 errors repo-wide. eslint and prettier clean on all 6 touched files.

**Manual End-to-End (E2E) Tests:**

Not run against a live model. The end-to-end test drives the real content processor with a real `LlmAgent`, so the request-building path is covered; what is not covered is a live multi-agent workflow observing the narrowed history in practice.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**This is a TypeScript-first semantic, not a port.** The ADK 2.0 Python source that defines what `isolation_scope` means for the mesh/chat rebase is not available (public `adk-python` is 1.28.0 and ships no `workflow/` module at all). The rule chosen here — *tagged events are private to their scope, untagged events are shared* — is the conservative reading, but it may need reconciling when the 2.0 semantics land. The alternative considered was deleting the dead plumbing until then.
