### PR TITLE
feat(workflow): let ctx.runNode() take what edges take

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -418,6 +418,7 @@ export type {
   RouteValue,
   RoutingMap,
   RunNodeOptions,
+  RunnableNode,
   ScheduleDynamicNode,
   ScheduleDynamicNodeOptions,
   ToolNodeConfig,

--- a/core/src/workflow/graph.ts
+++ b/core/src/workflow/graph.ts
@@ -40,6 +40,12 @@ export type NodeLike =
   | 'START';
 
 /**
+ * What `ctx.runNode()` accepts: everything an edge accepts except the `'START'`
+ * sentinel, which marks a graph entry point rather than something runnable.
+ */
+export type RunnableNode = Exclude<NodeLike, 'START'>;
+
+/**
  * A mapping from route values to destination node(s). A value may be a single
  * node or an array of nodes (fan-out).
  *

--- a/core/src/workflow/index.ts
+++ b/core/src/workflow/index.ts
@@ -46,6 +46,7 @@ export type {
   NodeLike,
   RouteValue,
   RoutingMap,
+  RunnableNode,
 } from './graph.js';
 
 // --- Execution context & state ---

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -9,10 +9,10 @@ import {Event} from '../events/event.js';
 import {createEventActions, EventActions} from '../events/event_actions.js';
 import {State} from '../sessions/state.js';
 import {AsyncQueue} from '../utils/async_queue.js';
-import type {BaseNode} from './base_node.js';
-import type {RouteValue} from './graph.js';
+import type {RouteValue, RunnableNode} from './graph.js';
 import {executeChildNode, RunNodeOptions} from './node_runner.js';
 import type {ScheduleDynamicNode} from './schedule_dynamic_node.js';
+import {buildNode} from './utils/workflow_graph_utils.js';
 
 /**
  * The result of running a node: the fields a caller (and the engine's
@@ -183,12 +183,21 @@ export class NodeContext {
    * When a dynamic-node {@link scheduler} is set (inside a Workflow subtree),
    * the call routes through it for dedup/resume; otherwise the child runs
    * directly.
+   *
+   * Takes anything an edge takes — an agent, a tool, a plain function, or an
+   * already-built node — and wraps it the same way the graph does, so
+   * `ctx.runNode(myAgent, input)` works without `node(myAgent)`. Wrap it
+   * yourself when you need the options `node()` carries, such as a schema or a
+   * name that differs from the value's own.
    */
   runNode(
-    node: BaseNode,
+    nodeLike: RunnableNode,
     input?: unknown,
     options?: RunNodeOptions,
   ): Promise<NodeContext | NodeResult> {
+    // Same builder edges use: an existing node passes through, an agent still
+    // gets its wrapper, a bare function or tool becomes a node.
+    const node = buildNode(nodeLike);
     if (this.scheduler) {
       const nodeName = options?.nodeName ?? node.name;
       let runId = options?.runId;

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -195,8 +195,6 @@ export class NodeContext {
     input?: unknown,
     options?: RunNodeOptions,
   ): Promise<NodeContext | NodeResult> {
-    // Same builder edges use: an existing node passes through, an agent still
-    // gets its wrapper, a bare function or tool becomes a node.
     const node = buildNode(nodeLike);
     if (this.scheduler) {
       const nodeName = options?.nodeName ?? node.name;

--- a/core/src/workflow/nodes/parallel_worker.ts
+++ b/core/src/workflow/nodes/parallel_worker.ts
@@ -5,7 +5,9 @@
  */
 
 import {BaseNode} from '../base_node.js';
+import {RunnableNode} from '../graph.js';
 import {NodeContext} from '../node_context.js';
+import {buildNode} from '../utils/workflow_graph_utils.js';
 
 /**
  * Default concurrency when `maxParallelWorkers` is not set. Bounded so a
@@ -33,10 +35,18 @@ export interface ParallelWorkerConfig {
  * `ctx.runNode(inner, item, {useSubBranch: true})`; the node's output is the
  * ordered list of the children's outputs.
  *
+ * The wrapped value is anything an edge accepts — an agent, a tool, a plain
+ * function, or an already-built node — and is built the same way, so
+ * `new ParallelWorker(myAgent)` works without `node(myAgent)`. It is built when
+ * the worker is constructed, not per item, so every item runs the one inner
+ * node — which is also where the worker's own name comes from.
+ *
  * Notes:
  * - **retry/timeout live on the inner node.** `retryConfig`/`timeout` passed to
  *   `buildNode` apply to the wrapped node (per item); the ParallelWorker itself
- *   carries neither, so the two levels don't compose.
+ *   carries neither, so the two levels don't compose. Wrapping the value
+ *   yourself — `new ParallelWorker(node(myAgent, {timeout: 5}))` — is how those
+ *   options are set.
  * - **All-or-nothing.** If any item throws, the first error is rethrown and the
  *   already-computed sibling outputs are discarded. Make individual items
  *   failure-tolerant if partial results matter.
@@ -48,15 +58,16 @@ export class ParallelWorker extends BaseNode {
   readonly maxParallelWorkers?: number;
   private readonly inner: BaseNode;
 
-  constructor(inner: BaseNode, config: ParallelWorkerConfig = {}) {
-    super({name: inner.name, rerunOnResume: true});
+  constructor(inner: RunnableNode, config: ParallelWorkerConfig = {}) {
+    const built = buildNode(inner);
+    super({name: built.name, rerunOnResume: true});
     if (
       config.maxParallelWorkers !== undefined &&
       config.maxParallelWorkers < 1
     ) {
       throw new Error('maxParallelWorkers must be greater than or equal to 1.');
     }
-    this.inner = inner;
+    this.inner = built;
     this.maxParallelWorkers = config.maxParallelWorkers;
   }
 

--- a/core/src/workflow/workflow.ts
+++ b/core/src/workflow/workflow.ts
@@ -37,6 +37,15 @@ import {
 } from './utils/rehydration_utils.js';
 
 /**
+ * A unique symbol branding {@link Workflow} instances.
+ *
+ * `isWorkflow` matches on this brand rather than `instanceof` so a workflow
+ * built by another copy of adk-js in the same runtime is still recognised —
+ * mirroring the `Symbol.for('google.adk.*')` brands used across ADK.
+ */
+const WORKFLOW_SIGNATURE_SYMBOL = Symbol.for('google.adk.workflow.workflow');
+
+/**
  * An imperative workflow entry point. Receives the workflow's node context and
  * input, drives execution via `ctx.runNode(...)`, and returns the workflow
  * output. Mutually exclusive with `edges`.
@@ -122,6 +131,9 @@ interface CompletedTask {
  */
 @experimental
 export class Workflow extends BaseNode {
+  /** Brand identifying this object as a {@link Workflow} (see `isWorkflow`). */
+  readonly [WORKFLOW_SIGNATURE_SYMBOL] = true;
+
   readonly graph?: Graph;
   readonly dynamicEntry?: DynamicEntry;
   readonly maxConcurrency?: number;
@@ -665,6 +677,21 @@ export class Workflow extends BaseNode {
     loop.pending.clear();
     await Promise.allSettled(outstanding);
   }
+}
+
+/**
+ * Type guard for {@link Workflow}.
+ *
+ * Matches on the {@link WORKFLOW_SIGNATURE_SYMBOL} brand rather than
+ * `instanceof` so it stays correct across package copies (see the brand's doc).
+ */
+export function isWorkflow(value: unknown): value is Workflow {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    WORKFLOW_SIGNATURE_SYMBOL in value &&
+    value[WORKFLOW_SIGNATURE_SYMBOL] === true
+  );
 }
 
 /**

--- a/core/src/workflow/workflow_agent.ts
+++ b/core/src/workflow/workflow_agent.ts
@@ -10,13 +10,15 @@ import {InvocationContext} from '../agents/invocation_context.js';
 import {createEvent, Event} from '../events/event.js';
 import {AsyncQueue} from '../utils/async_queue.js';
 import {experimental} from '../utils/experimental.js';
-import {isBaseNode, toContent} from './base_node.js';
+import {toContent} from './base_node.js';
+import type {RunnableNode} from './graph.js';
 import {NodeContext} from './node_context.js';
 import {
   eventsForCurrentRun,
   reconstructNodeStates,
 } from './utils/rehydration_utils.js';
-import {Workflow, WorkflowConfig} from './workflow.js';
+import {buildNode, isNodeLike} from './utils/workflow_graph_utils.js';
+import {isWorkflow, Workflow, WorkflowConfig} from './workflow.js';
 
 const WORKFLOW_AGENT_SIGNATURE_SYMBOL = Symbol.for(
   'google.adk.workflow.workflowAgent',
@@ -44,10 +46,15 @@ export class WorkflowAgent extends BaseAgent {
   readonly workflow: Workflow;
 
   /**
-   * Wraps an existing {@link Workflow}. The agent's name/description default to
-   * the workflow's; pass `config` to override them.
+   * Wraps an existing {@link Workflow}, or anything an edge accepts — an agent,
+   * a tool, a plain function, or an already-built node — which becomes the one
+   * node of a one-node workflow, so `new WorkflowAgent(myAgent)` works without
+   * spelling out `new Workflow({name, edges: [['START', myAgent]]})`.
+   *
+   * The agent's name/description default to the workflow's (for a bare value,
+   * to the built node's); pass `config` to override them.
    */
-  constructor(workflow: Workflow, config?: WorkflowAgentConfig);
+  constructor(nodeLike: RunnableNode, config?: WorkflowAgentConfig);
   /**
    * Convenience form: pass the {@link Workflow} constructor options directly and
    * the workflow is created internally, so you can write
@@ -57,15 +64,10 @@ export class WorkflowAgent extends BaseAgent {
    */
   constructor(config: WorkflowConfig);
   constructor(
-    workflowOrConfig: Workflow | WorkflowConfig,
+    nodeLikeOrConfig: RunnableNode | WorkflowConfig,
     config: WorkflowAgentConfig = {},
   ) {
-    // A branded BaseNode is an already-built Workflow; anything else is config
-    // to build one from (avoids `instanceof`, per the workflow conventions).
-    // The overload signatures guarantee an instance here is a Workflow.
-    const workflow = isBaseNode(workflowOrConfig)
-      ? (workflowOrConfig as Workflow)
-      : new Workflow(workflowOrConfig);
+    const workflow = toWorkflow(nodeLikeOrConfig);
     super({
       name: config.name ?? workflow.name,
       description: config.description ?? workflow.description,
@@ -156,6 +158,38 @@ export class WorkflowAgent extends BaseAgent {
   protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
     throw new Error('WorkflowAgent does not support live mode.');
   }
+}
+
+/**
+ * Resolves a constructor argument to the {@link Workflow} the agent adapts.
+ *
+ * A workflow is used as it is. Anything else node-like becomes the single node
+ * of a one-node workflow — exactly what `edges: [['START', value]]` spells by
+ * hand — rather than being adapted directly, so
+ * {@link WorkflowAgent.workflow} stays a `Workflow` for every caller that reads
+ * it (the dev UI's graph renderer, for one).
+ *
+ * Everything else is {@link WorkflowConfig} to build a workflow from. The two
+ * cannot be confused: a config is a plain object literal, and no builder
+ * matches one.
+ *
+ * The value is built before it reaches the graph parser, which would build it
+ * anyway, because the built node is what carries the name and description the
+ * workflow — and through it the agent — takes.
+ */
+function toWorkflow(value: RunnableNode | WorkflowConfig): Workflow {
+  if (!isNodeLike(value)) {
+    return new Workflow(value);
+  }
+  if (isWorkflow(value)) {
+    return value;
+  }
+  const built = buildNode(value);
+  return new Workflow({
+    name: built.name,
+    description: built.description,
+    edges: [['START', built]],
+  });
 }
 
 /** Whether `value` is a graph `WorkflowAgent` (brand check, not `instanceof`). */

--- a/core/test/workflow/dynamic_workflow_test.ts
+++ b/core/test/workflow/dynamic_workflow_test.ts
@@ -87,6 +87,70 @@ describe('Phase 4 — dynamic (imperative) workflows', () => {
     });
   });
 
+  describe('ctx.runNode() accepts what edges accept', () => {
+    it('runs a plain function without wrapping it in node()', async () => {
+      function shout(_c: unknown, input: string) {
+        return `${input}!`;
+      }
+      const wf = new Workflow({
+        name: 'bare-function',
+        dynamicEntry: async (ctx, input) =>
+          (await ctx.runNode(shout, input)).output,
+      });
+
+      expect((await driveWorkflow(wf, 'hi')).output).toBe('hi!');
+    });
+
+    it('names the node after the value, as an edge would', async () => {
+      function shout(_c: unknown, input: string) {
+        return `${input}!`;
+      }
+      const wf = new Workflow({
+        name: 'bare-function-events',
+        dynamicEntry: async (ctx, input) =>
+          (await ctx.runNode(shout, input)).output,
+      });
+
+      const {events} = await driveWorkflow(wf, 'hi');
+      expect(events.some((e) => e.author === 'shout')).toBe(true);
+    });
+
+    it('still takes an already-built node', async () => {
+      const built = new FunctionNode(
+        'built',
+        (_c, input: string) => `${input}?`,
+      );
+      const wf = new Workflow({
+        name: 'built-node',
+        dynamicEntry: async (ctx, input) =>
+          (await ctx.runNode(built, input)).output,
+      });
+
+      expect((await driveWorkflow(wf, 'hi')).output).toBe('hi?');
+    });
+
+    it('keeps the automatic run-id sequence across calls', async () => {
+      function step(_c: unknown, input: string) {
+        return input;
+      }
+      const wf = new Workflow({
+        name: 'sequence-ids',
+        dynamicEntry: async (ctx) => {
+          // A node is built per call, but the run-id counter is keyed by node
+          // name, so the two calls are runs "1" and "2" of one node rather
+          // than run "1" of two nodes.
+          const a = await ctx.runNode(step, 'a');
+          const b = await ctx.runNode(step, 'b');
+          return [a.output, b.output];
+        },
+      });
+
+      const {events, output} = await driveWorkflow(wf);
+      expect(output).toEqual(['a', 'b']);
+      expect(events.filter((e) => e.author === 'step').length).toBe(2);
+    });
+  });
+
   describe('custom run ids', () => {
     /** Runs `child` once automatically, then once with `runId`. */
     function workflowUsing(runId: string) {

--- a/core/test/workflow/dynamic_workflow_test.ts
+++ b/core/test/workflow/dynamic_workflow_test.ts
@@ -136,9 +136,6 @@ describe('Phase 4 — dynamic (imperative) workflows', () => {
       const wf = new Workflow({
         name: 'sequence-ids',
         dynamicEntry: async (ctx) => {
-          // A node is built per call, but the run-id counter is keyed by node
-          // name, so the two calls are runs "1" and "2" of one node rather
-          // than run "1" of two nodes.
           const a = await ctx.runNode(step, 'a');
           const b = await ctx.runNode(step, 'b');
           return [a.output, b.output];

--- a/core/test/workflow/parallel_worker_test.ts
+++ b/core/test/workflow/parallel_worker_test.ts
@@ -9,7 +9,7 @@ import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
 import {JoinNode} from '../../src/workflow/nodes/join_node.js';
 import {ParallelWorker} from '../../src/workflow/nodes/parallel_worker.js';
 import {buildNode} from '../../src/workflow/utils/workflow_graph_utils.js';
-import {createIc, driveNode} from './test_helpers.js';
+import {createIc, driveNode, ReplyAgent} from './test_helpers.js';
 
 describe('ParallelWorker', () => {
   it('maps a list input through the inner node, preserving order', async () => {
@@ -122,6 +122,42 @@ describe('ParallelWorker', () => {
     // No item was scheduled, and no wrong partial list was emitted.
     expect(calls).toBe(0);
     expect(output).toBeUndefined();
+  });
+});
+
+describe('ParallelWorker takes what edges take', () => {
+  it('maps a bare function across the list without node()', async () => {
+    function double(_c: unknown, n: number) {
+      return n * 2;
+    }
+    const {output} = await driveNode(new ParallelWorker(double), [1, 2, 3]);
+    expect(output).toEqual([2, 4, 6]);
+  });
+
+  it('names itself after the value, as an edge would name it', () => {
+    function double(_c: unknown, n: number) {
+      return n * 2;
+    }
+    expect(new ParallelWorker(double).name).toBe('double');
+  });
+
+  it('maps a bare agent across the list, with its reply as each output', async () => {
+    const worker = new ParallelWorker(new ReplyAgent('reply'));
+    const {output} = await driveNode(worker, [1, 2]);
+    expect(output).toEqual(['ok', 'ok']);
+  });
+
+  it('reports an unnameable value with the builder’s message', () => {
+    expect(() => new ParallelWorker((_c: unknown, n: number) => n)).toThrow(
+      /has no name; pass \{name\} explicitly/,
+    );
+  });
+
+  it('still takes an already-built node, unchanged', async () => {
+    const inner = new FunctionNode('double', (_c, n: number) => n * 2);
+    const worker = new ParallelWorker(inner);
+    expect(worker.name).toBe('double');
+    expect((await driveNode(worker, [1, 2])).output).toEqual([2, 4]);
   });
 });
 

--- a/core/test/workflow/test_helpers.ts
+++ b/core/test/workflow/test_helpers.ts
@@ -6,7 +6,7 @@
 
 import {BaseAgent} from '../../src/agents/base_agent.js';
 import {InvocationContext} from '../../src/agents/invocation_context.js';
-import {Event} from '../../src/events/event.js';
+import {createEvent, Event} from '../../src/events/event.js';
 import {PluginManager} from '../../src/plugins/plugin_manager.js';
 import {createSession} from '../../src/sessions/session.js';
 import {AsyncQueue} from '../../src/utils/async_queue.js';
@@ -19,6 +19,35 @@ class TestAgent extends BaseAgent {
   protected async *runAsyncImpl(): AsyncGenerator<Event, void, void> {
     return;
   }
+  // eslint-disable-next-line require-yield
+  protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
+    return;
+  }
+}
+
+/**
+ * An agent that replies with `reply` and leaves `output` unset on its event, so
+ * a node output can only have come from the wrapper `buildNode` puts around an
+ * agent — which is what a caller passing one bare has to still get.
+ */
+export class ReplyAgent extends BaseAgent {
+  constructor(
+    name: string,
+    private readonly reply = 'ok',
+  ) {
+    super({name});
+  }
+
+  protected async *runAsyncImpl(
+    ic: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    yield createEvent({
+      author: this.name,
+      invocationId: ic.invocationId,
+      content: {role: 'model', parts: [{text: this.reply}]},
+    });
+  }
+
   // eslint-disable-next-line require-yield
   protected async *runLiveImpl(): AsyncGenerator<Event, void, void> {
     return;

--- a/core/test/workflow/workflow_agent_test.ts
+++ b/core/test/workflow/workflow_agent_test.ts
@@ -23,6 +23,7 @@ import {
   isGraphWorkflowAgent,
   WorkflowAgent,
 } from '../../src/workflow/workflow_agent.js';
+import {ReplyAgent} from './test_helpers.js';
 
 /** A session event standing in for a node that raised an unresolved interrupt. */
 function pendingInterruptEvent(id: string): Event {
@@ -117,10 +118,47 @@ describe('WorkflowAgent — constructor forms', () => {
   it('still accepts a pre-built Workflow, with optional overrides', () => {
     const workflow = new Workflow({name: 'wf', edges: [['START', step]]});
     expect(new WorkflowAgent(workflow).name).toBe('wf');
+    // The workflow it was handed, not a copy wrapped around it.
     expect(new WorkflowAgent(workflow).workflow).toBe(workflow);
     expect(new WorkflowAgent(workflow, {name: 'override'}).name).toBe(
       'override',
     );
+  });
+});
+
+describe('WorkflowAgent — takes what edges take', () => {
+  it('makes a bare function the one node of a one-node workflow', async () => {
+    function greet() {
+      return 'hello';
+    }
+    const agent = new WorkflowAgent(greet);
+
+    expect(agent.name).toBe('greet');
+    expect(agent.workflow.graph?.nodes.map((n) => n.name)).toEqual([
+      '__START__',
+      'greet',
+    ]);
+    const withOutput = (await runAgent(agent)).filter(
+      (e) => e.output !== undefined,
+    );
+    expect(withOutput.map((e) => e.output)).toEqual(['hello']);
+  });
+
+  it('runs a bare agent, with its reply as the output', async () => {
+    const agent = new WorkflowAgent(new ReplyAgent('reply'));
+
+    const withOutput = (await runAgent(agent)).filter(
+      (e) => e.output !== undefined,
+    );
+    expect(withOutput.map((e) => e.output)).toEqual(['ok']);
+  });
+
+  it('takes name and description from the value, and lets config win', () => {
+    const built = node(() => 'x', {name: 'built', description: 'from node'});
+
+    expect(new WorkflowAgent(built).name).toBe('built');
+    expect(new WorkflowAgent(built).description).toBe('from node');
+    expect(new WorkflowAgent(built, {name: 'over'}).name).toBe('over');
   });
 });
 

--- a/tests/integration/workflows/agent_pipeline/agent_pipeline_test.ts
+++ b/tests/integration/workflows/agent_pipeline/agent_pipeline_test.ts
@@ -64,9 +64,6 @@ describe('workflow integration — multi-agent orchestration (LLM)', () => {
     const wf = new Workflow({
       name: 'coordinator',
       dynamicEntry: async (ctx, input) => {
-        // Agents are passed bare. An agent is itself a BaseNode, so this also
-        // pins that ctx.runNode still routes it through its wrapper -- without
-        // that, the agent runs but produces no node output.
         const research = await ctx.runNode(researcher, input);
         const report = await ctx.runNode(writer, research.output);
         return {research: research.output, report: report.output};

--- a/tests/integration/workflows/agent_pipeline/agent_pipeline_test.ts
+++ b/tests/integration/workflows/agent_pipeline/agent_pipeline_test.ts
@@ -10,7 +10,7 @@
  * orchestration driven imperatively via ctx.runNode.
  */
 
-import {FunctionNode, node, Workflow} from '@google/adk';
+import {FunctionNode, Workflow} from '@google/adk';
 import {describe, expect, it} from 'vitest';
 import {RawGenerateContentResponse} from '../../test_case_utils.js';
 import {
@@ -64,8 +64,11 @@ describe('workflow integration — multi-agent orchestration (LLM)', () => {
     const wf = new Workflow({
       name: 'coordinator',
       dynamicEntry: async (ctx, input) => {
-        const research = await ctx.runNode(node(researcher), input);
-        const report = await ctx.runNode(node(writer), research.output);
+        // Agents are passed bare. An agent is itself a BaseNode, so this also
+        // pins that ctx.runNode still routes it through its wrapper -- without
+        // that, the agent runs but produces no node output.
+        const research = await ctx.runNode(researcher, input);
+        const report = await ctx.runNode(writer, research.output);
         return {research: research.output, report: report.output};
       },
     });

--- a/tests/integration/workflows/llm_loop/llm_loop_test.ts
+++ b/tests/integration/workflows/llm_loop/llm_loop_test.ts
@@ -9,7 +9,7 @@
  * ("continue"/"done"), with model responses from a JSON fixture.
  */
 
-import {node, Workflow} from '@google/adk';
+import {Workflow} from '@google/adk';
 import {describe, expect, it} from 'vitest';
 import {RawGenerateContentResponse} from '../../test_case_utils.js';
 import {
@@ -39,7 +39,7 @@ describe('workflow integration — LLM-driven loop', () => {
       dynamicEntry: async (ctx) => {
         let rounds = 0;
         for (;;) {
-          const decision = await ctx.runNode(node(decider), `round ${rounds}`, {
+          const decision = await ctx.runNode(decider, `round ${rounds}`, {
             runId: `d${rounds}`,
           });
           rounds++;

--- a/tests/integration/workflows/parallel_llm/parallel_llm_test.ts
+++ b/tests/integration/workflows/parallel_llm/parallel_llm_test.ts
@@ -35,9 +35,7 @@ describe('workflow integration — ParallelWorker over an LLM agent', () => {
     const produce = node((): string[] => ['alpha', 'beta', 'gamma'], {
       name: 'produce',
     });
-    const worker = new ParallelWorker(node(classifier) as never, {
-      maxParallelWorkers: 1,
-    });
+    const worker = new ParallelWorker(classifier, {maxParallelWorkers: 1});
 
     const wf = new Workflow({
       name: 'parallel_llm',


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Edges accept an agent, a tool or a plain function and build the node for you.
`ctx.runNode()` did not — it demanded an already-built `BaseNode`. So a dynamic
workflow had to write

```ts
const research = await ctx.runNode(node(researcher), input);
```

where the equivalent edge just writes `researcher`. Every sample and test that
orchestrates in code carries that wrapper, and nothing at the call site explains
why it is there. It reads as ceremony, and "edges take an agent but `runNode`
doesn't" is the kind of inconsistency people trip over once and remember.

**Solution:**

`ctx.runNode()` now takes the same `NodeLike` an edge takes — minus `'START'`,
which marks a graph entry point rather than something runnable — and builds it
with the same `buildNode` the graph uses:

```ts
const research = await ctx.runNode(researcher, input);
```

Wrapping still works, and is still the way to pass options (`node(agent,
{inputSchema})`), so this is additive: the new parameter type is a superset of
the old one.

Two things worth a reviewer's eye, both learned the hard way while building it:

- **`buildNode` is called unconditionally, and that is the point.**
  Short-circuiting on `isBaseNode` looks equivalent and is not. Since
  `BaseAgent` became a `BaseNode`, an agent passed bare satisfies `isBaseNode`
  and would pass straight through — running *without* the wrapper that injects
  the node input into the prompt and turns the reply into node output. The
  failure is silent: the agent runs and the caller gets `output: undefined`.
  `buildNode` already owns that fork (`workflow_graph_utils.ts:140`), so the fix
  is to not duplicate its logic.
- **A node is built per call.** That matches what an inline `node(value)`
  argument did. Caching one node per value is tempting — I tried it — and wrong:
  an agent wrapper carries per-run state, and sharing it across calls changes
  what the second call produces. Run ids are unaffected either way, because the
  automatic sequence is keyed by node name, not node identity.

### Testing Plan

**Unit Tests:**

- [x] I have added unit tests for my change — four cases in
      `dynamic_workflow_test.ts`: a bare function runs, the node is named after
      the value as an edge would name it, an already-built node still works, and
      the automatic run-id sequence survives building per call.
- [x] All unit tests pass locally — `unit:core` + `unit:dev` **3248 passed**
      (228 files).
- [x] Integration — 74 files, 206 passed, 8 skipped.

Mutation-checked: replacing `buildNode(nodeLike)` with a bare cast fails the
three new bare-value tests, so they are guarding the conversion rather than
restating it.

**Manual End-to-End (E2E) Tests:**

The three call sites this frees are simplified in the same commit
(`agent_pipeline`, `llm_loop`), which is also how the `isBaseNode` trap above
surfaced — both went green, then red, then green again as the implementation
converged. `agent_pipeline` now doubles as the regression test for the agent
wrapper fork.


