### PR TITLE
fix(workflow): check a structured HITL reply against its responseSchema

### DIFF
--- a/core/src/agents/processors/request_input_llm_request_processor.ts
+++ b/core/src/agents/processors/request_input_llm_request_processor.ts
@@ -14,7 +14,11 @@ import {
 import {ToolConfirmation} from '../../tools/tool_confirmation.js';
 import {AsyncQueue} from '../../utils/async_queue.js';
 import {isNodeTool} from '../../workflow/nodes/node_tool.js';
-import {REQUEST_INPUT_FUNCTION_CALL_NAME} from '../../workflow/utils/hitl_utils.js';
+import {
+  REQUEST_INPUT_FUNCTION_CALL_NAME,
+  responseSchemasByInterruptId,
+  validateInterruptResponse,
+} from '../../workflow/utils/hitl_utils.js';
 import {unwrapResponse} from '../../workflow/utils/rehydration_utils.js';
 import {handleFunctionCallList} from '../functions.js';
 import {InvocationContext} from '../invocation_context.js';
@@ -134,6 +138,7 @@ export class RequestInputLlmRequestProcessor extends BaseLlmRequestProcessor {
  * every still-pending interrupt id.
  */
 function collectResumeInputs(events: Event[]): Record<string, unknown> {
+  const responseSchemas = responseSchemasByInterruptId(events);
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i];
     if (event.author !== 'user') {
@@ -143,7 +148,9 @@ function collectResumeInputs(events: Event[]): Record<string, unknown> {
     let found = false;
     for (const fr of getFunctionResponses(event)) {
       if (fr.name === REQUEST_INPUT_FUNCTION_CALL_NAME && fr.id) {
-        structured[fr.id] = unwrapResponse(fr.response);
+        const response = unwrapResponse(fr.response);
+        validateInterruptResponse(fr.id, response, responseSchemas.get(fr.id));
+        structured[fr.id] = response;
         found = true;
       }
     }

--- a/core/src/utils/schema.ts
+++ b/core/src/utils/schema.ts
@@ -64,3 +64,25 @@ export function toJsonSchema(schema: SchemaLike): Record<string, unknown> {
   }
   return schema as Record<string, unknown>;
 }
+
+/**
+ * Compiles a plain JSON Schema into a validator, for schemas that survive only
+ * in serialized form — a `RequestInput.responseSchema` reaches the resume that
+ * answers it as the JSON Schema recorded on the interrupt event, not as the
+ * original {@link SchemaLike}.
+ *
+ * Returns `undefined` when the schema cannot be compiled (JSON Schema is wider
+ * than Zod can express). Callers treat that as "no contract to check" rather
+ * than failing: refusing data because we could not build the validator would be
+ * worse than the unchecked pass-through this replaces.
+ */
+export function compileJsonSchema(jsonSchema: unknown): z4.ZodType | undefined {
+  if (jsonSchema === null || typeof jsonSchema !== 'object') {
+    return undefined;
+  }
+  try {
+    return z4.fromJSONSchema(jsonSchema as Record<string, unknown>);
+  } catch {
+    return undefined;
+  }
+}

--- a/core/src/workflow/request_input.ts
+++ b/core/src/workflow/request_input.ts
@@ -30,7 +30,14 @@ export interface RequestInputParams {
   payload?: unknown;
   /** A message to display to the user when requesting input. */
   message?: string;
-  /** The expected schema of the response (Zod v3/v4 or genai `Schema`). */
+  /**
+   * The expected shape of the reply (Zod v3/v4 or genai `Schema`).
+   *
+   * It tells a client what to collect, and a *structured* reply is checked
+   * against it on resume. Nothing coerces a human's answer into the shape: a
+   * plain-text reply is routed to the interrupt as-is and is not checked, so
+   * put an agent node after the pause if you need free text normalized.
+   */
   responseSchema?: SchemaLike;
 }
 
@@ -39,6 +46,15 @@ export interface RequestInputParams {
  * workflow (Human-in-the-Loop). The framework converts it to an interrupt
  * event; the workflow surfaces the interrupt id to the caller, which later
  * resumes by providing `resumeInputs[interruptId]`.
+ *
+ * A client answers in one of two ways:
+ *
+ * - **Plain text.** A text turn is routed to every pending interrupt as-is.
+ *   This is what the interactive CLI and the dev UI send.
+ * - **A `functionResponse`** named `adk_request_input`, carrying the interrupt
+ *   id. Wrap a bare value as `{result: <value>}` — that envelope is unwrapped
+ *   for you. Any other object is delivered to the node unchanged, so it must
+ *   already match {@link RequestInputParams.responseSchema} when one is set.
  *
  * Ported from `google/adk-python` `events/request_input.py`.
  */

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -24,7 +24,7 @@ import {AuthHandler} from '../../auth/auth_handler.js';
 import {AuthConfig} from '../../auth/auth_tool.js';
 import {createEvent, Event} from '../../events/event.js';
 import {State} from '../../sessions/state.js';
-import {toJsonSchema} from '../../utils/schema.js';
+import {compileJsonSchema, toJsonSchema} from '../../utils/schema.js';
 import {RequestInput} from '../request_input.js';
 
 export {
@@ -62,6 +62,75 @@ export function createRequestInputEvent(requestInput: RequestInput): Event {
     },
     longRunningToolIds: [requestInput.interruptId],
   });
+}
+
+/**
+ * Collects the `responseSchema` each pending interrupt declared, keyed by
+ * interrupt id, as the JSON Schema recorded on its `adk_request_input` call.
+ *
+ * The original {@link RequestInput} is long gone by the time a reply arrives —
+ * a node with `rerunOnResume: false` never runs its body again — so the
+ * serialized copy on the event is the only surviving record of the contract.
+ */
+export function responseSchemasByInterruptId(
+  events: Event[],
+): Map<string, unknown> {
+  const schemas = new Map<string, unknown>();
+  for (const event of events) {
+    for (const part of event.content?.parts ?? []) {
+      const fc = part.functionCall;
+      if (fc?.name !== REQUEST_INPUT_FUNCTION_CALL_NAME || !fc.id) {
+        continue;
+      }
+      const schema = (fc.args as Record<string, unknown> | undefined)?.[
+        'responseSchema'
+      ];
+      if (schema) {
+        schemas.set(fc.id, schema);
+      }
+    }
+  }
+  return schemas;
+}
+
+/**
+ * Checks a *structured* reply against the `responseSchema` its interrupt
+ * declared, and throws when it does not match.
+ *
+ * Only structured replies are checked. A plain-text reply is routed to every
+ * pending interrupt as-is (the interactive CLI and the dev UI both rely on
+ * that), and holding free text to an object schema would break it.
+ *
+ * Without this, a reply in the wrong shape is simply handed to the next node:
+ * a client that wraps its answer as `{response: x}` instead of `{result: x}`
+ * gets the whole envelope delivered as the node's input, which typically
+ * surfaces far downstream as a stringified `[object Object]`.
+ */
+export function validateInterruptResponse(
+  interruptId: string,
+  value: unknown,
+  jsonSchema: unknown,
+): void {
+  const validator = compileJsonSchema(jsonSchema);
+  if (!validator) {
+    return;
+  }
+  const result = validator.safeParse(value);
+  if (result.success) {
+    return;
+  }
+  const issues = result.error.issues
+    .map((issue) => {
+      const at = issue.path.length ? ` at '${issue.path.join('.')}'` : '';
+      return `${issue.message}${at}`;
+    })
+    .join('; ');
+  throw new Error(
+    `The reply to interrupt '${interruptId}' does not match the ` +
+      `responseSchema it declared: ${issues}. A structured reply must either ` +
+      `match that schema, or wrap a bare value as {result: <value>}; a ` +
+      `plain-text reply is accepted as-is and is not checked.`,
+  );
 }
 
 /** Returns whether an event contains a `request_input` function call. */

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -17,6 +17,10 @@ import {requiresUserInput} from '../../agents/user_input_request.js';
 import {Event} from '../../events/event.js';
 import {RouteValue} from '../graph.js';
 import type {NodeContext, NodeResult} from '../node_context.js';
+import {
+  responseSchemasByInterruptId,
+  validateInterruptResponse,
+} from './hitl_utils.js';
 
 const RESULT_KEY = 'result';
 
@@ -168,6 +172,7 @@ function reconstruct(
 ): Map<string, RehydratedNode> {
   const nodes = new Map<string, RehydratedNode>();
   const interruptOwner = new Map<string, string>();
+  const responseSchemas = responseSchemasByInterruptId(events);
 
   const getNode = (name: string): RehydratedNode => {
     let node = nodes.get(name);
@@ -185,10 +190,13 @@ function reconstruct(
         const fr = part.functionResponse;
         if (fr?.id && interruptOwner.has(fr.id)) {
           const owner = interruptOwner.get(fr.id)!;
-          getNode(owner).resolvedResponses.set(
+          const response = unwrapResponse(fr.response);
+          validateInterruptResponse(
             fr.id,
-            unwrapResponse(fr.response),
+            response,
+            responseSchemas.get(fr.id),
           );
+          getNode(owner).resolvedResponses.set(fr.id, response);
         }
       }
       continue;

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -12,6 +12,7 @@ import {AuthCredentialTypes} from '../../src/auth/auth_credential.js';
 import {AuthConfig} from '../../src/auth/auth_tool.js';
 import type {Event} from '../../src/events/event.js';
 import {State} from '../../src/sessions/state.js';
+import {toJsonSchema} from '../../src/utils/schema.js';
 import {
   isRequestInput,
   RequestInput,
@@ -24,7 +25,10 @@ import {
   hasRequestInputFunctionCall,
   processAuthResume,
   REQUEST_INPUT_FUNCTION_CALL_NAME,
+  responseSchemasByInterruptId,
+  validateInterruptResponse,
 } from '../../src/workflow/utils/hitl_utils.js';
+import {unwrapResponse} from '../../src/workflow/utils/rehydration_utils.js';
 
 /** Extracts the first function-call args from an event. */
 function firstFunctionCall(event: Event) {
@@ -157,5 +161,77 @@ describe('auth gate', () => {
       authType: 'apiKey',
       apiKey: 'my-key',
     });
+  });
+});
+
+describe('responseSchemasByInterruptId', () => {
+  it('recovers the schema an interrupt declared, keyed by id', () => {
+    const event = createRequestInputEvent(
+      new RequestInput({
+        interruptId: 'i1',
+        responseSchema: z4.object({userResponse: z4.string()}),
+      }),
+    );
+
+    const schemas = responseSchemasByInterruptId([event]);
+
+    expect(schemas.get('i1')).toMatchObject({type: 'object'});
+  });
+
+  it('omits interrupts that declared no schema', () => {
+    const event = createRequestInputEvent(
+      new RequestInput({interruptId: 'i1'}),
+    );
+
+    expect(responseSchemasByInterruptId([event]).has('i1')).toBe(false);
+  });
+});
+
+describe('validateInterruptResponse', () => {
+  const objectSchema = toJsonSchema(z4.object({userResponse: z4.string()}));
+
+  it('accepts a reply matching the declared schema', () => {
+    expect(() =>
+      validateInterruptResponse('i1', {userResponse: 'yes'}, objectSchema),
+    ).not.toThrow();
+  });
+
+  it('rejects a reply in the wrong shape, naming the interrupt', () => {
+    // The `{response: x}` envelope a client reaches for instead of `{result: x}`:
+    // it is not unwrapped, so the whole object arrives as the node's input.
+    expect(() =>
+      validateInterruptResponse('i1', {response: '21'}, objectSchema),
+    ).toThrow(/reply to interrupt 'i1' does not match/i);
+  });
+
+  it('explains how a structured reply is expected to look', () => {
+    expect(() =>
+      validateInterruptResponse('i1', {response: '21'}, objectSchema),
+    ).toThrow(/\{result: <value>\}/);
+  });
+
+  it('passes through when the interrupt declared no schema', () => {
+    expect(() =>
+      validateInterruptResponse('i1', {anything: true}, undefined),
+    ).not.toThrow();
+  });
+
+  it('passes through when the schema cannot be compiled', () => {
+    expect(() =>
+      validateInterruptResponse('i1', 'anything', {
+        $ref: 'https://example.com/unresolvable.json',
+      }),
+    ).not.toThrow();
+  });
+
+  it('checks the unwrapped value, so {result: x} satisfies a bare schema', () => {
+    const stringSchema = toJsonSchema(z4.string());
+    expect(() =>
+      validateInterruptResponse(
+        'i1',
+        unwrapResponse({result: '21'}),
+        stringSchema,
+      ),
+    ).not.toThrow();
   });
 });

--- a/core/test/workflow/resume_test.ts
+++ b/core/test/workflow/resume_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {describe, expect, it} from 'vitest';
+import {z} from 'zod/v4';
 import {
   createEvent,
   Event,
@@ -17,7 +18,10 @@ import {InMemorySessionService} from '../../src/sessions/in_memory_session_servi
 import {node} from '../../src/workflow/node.js';
 import {NodeContext} from '../../src/workflow/node_context.js';
 import {RequestInput} from '../../src/workflow/request_input.js';
-import {hasRequestInputFunctionCall} from '../../src/workflow/utils/hitl_utils.js';
+import {
+  createRequestInputEvent,
+  hasRequestInputFunctionCall,
+} from '../../src/workflow/utils/hitl_utils.js';
 import {
   isFastForwardable,
   reconstructNodeStates,
@@ -75,6 +79,57 @@ describe('Phase 5b — rehydration utility', () => {
     expect(states.get('gate')?.resolvedResponses.get('gate-1')).toBe(
       'approved',
     );
+  });
+
+  describe('a reply checked against the schema its interrupt declared', () => {
+    /** An interrupt that asked for `{userResponse: string}`, and a reply to it. */
+    function eventsWithReply(response: Record<string, unknown>): Event[] {
+      const interrupt = createRequestInputEvent(
+        new RequestInput({
+          interruptId: 'gate-1',
+          responseSchema: z.object({userResponse: z.string()}),
+        }),
+      );
+      interrupt.author = 'gate';
+      interrupt.nodeInfo = {path: 'wf.gate'};
+      return [
+        interrupt,
+        createEvent({
+          author: 'user',
+          content: {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'gate-1',
+                  name: 'adk_request_input',
+                  response,
+                },
+              },
+            ],
+          },
+        }),
+      ];
+    }
+
+    it('resolves a reply in the declared shape', () => {
+      const states = reconstructNodeStates(
+        eventsWithReply({userResponse: 'yes'}),
+      );
+
+      expect(states.get('gate')?.resolvedResponses.get('gate-1')).toEqual({
+        userResponse: 'yes',
+      });
+    });
+
+    it('rejects the wrong envelope instead of passing it to the next node', () => {
+      // `{response: x}` is not the `{result: x}` envelope, so it is not
+      // unwrapped; before this check it reached the successor whole and
+      // surfaced downstream as a stringified "[object Object]".
+      expect(() =>
+        reconstructNodeStates(eventsWithReply({response: '21'})),
+      ).toThrow(/reply to interrupt 'gate-1' does not match/i);
+    });
   });
 
   it('recovers structured output and interrupt input after a DB serialization round-trip', () => {

--- a/samples/workflows/README.md
+++ b/samples/workflows/README.md
@@ -69,6 +69,26 @@ request). Just type your reply on the next turn — a plain-text reply is routed
 to the pending interrupt, so you can approve, reject, or supply a value
 interactively.
 
+Answering from your own client rather than the CLI, over `/run`, there are two
+shapes and the difference matters:
+
+```jsonc
+// Plain text: routed to every pending interrupt, never schema-checked.
+{"role": "user", "parts": [{"text": "21"}]}
+
+// Structured: name the interrupt, and wrap a bare value as {result: <value>}.
+{"role": "user", "parts": [{"functionResponse": {
+  "id": "<interruptId>", "name": "adk_request_input",
+  "response": {"result": "21"}}}]}
+```
+
+`{result: …}` is the only envelope that gets unwrapped. Any other object is
+handed to the next node exactly as sent — which is what makes a structured
+reply carrying an object (`{userResponse: …}` in `payload_and_schema`) work. If
+the interrupt declared a `responseSchema`, a structured reply is checked
+against it and a mismatch fails loudly; if it declared none, whatever you send
+is what the next node receives.
+
 ## Samples
 
 ### [`/graphs/`](https://adk.dev/graphs/) — `graphs/`


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Found while bug-bashing the graph-workflow docs samples (follow-up to #664).

A client answering a HITL interrupt with the wrong envelope —
`response: {"response": "21"}` instead of `response: {"result": "21"}` — got no
error. The object was handed to the next node whole and surfaced several steps
downstream as a stringified `[object Object]`.

The unwrapping itself is not the bug. `{result: <value>}` is the envelope, and
passing anything else through untouched is **required**: that is how a
structured reply carrying an object reaches its node, as
`human_input/payload_and_schema` does with `{userResponse: …}`. The two cases
are indistinguishable from the framework's side, so the pass-through cannot
just be tightened.

What was actually missing: **`responseSchema` was decorative.**
`createRequestInputEvent` serialized it into the interrupt payload for clients
to read, and nothing ever checked a reply against it. Declaring a contract and
never enforcing it is what let the wrong shape travel silently.

**Solution:**

Check a reply against the `responseSchema` its interrupt declared — for
**structured replies only**.

- A plain-text reply is still routed to every pending interrupt as-is. The
  interactive CLI and the dev UI both depend on that, and holding free text to
  an object schema would break them, along with `payload_and_schema`'s own
  replay.
- An interrupt that declares no schema is unaffected.
- The schema survives only in serialized form — a node with
  `rerunOnResume: false` never re-runs its body, so the original `RequestInput`
  is gone by resume time — so it is read back off the interrupt event and
  compiled with a new `compileJsonSchema` helper.
- A schema that will not compile is treated as *no contract* rather than as a
  failure. JSON Schema is wider than Zod, and rejecting valid data because we
  could not build the validator would be worse than the pass-through this
  replaces.
- Both resume paths share the check — the graph's rehydration and the
  `LlmAgent` request-input processor — so they cannot drift.

The error names the interrupt, the mismatch, and the envelope:

```
The reply to interrupt 'gate-1' does not match the responseSchema it declared:
Invalid input: expected string, received undefined at 'userResponse';
Unrecognized key: "response". A structured reply must either match that schema,
or wrap a bare value as {result: <value>}; a plain-text reply is accepted as-is
and is not checked.
```

Also documents the two reply shapes, which were written down nowhere a client
author would look: on `RequestInput` and in the samples README.

**Scope note:** an interrupt that declares *no* `responseSchema` still cannot be
protected — there is no contract to check, and a wrong envelope is
indistinguishable from a legitimate structured reply. That case is now covered
by documentation rather than code.

**Merge note:** `core/src/utils/schema.ts` is also being reworked in
`feat/validate-all-schema-forms` (genai-dialect validation). This adds one
function at the end of that file to keep the overlap small, and
`compileJsonSchema` is a natural thing for that work to absorb.

### Testing Plan

**Unit Tests:**

- [x] I have added unit tests for my change — 11 new (`hitl_test.ts`,
      `resume_test.ts`) covering: schema recovery by interrupt id, a matching
      reply, the wrong envelope, the message naming the envelope, no-schema
      pass-through, uncompilable-schema pass-through, and `{result: x}`
      satisfying a bare schema.
- [x] All unit tests pass locally — `unit:core` 2870 passed (209 files).
- [x] `tests/integration/docs_samples` — 27 passed.

**Manual End-to-End (E2E) Tests:**

Against `adk web samples/workflows/human_input`, on `payload_and_schema` (which
declares a `responseSchema`):

```
wrong envelope   {"response":"21"}          → 400, error above, workflow not advanced
correct reply    {"userResponse":"the museum"} → apply_feedback → "Noted. Building the
                                                 final itinerary around: the museum"
plain text       "the museum and the lunch"    → unchanged, still accepted
```

All 26 graph-workflow samples were re-run (30 runs including both branches of
each router): **30 pass, 0 fail**, so the three HITL samples and
`dynamic/human_input` still resume on plain text exactly as before.

**Note on a pre-existing failure:** `dev/test/cli/cli_create_test.ts` fails on
any machine with `GOOGLE_CLOUD_PROJECT` set — it expects the mocked
`gcloud-project` but reads the ambient value. `env -u GOOGLE_CLOUD_PROJECT`
makes all 11 pass. Unrelated to this PR.
