### PR TITLE
fix(sessions): send the agent-transfer action under the name the API defines

### DIFF
--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -7,6 +7,7 @@
 import {Client} from '@google-cloud/vertexai/build/src/genai/client.js';
 import {Sessions} from '@google-cloud/vertexai/build/src/genai/sessions.js';
 import {
+  EventActions as ApiEventActions,
   AppendAgentEngineSessionEventConfig,
   AppendAgentEngineSessionEventRequestParameters,
   EventMetadata,
@@ -456,10 +457,10 @@ export class VertexAiSessionService extends BaseSessionService {
 
     const config = partialCopy<AppendAgentEngineSessionEventConfig>(event, [
       'content',
-      'actions',
       'errorCode',
       'errorMessage',
     ]);
+    config.actions = toApiActions(event.actions);
 
     config.eventMetadata = {
       ...partialCopy<EventMetadata>(event, [
@@ -564,6 +565,25 @@ function applyWorkflowMetadata(
   if (metadata.endOfAgent !== undefined) {
     event.actions.endOfAgent = metadata.endOfAgent;
   }
+}
+
+/**
+ * Renames `transferToAgent` to the `transferAgent` the Agent Engine sessions
+ * API actually defines, mirroring what `_fromApiEvent` reads back and what
+ * adk-python writes. Returns a new object: `partialCopy` is shallow, so
+ * rewriting the event's own `actions` in place would mutate the caller's event.
+ */
+function toApiActions(
+  actions: EventActions | undefined,
+): ApiEventActions | undefined {
+  if (!actions) {
+    return undefined;
+  }
+  const {transferToAgent, ...rest} = actions;
+  return {
+    ...rest,
+    ...(transferToAgent !== undefined ? {transferAgent: transferToAgent} : {}),
+  } as ApiEventActions;
 }
 
 interface ExtendedEventActions extends EventActions {

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -1358,9 +1358,7 @@ describe('VertexAiSessionService', () => {
         await service.appendEvent({session: transferSession(), event});
 
         expect(event.actions.transferToAgent).toBe('billing_agent');
-        expect(
-          (event.actions as Record<string, unknown>)['transferAgent'],
-        ).toBeUndefined();
+        expect('transferAgent' in event.actions).toBe(false);
       });
 
       it('adds no transfer key when the event has none', async () => {

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -1286,6 +1286,97 @@ describe('VertexAiSessionService', () => {
         }),
       );
     });
+
+    describe('agent transfer action', () => {
+      const transferSession = () =>
+        ({
+          id: 'transfer-session',
+          appName: '12345',
+          userId: 'testUser',
+          events: [],
+          lastUpdateTime: Date.now(),
+        }) as unknown as Session;
+
+      it('sends the transfer under the name the API defines', async () => {
+        const event = createEvent({
+          timestamp: 1620000000000,
+          author: 'router',
+          invocationId: 'inv-1',
+          actions: {transferToAgent: 'billing_agent'},
+        });
+
+        await service.appendEvent({session: transferSession(), event});
+
+        const sent = mockClient.events.append.mock.calls.at(-1)![0];
+        expect(sent.config.actions.transferAgent).toBe('billing_agent');
+        expect(sent.config.actions.transferToAgent).toBeUndefined();
+      });
+
+      it('round-trips the transfer when rawEvent is absent', async () => {
+        const event = createEvent({
+          timestamp: 1620000000000,
+          author: 'router',
+          invocationId: 'inv-1',
+          actions: {transferToAgent: 'billing_agent'},
+        });
+
+        await service.appendEvent({session: transferSession(), event});
+        const sent = mockClient.events.append.mock.calls.at(-1)![0];
+        mockClient.events.listInternal.mockResolvedValue({
+          sessionEvents: [
+            {
+              name: 'reasoningEngines/12345/sessions/transfer-session/events/e1',
+              author: sent.author,
+              invocationId: sent.invocationId,
+              timestamp: sent.timestamp,
+              content: sent.config.content,
+              actions: sent.config.actions,
+              eventMetadata: sent.config.eventMetadata,
+            },
+          ],
+        });
+
+        const session = await service.getSession({
+          appName: '12345',
+          userId: 'testUser',
+          sessionId: 'transfer-session',
+        });
+
+        expect(session!.events[0].actions.transferToAgent).toBe(
+          'billing_agent',
+        );
+      });
+
+      it('does not mutate the caller event', async () => {
+        const event = createEvent({
+          timestamp: 1620000000000,
+          author: 'router',
+          invocationId: 'inv-1',
+          actions: {transferToAgent: 'billing_agent'},
+        });
+
+        await service.appendEvent({session: transferSession(), event});
+
+        expect(event.actions.transferToAgent).toBe('billing_agent');
+        expect(
+          (event.actions as Record<string, unknown>)['transferAgent'],
+        ).toBeUndefined();
+      });
+
+      it('adds no transfer key when the event has none', async () => {
+        const event = createEvent({
+          timestamp: 1620000000000,
+          author: 'agent',
+          invocationId: 'inv-1',
+          content: {role: 'model', parts: [{text: 'hi'}]},
+        });
+
+        await service.appendEvent({session: transferSession(), event});
+
+        const sent = mockClient.events.append.mock.calls.at(-1)![0];
+        expect('transferAgent' in sent.config.actions).toBe(false);
+      });
+    });
   });
 
   describe('workflow event fields', () => {


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`VertexAiSessionService.appendEvent` copies `event.actions` through verbatim, so it sends **`transferToAgent`** — ADK's name for the field. The Agent Engine sessions API does not define that. Its `EventActions` has **`transferAgent`** ([`@google-cloud/vertexai/…/types/common.d.ts:2154`](https://github.com/google/adk-js/blob/main/core/src/sessions/vertex_ai_session_service.ts)), which is exactly what `_fromApiEvent` reads back:

```ts
transferToAgent: actions['transferAgent'] as string | undefined,
```

So the writer sends one name and the reader looks for another — the value can never survive a round-trip. adk-python gets this right in both directions: it writes `'transfer_agent': event.actions.transfer_to_agent` and renames back on read.

This has gone unnoticed because the whole event is also stored as `rawEvent`, which `_fromApiEvent` prefers when present. The loss shows up only on the fallback path taken when an append fails and is retried without `rawEvent`, where the event is rebuilt field by field.

**What is actually lost is the record, not the behaviour** — I traced the consumers before writing this:

- **Runtime transfers are unaffected.** `llm_agent.ts:1089` and `llm_agent_wrapper.ts:192` read the action off the live event mid-invocation, never from storage.
- **Resumption is unaffected.** `determineAgentForResumption` (`runner.ts:587`) picks the agent from `event.author`, not from this action.
- **A reloaded session carries no trace that a hand-off happened.** That affects A2A conversion of reloaded events (`event_processor_utils.ts:59`, `metadata_converter_utils.ts:137`) and any audit or telemetry view of stored actions.

It is also asymmetric across languages, which matters given the cross-language suite: a session written by **Python** reads back correctly in adk-js, while one written by **adk-js** loses the transfer for every reader, Python included.

**Solution:**

Map `transferToAgent` → `transferAgent` on the way out, mirroring Python.

The mapping builds a **new** actions object rather than rewriting the event's own. `partialCopy` is shallow, so `config.actions` *is* the caller's live `event.actions`; renaming a key in place would mutate the event the caller still holds. There is a test pinning that.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

4 new tests under `describe('agent transfer action')`: the transfer is sent as `transferAgent` and not as `transferToAgent`; it round-trips back to `actions.transferToAgent` through the no-`rawEvent` read path; the caller's event is not mutated; and an event with no transfer gains no `transferAgent` key.

**2 of the 4 fail without the source change** — verified by reverting it and re-running.

```
npx vitest run --project unit:core
 Test Files  207 passed (207)
      Tests  2848 passed (2848)
```

`tsc --noEmit`: 0 errors repo-wide. eslint and prettier clean.

**Manual End-to-End (E2E) Tests:**

Not run — needs a live Agent Engine project plus an induced append failure to reach the fallback path.

One thing I could **not** confirm without that project: whether the service silently ignores the unknown `transferToAgent` field today or rejects the write. The SDK's converter passes `actions` through wholesale without name mapping, so it does reach the service under the wrong name. Silent-ignore is the likely behaviour, since a rejection would make every transfer event fail loudly — but it is worth a reviewer's confirmation, because if it rejects, this fix also repairs writes that are currently failing.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Found while working on #649 and deliberately kept out of it: that PR is scoped to workflow event fields, whereas this affects any user of agent transfer. The two touch adjacent lines in `appendEvent`, so expect a small conflict for whichever lands second.