### PR TITLE
test(workflow): pin agent-node state reads, and correct what the seam claims

### DIFF
--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -155,13 +155,27 @@ export class NodeContext {
    * agent sees", so an agent run as a node (`BaseAgent.runImpl`) and one run
    * directly go through the same seam.
    *
-   * Today it hands back the node's own invocation context unchanged, which is
-   * what the agent wrapper already did. adk-python returns a copy carrying the
-   * proxy session and the isolation scope (`agents/context.py`
-   * `get_invocation_context`); matching that here means giving the agent the
-   * node's `state` view rather than letting it read through to `session.state`,
-   * which is a behaviour change for every agent and is deliberately not part of
-   * introducing the seam.
+   * It hands back the node's own invocation context unchanged, and that is the
+   * intended behaviour rather than a placeholder.
+   *
+   * adk-python's counterpart (`agents/context.py` `get_invocation_context`) is
+   * documented as returning "a copy with the proxy session", which reads as
+   * though the agent is handed a different view of state. It is not: that
+   * `Context.session` returns `self._invocation_context.session`, so the copy
+   * substitutes the same object, and `Context._state` is built directly over
+   * `session.state`. A Python agent run as a node reads session state exactly
+   * as a TypeScript one does.
+   *
+   * The other thing that copy carries — the isolation scope — is already
+   * applied by the time this runs: the node runner builds the child invocation
+   * context with the node's scope, so it is present on the object returned.
+   *
+   * That leaves the node's own `state` view, which layers this node's pending
+   * delta over an invocation-wide overlay. Nodes read through it; an agent
+   * reads `session.state`. The two agree because every write through the view
+   * is also written through to the session — see `NodeStateView` below — and
+   * the agent-node cases in `core/test/workflow/state_consistency_test.ts` pin
+   * that.
    */
   getInvocationContext(): InvocationContext {
     return this.invocationContext;

--- a/core/test/workflow/state_consistency_test.ts
+++ b/core/test/workflow/state_consistency_test.ts
@@ -5,6 +5,8 @@
  */
 
 import {describe, expect, it} from 'vitest';
+import {BaseAgent} from '../../src/agents/base_agent.js';
+import {InvocationContext} from '../../src/agents/invocation_context.js';
 import {LlmAgent} from '../../src/agents/llm_agent.js';
 import {Event} from '../../src/events/event.js';
 import {BaseLlm} from '../../src/models/base_llm.js';
@@ -38,6 +40,34 @@ class MockLlm extends BaseLlm {
 
   async connect(_request: LlmRequest): Promise<BaseLlmConnection> {
     throw new Error('not implemented');
+  }
+}
+
+/**
+ * A non-LLM agent node that records `session.state['attempts']` as it runs,
+ * reading twice across a tick so a mid-run rollback would be visible.
+ */
+class StateReaderAgent extends BaseAgent {
+  constructor(
+    config: {name: string},
+    private readonly reads: Array<number | undefined>,
+  ) {
+    super(config);
+  }
+
+  // eslint-disable-next-line require-yield
+  protected async *runAsyncImpl(
+    ctx: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    this.reads.push(ctx.session.state['attempts'] as number | undefined);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    this.reads.push(ctx.session.state['attempts'] as number | undefined);
+    return;
+  }
+
+  // eslint-disable-next-line require-yield
+  protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
+    return;
   }
 }
 
@@ -238,6 +268,65 @@ describe('workflow state consistency across nodes', () => {
     expect(readBack).toEqual({result: 'done'});
     expect(onSession).toEqual({result: 'done'});
     expect(state['summary']).toEqual({result: 'done'});
+  });
+
+  it('an agent node reads what the preceding nodes wrote', async () => {
+    // Nodes read state through `NodeContext.state`, which layers a pending
+    // delta over an invocation-wide overlay; an agent reads `session.state`
+    // instead. The two only agree because every write through the view is also
+    // written through to the session, so this pins that they do.
+    const reads: Array<number | undefined> = [];
+    const a = new FunctionNode('a', (ctx: NodeContext) => {
+      ctx.state.set('attempts', 0);
+      return 'a';
+    });
+    const b = new FunctionNode('b', (ctx: NodeContext) => {
+      ctx.state.set('attempts', (ctx.state.get<number>('attempts') ?? -1) + 1);
+      return 'b';
+    });
+    const reader = new StateReaderAgent({name: 'reader'}, reads);
+
+    const {state} = await runOnce(
+      new WorkflowAgent({
+        name: 'agent_reads_wf',
+        edges: [['START', a, b, reader]],
+      }),
+    );
+
+    // Both reads straddle a tick, so a delta re-applied by the runner's event
+    // commit mid-run would show up as a rollback here.
+    expect(reads).toEqual([1, 1]);
+    expect(state['attempts']).toBe(1);
+  });
+
+  it('an agent node reads the surviving write after parallel writers', async () => {
+    const reads: Array<number | undefined> = [];
+    const slow = new FunctionNode('slow', async (ctx: NodeContext) => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      ctx.state.set('attempts', 10);
+      return 'slow';
+    });
+    const quick = new FunctionNode('quick', (ctx: NodeContext) => {
+      ctx.state.set('attempts', 20);
+      return 'quick';
+    });
+    const join = new FunctionNode('join', () => 'join');
+    const reader = new StateReaderAgent({name: 'reader'}, reads);
+
+    const {state} = await runOnce(
+      new WorkflowAgent({
+        name: 'parallel_writers_wf',
+        edges: [
+          ['START', slow, join],
+          ['START', quick, join],
+          [join, reader],
+        ],
+      }),
+    );
+
+    // Which branch wins is the workflow's business; that the agent and the
+    // committed session agree on it is not.
+    expect(reads[reads.length - 1]).toBe(state['attempts']);
   });
 
   it('serves a second invocation over the same session from committed state', () => {


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

This started as "M2": give an agent running as a workflow node the node's `state` view, on the grounds that adk-python's `get_investigation_context` returns "a copy with the proxy session". I wrote that note on the seam in #667, and it is wrong.

Reading the Python side rather than its docstring:

- `Context.session` returns `self._invocation_context.session` — so `model_copy(update={'session': self.session})` substitutes **the same object**. There is no proxy.
- `Context._state` is `State(value=invocation_context.session.state, delta=...)` — built directly over session state.

So a Python agent run as a node reads session state exactly as a TypeScript one does; we are already at parity. The other thing that copy carries, the isolation scope, is **also already applied** — `node_runner.ts` builds the child invocation context with the node's scope before the `NodeContext` exists, and `isolation_scope_test.ts` covers it.

Building the "fix" would therefore have moved us *away* from parity, and the note was pointing the next person at it.

**What is actually true, and now tested:**

Nodes read through `NodeStateView` (a pending delta over an invocation-wide overlay); an agent reads `session.state`. They agree only because every write through the view is also written through to the session. That is load-bearing and was untested.

I tried to provoke a divergence three ways and could not:

- a sequential chain (`a` writes, `b` read-modify-writes, agent reads);
- reads straddling a tick, so a delta re-applied by the runner's event commit mid-run would surface as a rollback;
- parallel writers joined before the reader.

All three show the agent reading what the nodes read. Those three cases are now regression tests, and the seam's note says why it returns the context unchanged instead of promising a change.

**So this PR is documentation and tests — no behaviour change.** The `getInvocationContext()` seam stays exactly as it is.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Two new cases in `core/test/workflow/state_consistency_test.ts`, alongside the existing node-side ones, using a non-LLM agent so the agent wrapper is not what is being measured.

```
npm run ts:check          clean
npx vitest --project unit:core    211 files, 2943 passed
npm run test:integration           74 files, 206 passed | 8 skipped
```

**Manual End-to-End (E2E) Tests:**

Not applicable — no behaviour change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

If the write-through in `NodeStateView` is ever removed or narrowed, these tests are what will catch it — that is the coupling worth knowing about.
