### PR TITLE
fix: three defects found bug-bashing the graph-workflow docs samples

### DIFF
--- a/core/build.js
+++ b/core/build.js
@@ -45,6 +45,11 @@ function build({
     format,
     bundle,
     minify: bundle,
+    // Minification renames classes, and we report those names at runtime:
+    // `@experimental` logs `target.name`, which otherwise reads "Class oR is
+    // experimental". User code that logs `constructor.name` sees the same
+    // mangling, so keep the original names in the bundle.
+    keepNames: true,
     sourcemap: bundle,
     packages: 'external',
     logLevel: 'info',

--- a/core/src/utils/experimental.ts
+++ b/core/src/utils/experimental.ts
@@ -40,6 +40,13 @@ export function experimental<
       }
     };
 
+    // The subclass above is anonymous, so it would otherwise report the
+    // binding name ("newConstructor") to anyone reading `SomeClass.name`.
+    Object.defineProperty(newConstructor, 'name', {
+      value: className,
+      configurable: true,
+    });
+
     // We must cast to the conditional return type because TS cannot
     // narrow return types based on control flow across conditional types.
     return newConstructor as P extends undefined ? T : PropertyDescriptor;

--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -384,6 +384,7 @@ export function createProgram(): Command {
         });
       } catch (error) {
         logger.error('Error running agent:', (error as Error).message);
+        process.exit(1);
       }
     });
 

