### PR TITLE
fix(runner): stop warning about workflow nodes when resuming

### DIFF
--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -617,6 +617,17 @@ export function determineAgentForResumption(
       continue;
     }
 
+    // A graph-workflow node is not an agent. Its events are authored by the
+    // node name and stamped with a node path, and nodes never appear in the
+    // agent tree — a WorkflowAgent keeps its structure in `edges`, so its
+    // `subAgents` is empty. The lookup below therefore always missed, warning
+    // about every node of every workflow, including on the happy path of an
+    // ordinary human-in-the-loop resume. Nodes are not transfer targets
+    // either, so skipping them leaves the resolved agent unchanged.
+    if (event.nodeInfo?.path) {
+      continue;
+    }
+
     if (event.author === rootAgent.name) {
       return rootAgent;
     }

--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -600,9 +600,11 @@ export function determineAgentForResumption(
     if (resumedAgent) {
       return resumedAgent;
     }
-    logger.warn(
-      `Function response from an unknown agent: ${event.author}, event id: ${event.id}`,
-    );
+    if (!isWorkflowNodeEvent(event)) {
+      logger.warn(
+        `Function response from an unknown agent: ${event.author}, event id: ${event.id}`,
+      );
+    }
   }
 
   // =========================================================================
@@ -617,26 +619,17 @@ export function determineAgentForResumption(
       continue;
     }
 
