### PR TITLE
fix(workflow): stop delivering a workflow's output as two events

### DIFF
--- a/core/src/workflow/workflow_agent.ts
+++ b/core/src/workflow/workflow_agent.ts
@@ -85,33 +85,30 @@ export class WorkflowAgent extends BaseAgent {
 
     const input = extractWorkflowInput(ic.userContent);
 
+    let interrupted = false;
     const settle = (async () => {
       try {
         const wfCtx = await root.runNode(this.workflow, input, {
           useAsOutput: true,
         });
-        // Surface the workflow's final output as an event so consumers (and
-        // the Runner) can observe it — important for dynamicEntry workflows
-        // whose return value differs from the last node's event.
-        if (wfCtx.interruptIds.length === 0 && root.output !== undefined) {
-          channel.push(
-            createEvent({
-              author: this.name,
-              invocationId: ic.invocationId,
-              branch: ic.branch,
-              content: toContent(root.output),
-              output: root.output,
-            }),
-          );
-        }
+        interrupted = wfCtx.interruptIds.length > 0;
         channel.close();
       } catch (err) {
         channel.fail(err);
       }
     })();
 
+    // The last output handed to the caller, tracked so the workflow's own
+    // output is not delivered twice.
+    let lastOutput: unknown;
+    let sawOutput = false;
+
     try {
       for await (const event of channel) {
+        if (event.output !== undefined) {
+          lastOutput = event.output;
+          sawOutput = true;
+        }
         yield event;
       }
       await settle;
@@ -123,6 +120,29 @@ export class WorkflowAgent extends BaseAgent {
       // normal path (the channel is already closed and `settle` resolved).
       channel.close();
       await settle;
+    }
+
+    // The contract this keeps is that the workflow's output is the last output
+    // on the stream, so a consumer can read the result by taking the last one.
+    // When the terminal node already put it there — the ordinary case — saying
+    // it again would deliver one node output as two data events. When it did
+    // not, the value still has to be announced: a `dynamicEntry` can return
+    // something it computed rather than a child's value, a node can set
+    // `ctx.output` without emitting, and a later branch can emit after the
+    // node that produced the result.
+    //
+    // Deciding after the drain, rather than when the workflow settles, is what
+    // makes this exact: by then every node event has been seen, whereas
+    // `root.output` is only assigned once the whole workflow has finished.
+    const alreadyLast = sawOutput && Object.is(lastOutput, root.output);
+    if (!interrupted && root.output !== undefined && !alreadyLast) {
+      yield createEvent({
+        author: this.name,
+        invocationId: ic.invocationId,
+        branch: ic.branch,
+        content: toContent(root.output),
+        output: root.output,
+      });
     }
   }
 

--- a/core/test/workflow/workflow_agent_test.ts
+++ b/core/test/workflow/workflow_agent_test.ts
@@ -116,3 +116,144 @@ describe('WorkflowAgent — constructor forms', () => {
     );
   });
 });
