### PR TITLE
fix(tests): stop cli_create tests reading the developer's gcloud env

### DIFF
--- a/dev/test/cli/cli_create_test.ts
+++ b/dev/test/cli/cli_create_test.ts
@@ -74,10 +74,17 @@ describe('createAgent', () => {
     vi.clearAllMocks();
     (isCancel as unknown as Mock).mockReturnValue(false);
     (listFiles as Mock).mockResolvedValue(['file1', 'file2']);
+    // `createAgent` prefers these over `gcloud config`, so a machine with
+    // either one exported takes a different path through the code than the one
+    // under test. Clear them: what this suite asserts has to come from its own
+    // mocks, not from the environment that happens to be running it.
+    vi.stubEnv('GOOGLE_CLOUD_PROJECT', undefined);
+    vi.stubEnv('GOOGLE_CLOUD_LOCATION', undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe('Non-interactive Mode (forceYes: true)', () => {
@@ -222,6 +229,35 @@ describe('createAgent', () => {
         expect.stringContaining('.env'),
         expect.stringContaining('GOOGLE_CLOUD_PROJECT=gcloud-project'),
       );
+    });
+
+    it('should prefer the environment over gcloud defaults', async () => {
+      // The precedence the test above depends on NOT being in play. It is real
+      // behaviour, so pin it here rather than leave it to whatever the machine
+      // running the suite happens to export.
+      vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'env-project');
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'env-region');
+
+      (select as Mock).mockResolvedValueOnce('gemini-2.5-flash');
+      (select as Mock).mockResolvedValueOnce('ts');
+      (select as Mock).mockResolvedValueOnce('vertex'); // Backend
+
+      (execSync as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('project')) return 'gcloud-project\n';
+        if (cmd.includes('region')) return 'gcloud-region\n';
+        return '';
+      });
+
+      (text as Mock).mockResolvedValueOnce('env-project');
+      (text as Mock).mockResolvedValueOnce('env-region');
+
+      await createAgent(getFreshOptions());
+
+      expect(text).toHaveBeenCalledWith(
+        expect.objectContaining({initialValue: 'env-project'}),
+      );
+      // `gcloud config` is not consulted at all when the env supplies both.
+      expect(execSync).not.toHaveBeenCalled();
     });
 
     it('should exit without writing files if project prompt is cancelled', async () => {


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

`dev/test/cli/cli_create_test.ts > should handle Vertex AI selection with gcloud
defaults` fails on any machine with `GOOGLE_CLOUD_PROJECT` exported — which is
most machines that have ever run an ADK sample against Vertex:

```
-   "initialValue": "gcloud-project"
+   "initialValue": "cloud-ai-agentic-coding"
```

`createAgent` prefers `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` over
`gcloud config` (`cli_create.ts:104,119`), so the environment short-circuits
before the mocked `execSync` is ever reached. The test mocked the fallback and
then never exercised it — it asserted a value the environment was free to
overwrite.

The source precedence is correct and deliberate; only the test is at fault.

**Solution:**

- Clear both variables in `beforeEach` (and `vi.unstubAllEnvs()` in
  `afterEach`), so every test in the file takes its values from its own mocks
  rather than from whatever machine is running it. Applied suite-wide, not just
  to the one failing test, since any of them could grow an env-sensitive path.
- Add the case the failure was accidentally covering: the environment wins over
  `gcloud config`, and `gcloud` is not consulted at all when it supplies both.
  That precedence is real behaviour and was previously pinned by nothing.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Verified in both directions, since a hermeticity fix that only ever runs one way
proves nothing:

```
GOOGLE_CLOUD_PROJECT=… GOOGLE_CLOUD_LOCATION=… vitest run … → 12 passed
env -u GOOGLE_CLOUD_PROJECT -u GOOGLE_CLOUD_LOCATION …      → 12 passed
```

Full `unit:dev` on a machine with the variables exported: **266 passed, 16
files** — previously 1 failed.

The new test was mutation-checked: deleting the `process.env.GOOGLE_CLOUD_PROJECT`
short-circuit from `getGcpProject` makes it fail, and restoring it makes it pass,
so it is guarding the behaviour rather than restating the mocks.

**Manual End-to-End (E2E) Tests:**

n/a — test-only change, no shipped code touched.
