### PR TITLE
fix(server): serve /version, which the dev UI reads on load

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -32,6 +32,7 @@ import cors from 'cors';
 import express, {Request, Response} from 'express';
 import * as http from 'node:http';
 import * as path from 'node:path';
+import {version} from '../version.js';
 
 import {AgentFileOptions, AgentLoader} from '../utils/agent_loader.js';
 import {AdkLogger} from '../utils/logger.js';
@@ -231,6 +232,10 @@ export class AdkApiServer {
         res.status(200).send('OK');
       });
     }
+
+    app.get('/version', (req: Request, res: Response) => {
+      res.status(200).json({version});
+    });
 
     if (this.allowOrigins) {
       app.use(

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -32,6 +32,7 @@ import {
   AdkApiServer,
 } from '../../src/server/adk_api_server.js';
 import {AgentLoader} from '../../src/utils/agent_loader.js';
+import {version} from '../../src/version.js';
 
 interface JsonRpcResponse {
   result?: unknown;
@@ -252,6 +253,16 @@ describe('AdkWebServer', () => {
 
   afterEach(async () => {
     await server.stop();
+  });
+
+  describe('Version', () => {
+    it('reports the ADK version the server is running', async () => {
+      const response = await client.get<{version: string}>('/version');
+
+      expect(response.status).toBe(200);
+      expect(response.data?.version).toBe(version);
+      expect(response.data?.version).toMatch(/^\d+\.\d+\.\d+/);
+    });
   });
 
   describe('Sessions', () => {


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

The dev UI requests `/version` as it starts, to show which ADK it is talking to
(`agentService.getVersion().subscribe(i => adkVersion.set(i.version))`). Nothing
served it, so the request 404'd and the subscribe raised an unhandled error on
**every page load**:

```
200 GET /dev-ui/
404 GET /version
PAGEERROR _o
```

Nothing breaks — I confirmed that by adding the route and watching the UI behave
identically — but an uncaught error on load is what buries the next real one.

**Solution:**

Serve `{version}`, the shape the UI reads, from the same constant `adk --version`
prints. Registered outside the `serveDebugUI` branch so the API server has it
too, where it is the cheapest way to ask a deployment what it is running.

### Testing Plan

**Unit Tests:**

- [x] I have added a unit test — `adk_api_server_test.ts` asserts `/version`
      returns 200 and the ADK version.
- [x] All unit tests pass locally — `unit:dev` **284 passed** (16 files).

**Manual End-to-End (E2E) Tests:**

Driven in real Chrome against `adk web samples/workflows/routes`:

```
before:  200 /dev-ui/ → 404 /version → PAGEERROR _o
after:   200 /dev-ui/ → 200 /version → (no page error on load)

curl localhost:8180/version → {"version":"1.6.0"}
```

The UI still selects an app and runs a workflow normally afterwards.

**Out of scope, found while verifying:** the pinned adk-web also calls six
endpoints this server does not implement —

```
/dev/apps/<app>/build_graph          /dev/apps/<app>/eval_sets
/dev/apps/<app>/build_graph_image    /dev/apps/<app>/eval_results
/dev/apps/<app>/builder              /dev/apps/<app>/debug/trace/session/<id>
```

Each 404s and produces its own console error. Those are unimplemented features
rather than a missing line, so they are not in this PR — but worth knowing that
the first one is why the UI's **graph tab renders nothing**, even though the
per-event graph endpoint added in #654 works and returns the full DOT. That is
probably worth its own issue.
