### PR TITLE
feat(plugins): add before/after node callbacks

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -341,7 +341,7 @@ export async function handleFunctionCallList({
     // Step 1: Check if plugin before_tool_callback overrides the function
     // response.
     let functionResponse = null;
-    let functionResponseError: string | unknown | undefined;
+    let functionResponseError: unknown;
     functionResponse =
       await invocationContext.pluginManager.runBeforeToolCallback({
         tool: tool,

--- a/core/src/plugins/base_plugin.ts
+++ b/core/src/plugins/base_plugin.ts
@@ -255,7 +255,7 @@ export abstract class BasePlugin {
     node: BaseNode;
     nodeContext: NodeContext;
     input: unknown;
-  }): Promise<unknown | undefined> {
+  }): Promise<unknown> {
     return;
   }
 
@@ -276,7 +276,7 @@ export abstract class BasePlugin {
     node: BaseNode;
     nodeContext: NodeContext;
     output: unknown;
-  }): Promise<unknown | undefined> {
+  }): Promise<unknown> {
     return;
   }
 

--- a/core/src/plugins/base_plugin.ts
+++ b/core/src/plugins/base_plugin.ts
@@ -14,6 +14,8 @@ import {LlmRequest} from '../models/llm_request.js';
 import {LlmResponse} from '../models/llm_response.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {experimental} from '../utils/experimental.js';
