### PR TITLE
fix(workflow): apply node overrides to an already-built node

### DIFF
--- a/core/src/workflow/utils/workflow_graph_utils.ts
+++ b/core/src/workflow/utils/workflow_graph_utils.ts
@@ -9,7 +9,7 @@ import {SchemaLike} from '../../utils/schema.js';
 import {BaseNode, isBaseNode, START} from '../base_node.js';
 import {NodeLike} from '../graph.js';
 import {NODE_BUILDERS, PARALLEL_WORKER_FACTORY} from '../node_builders.js';
-import {RetryConfig} from '../retry_config.js';
+import {prepareRetryConfig, RetryConfig} from '../retry_config.js';
 
 /**
  * Property overrides applied when building a node from a {@link NodeLike}.
@@ -133,8 +133,7 @@ function buildInnerNode(
     return START;
   }
   if (isBaseNode(nodeLike)) {
-    // TODO(phase-3+): apply property overrides via a clone when options differ.
-    return nodeLike;
+    return cloneWithOverrides(nodeLike, options);
   }
   for (const builder of NODE_BUILDERS) {
     if (builder.match(nodeLike)) {
@@ -145,4 +144,70 @@ function buildInnerNode(
     `build_node: unsupported node-like value of type ${typeof nodeLike}. ` +
       'Import the node module that handles it (e.g. via the workflow barrel).',
   );
+}
+
+/** The {@link BuildNodeOptions} keys that name a property of `BaseNode`. */
+const OVERRIDABLE_KEYS = [
+  'name',
+  'description',
+  'rerunOnResume',
+  'retryConfig',
+  'timeout',
+  'inputSchema',
+  'outputSchema',
+  'stateSchema',
+] as const satisfies ReadonlyArray<keyof BuildNodeOptions & keyof BaseNode>;
+
+/**
+ * Returns a copy of `node` with the given node properties replaced, or `node`
+ * itself when nothing is being overridden.
+ *
+ * A node that was built before it reached the graph — `node(existingNode,
+ * {timeout: 5})`, or a `Workflow` reused in two graphs with different retry
+ * policies — cannot have its properties assigned in place: nodes are shared,
+ * and mutating one would reach through to every graph holding it. adk-python
+ * copies instead (`model_copy(update=...)`); this is the same move.
+ *
+ * The copy keeps the node's prototype, so its behaviour and its class are
+ * unchanged, and carries over own properties including the `BaseNode` brand.
+ * `preparedRetryConfig` is derived from `retryConfig` at construction, so it is
+ * recomputed rather than copied — otherwise overriding the retry policy would
+ * appear to work while the node kept retrying on the old one.
+ */
+function cloneWithOverrides(
+  node: BaseNode,
+  options: BuildNodeOptions,
+): BaseNode {
+  const overrides: Record<string, unknown> = {};
+  for (const key of OVERRIDABLE_KEYS) {
+    if (options[key] !== undefined) {
+      overrides[key] = options[key];
+    }
+  }
+  if (Object.keys(overrides).length === 0) {
+    // Identity matters: callers compare the node they passed in against the one
+    // the graph holds.
+    return node;
+  }
+
+  if (typeof overrides['name'] === 'string') {
+    const name = overrides['name'].trim();
+    if (!name) {
+      throw new Error('Node name must be a non-empty string.');
+    }
+    overrides['name'] = name;
+  }
+
+  const clone = Object.create(
+    Object.getPrototypeOf(node) as object,
+  ) as BaseNode;
+  Object.assign(clone, node, overrides);
+  if ('retryConfig' in overrides) {
+    Object.assign(clone, {
+      preparedRetryConfig: options.retryConfig
+        ? prepareRetryConfig(options.retryConfig)
+        : undefined,
+    });
+  }
+  return clone;
 }

--- a/core/test/workflow/workflow_graph_utils_test.ts
+++ b/core/test/workflow/workflow_graph_utils_test.ts
@@ -12,7 +12,7 @@ import {
   isNodeLike,
   isPlainObject,
 } from '../../src/workflow/utils/workflow_graph_utils.js';
