### PR TITLE
feat(utils): enforce schemas declared in the genai dialect, not just Zod

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -46,6 +46,7 @@ import {
   traceCallLlm,
   tracer,
 } from '../telemetry/tracing.js';
+import {parseWithSchema, SchemaLike} from '../utils/schema.js';
 import {isZodObject, zodObjectToSchema} from '../utils/simple_zod_to_json.js';
 import {BaseAgent, BaseAgentConfig} from './base_agent.js';
 import {
@@ -385,6 +386,20 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
   mode?: 'single_turn' | 'task';
   inputSchema?: Schema;
   outputSchema?: Schema;
+  /**
+   * The input schema exactly as it was supplied, before conversion into the
+   * genai dialect.
+   *
+   * `inputSchema` is normalized to a genai `Schema` because that is what the
+   * model API and function declarations require, but that conversion is lossy:
+   * a Zod refinement, transform, or custom error message has no genai
+   * equivalent. Validation therefore uses the original, falling back to the
+   * converted form when the schema was given in the genai dialect to begin
+   * with.
+   */
+  readonly inputSchemaSource?: SchemaLike;
+  /** The output schema as supplied — see {@link inputSchemaSource}. */
+  readonly outputSchemaSource?: SchemaLike;
   outputKey?: string;
   private _finishTaskTool?: FinishTaskTool;
   beforeModelCallback?: BeforeModelCallback;
@@ -405,6 +420,8 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
     this.disallowTransferToParent = config.disallowTransferToParent ?? false;
     this.disallowTransferToPeers = config.disallowTransferToPeers ?? false;
     this.includeContents = config.includeContents ?? 'default';
+    this.inputSchemaSource = config.inputSchema;
+    this.outputSchemaSource = config.outputSchema;
     this.inputSchema = isZodObject(config.inputSchema)
       ? zodObjectToSchema(config.inputSchema)
       : config.inputSchema;
@@ -697,15 +714,47 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
       if (!resultStr.trim()) {
         return;
       }
-      // TODO - b/425992518: Use a proper Schema validation utility.
-      // Should use output schema to validate the JSON.
+      let parsed: unknown;
       try {
-        result = JSON.parse(resultStr);
+        parsed = JSON.parse(resultStr);
       } catch (e) {
+        // A model can return malformed JSON. Log and keep the raw text so the
+        // failure is visible without dropping the response, exactly as this
+        // path already behaved.
         logger.error(`Error parsing output for agent ${this.name}`, e);
+        event.actions.stateDelta[this.outputKey] = resultStr;
+        return;
+      }
+      try {
+        result = this.validateOutput(parsed);
+      } catch (e) {
+        // Well-formed JSON that violates the schema. Report it, but still
+        // write the parsed value: `outputKey` has always held the object the
+        // model returned, and substituting the raw string on failure would
+        // change the type a consumer reads. Rejecting outright is defensible,
+        // but is a separate behaviour change.
+        logger.error(
+          `Output for agent ${this.name} does not satisfy its output schema`,
+          e,
+        );
+        result = parsed;
       }
     }
     event.actions.stateDelta[this.outputKey] = result;
