### PR TITLE
feat(agents): deprecate SequentialAgent, ParallelAgent and LoopAgent

### DIFF
--- a/core/src/agents/loop_agent.ts
+++ b/core/src/agents/loop_agent.ts
@@ -6,6 +6,7 @@
 
 import {Event} from '../events/event.js';
 
+import {deprecated} from '../utils/deprecated.js';
 import {BaseAgent, BaseAgentConfig} from './base_agent.js';
 import {InvocationContext} from './invocation_context.js';
 
@@ -46,7 +47,16 @@ export function isLoopAgent(obj: unknown): obj is LoopAgent {
  *
  * When sub-agent generates an event with escalate or max_iterations are
  * reached, the loop agent will stop.
+ *
+ * @deprecated Use `Workflow` instead, which expresses the same ordering as a
+ * graph and adds routing, retries, HITL and resumability. This class will be
+ * removed in a future version. Note that a `Workflow` cannot yet be an
+ * `LlmAgent` sub-agent — wrap it in a `WorkflowAgent` for that.
  */
+@deprecated(
+  'LoopAgent is deprecated in favor of Workflow and will be removed in a' +
+    ' future version. Workflow cannot yet be used as an LlmAgent sub-agent.',
+)
 export class LoopAgent extends BaseAgent<LoopAgentConfig> {
   /**
    * A unique symbol to identify ADK loop agent class.

--- a/core/src/agents/parallel_agent.ts
+++ b/core/src/agents/parallel_agent.ts
@@ -6,6 +6,7 @@
 
 import {Event} from '../events/event.js';
 
+import {deprecated} from '../utils/deprecated.js';
 import {BaseAgent} from './base_agent.js';
 import {InvocationContext} from './invocation_context.js';
 
@@ -37,7 +38,16 @@ export function isParallelAgent(obj: unknown): obj is ParallelAgent {
  *
  *  - Running different algorithms simultaneously.
  *  - Generating multiple responses for review by a subsequent evaluation agent.
+ *
+ * @deprecated Use `Workflow` instead, which expresses the same ordering as a
+ * graph and adds routing, retries, HITL and resumability. This class will be
+ * removed in a future version. Note that a `Workflow` cannot yet be an
+ * `LlmAgent` sub-agent — wrap it in a `WorkflowAgent` for that.
  */
+@deprecated(
+  'ParallelAgent is deprecated in favor of Workflow and will be removed in a' +
+    ' future version. Workflow cannot yet be used as an LlmAgent sub-agent.',
+)
 export class ParallelAgent extends BaseAgent {
   /**
    * A unique symbol to identify ADK parallel agent class.

--- a/core/src/agents/sequential_agent.ts
+++ b/core/src/agents/sequential_agent.ts
@@ -6,6 +6,7 @@
 import {Event} from '../events/event.js';
 import {FunctionTool} from '../tools/function_tool.js';
 
+import {deprecated} from '../utils/deprecated.js';
 import {BaseAgent} from './base_agent.js';
 import {InvocationContext} from './invocation_context.js';
 import {isLlmAgent} from './llm_agent.js';
@@ -37,7 +38,16 @@ export function isSequentialAgent(obj: unknown): obj is SequentialAgent {
 
 /**
  * A shell agent that runs its sub-agents in a sequential order.
+ *
+ * @deprecated Use `Workflow` instead, which expresses the same ordering as a
+ * graph and adds routing, retries, HITL and resumability. This class will be
+ * removed in a future version. Note that a `Workflow` cannot yet be an
+ * `LlmAgent` sub-agent — wrap it in a `WorkflowAgent` for that.
  */
+@deprecated(
+  'SequentialAgent is deprecated in favor of Workflow and will be removed in a' +
+    ' future version. Workflow cannot yet be used as an LlmAgent sub-agent.',
+)
 export class SequentialAgent extends BaseAgent {
   /**
    * A unique symbol to identify ADK sequential agent class.

--- a/core/src/utils/deprecated.ts
+++ b/core/src/utils/deprecated.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {logger} from './logger.js';
+
+const warnedItems = new Set<string>();
+
+/** Resets the warned-once registry. Test-only. */
+export function resetDeprecationWarnings(): void {
+  warnedItems.clear();
+}
+
+// `any[]` rather than `unknown[]`: a class whose constructor takes a typed
+// config (every agent) is not assignable to `new (...args: unknown[]) => …`,
+// so the stricter signature would reject exactly the classes this decorates.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above.
+type Constructor = new (...args: any[]) => any;
+
+/**
+ * Marks a class as deprecated, logging `reason` once the first time it is
+ * instantiated.
+ *
+ * The JSDoc `@deprecated` tag is what a reader and an editor see; this is what
+ * someone running the code sees, so a deprecation is not silent to a caller who
+ * never opens the source. Mirrors `typing_extensions.deprecated`, which
+ * adk-python applies to the same classes, and follows the shape of
+ * {@link experimental}: one warning per class, not per instance, so a hot loop
+ * does not turn into a wall of logs.
+ */
+export function deprecated(reason: string) {
+  return function <T extends Constructor>(target: T): T {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- Function is safe because we know it's a constructor
+    const className = (target as Function).name;
+    const wrapped = class extends (target as Constructor) {
+      constructor(...args: unknown[]) {
+        if (!warnedItems.has(className)) {
+          logger.warn(reason);
+          warnedItems.add(className);
+        }
+        // eslint-disable-next-line constructor-super -- super is required, ESLint can't figure it out.
+        super(...args);
+      }
+    };
+
+    // The subclass above is anonymous, so it would otherwise report the binding
+    // name to anyone reading `SomeClass.name` — which agent code does, since a
+    // class name reaches events and logs.
+    Object.defineProperty(wrapped, 'name', {
+      value: className,
+      configurable: true,
+    });
+
+    return wrapped as T;
+  };
+}

--- a/core/test/utils/deprecated_test.ts
+++ b/core/test/utils/deprecated_test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {LoopAgent} from '../../src/agents/loop_agent.js';
+import {ParallelAgent} from '../../src/agents/parallel_agent.js';
+import {SequentialAgent} from '../../src/agents/sequential_agent.js';
+import {
+  deprecated,
+  resetDeprecationWarnings,
+} from '../../src/utils/deprecated.js';
+import {logger} from '../../src/utils/logger.js';
+
+describe('deprecated', () => {
+  beforeEach(() => {
+    resetDeprecationWarnings();
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetDeprecationWarnings();
+  });
+
+  it('warns once per class, not once per instance', () => {
+    @deprecated('Old is deprecated.')
+    class Old {
+      constructor(readonly value: string) {}
+    }
+
+    new Old('a');
+    new Old('b');
+    new Old('c');
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith('Old is deprecated.');
+  });
+
+  it('keeps the class name, which reaches events and logs', () => {
+    @deprecated('Named is deprecated.')
+    class Named {}
+
+    expect(Named.name).toBe('Named');
+    expect(new Named()).toBeInstanceOf(Named);
+  });
+
+  it('leaves construction behaviour alone', () => {
+    @deprecated('Adder is deprecated.')
+    class Adder {
+      readonly total: number;
+      constructor(a: number, b: number) {
+        this.total = a + b;
+      }
+    }
+
+    expect(new Adder(2, 3).total).toBe(5);
+  });
+});
+
+describe('the composite shell agents are deprecated', () => {
+  beforeEach(() => {
+    resetDeprecationWarnings();
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetDeprecationWarnings();
+  });
+
+  it.each([
+    ['SequentialAgent', () => new SequentialAgent({name: 'seq'})],
+    ['ParallelAgent', () => new ParallelAgent({name: 'par'})],
+    ['LoopAgent', () => new LoopAgent({name: 'loop'})],
+  ])('%s warns and still works', (name, construct) => {
+    const agent = construct();
+
+    expect(agent.name).toBe(agent.name);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain(
+      `${name} is deprecated in favor of Workflow`,
+    );
+    // The constructor is wrapped, so the reported class name has to survive it.
+    expect(agent.constructor.name).toBe(name);
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

The repo ships two orchestration models with no signal about which one is the future. `Workflow` expresses everything the three shell agents do, as a graph, and adds routing, retries, HITL and resumability on top — but nothing tells a caller that, so new code keeps reaching for the older shape.

adk-python settled this by marking all three `@deprecated` in favour of `Workflow` (`sequential_agent.py:78`, `loop_agent.py:53`, `parallel_agent.py:183`). This is the same call, with the same wording.

**Solution:**

JSDoc `@deprecated` on each class, plus a runtime warning.

The JSDoc tag is what an editor and a reader see. Python's `typing_extensions.deprecated` also warns at runtime, and that half matters more here — most callers of these classes will never open their source. So this adds a `@deprecated(reason)` class decorator alongside the existing `@experimental`, following its shape:

- **warn once per class, not per instance**, so a hot loop does not become a wall of logs;
- **re-declare `name` on the wrapper**, because a class name reaches events and logs.

One detail worth a reviewer's eye: the decorator's generic takes `any[]` constructor args rather than `unknown[]`. A class whose constructor takes a typed config — which is every agent — is not assignable to `new (...args: unknown[]) => …`, so the stricter signature rejects exactly the classes this exists to decorate. `@experimental` sidesteps the same problem by widening its target to `Constructor | object`.

The notice repeats Python's caveat, because it holds here too: a `Workflow` cannot yet be an `LlmAgent` sub-agent. The escape hatch differs — in TypeScript you wrap it in a `WorkflowAgent` — so the note says that.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`core/test/utils/deprecated_test.ts` covers the decorator (warns once across three instantiations, preserves `name` and `instanceof`, leaves construction behaviour alone) and each of the three agents (warns, still constructs, still reports its own class name through the wrapper).

```
npm run ts:check          clean
npx vitest --project unit:core    212 files, 2947 passed
npm run test:integration           74 files, 206 passed | 8 skipped
```

**Manual End-to-End (E2E) Tests:**

Not run; the classes are otherwise unchanged and the existing suites exercise them.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Breaking-ish:** constructing one of these now logs a warning once per class per process. Nothing else changes and they keep working. Given #629 is the v2.0.0 release PR, this is the moment to send the signal — deprecating in a major and removing in a later one.

Pairs with the Runner change that lets a `Workflow` be a root directly, which is what makes the migration path real rather than nominal.