+
+/** Runs an agent to completion and returns every event it yielded. */
+async function runAgent(agent: WorkflowAgent): Promise<Event[]> {
+  const ic = new InvocationContext({
+    invocationId: 'inv-1',
+    session: createSession({
+      id: 's1',
+      appName: 'app',
+      userId: 'u',
+      lastUpdateTime: Date.now(),
+    }),
+    agent,
+    userContent: {role: 'user', parts: [{text: 'go'}]},
+    pluginManager: new PluginManager(),
+  });
+  const events: Event[] = [];
+  for await (const event of agent.runAsync(ic)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe('WorkflowAgent — the workflow output reaches the caller once', () => {
+  it('does not repeat the terminal node’s output', async () => {
+    const agent = new WorkflowAgent({
+      name: 'wf',
+      edges: [['START', node(() => 'result', {name: 'only'})]],
+    });
+
+    const withOutput = (await runAgent(agent)).filter(
+      (e) => e.output !== undefined,
+    );
+
+    // The terminal node already emitted its output on the way past; announcing
+    // it again would make one node output arrive as two data events.
+    expect(withOutput).toHaveLength(1);
+    expect(withOutput[0].author).toBe('only');
+    expect(withOutput[0].output).toBe('result');
+  });
+
+  it('announces a dynamicEntry’s return value, which no node emitted', async () => {
+    const agent = new WorkflowAgent({
+      name: 'dyn',
+      dynamicEntry: async (ctx: NodeContext) => {
+        const child = await ctx.runNode(
+          node(() => 2, {name: 'double'}),
+          null,
+        );
+        // Derived from the child rather than returned verbatim, so nothing on
+        // the channel carries it.
+        return (child.output as number) * 21;
+      },
+    });
+
+    const withOutput = (await runAgent(agent)).filter(
+      (e) => e.output !== undefined,
+    );
+
+    expect(withOutput.map((e) => e.output)).toEqual([2, 42]);
+    expect(withOutput[1].author).toBe('dyn');
+  });
+
+  it('re-announces the result when a later node emitted after it', async () => {
+    const agent = new WorkflowAgent({
+      name: 'later',
+      dynamicEntry: async (ctx: NodeContext) => {
+        const result = await ctx.runNode(
+          node(() => 'headline', {name: 'make'}),
+          null,
+        );
+        // A scoring pass runs after the value that becomes the result, so the
+        // result is no longer the last output on the stream.
+        await ctx.runNode(
+          node(() => ({score: 9}), {name: 'grade'}),
+          null,
+        );
+        return result.output;
+      },
+    });
+
+    const withOutput = (await runAgent(agent)).filter(
+      (e) => e.output !== undefined,
+    );
+
+    // Without the trailing event, a consumer taking the last output would read
+    // the score instead of the headline.
+    expect(withOutput.map((e) => e.output)).toEqual([
+      'headline',
+      {score: 9},
+      'headline',
+    ]);
+    expect(withOutput[2].author).toBe('later');
+  });
+
+  it('does not repeat a dynamicEntry’s value when a child already emitted it', async () => {
+    const agent = new WorkflowAgent({
+      name: 'passthrough',
+      dynamicEntry: async (ctx: NodeContext) => {
+        const child = await ctx.runNode(
+          node(() => 'x', {name: 'inner'}),
+          null,
+        );
+        return child.output;
+      },
+    });
+
+    const withOutput = (await runAgent(agent)).filter(
+      (e) => e.output !== undefined,
+    );
+
+    expect(withOutput).toHaveLength(1);
+    expect(withOutput[0].author).toBe('inner');
+  });
+
+  it('announces a terminal node’s output that was set without emitting', async () => {
+    const agent = new WorkflowAgent({
+      name: 'assigns',
+      edges: [
+        [
+          'START',
+          node(
+            (ctx: NodeContext) => {
+              // Assigning rather than returning: nothing is yielded, so no
+              // event carries this value out.
+              ctx.output = 'assigned';
+            },
+            {name: 'quiet'},
+          ),
+        ],
+      ],
+    });
+
+    const withOutput = (await runAgent(agent)).filter(
+      (e) => e.output !== undefined,
+    );
+
+    expect(withOutput).toHaveLength(1);
+    expect(withOutput[0].output).toBe('assigned');
+    expect(withOutput[0].author).toBe('assigns');
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`WorkflowAgent` announced the workflow's output as an extra event once the run settled. In the ordinary case that output *is* the terminal node's, and that node already emitted it on the way past — so a one-node workflow delivered its single result twice: once authored by the node, once by the agent.

Anything counting data events, or replaying them into a session, sees a duplicate. It also breaks the "at most one data event per node output" invariant that adk-python enforces with its `_output_emitted` / `_output_delegated` flags.

**Solution:**

The event cannot simply be dropped, because it carries a second, unstated contract: **the workflow's output is the last output on the stream**, which is how a consumer reads the result. Three cases depend on it:

- a `dynamicEntry` returning something it computed rather than a child's value;
- a node that sets `ctx.output` without ever emitting;
- a later branch emitting *after* the node that produced the result, leaving the result buried mid-stream.

So: keep the contract, drop only the redundancy — announce the output unless it is already the last one delivered.

The decision also moves *after* the drain, which is what makes it exact. By then every node event has been seen, whereas `root.output` is only assigned once the whole workflow finishes, so a check made while events are still in flight would compare against a value that is not set yet.

**Worth flagging for review:** my first attempt skipped the event whenever the value had been emitted *at all*. The `dynamic_nodes` integration sample caught it — its `dynamicEntry` returns a headline that a node emitted earlier, then a scoring pass emits after it, so dropping the trailing event made the last output the score rather than the headline. That third bullet above is a real case, not a hypothetical, and there is now a unit test for it.

Longer term this is what `nodeInfo.outputFor` is for: adk-python marks the existing event as also serving as the ancestor's output instead of re-emitting. The field exists on the TypeScript `Event` but nothing writes it, so making it real is left to its own change.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Five tests in `core/test/workflow/workflow_agent_test.ts`. Two pin the fix (terminal-node output, and a `dynamicEntry` returning a child's value verbatim) and **fail without it**. Three guard against over-correcting — a computed `dynamicEntry` value, a node that assigns `ctx.output` without emitting, and the ordering case above — and pass either way, which is the point.

```
npm run ts:check          clean
npx vitest --project unit:core    209 files, 2865 passed
npm run test:integration           74 files, 206 passed | 8 skipped
```

**Manual End-to-End (E2E) Tests:**

Not run; covered by the workflow integration samples, which execute the real agents against recorded model responses.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Independent of the other workflow PRs in flight. #654 and #641 both edit `workflow_agent.ts` but neither touches this block, so conflicts should be textual at worst.