--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -282,134 +282,129 @@ export interface RunAgentOptions {
   reloadAgents?: boolean;
 }
 export async function runAgent(options: RunAgentOptions): Promise<void> {
-  try {
-    const userId = 'test_user';
-    const artifactService =
-      options.artifactService || new InMemoryArtifactService();
-    const sessionService =
-      options.sessionService || new InMemorySessionService();
-    const memoryService = options.memoryService || new InMemoryMemoryService();
-    await using agentFile = new AgentFile(
-      getAbsolutePath(options.agentPath),
-      options.agentFileLoadOptions,
-    );
-    const loaded = await agentFile.load();
-    const rootAgent = isApp(loaded) ? loaded.rootAgent : loaded;
-    const app = isApp(loaded) ? loaded : undefined;
+  const userId = 'test_user';
+  const artifactService =
+    options.artifactService || new InMemoryArtifactService();
+  const sessionService = options.sessionService || new InMemorySessionService();
+  const memoryService = options.memoryService || new InMemoryMemoryService();
+  await using agentFile = new AgentFile(
+    getAbsolutePath(options.agentPath),
+    options.agentFileLoadOptions,
+  );
+  const loaded = await agentFile.load();
+  const rootAgent = isApp(loaded) ? loaded.rootAgent : loaded;
+  const app = isApp(loaded) ? loaded : undefined;
 
-    let session = await sessionService.createSession({
-      appName: app?.name ?? rootAgent.name,
-      userId,
-    });
+  let session = await sessionService.createSession({
+    appName: app?.name ?? rootAgent.name,
+    userId,
+  });
 
-    const reloadSubscribers: Array<(agent: BaseAgent) => void> = [];
-    let watcher: fs.FSWatcher | undefined;
+  const reloadSubscribers: Array<(agent: BaseAgent) => void> = [];
+  let watcher: fs.FSWatcher | undefined;
 
-    if (options.reloadAgents) {
-      const agentFilePath = getAbsolutePath(options.agentPath);
-      watcher = fs.watch(agentFilePath, async () => {
-        try {
-          await using reloadedFile = new AgentFile(
-            agentFilePath,
-            options.agentFileLoadOptions,
-          );
-          const reloaded = await reloadedFile.load();
-          const newAgent = isApp(reloaded) ? reloaded.rootAgent : reloaded;
-          for (const subscriber of reloadSubscribers) {
-            subscriber(newAgent);
-          }
-        } catch (err) {
-          console.warn('Failed to reload agent:', (err as Error).message);
-        }
-      });
-    }
-
-    const onAgentFileReloaded = (subscribe: (agent: BaseAgent) => void) => {
-      reloadSubscribers.push(subscribe);
-    };
-
-    try {
-      if (options.inputFile) {
-        session =
-          (await runFromInputFile({
-            appName: app?.name ?? rootAgent.name,
-            userId,
-            agent: rootAgent,
-            artifactService,
-            sessionService,
-            memoryService,
-            filePath: options.inputFile,
-          })) || session;
-      } else if (options.savedSessionFile) {
-        const loadedSession = await loadFileData<Session>(
-          options.savedSessionFile,
+  if (options.reloadAgents) {
+    const agentFilePath = getAbsolutePath(options.agentPath);
+    watcher = fs.watch(agentFilePath, async () => {
+      try {
+        await using reloadedFile = new AgentFile(
+          agentFilePath,
+          options.agentFileLoadOptions,
         );
-        if (loadedSession) {
-          for (const event of loadedSession.events) {
-            await sessionService.appendEvent({session, event});
-            printEvent(event, {announcePauses: false});
-          }
-
-          // Only the pauses the transcript never answered are still live, and
-          // they are what the prompt below is waiting on.
-          for (const request of getPendingUserInputRequests(
-            loadedSession.events,
-          )) {
-            console.log(renderUserInputRequest(request));
-          }
+        const reloaded = await reloadedFile.load();
+        const newAgent = isApp(reloaded) ? reloaded.rootAgent : reloaded;
+        for (const subscriber of reloadSubscribers) {
+          subscriber(newAgent);
         }
-
-        await runInteractively({
-          rootAgent,
-          app,
-          artifactService,
-          sessionService,
-          memoryService,
-          session,
-          onAgentFileReloaded: options.reloadAgents
-            ? onAgentFileReloaded
-            : undefined,
-        });
-      } else {
-        console.log(
-          `Running ${app ? `app ${app.name}` : `agent ${rootAgent.name}`}, type exit to exit.`,
-        );
-        await runInteractively({
-          rootAgent,
-          app,
-          artifactService,
-          sessionService,
-          memoryService,
-          session,
-          onAgentFileReloaded: options.reloadAgents
-            ? onAgentFileReloaded
-            : undefined,
-        });
+      } catch (err) {
+        console.warn('Failed to reload agent:', (err as Error).message);
       }
-    } finally {
-      watcher?.close();
-    }
+    });
+  }
 
-    if (options.saveSession) {
-      const sessionId =
-        options.sessionId || (await getUserInput('Session ID to save: '));
-      // Sibling of the agent file, not inside it: joining onto the agent path
-      // itself yields `<cwd>/agent.ts/<id>.session.json`, and saveToFile does
-      // no mkdir, so the write failed with ENOTDIR.
-      const sessionPath = path.join(
-        path.dirname(options.agentPath),
-        `${sessionId}.session.json`,
+  const onAgentFileReloaded = (subscribe: (agent: BaseAgent) => void) => {
+    reloadSubscribers.push(subscribe);
+  };
+
+  try {
+    if (options.inputFile) {
+      session =
+        (await runFromInputFile({
+          appName: app?.name ?? rootAgent.name,
+          userId,
+          agent: rootAgent,
+          artifactService,
+          sessionService,
+          memoryService,
+          filePath: options.inputFile,
+        })) || session;
+    } else if (options.savedSessionFile) {
+      const loadedSession = await loadFileData<Session>(
+        options.savedSessionFile,
       );
-      const sessionToStore = await sessionService.getSession({
-        appName: session.appName,
-        userId: session.userId,
-        sessionId: session.id,
-      });
-      await saveToFile(getAbsolutePath(sessionPath), sessionToStore);
+      if (loadedSession) {
+        for (const event of loadedSession.events) {
+          await sessionService.appendEvent({session, event});
+          printEvent(event, {announcePauses: false});
+        }
 
-      console.log('Session saved to', sessionPath);
+        // Only the pauses the transcript never answered are still live, and
+        // they are what the prompt below is waiting on.
+        for (const request of getPendingUserInputRequests(
+          loadedSession.events,
+        )) {
+          console.log(renderUserInputRequest(request));
+        }
+      }
+
+      await runInteractively({
+        rootAgent,
+        app,
+        artifactService,
+        sessionService,
+        memoryService,
+        session,
+        onAgentFileReloaded: options.reloadAgents
+          ? onAgentFileReloaded
+          : undefined,
+      });
+    } else {
+      console.log(
+        `Running ${app ? `app ${app.name}` : `agent ${rootAgent.name}`}, type exit to exit.`,
+      );
+      await runInteractively({
+        rootAgent,
+        app,
+        artifactService,
+        sessionService,
+        memoryService,
+        session,
+        onAgentFileReloaded: options.reloadAgents
+          ? onAgentFileReloaded
+          : undefined,
+      });
     }
-  } catch (e) {
-    console.log(e);
+  } finally {
+    watcher?.close();
+  }
+
+  if (options.saveSession) {
+    const sessionId =
+      options.sessionId || (await getUserInput('Session ID to save: '));
+    // Sibling of the agent file, not inside it: joining onto the agent path
+    // itself yields `<cwd>/agent.ts/<id>.session.json`, and saveToFile does
+    // no mkdir, so the write failed with ENOTDIR.
+    const sessionPath = path.join(
+      path.dirname(options.agentPath),
+      `${sessionId}.session.json`,
+    );
+    const sessionToStore = await sessionService.getSession({
+      appName: session.appName,
+      userId: session.userId,
+      sessionId: session.id,
+    });
+    await saveToFile(getAbsolutePath(sessionPath), sessionToStore);
+
+    console.log('Session saved to', sessionPath);
   }
 }

--- a/dev/src/utils/file_utils.ts
+++ b/dev/src/utils/file_utils.ts
@@ -89,9 +89,12 @@ export async function loadFileData<T>(
   try {
     return JSON.parse(await fs.readFile(filePath, {encoding: 'utf-8'})) as T;
   } catch (e) {
-    console.error(`Failed to read or parse file ${filePath}:`, e);
-
-    throw e;
+    // Carry the path in the message and let the caller report it. Logging here
+    // as well as throwing printed every failure twice.
+    throw new Error(
+      `Failed to read or parse file ${filePath}: ${(e as Error).message}`,
+      {cause: e},
+    );
   }
 }
 

--- a/samples/workflows/data_handling/structured_access/agent.ts
+++ b/samples/workflows/data_handling/structured_access/agent.ts
@@ -54,10 +54,13 @@ const cityReportAgent = new LlmAgent({
   // instruction: `Return a sentence in the following format:
   //     It is {CityTime.timeInfo} in {CityTime.city} right now.`,
 
-  // More restrictive data selection, qualified by source node name:
-  instruction: `Return a sentence in the following format:
-    It is <CityTime.timeInfo from lookup_time_function> in
-    <CityTime.city from lookup_time_function> right now.`,
+  // More restrictive data selection, qualified by source node name. Keep the
+  // template on ONE line: a model reproduces a line break inside the format
+  // string, which splits the answer mid-sentence.
+  instruction:
+    'Return a sentence in the following format: It is ' +
+    '<CityTime.timeInfo from lookup_time_function> in ' +
+    '<CityTime.city from lookup_time_function> right now.',
 });
 
 export const rootAgent = new WorkflowAgent({

--- a/samples/workflows/dynamic/loop_route/agent.ts
+++ b/samples/workflows/dynamic/loop_route/agent.ts
@@ -18,7 +18,11 @@
  *
  * REQUIRES an API key (two agents call a live model). Set GEMINI_API_KEY:
  *   npm run sample -- samples/workflows/dynamic/loop_route/agent.ts
- * Try "a function that returns the nth fibonacci number".
+ * Try "a one-line function that adds two numbers, no comments, no type
+ * annotations" — asking for code the linter will reject is what makes the loop
+ * run. A plainly-worded request ("a function that returns the nth fibonacci
+ * number") comes back documented and annotated on the first try, `findings` is
+ * empty, and the loop exits before the fixer ever runs.
  */
 
 import {LlmAgent, node, NodeContext, WorkflowAgent} from '@google/adk';

--- a/samples/workflows/routes/function_node/agent.ts
+++ b/samples/workflows/routes/function_node/agent.ts
@@ -13,7 +13,14 @@
  * node as its input — no session-state writes needed.
  *
  * A bare return value is boxed into an `Event` carrying that `output` for you,
- * so both forms below are equivalent.
+ * so both forms below hand the next node the same thing.
+ *
+ * They do NOT render the same, though: boxing a bare return also gives the
+ * event display `content`, so `my_function_node` prints a `[my_function_node]:`
+ * line, while `add_suffix` sets `output` only and prints nothing. A node that
+ * emits no display content is invisible in the CLI — expected, and worth
+ * recognising now, because most routers later on look "skipped" for the same
+ * reason.
  *
  * Run (offline, no API key):
  *   npm run sample -- samples/workflows/routes/function_node/agent.ts


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Three independent defects surfaced while running all 26 graph-workflow docs
samples (`samples/workflows/`) end to end, on the CLI and through `adk web`.
All 26 samples pass functionally; these are the things around them that are
wrong.

1. **`adk run` exits 0 after a fatal error.** A missing agent file, or an
   unreadable `--replay` file, prints a stack trace and reports success. A CI
   step that runs an agent passes while having run nothing. Load failures were
   also printed twice.
2. **Experimental warnings name nothing.** Every graph workflow opens with
   `Class oR is experimental and may change in the future`. Related:
   `WorkflowAgent.name` read `newConstructor`, and `constructor.name` was
   mangled for every class in the bundle.
3. **Three samples describe themselves inaccurately** — one calls two forms
   "equivalent" when they render differently, one splits its output
   mid-sentence, and one suggests a prompt under which the loop it exists to
   demonstrate never runs.

**Solution:**

One commit per defect, each self-contained:

- `docs(workflow)` — correct the three sample header comments; only
  `structured_access` changes code (its instruction is reflowed onto one line).
- `fix(cli)` — remove the blanket `catch (e) { console.log(e) }` in `runAgent`,
  `process.exit(1)` from the `run` action to match `web`/`api_server`, and stop
  `loadFileData` from logging *and* rethrowing.
- `fix(core)` — `keepNames: true` in the core bundle so `target.name` survives
  minification, and restore the original name on the decorator's wrapper class.

**Tradeoff worth a reviewer's opinion:** `keepNames` costs ~152K across
`core/dist` (~2.7%, spread over the esm/cjs/web targets). It was chosen because
it fixes the warning for all 24 decorated classes at once *and* repairs
`constructor.name` for user code generally. The zero-cost alternative is giving
`@experimental` an explicit name argument at 24 call sites, which fixes only the
decorated classes. Happy to switch.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally — 3124 passed (`unit:core` + `unit:dev`).
- [x] `tests/integration/docs_samples` — 27 passed.

**Manual End-to-End (E2E) Tests:**

All 26 samples were run individually, 30 runs including both branches of each
router, before and after the change: **30 pass, 0 fail**. The 8 model-backed
samples ran against a live `gemini-flash-latest`.

Behaviour verified directly:

```
adk run /nope/missing.ts                       → exit 1, one line, no stack dump
adk run <valid>.ts --replay /nope/missing.json → exit 1, one line
adk run <valid>.ts                             → exit 0   (unchanged)

WARN … Class WorkflowAgent is experimental and may change in the future.
WARN … Class Workflow is experimental and may change in the future.
WorkflowAgent.name === 'WorkflowAgent'
```

`structured_access` now prints `It is 10:10 AM in Reykjavik right now.` on one
line, and `loop_route`'s suggested prompt drives two full fixer rounds instead
of exiting before the fixer runs.

**Note on a pre-existing failure:** `dev/test/cli/cli_create_test.ts` fails on
any machine with `GOOGLE_CLOUD_PROJECT` set — it expects the mocked
`gcloud-project` but reads the ambient value. `env -u GOOGLE_CLOUD_PROJECT`
makes all 11 pass. Unrelated to this PR and left alone.
