### PR TITLE
fix(workflow): refuse a runId that collides with an automatic one

### DIFF
--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -106,6 +106,10 @@ export class NodeContext {
 
   private readonly _state: State;
   private readonly dynamicRunCounters = new Map<string, number>();
+  /** Run ids this context handed out automatically, per node name. */
+  private readonly autoRunIds = new Map<string, Set<string>>();
+  /** Every run id used for a node name here, automatic or caller-supplied. */
+  private readonly usedRunIds = new Map<string, Set<string>>();
 
   constructor(opts: NodeContextOptions) {
     this.invocationContext = opts.invocationContext;
@@ -169,11 +173,22 @@ export class NodeContext {
     if (this.scheduler) {
       const nodeName = options?.nodeName ?? node.name;
       let runId = options?.runId;
+      const used = mapSet(this.usedRunIds, nodeName);
+      if (runId !== undefined) {
+        assertCustomRunId(runId, nodeName, mapSet(this.autoRunIds, nodeName));
+      }
       if (!runId) {
-        const next = (this.dynamicRunCounters.get(nodeName) ?? 0) + 1;
+        // Skip anything a caller already claimed, so the automatic sequence
+        // cannot grow into a custom id and silently dedup against it.
+        let next = (this.dynamicRunCounters.get(nodeName) ?? 0) + 1;
+        while (used.has(String(next))) {
+          next++;
+        }
         this.dynamicRunCounters.set(nodeName, next);
         runId = String(next);
+        mapSet(this.autoRunIds, nodeName).add(runId);
       }
+      used.add(runId);
       return this.scheduler.schedule(this, node, input, {
         ...options,
         nodeName,
@@ -181,6 +196,53 @@ export class NodeContext {
       });
     }
     return executeChildNode({parent: this, node, input, options});
+  }
+}
+
+/** Returns the set stored under `key`, creating it on first use. */
+function mapSet(map: Map<string, Set<string>>, key: string): Set<string> {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set();
+    map.set(key, set);
+  }
+  return set;
+}
+
+/**
+ * Rejects a caller-supplied run id that collides with an automatic one.
+ *
+ * Run ids key the checkpoint lookup that lets a resumed or retried workflow
+ * skip work it already did, so an id that names a run the caller never made is
+ * silently wrong: the scheduler finds the earlier run's checkpoint, returns
+ * *its* output, and the input passed here is dropped without executing.
+ * Nothing downstream can detect that, so it is refused at the call.
+ *
+ * Only collisions with ADK's own numbering are refused. Reusing a custom id
+ * deliberately is a supported way to dedup concurrent calls onto one run, and
+ * `ParallelWorker` keys its fan-out by item index, so neither digits nor
+ * repetition can be banned outright.
+ */
+function assertCustomRunId(
+  runId: string,
+  nodeName: string,
+  autoRunIds: ReadonlySet<string>,
+): void {
+  if (runId.trim() === '') {
+    throw new Error(
+      `Invalid runId for node '${nodeName}': a custom run id cannot be empty. ` +
+        `Omit runId to let ADK number the run automatically.`,
+    );
+  }
+  if (autoRunIds.has(runId)) {
+    throw new Error(
+      `Invalid runId '${runId}' for node '${nodeName}': ADK already numbered ` +
+        `an automatic run of that node '${runId}' in this context, so this ` +
+        `call would resolve to that run's cached output instead of ` +
+        `executing, and the input passed here would be dropped. Automatic ` +
+        `ids are "1", "2", "3" per node; give a custom id a non-numeric ` +
+        `part, e.g. '${nodeName}-${runId}'.`,
+    );
   }
 }
 

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -24,7 +24,14 @@ import {getRetryDelaySeconds, shouldRetryNode} from './utils/retry_utils.js';
 export interface RunNodeOptions {
   /** Deterministic tracking name; defaults to `node.name`. */
   nodeName?: string;
-  /** Unique id for this specific run; defaults to `nodeName`. */
+  /**
+   * Unique id for this specific run. Defaults to a per-node sequence — "1",
+   * "2", "3" in call order — which is what a resume matches checkpoints on.
+   *
+   * Supply one only when position is not stable but identity is (a reorderable
+   * collection: key it off the item's own id). It must contain a non-numeric
+   * character so it cannot collide with the automatic sequence.
+   */
   runId?: string;
   /** If true, the child's output replaces the caller's output. */
   useAsOutput?: boolean;

--- a/core/test/workflow/dynamic_workflow_test.ts
+++ b/core/test/workflow/dynamic_workflow_test.ts
@@ -87,6 +87,67 @@ describe('Phase 4 — dynamic (imperative) workflows', () => {
     });
   });
 
