### PR TITLE
fix(tests): give the local code executor tests a Windows-sized budget

### DIFF
--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -19,6 +19,21 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
+/**
+ * Most of these tests spawn a real interpreter. On Windows the shell case means
+ * Windows PowerShell, whose cold start on a loaded CI runner costs seconds --
+ * enough that `should execute shell code and return stdout` intermittently blew
+ * Vitest's 5s default and, through fail-fast, took the macOS and Linux jobs down
+ * with it. A healthy Windows run needs ~5.3s for the file as a whole, so the
+ * default left no margin.
+ *
+ * Budget by what is actually under test: the executor's own default timeout is
+ * 30s, and a harness that gives up sooner can never observe the behaviour it
+ * covers. This is a ceiling, not a delay -- a passing test still finishes in
+ * milliseconds.
+ */
+vi.setConfig({testTimeout: 30_000});
+
 // Only `spawn` is mocked; it defaults to the real implementation (see
 // `beforeEach`) so the pre-existing tests still execute real scripts.
 const spawnMock = vi.hoisted(() => vi.fn());


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`UnsafeLocalCodeExecutor > should execute shell code and return stdout` spawns a real shell. On Windows that is Windows PowerShell, whose cold start on a loaded CI runner costs seconds. Vitest's 5s default left no margin: a *healthy* Windows run needs ~5.3s for the whole file, so the slowest single test sat on the limit and went over it whenever the runner was busy.

It is not a rare flake. It has taken out at least three `main` runs today — 31570504892, 31556199700, 31554615485 — plus a PR run, always the same test with the same `Error: Test timed out in 5000ms`.

It is also expensive out of all proportion to itself. `fail-fast` cancels the macOS and Linux jobs the moment it trips, so one slow PowerShell start costs the entire matrix and the run reports three red jobs. Whoever is on the PR then goes looking for a bug in their own change; that is exactly what happened on #659, where a genuine failure and this flake landed in the same run and the flake made the real one easy to wave off.

**Solution:**

Budget the file by what it actually exercises instead of by the default. The executor's own `timeoutSeconds` default is 30s, so a harness that gave up at 5s could never observe the behaviour these tests are written to cover — the test budget was 6x tighter than the contract under test.

This is a ceiling, not a delay. The file still finishes in ~1.8s locally; the only thing that gets slower is a test that was going to fail anyway.

One note on spelling. `describe('...', fn, TIMEOUT)` is the more obvious form and does work, including for nested describes — but adding a third argument makes Prettier break the call across lines and re-indent the whole suite, turning a one-line change into a ~700-line diff. `vi.setConfig` gets the same file-scoped effect in one line, and `vi` is already imported here.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

No new tests — this changes a test budget, not behaviour. Verified the mechanism rather than assuming it: a scratch suite with 6s tests under an 8s `vi.setConfig({testTimeout})` passes where it would fail on the 5s default, and the override reaches nested `describe` blocks.

```
npx vitest run --project unit:core
 Test Files  208 passed (208)
      Tests  2854 passed (2854)
```

`core/test/code_executors/` 117 passed, file total 1821ms. `tsc --noEmit` clean, eslint and prettier clean.

The thing this actually fixes only reproduces on a loaded Windows runner, so CI on this PR is the real test.

**Manual End-to-End (E2E) Tests:**

Not applicable.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Found while diagnosing CI on #659. Independent of it and of the other workflow PRs in flight; touches one test file that none of them go near.
