### PR TITLE
refactor(tests): build the workflow agents in the error-event tests from config

### DIFF
--- a/core/test/workflow/node_error_event_test.ts
+++ b/core/test/workflow/node_error_event_test.ts
@@ -66,12 +66,10 @@ function icWithId(invocationId: string): InvocationContext {
       userId: 'u',
       lastUpdateTime: Date.now(),
     }),
-    agent: new WorkflowAgent(
-      new Workflow({
-        name: 'wf',
-        edges: [['START', new FunctionNode('n', () => null)]],
-      }),
-    ),
+    agent: new WorkflowAgent({
+      name: 'wf',
+      edges: [['START', new FunctionNode('n', () => null)]],
+    }),
     pluginManager: new PluginManager(),
   });
 }
@@ -218,12 +216,10 @@ describe('NodeErrorEvent — a failure is recorded once, where it happened', () 
 describe('NodeErrorEvent — delivery ordering through WorkflowAgent', () => {
   it('reaches the caller BEFORE the rejection surfaces', async () => {
     const kaboom = new Error('kaboom');
-    const agent = new WorkflowAgent(
-      new Workflow({
-        name: 'wf',
-        edges: [['START', throwingNode('boom', kaboom)]],
-      }),
-    );
+    const agent = new WorkflowAgent({
+      name: 'wf',
+      edges: [['START', throwingNode('boom', kaboom)]],
+    });
     const ic = new InvocationContext({
       invocationId: 'inv-1',
       session: createSession({


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

Two spots in `node_error_event_test.ts` built a workflow agent as:

```ts
new WorkflowAgent(new Workflow({name: 'wf', edges: [...]}))
```

`WorkflowAgent` has a convenience overload that takes the workflow config directly and constructs the `Workflow` itself, so the inner constructor was only adding a nesting level.

**Solution:**

Use the config overload in both places.

The other two `new WorkflowAgent(existingWorkflow)` uses in the suite are deliberate and stay — `workflow_agent_test.ts` covers that overload specifically ("still accepts a pre-built Workflow, with optional overrides").

No behaviour change: the config form constructs the same `Workflow` from the same config, including the `rerunOnResume` default.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

No new tests — this is a readability change inside existing ones.

```
npm run ts:check          clean
npx vitest --project unit:core    212 files, 2963 passed
```

**Manual End-to-End (E2E) Tests:**

Not applicable.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Touches only a file from #657, so it is independent of the other workflow PRs in flight.

For the record on the larger question this came out of — whether the sample and integration tests could drop `WorkflowAgent` now that #680 lets a `Workflow` be a `Runner` root — they cannot, and it is worth knowing why. `agent_loader.ts:277` selects exports with `isBaseAgent`, so a sample exporting a bare `Workflow` would not load at all; and `agent_graph.ts:50` reads `rootAgent.workflow` through `isGraphWorkflowAgent` to render the graph added in #654. Widening those two seams is the same work as dissolving `WorkflowAgent`, which belongs with the `LLMAgentWrapper` cleanup rather than being done piecemeal.