+import type {BaseNode} from '../workflow/base_node.js';
+import type {NodeContext} from '../workflow/node_context.js';
 
 /**
  * Trigger for context compaction.
@@ -234,6 +236,47 @@ export abstract class BasePlugin {
     agent: BaseAgent;
     callbackContext: Context;
   }): Promise<Content | undefined> {
+    return;
+  }
+
+  /**
+   * Callback executed before a workflow node runs.
+   *
+   * @param params.node The node that is about to run.
+   * @param params.nodeContext The node's execution context.
+   * @param params.input The input the node is about to receive.
+   * @returns An optional value. If anything other than `undefined` is returned,
+   *     the node's body is skipped and the returned value becomes its output,
+   *     which is how a plugin implements a node-level cache or a stub.
+   *     Returning `undefined` lets the node run normally.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async beforeNodeCallback(params: {
+    node: BaseNode;
+    nodeContext: NodeContext;
+    input: unknown;
+  }): Promise<unknown | undefined> {
+    return;
+  }
+
+  /**
+   * Callback executed after a workflow node has run.
+   *
+   * Not called for a node whose body was skipped by `beforeNodeCallback`, and
+   * not called when the node throws.
+   *
+   * @param params.node The node that has just run.
+   * @param params.nodeContext The node's execution context.
+   * @param params.output The output the node produced.
+   * @returns An optional value replacing the node's output. Returning
+   *     `undefined` keeps the original.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async afterNodeCallback(params: {
+    node: BaseNode;
+    nodeContext: NodeContext;
+    output: unknown;
+  }): Promise<unknown | undefined> {
     return;
   }
 

--- a/core/src/plugins/plugin_manager.ts
+++ b/core/src/plugins/plugin_manager.ts
@@ -35,6 +35,12 @@ import {BasePlugin, ContextCompactionTrigger} from './base_plugin.js';
  */
 export class PluginManager {
   private readonly plugins: Set<BasePlugin> = new Set();
+
+  /** Whether any plugin is registered. */
+  get hasPlugins(): boolean {
+    return this.plugins.size > 0;
+  }
+
   /**
    * Initializes the plugin service.
    *

--- a/core/src/plugins/plugin_manager.ts
+++ b/core/src/plugins/plugin_manager.ts
@@ -235,7 +235,7 @@ export class PluginManager {
     node: BaseNode;
     nodeContext: NodeContext;
     input: unknown;
-  }): Promise<unknown | undefined> {
+  }): Promise<unknown> {
     return this.runCallbacks(
       this.plugins,
       (plugin: BasePlugin) =>
@@ -255,7 +255,7 @@ export class PluginManager {
     node: BaseNode;
     nodeContext: NodeContext;
     output: unknown;
-  }): Promise<unknown | undefined> {
+  }): Promise<unknown> {
     return this.runCallbacks(
       this.plugins,
       (plugin: BasePlugin) =>

--- a/core/src/plugins/plugin_manager.ts
+++ b/core/src/plugins/plugin_manager.ts
@@ -14,6 +14,8 @@ import {LlmRequest} from '../models/llm_request.js';
 import {LlmResponse} from '../models/llm_response.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {logger} from '../utils/logger.js';
+import type {BaseNode} from '../workflow/base_node.js';
+import type {NodeContext} from '../workflow/node_context.js';
 
 import {BasePlugin, ContextCompactionTrigger} from './base_plugin.js';
 
@@ -214,6 +216,46 @@ export class PluginManager {
         plugin.afterAgentCallback({agent, callbackContext}),
       'afterAgentCallback',
     )) as Content | undefined;
+  }
+
+  /**
+   * Runs the `beforeNodeCallback` for all plugins.
+   */
+  async runBeforeNodeCallback({
+    node,
+    nodeContext,
+    input,
+  }: {
+    node: BaseNode;
+    nodeContext: NodeContext;
+    input: unknown;
+  }): Promise<unknown | undefined> {
+    return this.runCallbacks(
+      this.plugins,
+      (plugin: BasePlugin) =>
+        plugin.beforeNodeCallback({node, nodeContext, input}),
+      'beforeNodeCallback',
+    );
+  }
+
+  /**
+   * Runs the `afterNodeCallback` for all plugins.
+   */
+  async runAfterNodeCallback({
+    node,
+    nodeContext,
+    output,
+  }: {
+    node: BaseNode;
+    nodeContext: NodeContext;
+    output: unknown;
+  }): Promise<unknown | undefined> {
+    return this.runCallbacks(
+      this.plugins,
+      (plugin: BasePlugin) =>
+        plugin.afterNodeCallback({node, nodeContext, output}),
+      'afterNodeCallback',
+    );
   }
 
   /**

--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -23,7 +23,7 @@ import {
 export async function getConnectionOptionsFromUri(
   uri: string,
 ): Promise<MikroORMOptions> {
-  let driver: unknown | undefined;
+  let driver: unknown;
 
   if (uri.startsWith('postgres://') || uri.startsWith('postgresql://')) {
     const {PostgreSqlDriver} = await import('@mikro-orm/postgresql');

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -134,6 +134,21 @@ export async function executeChildNode({
     runId,
   });
 
+  const pluginManager = child.invocationContext.pluginManager;
+  const skipOutput = await pluginManager?.runBeforeNodeCallback({
+    node,
+    nodeContext: child,
+    input,
+  });
+  if (skipOutput !== undefined) {
+    child.output = skipOutput;
+    if (options.useAsOutput) {
+      parent.output = child.output;
+      parent.route = child.route;
+    }
+    return child;
+  }
+
   let succeeded = false;
   while (!succeeded) {
     resetState(child);
@@ -160,6 +175,15 @@ export async function executeChildNode({
       nodeState.attemptCount += 1;
       await delay(delaySeconds * 1000, effectiveAbortSignal);
     }
+  }
+
+  const replacedOutput = await pluginManager?.runAfterNodeCallback({
+    node,
+    nodeContext: child,
+    output: child.output,
+  });
+  if (replacedOutput !== undefined) {
+    child.output = replacedOutput;
   }
 
   if (options.useAsOutput) {

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -135,18 +135,20 @@ export async function executeChildNode({
   });
 
   const pluginManager = child.invocationContext.pluginManager;
-  const skipOutput = await pluginManager?.runBeforeNodeCallback({
-    node,
-    nodeContext: child,
-    input,
-  });
-  if (skipOutput !== undefined) {
-    child.output = skipOutput;
-    if (options.useAsOutput) {
-      parent.output = child.output;
-      parent.route = child.route;
+  if (pluginManager?.hasPlugins) {
+    const skipOutput = await pluginManager.runBeforeNodeCallback({
+      node,
+      nodeContext: child,
+      input,
+    });
+    if (skipOutput !== undefined) {
+      child.output = skipOutput;
+      if (options.useAsOutput) {
+        parent.output = child.output;
+        parent.route = child.route;
+      }
+      return child;
     }
-    return child;
   }
 
   let succeeded = false;
@@ -177,13 +179,15 @@ export async function executeChildNode({
     }
   }
 
-  const replacedOutput = await pluginManager?.runAfterNodeCallback({
-    node,
-    nodeContext: child,
-    output: child.output,
-  });
-  if (replacedOutput !== undefined) {
-    child.output = replacedOutput;
+  if (pluginManager?.hasPlugins) {
+    const replacedOutput = await pluginManager.runAfterNodeCallback({
+      node,
+      nodeContext: child,
+      output: child.output,
+    });
+    if (replacedOutput !== undefined) {
+      child.output = replacedOutput;
+    }
   }
 
   if (options.useAsOutput) {

--- a/core/test/workflow/node_plugin_hooks_test.ts
+++ b/core/test/workflow/node_plugin_hooks_test.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {InvocationContext} from '../../src/agents/invocation_context.js';
+import {BasePlugin} from '../../src/plugins/base_plugin.js';
+import {PluginManager} from '../../src/plugins/plugin_manager.js';
+import {createSession} from '../../src/sessions/session.js';
+import {BaseNode} from '../../src/workflow/base_node.js';
+import {node} from '../../src/workflow/node.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {Workflow} from '../../src/workflow/workflow.js';
+import {createIc, driveNode} from './test_helpers.js';
+
+class RecordingPlugin extends BasePlugin {
+  readonly before: Array<{name: string; input: unknown}> = [];
+  readonly after: Array<{name: string; output: unknown}> = [];
+
+  constructor(
+    name = 'recorder',
+    private readonly beforeResult?: unknown,
+    private readonly afterResult?: unknown,
+  ) {
+    super(name);
+  }
+
+  override async beforeNodeCallback(params: {
+    node: BaseNode;
+    nodeContext: NodeContext;
+    input: unknown;
+  }): Promise<unknown | undefined> {
+    this.before.push({name: params.node.name, input: params.input});
+    return this.beforeResult;
+  }
+
+  override async afterNodeCallback(params: {
+    node: BaseNode;
+    nodeContext: NodeContext;
+    output: unknown;
+  }): Promise<unknown | undefined> {
+    this.after.push({name: params.node.name, output: params.output});
+    return this.afterResult;
+  }
+}
+
+function icWith(plugin: BasePlugin): InvocationContext {
+  const ic = createIc();
+  return ic.clone({pluginManager: new PluginManager([plugin])});
+}
+
+describe('workflow node plugin hooks', () => {
+  it('reports each node run to before and after callbacks', async () => {
+    const plugin = new RecordingPlugin();
+    const target = node((_ctx: NodeContext, input: unknown) => `saw:${input}`, {
+      name: 'target',
+    });
+
+    const {output} = await driveNode(target, 'in', icWith(plugin));
+
+    expect(output).toBe('saw:in');
+    expect(plugin.before).toEqual([{name: 'target', input: 'in'}]);
+    expect(plugin.after).toEqual([{name: 'target', output: 'saw:in'}]);
+  });
+
+  it('skips the node body when beforeNodeCallback returns a value', async () => {
+    const plugin = new RecordingPlugin('cache', 'cached-value');
+    let ran = false;
+    const target = node(
+      () => {
+        ran = true;
+        return 'fresh';
+      },
+      {name: 'target'},
+    );
+
+    const {output} = await driveNode(target, 'in', icWith(plugin));
+
+    expect(ran).toBe(false);
+    expect(output).toBe('cached-value');
+    expect(plugin.after).toEqual([]);
+  });
+
+  it('replaces the output when afterNodeCallback returns a value', async () => {
+    const plugin = new RecordingPlugin('rewriter', undefined, 'rewritten');
+    const target = node(() => 'original', {name: 'target'});
+
+    const {output} = await driveNode(target, 'in', icWith(plugin));
+
+    expect(output).toBe('rewritten');
+    expect(plugin.after).toEqual([{name: 'target', output: 'original'}]);
+  });
+
+  it('fires for every node of a graph, and for the workflow node itself', async () => {
+    const plugin = new RecordingPlugin();
+    const a = node(() => 'a', {name: 'a'});
+    const b = node((_ctx: NodeContext, input: unknown) => `${input}b`, {
+      name: 'b',
+    });
+    const wf = new Workflow({name: 'wf', edges: [['START', a, b]]});
+
+    const {output} = await driveNode(wf, 'in', icWith(plugin));
+
+    expect(output).toBe('ab');
+    expect(plugin.before.map((c) => c.name)).toEqual(['wf', 'a', 'b']);
+    expect(plugin.after.map((c) => c.name)).toEqual(['a', 'b', 'wf']);
+  });
+
+  it('does not fire afterNodeCallback when the node throws', async () => {
+    const plugin = new RecordingPlugin();
+    const boom = node(
+      () => {
+        throw new Error('nope');
+      },
+      {name: 'boom'},
+    );
+
+    await expect(driveNode(boom, 'in', icWith(plugin))).rejects.toThrow('nope');
+    expect(plugin.before.map((c) => c.name)).toEqual(['boom']);
+    expect(plugin.after).toEqual([]);
+  });
+
+  it('leaves execution untouched when no plugin implements the hooks', async () => {
+    const target = node(() => 'plain', {name: 'target'});
+    const ic = new InvocationContext({
+      invocationId: 'inv-1',
+      session: createSession({
+        id: 's1',
+        appName: 'app',
+        userId: 'u',
+        state: {},
+        lastUpdateTime: Date.now(),
+      }),
+      agent: createIc().agent,
+      pluginManager: new PluginManager([]),
+    });
+
+    const {output} = await driveNode(target, 'in', ic);
+
+    expect(output).toBe('plain');
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`BasePlugin` has hooks for runs, agents, models and tools — but nothing for workflow nodes. A plugin could observe every layer of an agent's execution except the graph it was running inside. A node-level cache, a per-node audit trail, or stubbing one node out in a test all had nowhere to attach.

**Solution:**

Two hooks, following the early-exit convention the other plugin callbacks already use (first plugin to return a non-`undefined` value wins):

- **`beforeNodeCallback({node, nodeContext, input})`** — returning anything other than `undefined` **skips the node's body** and uses that value as its output. This is how a plugin implements a node cache or a stub.
- **`afterNodeCallback({node, nodeContext, output})`** — runs on success; a returned value replaces the node's output.

They hang off `executeChildNode`, so they cover graph nodes, dynamic `ctx.runNode()` children, and a nested `Workflow` (itself a node) alike. The before hook sits **outside** the retry loop, so a node that retries reports one before/after pair rather than one per attempt.

Two deliberate omissions:

- a node whose body was skipped fires **no** after callback — nothing ran to report on;
- a node that **throws** fires neither; failures are reported as a `NodeErrorEvent` (#657) rather than through this pair.

The plugin types import `BaseNode`/`NodeContext` as **type-only** imports. The runtime chain already runs workflow → `InvocationContext` → `PluginManager`, so a value import would close that cycle.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New `core/test/workflow/node_plugin_hooks_test.ts`, 6 tests: both hooks fire with the right node/input/output; a returned before-value skips the body (asserted by the body setting a flag that stays false) and suppresses the after hook; a returned after-value replaces the output; hooks fire for every node of a graph **and** for the workflow node itself, in the expected order (`wf, a, b` before / `a, b, wf` after); a throwing node fires no after hook; and a `PluginManager` with no plugins leaves execution untouched.

```
npx vitest run --project unit:core
 Test Files  208 passed (208)
      Tests  2850 passed (2850)
```

`tsc --noEmit`: 0 errors repo-wide. eslint and prettier clean on all 4 files.

**Manual End-to-End (E2E) Tests:**

Not run. The hooks are exercised through the real `PluginManager` in unit tests; what is unverified is a plugin registered on a live `Runner` against a real model.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Only the TSDoc on the two new public callbacks is present; per repo-owner instruction the change carries no other code comments.

Independent of the other workflow PRs in flight (#649, #653, #654, #656, #657); it touches `node_runner.ts`, which #653 and #657 also touch, so expect a small conflict for whichever lands last.