-import {FnNode} from './test_helpers.js';
+import {driveNode, FnNode} from './test_helpers.js';
 
 describe('isPlainObject', () => {
   it('is true for object literals', () => {
@@ -63,5 +63,74 @@ describe('buildNode', () => {
     expect(buildNode(node, {parallelWorker: true})).toBeInstanceOf(
       ParallelWorker,
     );
+  });
+});
+
+describe('buildNode — overriding an already-built node', () => {
+  it('returns the same instance when there is nothing to override', () => {
+    const original = new FnNode('keep', (_c, i) => i);
+    // Identity matters: callers compare what they passed in against what the
+    // graph holds.
+    expect(buildNode(original)).toBe(original);
+    expect(buildNode(original, {})).toBe(original);
+  });
+
+  it('applies node property overrides instead of dropping them', () => {
+    const original = new FnNode('original', (_c, i) => i);
+    const built = buildNode(original, {
+      name: 'renamed',
+      description: 'a description',
+      timeout: 5,
+      rerunOnResume: true,
+    });
+
+    expect(built).not.toBe(original);
+    expect(built.name).toBe('renamed');
+    expect(built.description).toBe('a description');
+    expect(built.timeout).toBe(5);
+    expect(built.rerunOnResume).toBe(true);
+  });
+
+  it('leaves the original node untouched', () => {
+    const original = new FnNode('original', (_c, i) => i);
+    buildNode(original, {name: 'renamed', timeout: 5});
+
+    // A node can sit in two graphs; overriding for one must not reach the other.
+    expect(original.name).toBe('original');
+    expect(original.timeout).toBeUndefined();
+  });
+
+  it('keeps the node’s class and behaviour', async () => {
+    const original = new FnNode('echo', (_c, input) => `echo:${input}`);
+    const built = buildNode(original, {name: 'renamed'});
+
+    expect(built).toBeInstanceOf(FnNode);
+    const {output} = await driveNode(built, 'hi');
+    expect(output).toBe('echo:hi');
+  });
+
+  it('recomputes the prepared retry config when retryConfig is overridden', () => {
+    const original = new FnNode('n', (_c, i) => i, {
+      retryConfig: {maxAttempts: 2},
+    });
+    const built = buildNode(original, {retryConfig: {maxAttempts: 7}});
+
+    expect(built.retryConfig).toEqual({maxAttempts: 7});
+    // The prepared form is derived at construction; copying it would leave the
+    // node retrying on the policy it was overriding.
+    expect(built.preparedRetryConfig?.maxAttempts).toBe(7);
+  });
+
+  it('rejects a blank name override', () => {
+    const original = new FnNode('original', (_c, i) => i);
+    expect(() => buildNode(original, {name: '   '})).toThrow();
+  });
+
+  it('overrides the inner node when wrapping in a parallel worker', () => {
+    const original = new FnNode('inner', (_c, i) => i);
+    const built = buildNode(original, {parallelWorker: true, timeout: 3});
+
+    expect(built).toBeInstanceOf(ParallelWorker);
+    expect(original.timeout).toBeUndefined();
   });
 });


### PR DESCRIPTION
> **Stacked on #667** (which is itself on #663). Base is `feat/base-agent-as-node`, so the diff here is just this fix. It stacks because #667 edits the adjacent lines in `buildInnerNode`; on `main` the two would collide. Retargets to `main` as the stack lands.

### Link to Issue or Description of Change

**Problem:**

`buildNode` dropped every override when handed a node that was already built. `node(existingNode, {timeout: 5})`, or an edge declaring a retry policy for a `Workflow` reused from elsewhere, returned the node untouched — so the timeout never applied and the retry policy was never installed, silently. The only clue was a `TODO(phase-3+)` sitting where the overrides should have been consumed.

**Solution:**

Assigning the overrides in place is not an option: nodes are shared, so a node used in two graphs would have one graph's settings reach through to the other. Copy instead — the same move adk-python makes with `model_copy(update=...)`.

Details worth a reviewer's attention:

- The copy keeps the node's prototype, so its class and behaviour are unchanged, and carries over own properties **including the `BaseNode` brand**, so the result still passes `isBaseNode`. Node classes hold no `#private` fields, which is what makes copying own properties sufficient — worth re-checking if that ever changes.
- **`preparedRetryConfig` is recomputed, not copied.** It is derived from `retryConfig` at construction, so copying it verbatim would leave a node whose `retryConfig` says one thing and whose retry behaviour follows another — the same silent failure this change exists to remove.
- A node with **no** overrides is returned as-is rather than copied, because callers compare the node they passed in against the one the graph holds (`new WorkflowAgent(workflow).workflow` is asserted to be the same instance).
- Only the `BuildNodeOptions` keys that name a `BaseNode` property are applied. `authConfig` is meaningful only at construction, and `parallelWorker` / `isolationScope` are handled by the caller.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Seven tests in `core/test/workflow/workflow_graph_utils_test.ts`: identity preserved with no overrides; overrides actually applied; the original left untouched; class and behaviour preserved (the copy still runs); `preparedRetryConfig` recomputed; a blank name rejected; and overrides applied to the inner node when wrapping in a `ParallelWorker`.

```
npm run ts:check          clean
npx vitest --project unit:core    210 files, 2886 passed
npm run test:integration           74 files, 206 passed | 8 skipped
```

**Manual End-to-End (E2E) Tests:**

Not run; the change is confined to node construction and is covered by the unit and integration suites.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context
