### PR TITLE
test(cli): cover the bug-bash fixes that shipped untested

### DIFF
--- a/core/test/utils/experimental_test.ts
+++ b/core/test/utils/experimental_test.ts
@@ -57,6 +57,14 @@ describe('experimental decorator', () => {
       expect(warnCalls).toHaveLength(0);
     });
 
+    it('keeps the class name, which the warning itself reports', () => {
+      @experimental
+      class NamedClass {}
+
+      expect(NamedClass.name).toBe('NamedClass');
+      expect(new NamedClass().constructor.name).toBe('NamedClass');
+    });
+
     it('preserves constructor arguments and behavior', () => {
       @experimental
       class ArgClass {

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -205,15 +205,18 @@ describe('cli_run', () => {
     );
   });
 
-  it('should handle missing input file', async () => {
-    (loadFileData as Mock).mockResolvedValue(null);
-    const mockSessionService = createMockSessionService();
+  it('propagates an unreadable --replay file instead of swallowing it', async () => {
+    (loadFileData as Mock).mockRejectedValue(
+      new Error('Failed to read or parse file input.json: ENOENT'),
+    );
 
-    await runAgent({
-      agentPath: 'agent.ts',
-      inputFile: 'input.json',
-      sessionService: mockSessionService,
-    });
+    await expect(
+      runAgent({
+        agentPath: 'agent.ts',
+        inputFile: 'input.json',
+        sessionService: createMockSessionService(),
+      }),
+    ).rejects.toThrow(/Failed to read or parse file input\.json/);
     expect(loadFileData).toHaveBeenCalled();
   });
 

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -237,6 +237,19 @@ describe('CLI Entrypoint', () => {
   });
 
   describe('command: run', () => {
+    it('exits non-zero when the run fails', async () => {
+      (runAgent as Mock).mockRejectedValueOnce(
+        new Error('Agent file /nope/agent.ts does not exists'),
+      );
+      const exit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => undefined) as never);
+
+      await parse(['run', '/nope/agent.ts']);
+
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+
     it('should call runAgent with required args', async () => {
       await parse(['run', 'agent.ts']);
 

--- a/dev/test/utils/file_utils_test.ts
+++ b/dev/test/utils/file_utils_test.ts
@@ -106,6 +106,19 @@ describe('file_utils', () => {
     await expect(loadFileData(testPath)).rejects.toThrow('read error');
   });
 
+  it('loadFileData names the file it could not read, and reports once', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    fsPromises.readFile.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(loadFileData(testPath)).rejects.toThrow(
+      new RegExp(`Failed to read or parse file ${testPath}: ENOENT`),
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   it('saveToFile writes string data as-is', async () => {
     fsPromises.writeFile.mockResolvedValue(undefined);
     await expect(saveToFile(testPath, testContent)).resolves.toBeUndefined();


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Auditing the bug-bash fixes against the test suite turned up four behaviours
that shipped in #664 with nothing holding them in place:

| Behaviour | Was resting on |
| --- | --- |
| `adk run` exits 1 when a run fails | nothing |
| `runAgent` propagates a load failure instead of swallowing it | nothing |
| `loadFileData` names the unreadable file, and reports it once | partially — the existing case only checked the inner message survived |
| `@experimental` keeps the decorated class's own name | nothing |

The last one matters more than it looks: the decorator returns an anonymous
`class extends target`, so without restoring the name every decorated class
reports its binding (`"newConstructor"`) from `.name` — including to user code
logging `constructor.name`.

Worse, `should handle missing input file` was actively misleading. It mocked
`loadFileData` resolving `null`, which the implementation can no longer do, and
asserted only that the mock had been called — so it would have passed against
the swallowing version it was supposed to describe.

**Solution:**

Test-only. Four cases added, one stale case replaced:

- `cli_test.ts` — the `run` command calls `process.exit(1)` when `runAgent`
  rejects.
- `cli_run_test.ts` — `runAgent` rejects on an unreadable `--replay` file
  (replaces the `null`-mock case).
- `file_utils_test.ts` — the thrown error carries the path, and nothing is
  written to `console.error`.
- `experimental_test.ts` — a decorated class keeps its name, from both
  `Class.name` and `instance.constructor.name`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change — this PR *is* the tests.
- [x] All unit tests pass locally — `unit:core` + `unit:dev` **3255 passed**
      (229 files).

Every case was checked against the pre-fix behaviour rather than assumed to
work — restoring the swallowing catch in `runAgent`, dropping the
`process.exit(1)`, and putting back `loadFileData`'s log-and-rethrow each fail
the matching test, and each source file was restored afterwards.

**Manual End-to-End (E2E) Tests:**

n/a — test-only change, no shipped code touched.