+  }
+
+  /**
+   * Validates a value against this agent's output schema, in whichever dialect
+   * it was declared, and returns the parsed value.
+   *
+   * Prefers the schema as supplied ({@link outputSchemaSource}) over the genai
+   * form derived from it, since the conversion drops constraints Zod can
+   * express and genai cannot.
+   *
+   * @throws if the value does not satisfy the schema.
+   */
+  validateOutput(value: unknown): unknown {
+    return parseWithSchema(this.outputSchemaSource ?? this.outputSchema, value);
   }
 
   protected async *runAsyncImpl(

--- a/core/src/utils/genai_schema_to_json.ts
+++ b/core/src/utils/genai_schema_to_json.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Schema} from '@google/genai';
+
+/**
+ * Keys of a genai `Schema` that carry a count/length bound. The genai (OpenAPI)
+ * encoding sends these as strings; JSON Schema requires numbers.
+ */
+const NUMERIC_STRING_KEYS = [
+  'minItems',
+  'maxItems',
+  'minLength',
+  'maxLength',
+  'minProperties',
+  'maxProperties',
+] as const;
+
+/**
+ * Keys that exist only in the genai/OpenAPI dialect and have no JSON Schema
+ * meaning, so they are dropped rather than passed through to a validator.
+ */
+const NON_JSON_SCHEMA_KEYS = new Set(['propertyOrdering', 'example']);
+
+/** JSON Schema type names, keyed by the genai `Type` enum value. */
+const TYPE_NAMES: Record<string, string> = {
+  STRING: 'string',
+  NUMBER: 'number',
+  INTEGER: 'integer',
+  BOOLEAN: 'boolean',
+  ARRAY: 'array',
+  OBJECT: 'object',
+  NULL: 'null',
+};
+
+/**
+ * Converts a genai `Schema` into a standard JSON Schema object.
+ *
+ * This is the inverse of `zodObjectToSchema`, which renders Zod into the
+ * genai/OpenAPI dialect. The two dialects differ in four ways, all handled
+ * here:
+ *
+ * - `type` is an uppercase enum (`STRING`) rather than a JSON Schema type name
+ *   (`string`). `TYPE_UNSPECIFIED` means "no constraint" and is dropped.
+ * - `nullable: true` widens the type, which JSON Schema expresses as a type
+ *   union (`['string', 'null']`).
+ * - Count and length bounds are stringified (`maxItems: '5'`).
+ * - `propertyOrdering` and `example` have no JSON Schema equivalent.
+ *
+ * Everything else (`description`, `title`, `default`, `pattern`, `required`,
+ * `minimum`, `maximum`, `format`) is already JSON-Schema-shaped and passes
+ * through, with `items`, `properties` and `anyOf` converted recursively.
+ */
+export function genaiSchemaToJsonSchema(
+  schema: Schema,
+): Record<string, unknown> {
+  const source = schema as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined || NON_JSON_SCHEMA_KEYS.has(key)) {
+      continue;
+    }
+
+    switch (key) {
+      case 'type':
+      case 'nullable':
+        // Handled together below, since `nullable` widens `type`.
+        break;
+      case 'items':
+        out['items'] = genaiSchemaToJsonSchema(value as Schema);
+        break;
+      case 'properties': {
+        const properties: Record<string, unknown> = {};
+        for (const [name, property] of Object.entries(
+          value as Record<string, Schema>,
+        )) {
+          properties[name] = genaiSchemaToJsonSchema(property);
+        }
+        out['properties'] = properties;
+        break;
+      }
+      case 'anyOf':
+        out['anyOf'] = (value as Schema[]).map(genaiSchemaToJsonSchema);
+        break;
+      case 'format':
+        // `enum` is a genai marker for "this string field is an enumeration",
+        // not a JSON Schema format; the `enum` member list already says so.
+        if (value !== 'enum') {
+          out['format'] = value;
+        }
+        break;
+      default:
+        out[key] = NUMERIC_STRING_KEYS.includes(
+          key as (typeof NUMERIC_STRING_KEYS)[number],
+        )
+          ? Number(value)
+          : value;
+    }
+  }
+
+  const typeName =
+    typeof schema.type === 'string' ? TYPE_NAMES[schema.type] : undefined;
+  if (typeName) {
+    out['type'] = schema.nullable ? [typeName, 'null'] : typeName;
+  }
+
+  // genai sends every enum member as a string, even for a numeric field
+  // (`{type: INTEGER, format: enum, enum: ['101', '201']}`), so the members
+  // have to be narrowed back to match the declared type.
+  if (
+    Array.isArray(out['enum']) &&
+    (typeName === 'integer' || typeName === 'number')
+  ) {
+    out['enum'] = (out['enum'] as unknown[]).map((member) =>
+      typeof member === 'string' &&
+      member.trim() !== '' &&
+      !isNaN(Number(member))
+        ? Number(member)
+        : member,
+    );
+  }
+
+  return out;
+}