-    // A graph-workflow node is not an agent. Its events are authored by the
-    // node name and stamped with a node path, and nodes never appear in the
-    // agent tree — a WorkflowAgent keeps its structure in `edges`, so its
-    // `subAgents` is empty. The lookup below therefore always missed, warning
-    // about every node of every workflow, including on the happy path of an
-    // ordinary human-in-the-loop resume. Nodes are not transfer targets
-    // either, so skipping them leaves the resolved agent unchanged.
-    if (event.nodeInfo?.path) {
-      continue;
-    }
-
     if (event.author === rootAgent.name) {
       return rootAgent;
     }
 
     const agent = rootAgent.findSubAgent(event.author);
     if (!agent) {
-      logger.warn(
-        `Event from an unknown agent: ${event.author}, event id: ${event.id}`,
-      );
+      if (!isWorkflowNodeEvent(event)) {
+        logger.warn(
+          `Event from an unknown agent: ${event.author}, event id: ${event.id}`,
+        );
+      }
       continue;
     }
     if (isRoutableLlmAgent(agent)) {
@@ -647,6 +640,26 @@ export function determineAgentForResumption(
   // Case 3: default to root agent.
   // =========================================================================
   return rootAgent;
+}
+
+/**
+ * Whether the event was emitted by a graph-workflow node, and so may be
+ * authored by a node name rather than an agent name.
+ *
+ * `nodeInfo.path` is stamped on everything a node emits (`node_runner.ts`).
+ * When the node emits an event of its own — a function node's output, or a HITL
+ * interrupt, which carries no author at all — the node name is stamped as the
+ * author. Nodes are not in the agent tree and never will be: a `WorkflowAgent`
+ * keeps its structure in `edges`, so its `subAgents` is empty. Looking such an
+ * author up could only ever miss, so the miss is not worth warning about — it
+ * fired on the happy path of every human-in-the-loop resume.
+ *
+ * Only the warning is suppressed, never the lookup: a node that wraps an agent
+ * (`LLMAgentWrapper`) yields the agent's own events, so the author is a real
+ * agent name that must still resolve.
+ */
+function isWorkflowNodeEvent(event: Event): boolean {
+  return Boolean(event.nodeInfo?.path);
 }
 
 /**

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -506,25 +506,31 @@ describe('Runner.determineAgentForResumption', () => {
   });
 
   describe('graph-workflow node events', () => {
-    /** A session holding one event authored by a workflow node. */
-    async function sessionWithNodeEvent(sessionId: string) {
+    /** A session holding the given events. */
+    async function sessionWith(sessionId: string, events: Event[]) {
       const session = await sessionService.createSession({
         appName: TEST_APP_ID,
         userId: TEST_USER_ID,
         sessionId,
       });
-      await sessionService.appendEvent({
-        session,
-        event: createEvent({
-          invocationId: 'inv1',
-          // A node is authored by its own name and stamped with a node path.
-          // It is not in the agent tree, and never can be.
-          author: 'step1',
-          nodeInfo: {path: 'root_agent.step1'},
-          content: {role: 'model', parts: [{text: 'Enter a number:'}]},
-        }),
-      });
+      for (const event of events) {
+        await sessionService.appendEvent({session, event});
+      }
       return session;
+    }
+
+    /**
+     * An event from a node that is not an agent: authored by the node's own
+     * name, stamped with a node path. It is not in the agent tree, and never
+     * can be.
+     */
+    function nodeEvent(author: string, text: string) {
+      return createEvent({
+        invocationId: 'inv1',
+        author,
+        nodeInfo: {path: `root_agent.${author}`},
+        content: {role: 'model', parts: [{text}]},
+      });
     }
 
     it('does not warn about a node that is not in the agent tree', async () => {
@@ -533,7 +539,9 @@ describe('Runner.determineAgentForResumption', () => {
       const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
       determineAgentForResumption(
-        await sessionWithNodeEvent('session_workflow_node'),
+        await sessionWith('session_workflow_node', [
+          nodeEvent('step1', 'Enter a number:'),
+        ]),
         rootAgent,
         createResumabilityConfig({isResumable: true}),
       );
@@ -542,32 +550,81 @@ describe('Runner.determineAgentForResumption', () => {
       warn.mockRestore();
     });
 
-    it('still resolves to the root agent', async () => {
+    it('does not warn when a resumed function call came from a node', async () => {
+      // A HITL interrupt event carries no author, so the workflow engine
+      // stamps the node name on it. Replying to it with a structured resume
+      // sends Case 1 looking for an agent named after the node.
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const interrupt = createEvent({
+        invocationId: 'inv1',
+        author: 'gate',
+        nodeInfo: {path: 'root_agent.gate'},
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'interrupt_1',
+                name: 'adk_request_input',
+                args: {},
+              },
+            },
+          ],
+        },
+      });
+      const reply = createEvent({
+        invocationId: 'inv2',
+        author: 'user',
+        content: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'interrupt_1',
+                name: 'adk_request_input',
+                response: {value: 21},
+              },
+            },
+          ],
+        },
+      });
+
       const result = determineAgentForResumption(
-        await sessionWithNodeEvent('session_workflow_node_2'),
+        await sessionWith('session_workflow_interrupt', [interrupt, reply]),
         rootAgent,
         createResumabilityConfig({isResumable: true}),
       );
 
+      expect(warn).not.toHaveBeenCalled();
       expect(result.name).toBe('root_agent');
+      warn.mockRestore();
+    });
+
+    it('still resolves an agent that a node wrapped', async () => {
+      // The LLMAgentWrapper shape: the node yields the agent's own events, so
+      // the author is a real agent even though the event carries a node path.
+      // Suppressing the warning must not cost us the lookup.
+      const result = determineAgentForResumption(
+        await sessionWith('session_workflow_wrapped_agent', [
+          nodeEvent('sub_agent1', 'Sub agent response'),
+        ]),
+        rootAgent,
+        createResumabilityConfig({isResumable: true}),
+      );
+
+      expect(result.name).toBe('sub_agent1');
     });
 
     it('still warns about a genuinely unknown agent', async () => {
       const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-      const session = await sessionService.createSession({
-        appName: TEST_APP_ID,
-        userId: TEST_USER_ID,
-        sessionId: 'session_unknown_agent',
-      });
       // No node path: this really is an agent nobody can find.
-      await sessionService.appendEvent({
-        session,
-        event: createEvent({
+      const session = await sessionWith('session_unknown_agent', [
+        createEvent({
           invocationId: 'inv1',
           author: 'ghost_agent',
           content: {role: 'model', parts: [{text: 'boo'}]},
         }),
-      });
+      ]);
 
       determineAgentForResumption(
         session,
@@ -577,6 +634,50 @@ describe('Runner.determineAgentForResumption', () => {
 
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('Event from an unknown agent: ghost_agent'),
+      );
+      warn.mockRestore();
+    });
+
+    it('still warns about a resumed function call from an unknown agent', async () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const callEvent = createEvent({
+        invocationId: 'inv1',
+        author: 'ghost_agent',
+        content: {
+          role: 'model',
+          parts: [{functionCall: {id: 'call_1', name: 'test_func', args: {}}}],
+        },
+      });
+      const responseEvent = createEvent({
+        invocationId: 'inv2',
+        author: 'user',
+        content: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'call_1',
+                name: 'test_func',
+                response: {},
+              },
+            },
+          ],
+        },
+      });
+
+      determineAgentForResumption(
+        await sessionWith('session_unknown_function_response', [
+          callEvent,
+          responseEvent,
+        ]),
+        rootAgent,
+        createResumabilityConfig({isResumable: true}),
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Function response from an unknown agent: ghost_agent',
+        ),
       );
       warn.mockRestore();
     });

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -21,6 +21,7 @@ import {
 } from '@google/adk';
 import {Content, FunctionCall, FunctionResponse} from '@google/genai';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {logger} from '../../src/utils/logger.js';
 
 const TEST_APP_ID = 'test_app_id';
 const TEST_USER_ID = 'test_user_id';