+  describe('custom run ids', () => {
+    /** Runs `child` once automatically, then once with `runId`. */
+    function workflowUsing(runId: string) {
+      const child = new FunctionNode('child', (_c, item) => `handled ${item}`);
+      return new Workflow({
+        name: 'run-ids',
+        dynamicEntry: async (ctx) => {
+          const auto = await ctx.runNode(child, 'auto');
+          const custom = await ctx.runNode(child, 'custom', {runId});
+          return {auto: auto.output, custom: custom.output};
+        },
+      });
+    }
+
+    it.each(['order-a91', '42', '007'])(
+      'accepts the non-colliding id %s',
+      async (id) => {
+        // Digits are fine in themselves -- ParallelWorker keys its fan-out by
+        // item index. Only an id ADK already handed out is refused.
+        expect((await driveWorkflow(workflowUsing(id))).output).toEqual({
+          auto: 'handled auto',
+          custom: 'handled custom',
+        });
+      },
+    );
+
+    it('rejects an id ADK already used for an automatic run', async () => {
+      // The auto run above took '1'. Before this check, passing '1' here
+      // resolved to that run's cached output -- returning 'handled auto' and
+      // dropping this call's input without executing.
+      await expect(driveWorkflow(workflowUsing('1'))).rejects.toThrow(
+        /Invalid runId '1' for node 'child'[\s\S]*'child-1'/,
+      );
+    });
+
+    it('rejects an empty id rather than silently auto-numbering it', async () => {
+      await expect(driveWorkflow(workflowUsing('   '))).rejects.toThrow(
+        /cannot be empty/,
+      );
+    });
+
+    it('numbers around a custom id claimed first, instead of deduping onto it', async () => {
+      const child = new FunctionNode('child', (_c, item) => `handled ${item}`);
+      const wf = new Workflow({
+        name: 'run-ids-reverse',
+        dynamicEntry: async (ctx) => {
+          // Custom '1' first, so the automatic sequence would otherwise walk
+          // straight into it on its first call.
+          const custom = await ctx.runNode(child, 'custom', {runId: '1'});
+          const auto = await ctx.runNode(child, 'auto');
+          return {custom: custom.output, auto: auto.output};
+        },
+      });
+
+      expect((await driveWorkflow(wf)).output).toEqual({
+        custom: 'handled custom',
+        auto: 'handled auto',
+      });
+    });
+  });
+
   it('supports the node-as-tool pattern (a node calls a sub-node)', async () => {
     const adder = new FunctionNode(
       'adder',


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Found while bug-bashing the graph-workflow docs samples (follow-up to #664,
#665, #666). This is the one that produces silently wrong data.

`ctx.runNode(child, input, {runId})` accepted an id ADK had already handed out,
and returned the earlier run's result instead of executing:

```ts
await ctx.runNode(child, 'auto');                  // gets automatic id "1"
await ctx.runNode(child, 'collide', {runId: '1'}); // -> "handled auto"
```

Only **two** child executions for three calls; the third call's input was
dropped. Deterministic, and there is no error, warning, or trace of it.

Run ids key the checkpoint lookup that lets a resumed or retried workflow skip
work it already did, so a duplicate id names a run the caller never made: the
scheduler finds the first run's checkpoint, hands back its output, and never
runs the node. Nothing downstream can distinguish that from a real result.

`dynamic/custom_run_ids` already documents the rule — a custom id "must contain
at least one non-numeric character so it cannot collide with the
auto-generated sequential ids" — but nothing enforced it.

**Solution:**

Enforcing the documented wording literally (reject digits-only ids) turned out
to be wrong twice over, and the full test suite caught it:

- `ParallelWorker` keys its fan-out by item index (`parallel_worker.ts:108`),
  so digits are load-bearing *inside* the framework — a shape ban broke six
  `parallel_test.ts` cases.
- Reusing a custom id deliberately is a supported way to dedup concurrent calls
  onto one run, covered by an existing test.

So neither digits nor repetition can be banned outright. This refuses the
actual collision instead: track the ids a context generated automatically, and
reject a custom id that matches one of them. The automatic sequence also skips
ids a caller already claimed, closing the same hole from the other direction —
custom `'1'` first, then automatic numbering walking into it — which the
digits-only rule never covered.

An empty id is refused too; it previously fell through to automatic numbering,
quietly ignoring an argument the caller meant.

The error names the id, the node, and the fix:

```
Invalid runId '1' for node 'child': ADK already numbered an automatic run of
that node '1' in this context, so this call would resolve to that run's cached
output instead of executing, and the input passed here would be dropped.
Automatic ids are "1", "2", "3" per node; give a custom id a non-numeric part,
e.g. 'child-1'.
```

Also corrects `RunNodeOptions.runId`'s doc comment, which described the default
as `nodeName` when it is actually a per-node sequence.

### Testing Plan

**Unit Tests:**

- [x] I have added unit tests for my change — 6 new cases in
      `dynamic_workflow_test.ts`: three non-colliding ids accepted (including
      digits-only `42` and `007`), the colliding id rejected with a message
      naming id and node, an empty id rejected, and the reverse ordering
      (custom `'1'` claimed first) numbering around it instead of deduping.
- [x] All unit tests pass locally — `unit:core` **2876 passed** (209 files),
      including the `ParallelWorker` and same-id dedup cases that constrain the
      design.
- [x] `tests/integration/docs_samples` — 27 passed.

**Manual End-to-End (E2E) Tests:**

Against the original repro:

```
'42'      -> handled input-42        (ACCEPTED — no collision)
'1'       -> REJECTED: Invalid runId '1' for node 'child' …
''        -> REJECTED: a custom run id cannot be empty
'order-1' -> handled input-order-1   (ACCEPTED)
```

All 26 graph-workflow samples re-run (30 runs including both branches of each
router): **30 pass, 0 fail**, so `dynamic/custom_run_ids` and
`dynamic/parallel_route` are unaffected.