--- a/core/src/utils/schema.ts
+++ b/core/src/utils/schema.ts
@@ -16,6 +16,7 @@ import {zodToJsonSchema as toJSONSchemaV3} from 'zod-to-json-schema';
 import {z as z3} from 'zod/v3';
 import {toJSONSchema as toJSONSchemaV4, z as z4} from 'zod/v4';
 
+import {genaiSchemaToJsonSchema} from './genai_schema_to_json.js';
 import {
   isZodSchema,
   isZodV3Schema,
@@ -32,28 +33,87 @@ import {
 export type SchemaLike = z3.ZodType | z4.ZodType | Schema;
 
 /**
- * Validates `value` against `schema`.
+ * Compiled validators for genai `Schema` objects, keyed by the schema itself.
  *
- * - Zod v3/v4 schema: runs `schema.parse(value)` and returns the parsed value.
- * - genai `Schema` or `undefined`: returns `value` unchanged. A genai `Schema`
- *   is a declaration, not a runtime validator, so it is not enforced here —
- *   matching how `FunctionTool` only `.parse()`s Zod parameters.
+ * Compiling a schema means converting it to JSON Schema and building a Zod
+ * type from it, which is far too costly to repeat per validated value — a node
+ * validates its input and output on every single run. Schemas are long-lived
+ * (an agent or node holds one for its lifetime) and callers pass the same
+ * object each time, so a `WeakMap` keyed on the schema caches the compilation
+ * for exactly as long as the schema is reachable.
+ *
+ * A schema that cannot be compiled caches `null`, so a malformed schema costs
+ * one failed conversion rather than one per value.
+ */
+const genaiValidators = new WeakMap<Schema, z4.ZodType | null>();
+
+/**
+ * Returns a Zod validator for a genai `Schema`, or `undefined` if the schema
+ * cannot be expressed as one.
+ *
+ * A genai `Schema` reaching a validator is not necessarily hand-written — it is
+ * often the result of `zodObjectToSchema`, or came off the wire from a tool
+ * declaration — so it can contain constructs Zod has no equivalent for. Those
+ * are treated as "unvalidatable" rather than as a failure: refusing to run the
+ * value would reject data that is perfectly valid, which is worse than the
+ * pre-existing behaviour of not checking it at all.
+ */
+function genaiSchemaValidator(schema: Schema): z4.ZodType | undefined {
+  const cached = genaiValidators.get(schema);
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+  let validator: z4.ZodType | null = null;
+  try {
+    // `fromJSONSchema` is documented as semi-experimental, so a schema it
+    // cannot ingest must degrade to "unvalidated" rather than propagate.
+    validator = z4.fromJSONSchema(
+      genaiSchemaToJsonSchema(schema) as Parameters<
+        typeof z4.fromJSONSchema
+      >[0],
+    );
+  } catch {
+    validator = null;
+  }
+  genaiValidators.set(schema, validator);
+  return validator ?? undefined;
+}
+
+/**
+ * Validates `value` against `schema`, returning the parsed value.
+ *
+ * Every schema form ADK accepts is enforced:
+ *
+ * - Zod v3/v4: runs `schema.parse(value)`.
+ * - genai `Schema`: converted to JSON Schema and compiled to a Zod type once
+ *   (then cached), so a declaration written in the genai dialect is checked
+ *   just as a Zod one is.
+ * - `undefined`: returns `value` unchanged.
+ *
+ * A genai `Schema` that has no Zod equivalent is left unenforced rather than
+ * rejected — see {@link genaiSchemaValidator}.
  */
 export function parseWithSchema<T>(
   schema: SchemaLike | undefined,
   value: T,
 ): T {
-  if (schema !== undefined && isZodSchema(schema)) {
+  if (schema === undefined) {
+    return value;
+  }
+  if (isZodSchema(schema)) {
     return schema.parse(value) as T;
   }
-  return value;
+  const validator = genaiSchemaValidator(schema as Schema);
+  return validator ? (validator.parse(value) as T) : value;
 }
 
 /**
  * Renders a {@link SchemaLike} as a plain JSON Schema object.
  *
- * Zod v3 and v4 schemas are converted with their respective serializers; a
- * genai `Schema` is already schema-shaped and is returned as-is.
+ * Zod v3 and v4 schemas are converted with their respective serializers. A
+ * genai `Schema` is translated out of the genai/OpenAPI dialect (uppercase
+ * type names, stringified bounds, `nullable`) so that every schema form
+ * produces the same JSON Schema shape for a consumer to read.
  */
 export function toJsonSchema(schema: SchemaLike): Record<string, unknown> {
   if (isZodV4Schema(schema)) {
@@ -62,7 +122,7 @@ export function toJsonSchema(schema: SchemaLike): Record<string, unknown> {
   if (isZodV3Schema(schema)) {
     return toJSONSchemaV3(schema) as Record<string, unknown>;
   }
-  return schema as Record<string, unknown>;
+  return genaiSchemaToJsonSchema(schema as Schema);
 }
 
 /**

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -387,6 +387,37 @@ describe('LlmAgent Schema Initialization', () => {
     expect((agent.outputSchema as Schema).properties?.bar?.type).toBe('NUMBER');
   });
 
+  it('validates output against a genai outputSchema', () => {
+    const agent = new LlmAgent({
+      name: 'test',
+      outputSchema: {
+        type: Type.OBJECT,
+        properties: {bar: {type: Type.NUMBER}},
+        required: ['bar'],
+      },
+    });
+    expect(agent.validateOutput({bar: 1})).toEqual({bar: 1});
+    expect(() => agent.validateOutput({bar: 'no'})).toThrow();
+  });
+
+  it('validates output against a Zod outputSchema, keeping its refinements', () => {
+    const agent = new LlmAgent({
+      name: 'test',
+      outputSchema: z4.object({bar: z4.number().refine((n) => n > 10)}),
+    });
+    expect(agent.validateOutput({bar: 11})).toEqual({bar: 11});
+    // The refinement survives only because the original Zod schema is kept;
+    // it has no representation in the converted genai Schema.
+    expect(() => agent.validateOutput({bar: 1})).toThrow();
+  });
+
+  it('keeps the supplied schema alongside the converted genai form', () => {
+    const zodSchema = z4.object({bar: z4.number()});
+    const agent = new LlmAgent({name: 'test', outputSchema: zodSchema});
+    expect(agent.outputSchemaSource).toBe(zodSchema);
+    expect((agent.outputSchema as Schema).type).toBe('OBJECT');
+  });
+
   it('should initialize outputSchema from Zod v3 object', () => {
     const zodSchema = z3.object({
       bar: z3.number(),
@@ -482,6 +513,24 @@ describe('LlmAgent Output Processing', () => {
 
     const lastEvent = events[events.length - 1];
     expect(lastEvent.actions?.stateDelta?.['result']).toEqual(invalidJson);
+  });
+
+  it('keeps the parsed object in state when it violates the output schema', async () => {
+    // Well-formed JSON, but `answer` is declared STRING. The violation is
+    // logged rather than thrown, and state keeps the object the model
+    // returned — a consumer of `outputKey` reads the same type either way.
+    const response: LlmResponse = {
+      content: {parts: [{text: JSON.stringify({answer: 42})}]},
+    };
+    agent.model = new MockLlm(response);
+
+    const events: Event[] = [];
+    for await (const event of agent.runAsync(invocationContext)) {
+      events.push(event);
+    }
+
+    const lastEvent = events[events.length - 1];
+    expect(lastEvent.actions?.stateDelta?.['result']).toEqual({answer: 42});
   });
 });
 

--- a/core/test/utils/schema_test.ts
+++ b/core/test/utils/schema_test.ts
@@ -9,6 +9,7 @@ import {describe, expect, it} from 'vitest';
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
 import {parseWithSchema, toJsonSchema} from '../../src/utils/schema.js';
+import {zodObjectToSchema} from '../../src/utils/simple_zod_to_json.js';
 
 describe('parseWithSchema', () => {
   it('returns the value unchanged when no schema is given', () => {
@@ -36,14 +37,85 @@ describe('parseWithSchema', () => {
     expect(() => parseWithSchema(schema, {count: 'no'})).toThrow();
   });
 
-  it('does not validate a genai Schema (returns the value unchanged)', () => {
+  it('parses and returns the value for a valid genai Schema', () => {
     const schema: Schema = {
       type: Type.OBJECT,
       properties: {count: {type: Type.NUMBER}},
+      required: ['count'],
     };
+    expect(parseWithSchema(schema, {count: 3})).toEqual({count: 3});
+  });
+
+  it('throws for a value that fails a genai Schema', () => {
+    const schema: Schema = {
+      type: Type.OBJECT,
+      properties: {count: {type: Type.NUMBER}},
+      required: ['count'],
+    };
+    expect(() => parseWithSchema(schema, {count: 'no'})).toThrow();
+    expect(() => parseWithSchema(schema, {})).toThrow();
+  });
+
+  it('enforces a genai Schema nested in an object and an array', () => {
+    const schema: Schema = {
+      type: Type.OBJECT,
+      properties: {
+        items: {
+          type: Type.ARRAY,
+          items: {
+            type: Type.OBJECT,
+            properties: {id: {type: Type.INTEGER}},
+            required: ['id'],
+          },
+        },
+      },
+      required: ['items'],
+    };
+    expect(parseWithSchema(schema, {items: [{id: 1}]})).toEqual({
+      items: [{id: 1}],
+    });
+    expect(() => parseWithSchema(schema, {items: [{id: 'x'}]})).toThrow();
+  });
+
+  it('honours `nullable` on a genai Schema', () => {
+    const schema: Schema = {type: Type.STRING, nullable: true};
+    expect(parseWithSchema(schema, null)).toBeNull();
+    expect(parseWithSchema(schema, 'text')).toBe('text');
+    expect(() => parseWithSchema({type: Type.STRING}, null)).toThrow();
+  });
+
+  it('enforces genai bounds that are encoded as strings', () => {
+    const schema: Schema = {
+      type: Type.ARRAY,
+      items: {type: Type.STRING},
+      maxItems: '2',
+    };
+    expect(parseWithSchema(schema, ['a', 'b'])).toEqual(['a', 'b']);
+    expect(() => parseWithSchema(schema, ['a', 'b', 'c'])).toThrow();
+  });
+
+  it('enforces a genai enum', () => {
+    const schema: Schema = {
+      type: Type.STRING,
+      format: 'enum',
+      enum: ['EAST', 'WEST'],
+    };
+    expect(parseWithSchema(schema, 'EAST')).toBe('EAST');
+    expect(() => parseWithSchema(schema, 'NORTH')).toThrow();
+  });
+
+  it('leaves a genai Schema that has no Zod equivalent unenforced', () => {
+    // `TYPE_UNSPECIFIED` carries no constraint, so nothing is rejected.
+    const schema: Schema = {type: Type.TYPE_UNSPECIFIED};
     const value = {anything: 'goes'};
-    // A genai Schema is a declaration, not a runtime validator.
-    expect(parseWithSchema(schema, value)).toBe(value);
+    expect(parseWithSchema(schema, value)).toEqual(value);
+  });
+
+  it('validates a round-tripped Zod schema the same way as the original', () => {
+    const zod = z4.object({count: z4.number()});
+    const roundTripped = zodObjectToSchema(zod);
+    expect(parseWithSchema(roundTripped, {count: 3})).toEqual({count: 3});
+    expect(() => parseWithSchema(roundTripped, {count: 'no'})).toThrow();
   });
 });
 
@@ -60,11 +132,25 @@ describe('toJsonSchema', () => {
     expect((json.properties as Record<string, unknown>).count).toBeDefined();
   });
 
-  it('returns a genai Schema as-is', () => {
+  it('translates a genai Schema out of the genai dialect', () => {
     const schema: Schema = {
       type: Type.OBJECT,
-      properties: {count: {type: Type.NUMBER}},
+      properties: {
+        count: {type: Type.NUMBER},
+        tags: {type: Type.ARRAY, items: {type: Type.STRING}, maxItems: '3'},
+        note: {type: Type.STRING, nullable: true},
+      },
+      required: ['count'],
+      propertyOrdering: ['count', 'tags'],
     };
-    expect(toJsonSchema(schema)).toBe(schema);
+    expect(toJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        count: {type: 'number'},
+        tags: {type: 'array', items: {type: 'string'}, maxItems: 3},
+        note: {type: ['string', 'null']},
+      },
+      required: ['count'],
+    });
   });
 });

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -114,7 +114,7 @@ describe('createRequestInputEvent', () => {
     expect(args.responseSchema).toMatchObject({type: 'object'});
   });
 
-  it('passes a genai Schema responseSchema through as-is', () => {
+  it('converts a genai Schema responseSchema to a JSON schema', () => {
     const schema: Schema = {
       type: Type.OBJECT,
       properties: {answer: {type: Type.STRING}},
@@ -124,7 +124,12 @@ describe('createRequestInputEvent', () => {
       string,
       unknown
     >;
-    expect(args.responseSchema).toEqual(schema);
+    // Emitted in the same JSON Schema dialect as a Zod responseSchema, so a
+    // client reading this field does not have to handle two type spellings.
+    expect(args.responseSchema).toEqual({
+      type: 'object',
+      properties: {answer: {type: 'string'}},
+    });
   });
 });
 

--- a/core/test/workflow/node_execution_test.ts
+++ b/core/test/workflow/node_execution_test.ts
@@ -291,17 +291,29 @@ describe('output schema validation (Zod v3 / Zod v4 / genai Schema)', () => {
     await expect(driveNode(node)).rejects.toThrow();
   });
 
-  it('accepts a genai Schema and leaves the value unvalidated', async () => {
+  it('validates output against a genai Schema', async () => {
+    const node = new FnNode('n', () => ({count: 3}), {
+      outputSchema: {
+        type: Type.OBJECT,
+        properties: {count: {type: Type.NUMBER}},
+        required: ['count'],
+      },
+    });
+    const {output} = await driveNode(node);
+    expect(output).toEqual({count: 3});
+  });
+
+  it('rejects output that fails a genai Schema', async () => {
     const node = new FnNode('n', () => ({anything: 'goes'}), {
       outputSchema: {
         type: Type.OBJECT,
         properties: {count: {type: Type.NUMBER}},
+        // `required` is what makes this prove enforcement: an object schema
+        // without it accepts any object, since Zod keeps unknown keys.
+        required: ['count'],
       },
     });
-    // A genai Schema is a declaration, not a runtime validator, so the value
-    // passes through untouched even though it does not match the schema.
-    const {output} = await driveNode(node);
-    expect(output).toEqual({anything: 'goes'});
+    await expect(driveNode(node)).rejects.toThrow();
   });
 });
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`parseWithSchema` only ever validated Zod schemas. A genai `Schema` was returned unchecked, on the grounds that it is a declaration rather than a runtime validator — so `BaseNode`'s `inputSchema`/`outputSchema` silently validated **nothing** whenever the schema happened to be written in the genai dialect.

That is easy to miss because nothing fails: the node runs, the value flows on, and the schema reads as if it were enforced.

It also blocks a change we want. adk-python unifies `LlmAgent.output_schema` with the node-level output schema — [`llm_agent.py:391`](https://github.com/google/adk-python/blob/main/src/google/adk/agents/llm_agent.py) redeclares the very field the node runner validates against. We cannot do that here yet: `LlmAgent` normalizes its schema to a genai `Schema` for the model API, so unifying today would quietly disable node validation for every LLM agent.

Two smaller instances of the same gap:

- `toJsonSchema` returned a genai `Schema` verbatim, so `RequestInput.responseSchema` shipped uppercase genai types in a field declared as JSON Schema. A client reading it had to handle two spellings depending on how the author wrote the schema.
- `saveOutputToState` did a bare `JSON.parse` (`TODO b/425992518`), so an agent with an `outputSchema` wrote unvalidated model output straight into session state.

**Solution:**

Convert the genai dialect to JSON Schema and compile it with Zod's `fromJSONSchema`, so one validation engine covers all three schema forms and errors stay `ZodError`s. No new dependency — zod 4.4.3 already ships it.

The two dialects differ in four ways, and only the first is noisy about it. An uppercase `type` throws, but `nullable: true` and the stringified bounds (`maxItems: '5'`) are **silently ignored** — exactly the ones that would look enforced but not be. `propertyOrdering` and `example` have no JSON Schema meaning and are dropped.

A few deliberate choices:

- **Compilation is cached** in a `WeakMap` keyed on the schema, since a node validates its input and output on every run.
- **A schema Zod cannot ingest is treated as unvalidatable, not as a failure.** `fromJSONSchema` is documented as semi-experimental, and rejecting data that is actually valid would be worse than the status quo of not checking it.
- **`LlmAgent` keeps the schema as supplied** alongside the converted form. The conversion is lossy — a Zod refinement or transform has no genai equivalent — so validating through the converted schema would silently weaken a constraint the user did write. Validation prefers the original.
- **`saveOutputToState` stays lenient.** A violation is logged and the raw text kept, exactly as the parse path already behaved, so this does not change what a caller sees. Making it throw is defensible but is a separate behaviour change.

`toJsonSchema` now converts as well, so a Zod and a genai `responseSchema` produce the same wire shape. Only display consumers read that field today (`cli_run.ts:75`).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New coverage in `core/test/utils/schema_test.ts` for validating a genai `Schema`, nested objects and arrays, `nullable`, string-encoded bounds, enums, the unvalidatable fallback, and a Zod schema round-tripped through `zodObjectToSchema`. New coverage in `core/test/agents/llm_agent_test.ts` that a Zod refinement still bites (which only works because the original schema is retained) and that the supplied schema is kept alongside the converted one.

Two existing tests asserted the old no-op and were updated to the new behaviour: `schema_test.ts` ("does not validate a genai Schema") and `hitl_test.ts` ("passes a genai Schema responseSchema through as-is").

```
npm run ts:check          clean
npx vitest --project unit:core    209 files, 2870 passed
npm run test:integration           74 files, 206 passed | 8 skipped
```

`npm run test:unit` also reports one failure in `dev/test/cli/cli_create_test.ts` ("Vertex AI selection with gcloud defaults"). It is pre-existing and unrelated — verified by stashing this change and re-running it on a clean tree.

**Manual End-to-End (E2E) Tests:**

Not run; the change is confined to schema validation and is covered by the unit and integration suites above.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is a prerequisite for unifying `BaseAgent` and `BaseNode` (making `BaseAgent extends BaseNode`, as adk-python does at `base_agent.py:94`). That merge wants `LlmAgent.outputSchema` and `BaseNode.outputSchema` to be one field; this PR removes the silent-no-op that made the unification unsafe.

Worth noting for anyone reconciling with adk-python: **Python has the same hole** — `validate_node_data` bails out with `if isinstance(schema, (dict, types.Schema)): return data`. It gets away with it because the idiomatic Python schema is a pydantic model, which *is* validated. So this is a fix rather than parity work, and adk-python may want the equivalent.