@@ -502,6 +503,83 @@ describe('Runner.determineAgentForResumption', () => {
       createResumabilityConfig({isResumable: true}),
     );
     expect(result.name).toBe('sub_agent1');
+  });
+
+  describe('graph-workflow node events', () => {
+    /** A session holding one event authored by a workflow node. */
+    async function sessionWithNodeEvent(sessionId: string) {
+      const session = await sessionService.createSession({
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId,
+      });
+      await sessionService.appendEvent({
+        session,
+        event: createEvent({
+          invocationId: 'inv1',
+          // A node is authored by its own name and stamped with a node path.
+          // It is not in the agent tree, and never can be.
+          author: 'step1',
+          nodeInfo: {path: 'root_agent.step1'},
+          content: {role: 'model', parts: [{text: 'Enter a number:'}]},
+        }),
+      });
+      return session;
+    }
+
+    it('does not warn about a node that is not in the agent tree', async () => {
+      // Every HITL resume replays node events, so this fired on the happy
+      // path of any workflow that pauses for input.
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      determineAgentForResumption(
+        await sessionWithNodeEvent('session_workflow_node'),
+        rootAgent,
+        createResumabilityConfig({isResumable: true}),
+      );
+
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('still resolves to the root agent', async () => {
+      const result = determineAgentForResumption(
+        await sessionWithNodeEvent('session_workflow_node_2'),
+        rootAgent,
+        createResumabilityConfig({isResumable: true}),
+      );
+
+      expect(result.name).toBe('root_agent');
+    });
+
+    it('still warns about a genuinely unknown agent', async () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const session = await sessionService.createSession({
+        appName: TEST_APP_ID,
+        userId: TEST_USER_ID,
+        sessionId: 'session_unknown_agent',
+      });
+      // No node path: this really is an agent nobody can find.
+      await sessionService.appendEvent({
+        session,
+        event: createEvent({
+          invocationId: 'inv1',
+          author: 'ghost_agent',
+          content: {role: 'model', parts: [{text: 'boo'}]},
+        }),
+      });
+
+      determineAgentForResumption(
+        session,
+        rootAgent,
+        createResumabilityConfig({isResumable: true}),
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Event from an unknown agent: ghost_agent'),
+      );
+      warn.mockRestore();
+    });
   });
 });
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Every human-in-the-loop resume logs warnings per workflow node — on the happy
path, with nothing wrong:

```
WARN: [ADK] Function response from an unknown agent: gate, event id: UEi3N0S3
WARN: [ADK] Event from an unknown agent: gate, event id: UEi3N0S3
WARN: [ADK] Event from an unknown agent: a, event id: LEAbo04a
```

`determineAgentForResumption` looks its authors up in the agent tree, in two
places: case 1 resolves the author of the resumed function call, and case 2
scans backwards for the last transferable agent. A graph-workflow node authors
its events under its own node name — a HITL interrupt carries no author at all
(`hitl_utils.ts`), so `enrichEvent` stamps the node name on it — and nodes are
**not** in the agent tree: a `WorkflowAgent` keeps its structure in `edges`, so
its `subAgents` is empty, and never will be. Both lookups could only ever miss,
so the warnings fired for something entirely normal and sent the reader looking
for an agent that does not exist.

Same underlying assumption as #654 (the dev UI walking `subAgents` to draw a
graph), in a different place.

**Solution:**

Suppress the warning — and only the warning — when the event carries a node
path. That is what marks an event as emitted by a node (`node_runner.ts` stamps
`nodeInfo.path` on everything a node emits), and it is the only shape whose
lookup is guaranteed to miss.

The lookup itself is untouched, because a node path does *not* mean "the author
is not an agent": `LLMAgentWrapper` yields the wrapped agent's own events, so
the author is a real agent name that must still resolve. Skipping such an event
outright would drop both the `rootAgent.name` check and the `findSubAgent`
return, and could change the resolved agent.

A genuinely unknown agent — an event with no node path whose author is not in
the tree — still warns, at both sites.

### Testing Plan

**Unit Tests:**

- [x] I have added unit tests for my change — five cases in `runner_test.ts`,
      each checked against all three versions rather than only against the fix:

      | test | main | node-path skip | this PR |
      |---|---|---|---|
      | does not warn about a node not in the agent tree | fail | pass | pass |
      | does not warn when a resumed function call came from a node | fail | fail | pass |
      | still resolves an agent that a node wrapped | pass | **fail** | pass |
      | still warns about a genuinely unknown agent | pass | pass | pass |
      | still warns about a resumed function call from an unknown agent | pass | pass | pass |

      The two `still warns` tests pass everywhere by design — they are there so
      a future guard cannot delete the warning outright.

- [x] All unit tests pass locally — `unit:core` + `unit:dev` **3141 passed**
      (225 files).
- [x] `tests/integration/workflows` — 84 passed (37 files), including every
      HITL path (`request_input*`, `plain_text_resume`, `node_as_tool_hitl`)
      and `agent_in_workflow` (the `LLMAgentWrapper` shape).
- [x] `tests/integration/docs_samples`, `runner`, `agents` — 36 passed.
- [x] `npm run ts:check`, `eslint` and `prettier --check` clean.

**Manual End-to-End (E2E) Tests:**

A resumable `Runner` driving the `resume_test.ts` gate workflow, with
`logger.warn` captured across both turns:

| | warnings logged |
|---|---|
| `main` | `Function response from an unknown agent: gate`, `Event from an unknown agent: gate`, `Event from an unknown agent: a` |
| node-path skip | `Function response from an unknown agent: gate` |
| this PR | none |

`human_input/get_started` re-run on this revision, warnings deliberately
unfiltered (`--log_level warning`) — before, the `unknown agent` line appeared
between the reply and the result:

```
[user]: 21
WARN: [ADK] Event from an unknown agent: step1, event id: io6LcbGm
[step2]: 42
[root_agent]: 42
```

now:

```
[user]: start
--- [step1] is waiting for your input ---
Enter a number:
[user]: 21
[step2]: 42
[root_agent]: 42
```

The 30-run sweep of all 26 graph-workflow samples (both branches of each
router) was run on the previous revision and passed 30/0. This revision only
narrows what the guard covers, and the samples are re-covered automatically by
`tests/integration/docs_samples`, which constructs all 26 and runs the offline
ones end-to-end.
