### PR TITLE
feat(agents): make BaseAgent a BaseNode

### DIFF
--- a/core/src/agents/base_agent.ts
+++ b/core/src/agents/base_agent.ts
@@ -14,6 +14,8 @@ import {
   traceAgentInvocation,
   tracer,
 } from '../telemetry/tracing.js';
+import {BaseNode, BaseNodeConfig} from '../workflow/base_node.js';
+import type {NodeContext} from '../workflow/node_context.js';
 import {Context} from './context.js';
 import {InvocationContext} from './invocation_context.js';
 
@@ -38,8 +40,13 @@ export type AfterAgentCallback = SingleAgentCallback | SingleAgentCallback[];
 
 /**
  * The config of a base agent.
+ *
+ * Extends {@link BaseNodeConfig}, so every agent also accepts the node-level
+ * options — `retryConfig`, `timeout`, `inputSchema`, `outputSchema`,
+ * `stateSchema`, `rerunOnResume`, `waitForOutput` — which apply when the agent
+ * runs inside a workflow.
  */
-export interface BaseAgentConfig {
+export interface BaseAgentConfig extends BaseNodeConfig {
   name: string;
   description?: string;
   parentAgent?: BaseAgent;
@@ -74,10 +81,15 @@ export function isBaseAgent(obj: unknown): obj is BaseAgent {
  * The class is generic over its config type so that {@link clone} can be typed
  * per subclass (e.g. `LlmAgent.clone({instruction})`). The default keeps bare
  * `BaseAgent` references valid as `BaseAgent<BaseAgentConfig>`.
+ *
+ * An agent **is** a {@link BaseNode}, so any agent can be dropped straight into
+ * a workflow graph without a wrapper — mirroring adk-python, where
+ * `BaseAgent(BaseNode)`. {@link runImpl} bridges the two contracts: the node
+ * runner calls it, and it delegates to the agent's own {@link runAsync}.
  */
 export abstract class BaseAgent<
   TConfig extends BaseAgentConfig = BaseAgentConfig,
-> {
+> extends BaseNode {
   /**
    * A unique symbol to identify ADK agent classes.
    */
@@ -100,13 +112,10 @@ export abstract class BaseAgent<
    */
   readonly name: string;
 
-  /**
-   * Description about the agent's capability.
-   *
-   * The model uses this to determine whether to delegate control to the agent.
-   * One-line description is enough and preferred.
-   */
-  readonly description?: string;
+  // `description` is inherited from BaseNode, which declares it `string` and
+  // defaults it to ''. It used to be `string | undefined` here; every consumer
+  // already coalesced (`agent.description || ''`), so the default is
+  // equivalent for them.
 
   /**
    * Root agent of this agent.
@@ -163,11 +172,13 @@ export abstract class BaseAgent<
   readonly afterAgentCallback: SingleAgentCallback[];
 
   constructor(config: BaseAgentConfig) {
+    // An agent name is stricter than a node name (a JS identifier, and never
+    // "user"), so it is validated here and handed to BaseNode already checked.
+    super({...config, name: validateAgentName(config.name)});
     // Captures every field the concrete subclass passed to super(...), even
     // though the parameter is typed BaseAgentConfig, so clone() can rebuild it.
     this.config = {...config} as TConfig;
     this.name = validateAgentName(config.name);
-    this.description = config.description;
     this.parentAgent = config.parentAgent;
     this.subAgents = config.subAgents || [];
     this.beforeAgentCallback = getCannonicalCallback(
@@ -279,6 +290,35 @@ export abstract class BaseAgent<
     } finally {
       span.end();
     }
+  }
+
+  /**
+   * Runs this agent as a workflow node.
+   *
+   * The node runner calls this; it delegates to {@link runAsync}, so an agent
+   * behaves identically whether it is run directly or as a node. Mirrors
+   * adk-python `BaseAgent._run_impl`.
+   *
+   * The invocation context comes from {@link NodeContext.getInvocationContext}
+   * rather than the raw field, so the agent runs against whatever view of the
+   * session the workflow wants it to see.
+   *
+   * Unlike adk-python's `_run_impl`, nothing is stamped onto the events here.
+   * Python has to fix up the author and the node path because it authors
+   * in-workflow events as the workflow itself; the TypeScript node runner
+   * already owns both (`enrichEvent` keeps an author the node set, and always
+   * stamps the true node path), so repeating it would be dead code.
+   *
+   * `nodeInput` is intentionally unused: an agent's input is its conversation,
+   * which the workflow supplies through the session. A node that needs to read
+   * its input — an `LlmAgent` injecting it into the prompt, say — does so in
+   * its own wrapper.
+   */
+  protected async *runImpl(
+    ctx: NodeContext,
+    _nodeInput: unknown,
+  ): AsyncGenerator<Event, void, void> {
+    yield* this.runAsync(ctx.getInvocationContext());
   }
 
   /**

--- a/core/src/workflow/node_builders.ts
+++ b/core/src/workflow/node_builders.ts
@@ -42,6 +42,7 @@ const TOOL_BUILDER: NodeBuilder = {
  * so the tool builder wins for those.
  */
 const AGENT_BUILDER: NodeBuilder = {
+  agentLike: true,
   match: (value) =>
     !isBaseTool(value) && (isBaseAgent(value) || isAgentLike(value)),
   build: (value, options) => new LLMAgentWrapper(value as BaseAgent, options),

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -148,6 +148,25 @@ export class NodeContext {
     return this.invocationContext.session;
   }
 
+  /**
+   * The invocation context to run a nested agent against.
+   *
+   * The single place where "what a node sees" is translated into "what an
+   * agent sees", so an agent run as a node (`BaseAgent.runImpl`) and one run
+   * directly go through the same seam.
+   *
+   * Today it hands back the node's own invocation context unchanged, which is
+   * what the agent wrapper already did. adk-python returns a copy carrying the
+   * proxy session and the isolation scope (`agents/context.py`
+   * `get_invocation_context`); matching that here means giving the agent the
+   * node's `state` view rather than letting it read through to `session.state`,
+   * which is a behaviour change for every agent and is deliberately not part of
+   * introducing the seam.
+   */
+  getInvocationContext(): InvocationContext {
+    return this.invocationContext;
+  }
+
   /** Streams a single event out through the workflow's event channel. */
   emit(event: Event): void {
     this.channel.push(event);

--- a/core/src/workflow/utils/workflow_graph_utils.ts
+++ b/core/src/workflow/utils/workflow_graph_utils.ts
@@ -47,6 +47,11 @@ export interface NodeBuilder {
   match(value: unknown): boolean;
   /** Builds a node from a value this builder previously matched. */
   build(value: NodeLike, options: BuildNodeOptions): BaseNode;
+  /**
+   * Whether this builder handles agents. An agent is already a `BaseNode`, so
+   * it would otherwise be used as-is; see {@link buildInnerNode}.
+   */
+  agentLike?: boolean;
 }
 
 /**
@@ -133,6 +138,17 @@ function buildInnerNode(
     return START;
   }
   if (isBaseNode(nodeLike)) {
+    // An agent is itself a BaseNode, so it would be returned as-is here and
+    // never reach its builder below. It still needs one: the wrapper is what
+    // injects the node input into the prompt, drives task mode, and turns the
+    // agent's reply into node output. adk-python has the same fork and
+    // resolves it the same way, special-casing LlmAgent inside its own
+    // `isinstance(node_like, BaseNode)` branch.
+    for (const builder of NODE_BUILDERS) {
+      if (builder.agentLike && builder.match(nodeLike)) {
+        return builder.build(nodeLike, options);
+      }
+    }
     // TODO(phase-3+): apply property overrides via a clone when options differ.
     return nodeLike;
   }

--- a/core/test/workflow/agent_as_node_test.ts
+++ b/core/test/workflow/agent_as_node_test.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {BaseAgent} from '../../src/agents/base_agent.js';
+import {InvocationContext} from '../../src/agents/invocation_context.js';
+import {createEvent, Event} from '../../src/events/event.js';
+import {node} from '../../src/workflow/node.js';
+import {LLMAgentWrapper} from '../../src/workflow/nodes/llm_agent_wrapper.js';
+import {createIc, driveNode, FnNode} from './test_helpers.js';
+
+/**
+ * A plain agent that is not an `LlmAgent` — the case the agent wrapper never
+ * exercises, and the reason these tests exist.
+ */
+class EchoAgent extends BaseAgent {
+  constructor(
+    name: string,
+    private readonly reply: string,
+  ) {
+    super({name, description: `echoes ${reply}`});
+  }
+
+  protected async *runAsyncImpl(
+    ctx: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    yield createEvent({
+      author: this.name,
+      invocationId: ctx.invocationId,
+      content: {role: 'model', parts: [{text: this.reply}]},
+      output: this.reply,
+    });
+  }
+
+  // eslint-disable-next-line require-yield
+  protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
+    return;
+  }
+}
+
+describe('an agent is a node', () => {
+  it('runs a plain agent directly as a node', async () => {
+    const {events, output} = await driveNode(new EchoAgent('echo', 'hi'));
+
+    expect(output).toBe('hi');
+    expect(events).toHaveLength(1);
+    expect(events[0].author).toBe('echo');
+    expect(events[0].nodeInfo?.path).toBe('echo');
+  });
+
+  it('runs an agent as a dynamic child via ctx.runNode()', async () => {
+    // Before an agent was a node this could not be expressed at all:
+    // `runNode` takes a BaseNode, and an agent had no `run()`.
+    const specialist = new EchoAgent('specialist', 'answer');
+    const coordinator = new FnNode('coordinator', async (ctx) => {
+      const child = await ctx.runNode(specialist);
+      return `got:${child.output}`;
+    });
+
+    const {events, output} = await driveNode(coordinator);
+
+    expect(output).toBe('got:answer');
+    // The agent's own event is streamed out through the parent's channel,
+    // carrying its nested node path.
+    const agentEvent = events.find((e) => e.author === 'specialist');
+    expect(agentEvent).toBeDefined();
+    expect(agentEvent!.nodeInfo?.path).toBe('coordinator.specialist');
+  });
+
+  it('sees the invocation context the node context hands it', async () => {
+    let seen: InvocationContext | undefined;
+    class CapturingAgent extends BaseAgent {
+      // eslint-disable-next-line require-yield
+      protected async *runAsyncImpl(
+        ctx: InvocationContext,
+      ): AsyncGenerator<Event, void, void> {
+        seen = ctx;
+        return;
+      }
+      // eslint-disable-next-line require-yield
+      protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
+        return;
+      }
+    }
+
+    const ic = createIc({greeting: 'hello'});
+    await driveNode(new CapturingAgent({name: 'capture'}), undefined, ic);
+
+    expect(seen).toBeDefined();
+    expect(seen!.invocationId).toBe(ic.invocationId);
+    expect(seen!.session.state['greeting']).toBe('hello');
+  });
+
+  it('accepts node configuration on the agent itself', () => {
+    class ConfiguredAgent extends BaseAgent {
+      // eslint-disable-next-line require-yield
+      protected async *runAsyncImpl(): AsyncGenerator<Event, void, void> {
+        return;
+      }
+      // eslint-disable-next-line require-yield
+      protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
+        return;
+      }
+    }
+
+    const agent = new ConfiguredAgent({
+      name: 'configured',
+      timeout: 5,
+      rerunOnResume: true,
+      waitForOutput: true,
+    });
+
+    expect(agent.timeout).toBe(5);
+    expect(agent.rerunOnResume).toBe(true);
+    expect(agent.waitForOutput).toBe(true);
+  });
+
+  it('still wraps an agent that is placed in a graph', () => {
+    // An agent is a node now, so `buildNode` would otherwise hand it back
+    // as-is and skip the wrapper that drives prompt injection and task mode.
+    const built = node(new EchoAgent('graphed', 'x'));
+    expect(built).toBeInstanceOf(LLMAgentWrapper);
+    expect(built.name).toBe('graphed');
+  });
+
+  it('keeps the agent name rules, which are stricter than a node’s', () => {
+    expect(() => new EchoAgent('user', 'x')).toThrow();
+    expect(() => new EchoAgent('not an identifier', 'x')).toThrow();
+  });
+
+  it('defaults description to the empty string, as a node does', () => {
+    class Bare extends BaseAgent {
+      // eslint-disable-next-line require-yield
+      protected async *runAsyncImpl(): AsyncGenerator<Event, void, void> {
+        return;
+      }
+      // eslint-disable-next-line require-yield
+      protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
+        return;
+      }
+    }
+    expect(new Bare({name: 'bare'}).description).toBe('');
+  });
+});


### PR DESCRIPTION
> **Stacked on #663.** Base is `feat/validate-all-schema-forms`, so the diff here is just the merge. #663 must land first — see "Why this needs #663" below. Once it merges, this retargets to `main`.

### Link to Issue or Description of Change

**Problem:**

An agent could not be used as a workflow node. `LLMAgentWrapper` bridged the gap for a graph, but the two hierarchies stayed separate, and the seams showed:

- `ctx.runNode()` takes a `BaseNode`, so an agent could not be run as a dynamic child at all.
- Node options — `timeout`, `retryConfig`, `rerunOnResume`, `waitForOutput`, the schemas — had nowhere to live on an agent.
- The `Runner` has no way to treat an agent and a node uniformly (adk-python's is typed `agent: BaseNode`).

adk-python does not have this split: `BaseAgent(BaseNode)` at `base_agent.py:94`. Everything above follows from that one line, and several later items on the workflow roadmap depend on it.

**Solution:**

`BaseAgentConfig` extends `BaseNodeConfig`, `BaseAgent extends BaseNode`, and `runImpl` delegates straight back to `runAsync` — so an agent behaves identically whether it is run directly or as a node. Python's bridge is 17 lines; this one is shorter.

Deliberate differences from Python, and the decisions taken:

- **Nothing is stamped onto events.** Python's `_run_impl` repairs the author and node path because it authors in-workflow events as the workflow itself. Here `enrichEvent` already keeps an author the node set and *always* stamps the true node path, so repeating it would be dead code.
- **`buildNode` had to change.** An agent is now already a `BaseNode`, so it would be handed back untouched and skip the wrapper that injects node input into the prompt, drives task mode, and turns the reply into node output. adk-python hits the same fork and answers it the same way — special-casing `LlmAgent` inside its own `isinstance(node_like, BaseNode)` branch. Builders that handle agents are marked `agentLike` and consulted there. **Without this, 11 existing tests fail**, which is how the fork was found.
- **`getInvocationContext()` is introduced as a seam, not a behaviour change.** It returns the context unchanged, matching what the wrapper already did. Python returns a copy carrying the proxy session and isolation scope, which would hand an agent the node's `state` view instead of letting it read through to `session.state`. That is a behaviour change for *every* agent — it belongs in its own PR, and the seam gives it one place to land.
- **`description` is inherited**, so it is `string` defaulting to `''` rather than `string | undefined`. Every consumer already coalesced (`agent.description || ''`).
- **Agent names keep their stricter rule** — a JS identifier, never `"user"` — validated before being handed to `BaseNode`.

**Why this needs #663:**

Inheriting `BaseNodeConfig` unifies `outputSchema`: `LlmAgent`'s field becomes the one the node runner validates against, exactly as in adk-python. Before #663, `parseWithSchema` ignored genai `Schema`s, and `LlmAgent` normalizes its schema into that dialect — so unifying on top of `main` today would silently disable node output validation for every LLM agent. #663 removes that trap.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New `core/test/workflow/agent_as_node_test.ts` deliberately uses a **non-LLM** agent, because the wrapper intercepts `LlmAgent` and would leave the new path untested. It covers: running a plain agent as a node; running one as a dynamic child through `ctx.runNode()` (previously impossible) and asserting the nested node path; the invocation context the agent receives; node options set on an agent; that a graph-placed agent still gets wrapped; the stricter name rules; and the `description` default.

```
npm run ts:check          clean
npx vitest --project unit:core    210 files, 2879 passed
npm run test:integration           74 files, 206 passed | 8 skipped
```

**Manual End-to-End (E2E) Tests:**

Not run. The change is structural and behaviour-preserving by construction — the existing suite is the evidence, in particular the 11 wrapper-dispatch tests that fail without the `buildNode` fix and pass with it.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**This is a breaking change** and should ride a major. `BaseAgent` subclasses now inherit nine fields; a subclass declaring one of the same names collides with the inherited one, and `description` is no longer `undefined` when unset. Internally only six concrete subclasses exist, so the cost is downstream, in user code.

What this unblocks, roughly in order: a workflow-native `Runner`; context unification; `node_input` for arbitrary agents; collapsing `LLMAgentWrapper` into `LlmAgent` (which is what enables agent transfer inside a workflow); and deprecating `SequentialAgent`/`ParallelAgent`/`LoopAgent` in favour of `Workflow`, as adk-python already has at `sequential_agent.py:79`.
