### PR TITLE
fix(cli): make --log_level debug actually set the debug level

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -44,7 +44,9 @@ function getLogLevelFromOptions(options: {
   }
 
   if (typeof options.log_level === 'string') {
-    return LOG_LEVEL_MAP[options.log_level.toLowerCase()] || LogLevel.INFO;
+    // `??`, not `||`: LogLevel.DEBUG is 0, so `||` fell through to INFO and
+    // made `--log_level debug` a silent no-op.
+    return LOG_LEVEL_MAP[options.log_level.toLowerCase()] ?? LogLevel.INFO;
   }
 
   return LogLevel.INFO;

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -102,6 +102,18 @@ describe('CLI Entrypoint', () => {
       expect(instance.start).toHaveBeenCalled();
     });
 
+    it('honours --log_level debug', async () => {
+      // LogLevel.DEBUG is 0, so the previous `|| LogLevel.INFO` fallback
+      // discarded it and the flag did nothing.
+      await parse(['web', '--log_level', 'debug']);
+      expect(setLogLevel).toHaveBeenCalledWith(LogLevel.DEBUG);
+    });
+
+    it('falls back to INFO for an unrecognised --log_level', async () => {
+      await parse(['web', '--log_level', 'not-a-level']);
+      expect(setLogLevel).toHaveBeenCalledWith(LogLevel.INFO);
+    });
+
     it('should pass options to AdkApiServer', async () => {
       await parse([
         'web',


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`--log_level debug` does nothing. `LogLevel.DEBUG` is `0`, and the lookup falls
back with `||`:

```ts
return LOG_LEVEL_MAP[options.log_level.toLowerCase()] || LogLevel.INFO;
```

`0 || LogLevel.INFO` is `LogLevel.INFO`, so the one level the flag exists to
select is the one value it cannot return. Debug output was reachable only via
`--verbose`, which takes an earlier branch in the same function.

```
$ npm run sample -- <agent> --log_level debug   # DEBUG lines: 0
$ npm run sample -- <agent> --verbose           # DEBUG lines: 1
```

This is worse than an inert flag: someone debugging a silent failure turns on
debug logging, sees no change, and concludes there is nothing to find.

**Solution:**

Use `??`, which returns `LogLevel.DEBUG` for `debug` and still falls back to
`INFO` for an unrecognised level.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Two tests in `dev/test/cli/cli_test.ts`: `--log_level debug` reaches
`setLogLevel(LogLevel.DEBUG)`, and an unrecognised level still falls back to
`INFO`. The first fails without the source change:

```
# with dev/src/cli/cli.ts stashed
× CLI Entrypoint > command: web > honours --log_level debug
  Tests  1 failed | 27 passed (28)

# with the fix
  Tests  28 passed (28)
```

Full dev project: `Tests 1 failed | 264 passed (265)` — the one failure is
`cli_create_test.ts > should handle Vertex AI selection with gcloud defaults`,
which reads local gcloud config and fails the same way on clean `main`.

**Manual End-to-End (E2E) Tests:**

```
# before
$ npm run sample -- <agent> --log_level debug 2>&1 | grep -c DEBUG
0
# after
$ npm run sample -- <agent> --log_level debug 2>&1 | grep -c DEBUG
1
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Found while bug-bashing the graph-workflow docs samples, and it matters for
#650: the reviewer there asked for the unmatched-route diagnostic to be logged
at `debug` on the reasoning that debug logging is how you investigate a workflow
that produced nothing. That reasoning only holds once this flag works.

Kept separate from #651 (absolute paths), which is already approved, since this
is an unrelated bug in a different function.

**A second, deeper gap this exposed, not fixed here.** Even with this merged,
library logs emitted from inside an agent file loaded by `adk run` still do not
respond to the flag: the loader bundles its own copy of `@google/adk` into the
temp module, so `core`'s logger singleton there is a different instance from the
one the CLI configures. `--log_level debug` raises the level on the CLI's copy
only. Worth its own issue; happy to file it.
