### PR TITLE
fix(workflow): emit the interrupt schema under the key clients read

### DIFF
--- a/core/src/agents/processors/request_input_llm_request_processor.ts
+++ b/core/src/agents/processors/request_input_llm_request_processor.ts
@@ -15,9 +15,9 @@ import {ToolConfirmation} from '../../tools/tool_confirmation.js';
 import {AsyncQueue} from '../../utils/async_queue.js';
 import {isNodeTool} from '../../workflow/nodes/node_tool.js';
 import {
+  interruptResponseMismatch,
   REQUEST_INPUT_FUNCTION_CALL_NAME,
   responseSchemasByInterruptId,
-  validateInterruptResponse,
 } from '../../workflow/utils/hitl_utils.js';
 import {unwrapResponse} from '../../workflow/utils/rehydration_utils.js';
 import {handleFunctionCallList} from '../functions.js';
@@ -136,9 +136,14 @@ export class RequestInputLlmRequestProcessor extends BaseLlmRequestProcessor {
  * Collects resume inputs from the session: structured `adk_request_input`
  * function responses take precedence; otherwise a plain-text reply is mapped to
  * every still-pending interrupt id.
+ *
+ * A reply that does not match its interrupt's schema is rejected loudly while
+ * it is the turn being processed, and skipped on later turns — it never
+ * resolved its interrupt, so the pause is still open for the next answer.
  */
 function collectResumeInputs(events: Event[]): Record<string, unknown> {
   const responseSchemas = responseSchemasByInterruptId(events);
+  let isCurrentTurn = true;
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i];
     if (event.author !== 'user') {
@@ -149,7 +154,17 @@ function collectResumeInputs(events: Event[]): Record<string, unknown> {
     for (const fr of getFunctionResponses(event)) {
       if (fr.name === REQUEST_INPUT_FUNCTION_CALL_NAME && fr.id) {
         const response = unwrapResponse(fr.response);
-        validateInterruptResponse(fr.id, response, responseSchemas.get(fr.id));
+        const mismatch = interruptResponseMismatch(
+          fr.id,
+          response,
+          responseSchemas.get(fr.id),
+        );
+        if (mismatch) {
+          if (isCurrentTurn) {
+            throw new Error(mismatch);
+          }
+          continue;
+        }
         structured[fr.id] = response;
         found = true;
       }
@@ -157,11 +172,12 @@ function collectResumeInputs(events: Event[]): Record<string, unknown> {
     if (found) {
       return structured;
     }
+    isCurrentTurn = false;
   }
 
   // Plain-text fallback: map the latest plain-text user turn to pending
   // interrupts (mirrors WorkflowAgent's interactive resume).
-  const pending = pendingInterruptIds(events);
+  const pending = pendingInterruptIds(events, responseSchemas);
   if (pending.size === 0) {
     return {};
   }
@@ -180,15 +196,31 @@ function collectResumeInputs(events: Event[]): Record<string, unknown> {
   return inputs;
 }
 
-/** Interrupt ids raised via `adk_request_input` that have no user response. */
-function pendingInterruptIds(events: Event[]): Set<string> {
+/**
+ * Interrupt ids raised via `adk_request_input` that have no user response.
+ *
+ * A reply rejected by its schema does not count as one: it was never handed to
+ * the waiting node, so the interrupt is still owed an answer.
+ */
+function pendingInterruptIds(
+  events: Event[],
+  responseSchemas: Map<string, unknown>,
+): Set<string> {
   const answered = new Set<string>();
   for (const event of events) {
     if (event.author !== 'user') {
       continue;
     }
     for (const fr of getFunctionResponses(event)) {
-      if (fr.id) {
+      if (!fr.id) {
+        continue;
+      }
+      const mismatch = interruptResponseMismatch(
+        fr.id,
+        unwrapResponse(fr.response),
+        responseSchemas.get(fr.id),
+      );
+      if (!mismatch) {
         answered.add(fr.id);
       }
     }

--- a/core/src/agents/user_input_request.ts
+++ b/core/src/agents/user_input_request.ts
@@ -107,8 +107,6 @@ export function getUserInputRequests(event: Event): UserInputRequest[] {
           kind: 'input',
           message: asString(args['message']),
           payload: args['payload'] ?? undefined,
-          // Snake_case on the wire, unlike its neighbours; see
-          // `RESPONSE_SCHEMA_ARG` in `workflow/utils/hitl_utils`.
           responseSchema: args['response_schema'] ?? undefined,
         });
         break;

--- a/core/src/agents/user_input_request.ts
+++ b/core/src/agents/user_input_request.ts
@@ -107,7 +107,11 @@ export function getUserInputRequests(event: Event): UserInputRequest[] {
           kind: 'input',
           message: asString(args['message']),
           payload: args['payload'] ?? undefined,
-          responseSchema: args['responseSchema'] ?? undefined,
+          // `response_schema` is the wire spelling (see `RESPONSE_SCHEMA_ARG`
+          // in `workflow/utils/hitl_utils`); `responseSchema` is what older
+          // adk-js sessions recorded.
+          responseSchema:
+            args['response_schema'] ?? args['responseSchema'] ?? undefined,
         });
         break;
 

--- a/core/src/agents/user_input_request.ts
+++ b/core/src/agents/user_input_request.ts
@@ -107,11 +107,9 @@ export function getUserInputRequests(event: Event): UserInputRequest[] {
           kind: 'input',
           message: asString(args['message']),
           payload: args['payload'] ?? undefined,
-          // `response_schema` is the wire spelling (see `RESPONSE_SCHEMA_ARG`
-          // in `workflow/utils/hitl_utils`); `responseSchema` is what older
-          // adk-js sessions recorded.
-          responseSchema:
-            args['response_schema'] ?? args['responseSchema'] ?? undefined,
+          // Snake_case on the wire, unlike its neighbours; see
+          // `RESPONSE_SCHEMA_ARG` in `workflow/utils/hitl_utils`.
+          responseSchema: args['response_schema'] ?? undefined,
         });
         break;
 

--- a/core/src/tools/request_input_tool.ts
+++ b/core/src/tools/request_input_tool.ts
@@ -11,6 +11,11 @@ import {LongRunningFunctionTool} from './long_running_tool.js';
 /**
  * A long-running tool that presents a custom message to the user and awaits
  * unstructured or structured input.
+ *
+ * `response_schema` is spelled the way a workflow's `RequestInput` spells it on
+ * the wire (`RESPONSE_SCHEMA_ARG` in `workflow/utils/hitl_utils`), so a client
+ * reads one key whichever way the pause was raised — the dev UI builds its
+ * reply form from it either way.
  */
 export const requestInputTool = new LongRunningFunctionTool({
   name: REQUEST_INPUT_FUNCTION_CALL_NAME,
@@ -18,7 +23,7 @@ export const requestInputTool = new LongRunningFunctionTool({
     'Presents a custom message to the user and awaits unstructured or structured input.',
   parameters: z.object({
     message: z.string().describe('The prompt for the user.'),
-    responseSchema: z
+    response_schema: z
       .record(z.string(), z.unknown())
       .optional()
       .describe('Expected schema of the response.'),

--- a/core/src/workflow/request_input.ts
+++ b/core/src/workflow/request_input.ts
@@ -33,10 +33,11 @@ export interface RequestInputParams {
   /**
    * The expected shape of the reply (Zod v3/v4 or genai `Schema`).
    *
-   * It tells a client what to collect, and a *structured* reply is checked
-   * against it on resume. Nothing coerces a human's answer into the shape: a
-   * plain-text reply is routed to the interrupt as-is and is not checked, so
-   * put an agent node after the pause if you need free text normalized.
+   * It tells a client what to collect — the dev UI renders a form from it —
+   * and a *structured* reply is checked against it on resume. Nothing coerces
+   * a human's answer into the shape: a plain-text reply is routed to the
+   * interrupt as-is and is not checked, so put an agent node after the pause
+   * if you need free text normalized.
    */
   responseSchema?: SchemaLike;
 }
@@ -50,11 +51,13 @@ export interface RequestInputParams {
  * A client answers in one of two ways:
  *
  * - **Plain text.** A text turn is routed to every pending interrupt as-is.
- *   This is what the interactive CLI and the dev UI send.
+ *   This is what the interactive CLI sends, and the dev UI whenever it has no
+ *   schema to build a form from.
  * - **A `functionResponse`** named `adk_request_input`, carrying the interrupt
  *   id. Wrap a bare value as `{result: <value>}` — that envelope is unwrapped
- *   for you. Any other object is delivered to the node unchanged, so it must
- *   already match {@link RequestInputParams.responseSchema} when one is set.
+ *   for you, and what it holds counts as plain text. Any other object is
+ *   delivered to the node unchanged, so it must already match
+ *   {@link RequestInputParams.responseSchema} when one is set.
  *
  * Ported from `google/adk-python` `events/request_input.py`.
  */

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -33,6 +33,20 @@ export {
 } from '../../agents/functions.js';
 
 /**
+ * The arg key the declared JSON Schema travels under on an `adk_request_input`
+ * call. Snake_case among camelCase neighbours because that is the cross-
+ * language wire format: `adk-python`'s `create_request_input_event` dumps the
+ * request by alias (`interruptId`, `payload`, `message`) and then sets
+ * `response_schema` explicitly, and clients read that spelling — the dev UI
+ * builds the reply form from `args.response_schema`, so emitting
+ * `responseSchema` leaves the user typing free text at a structured prompt.
+ */
+const RESPONSE_SCHEMA_ARG = 'response_schema';
+
+/** The pre-alignment spelling, still found in sessions written by older runs. */
+const LEGACY_RESPONSE_SCHEMA_ARG = 'responseSchema';
+
+/**
  * Creates an interrupt {@link Event} from a {@link RequestInput}. The event
  * carries an `adk_request_input` function call and marks the interrupt id as a
  * long-running tool id.
@@ -42,7 +56,7 @@ export function createRequestInputEvent(requestInput: RequestInput): Event {
     interruptId: requestInput.interruptId,
     payload: requestInput.payload ?? null,
     message: requestInput.message ?? null,
-    responseSchema: requestInput.responseSchema
+    [RESPONSE_SCHEMA_ARG]: requestInput.responseSchema
       ? toJsonSchema(requestInput.responseSchema)
       : null,
   };
@@ -65,6 +79,16 @@ export function createRequestInputEvent(requestInput: RequestInput): Event {
 }
 
 /**
+ * Reads the JSON Schema off an `adk_request_input` call's args, under either
+ * spelling (see {@link RESPONSE_SCHEMA_ARG}).
+ */
+function readResponseSchemaArg(
+  args: Record<string, unknown> | undefined,
+): unknown {
+  return args?.[RESPONSE_SCHEMA_ARG] ?? args?.[LEGACY_RESPONSE_SCHEMA_ARG];
+}
+
+/**
  * Collects the `responseSchema` each pending interrupt declared, keyed by
  * interrupt id, as the JSON Schema recorded on its `adk_request_input` call.
  *
@@ -82,9 +106,9 @@ export function responseSchemasByInterruptId(
       if (fc?.name !== REQUEST_INPUT_FUNCTION_CALL_NAME || !fc.id) {
         continue;
       }
-      const schema = (fc.args as Record<string, unknown> | undefined)?.[
-        'responseSchema'
-      ];
+      const schema = readResponseSchemaArg(
+        fc.args as Record<string, unknown> | undefined,
+      );
       if (schema) {
         schemas.set(fc.id, schema);
       }
@@ -101,16 +125,25 @@ export function responseSchemasByInterruptId(
  * pending interrupt as-is (the interactive CLI and the dev UI both rely on
  * that), and holding free text to an object schema would break it.
  *
- * Without this, a reply in the wrong shape is simply handed to the next node:
- * a client that wraps its answer as `{response: x}` instead of `{result: x}`
- * gets the whole envelope delivered as the node's input, which typically
- * surfaces far downstream as a stringified `[object Object]`.
+ * A reply that unwraps to a bare scalar counts as plain text and is exempt for
+ * the same reason: `{result: <text>}` is the envelope a client sends when it
+ * has only a chat box to offer, so checking it would reject the very answer
+ * the plain-text path accepts — permanently, since the reply is recorded in
+ * the session and re-checked on every later turn.
+ *
+ * What remains checked is the case this exists for: a reply in the wrong
+ * *shape*. A client that wraps its answer as `{response: x}` instead of
+ * `{result: x}` gets the whole envelope delivered as the node's input, which
+ * typically surfaces far downstream as a stringified `[object Object]`.
  */
 export function validateInterruptResponse(
   interruptId: string,
   value: unknown,
   jsonSchema: unknown,
 ): void {
+  if (typeof value !== 'object' || value === null) {
+    return;
+  }
   const validator = compileJsonSchema(jsonSchema);
   if (!validator) {
     return;

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -106,7 +106,13 @@ export function responseSchemasByInterruptId(
 
 /**
  * Checks a *structured* reply against the `responseSchema` its interrupt
- * declared, and throws when it does not match.
+ * declared, and describes the mismatch when there is one. Returns `undefined`
+ * when the reply is acceptable.
+ *
+ * Reporting rather than throwing is what lets a caller be loud about the reply
+ * that just arrived and quiet about the same reply on every later replay: a
+ * rejected reply stays in the session forever, so a checker that threw on
+ * sight would end the session rather than the turn.
  *
  * Only structured replies are checked. A plain-text reply is routed to every
  * pending interrupt as-is (the interactive CLI and the dev UI both rely on
@@ -115,29 +121,28 @@ export function responseSchemasByInterruptId(
  * A reply that unwraps to a bare scalar counts as plain text and is exempt for
  * the same reason: `{result: <text>}` is the envelope a client sends when it
  * has only a chat box to offer, so checking it would reject the very answer
- * the plain-text path accepts — permanently, since the reply is recorded in
- * the session and re-checked on every later turn.
+ * the plain-text path accepts.
  *
  * What remains checked is the case this exists for: a reply in the wrong
  * *shape*. A client that wraps its answer as `{response: x}` instead of
  * `{result: x}` gets the whole envelope delivered as the node's input, which
  * typically surfaces far downstream as a stringified `[object Object]`.
  */
-export function validateInterruptResponse(
+export function interruptResponseMismatch(
   interruptId: string,
   value: unknown,
   jsonSchema: unknown,
-): void {
+): string | undefined {
   if (typeof value !== 'object' || value === null) {
-    return;
+    return undefined;
   }
   const validator = compileJsonSchema(jsonSchema);
   if (!validator) {
-    return;
+    return undefined;
   }
   const result = validator.safeParse(value);
   if (result.success) {
-    return;
+    return undefined;
   }
   const issues = result.error.issues
     .map((issue) => {
@@ -145,11 +150,12 @@ export function validateInterruptResponse(
       return `${issue.message}${at}`;
     })
     .join('; ');
-  throw new Error(
+  return (
     `The reply to interrupt '${interruptId}' does not match the ` +
-      `responseSchema it declared: ${issues}. A structured reply must either ` +
-      `match that schema, or wrap a bare value as {result: <value>}; a ` +
-      `plain-text reply is accepted as-is and is not checked.`,
+    `responseSchema it declared: ${issues}. A structured reply must either ` +
+    `match that schema, or wrap a bare value as {result: <value>}; a ` +
+    `plain-text reply is accepted as-is and is not checked. The interrupt is ` +
+    `still waiting, so you can answer it again.`
   );
 }
 

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -43,9 +43,6 @@ export {
  */
 const RESPONSE_SCHEMA_ARG = 'response_schema';
 
-/** The pre-alignment spelling, still found in sessions written by older runs. */
-const LEGACY_RESPONSE_SCHEMA_ARG = 'responseSchema';
-
 /**
  * Creates an interrupt {@link Event} from a {@link RequestInput}. The event
  * carries an `adk_request_input` function call and marks the interrupt id as a
@@ -79,16 +76,6 @@ export function createRequestInputEvent(requestInput: RequestInput): Event {
 }
 
 /**
- * Reads the JSON Schema off an `adk_request_input` call's args, under either
- * spelling (see {@link RESPONSE_SCHEMA_ARG}).
- */
-function readResponseSchemaArg(
-  args: Record<string, unknown> | undefined,
-): unknown {
-  return args?.[RESPONSE_SCHEMA_ARG] ?? args?.[LEGACY_RESPONSE_SCHEMA_ARG];
-}
-
-/**
  * Collects the `responseSchema` each pending interrupt declared, keyed by
  * interrupt id, as the JSON Schema recorded on its `adk_request_input` call.
  *
@@ -106,9 +93,9 @@ export function responseSchemasByInterruptId(
       if (fc?.name !== REQUEST_INPUT_FUNCTION_CALL_NAME || !fc.id) {
         continue;
       }
-      const schema = readResponseSchemaArg(
-        fc.args as Record<string, unknown> | undefined,
-      );
+      const schema = (fc.args as Record<string, unknown> | undefined)?.[
+        RESPONSE_SCHEMA_ARG
+      ];
       if (schema) {
         schemas.set(fc.id, schema);
       }

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -18,8 +18,8 @@ import {Event} from '../../events/event.js';
 import {RouteValue} from '../graph.js';
 import type {NodeContext, NodeResult} from '../node_context.js';
 import {
+  interruptResponseMismatch,
   responseSchemasByInterruptId,
-  validateInterruptResponse,
 } from './hitl_utils.js';
 
 const RESULT_KEY = 'result';
@@ -173,6 +173,7 @@ function reconstruct(
   const nodes = new Map<string, RehydratedNode>();
   const interruptOwner = new Map<string, string>();
   const responseSchemas = responseSchemasByInterruptId(events);
+  const newestUserTurn = lastUserEvent(events);
 
   const getNode = (name: string): RehydratedNode => {
     let node = nodes.get(name);
@@ -191,11 +192,21 @@ function reconstruct(
         if (fr?.id && interruptOwner.has(fr.id)) {
           const owner = interruptOwner.get(fr.id)!;
           const response = unwrapResponse(fr.response);
-          validateInterruptResponse(
+          const mismatch = interruptResponseMismatch(
             fr.id,
             response,
             responseSchemas.get(fr.id),
           );
+          if (mismatch) {
+            // Loud for the reply that just arrived, silent for the same reply
+            // on every replay after it: a rejected reply leaves its interrupt
+            // unresolved, so the run pauses there again and the next answer —
+            // structured or plain text — still gets through.
+            if (event === newestUserTurn) {
+              throw new Error(mismatch);
+            }
+            continue;
+          }
           getNode(owner).resolvedResponses.set(fr.id, response);
         }
       }
@@ -229,6 +240,20 @@ function reconstruct(
   }
 
   return nodes;
+}
+
+/**
+ * The most recent user event, i.e. the turn currently being processed: the
+ * runner appends the incoming message before the agent runs, so a reply found
+ * there is one the caller can still do something about.
+ */
+function lastUserEvent(events: Event[]): Event | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].author === 'user') {
+      return events[i];
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -165,6 +165,60 @@ export function reconstructNodeStatesByPath(
   return reconstruct(events, (event) => event.nodeInfo?.path ?? event.author);
 }
 
+/**
+ * Every interrupt raised in `events` that now has an accepted reply, as
+ * interrupt id -> value.
+ *
+ * Flat and unscoped, unlike {@link reconstructNodeStates}: interrupt ids are
+ * unique, and a reply has to reach whoever raised it however deep that sits. A
+ * dynamic (`ctx.runNode`) child or a nested workflow's leaf is keyed out of the
+ * per-parent view, so a scoped map silently drops its answer and the run pauses
+ * on the same question forever.
+ *
+ * A reply that does not match the schema its interrupt declared resolves
+ * nothing. It throws while it is the turn being processed, so the client hears
+ * about it once, and is skipped on every replay after that (see
+ * {@link interruptResponseMismatch}).
+ */
+export function resolvedInterruptResponses(
+  events: Event[],
+): Map<string, unknown> {
+  const responseSchemas = responseSchemasByInterruptId(events);
+  const newestUserTurn = lastUserEvent(events);
+  const raised = new Set<string>();
+  const resolved = new Map<string, unknown>();
+
+  for (const event of events) {
+    if (event.author === 'user' && event.content?.parts) {
+      for (const part of event.content.parts) {
+        const fr = part.functionResponse;
+        if (!fr?.id || !raised.has(fr.id)) {
+          continue;
+        }
+        const response = unwrapResponse(fr.response);
+        const mismatch = interruptResponseMismatch(
+          fr.id,
+          response,
+          responseSchemas.get(fr.id),
+        );
+        if (mismatch) {
+          if (event === newestUserTurn) {
+            throw new Error(mismatch);
+          }
+          continue;
+        }
+        resolved.set(fr.id, response);
+      }
+      continue;
+    }
+    for (const id of event.longRunningToolIds ?? []) {
+      raised.add(id);
+    }
+  }
+
+  return resolved;
+}
+
 /** Shared scan that groups node events by the key returned by `keyFor`. */
 function reconstruct(
   events: Event[],
@@ -172,8 +226,7 @@ function reconstruct(
 ): Map<string, RehydratedNode> {
   const nodes = new Map<string, RehydratedNode>();
   const interruptOwner = new Map<string, string>();
-  const responseSchemas = responseSchemasByInterruptId(events);
-  const newestUserTurn = lastUserEvent(events);
+  const resolved = resolvedInterruptResponses(events);
 
   const getNode = (name: string): RehydratedNode => {
     let node = nodes.get(name);
@@ -185,29 +238,15 @@ function reconstruct(
   };
 
   for (const event of events) {
-    // 1. User function responses resolving prior interrupts.
+    // 1. User function responses resolving prior interrupts. A reply the
+    //    schema check refused is absent from `resolved`, leaving its interrupt
+    //    unresolved so the run pauses there again.
     if (event.author === 'user' && event.content?.parts) {
       for (const part of event.content.parts) {
         const fr = part.functionResponse;
-        if (fr?.id && interruptOwner.has(fr.id)) {
+        if (fr?.id && interruptOwner.has(fr.id) && resolved.has(fr.id)) {
           const owner = interruptOwner.get(fr.id)!;
-          const response = unwrapResponse(fr.response);
-          const mismatch = interruptResponseMismatch(
-            fr.id,
-            response,
-            responseSchemas.get(fr.id),
-          );
-          if (mismatch) {
-            // Loud for the reply that just arrived, silent for the same reply
-            // on every replay after it: a rejected reply leaves its interrupt
-            // unresolved, so the run pauses there again and the next answer —
-            // structured or plain text — still gets through.
-            if (event === newestUserTurn) {
-              throw new Error(mismatch);
-            }
-            continue;
-          }
-          getNode(owner).resolvedResponses.set(fr.id, response);
+          getNode(owner).resolvedResponses.set(fr.id, resolved.get(fr.id));
         }
       }
       continue;

--- a/core/src/workflow/workflow.ts
+++ b/core/src/workflow/workflow.ts
@@ -34,6 +34,7 @@ import {
   makeFastForwardResult,
   reconstructNodeStates,
   RehydratedNode,
+  resolvedInterruptResponses,
 } from './utils/rehydration_utils.js';
 
 /**
@@ -209,11 +210,15 @@ export class Workflow extends BaseNode {
     // in progress (so a run that already completed is not replayed), and to
     // this workflow's own direct children (by path) so nested workflows with
     // same-named nodes don't collide.
+    const runEvents = eventsForCurrentRun(
+      ctx.session?.events ?? [],
+      ctx.invocationId,
+    );
     const rehydrated = reconstructNodeStates(
-      eventsForCurrentRun(ctx.session?.events ?? [], ctx.invocationId),
+      runEvents,
       ctx.nodePath || undefined,
     );
-    this.applyResumeInputs(ctx, rehydrated);
+    this.applyResumeInputs(ctx, runEvents);
 
     if (this.dynamicEntry) {
       await this.runDynamicEntry(ctx, nodeInput, dynamicState);
@@ -267,15 +272,17 @@ export class Workflow extends BaseNode {
    * Merges resolved interrupt responses from prior session events into
    * `ctx.resumeInputs`, so waiting nodes (which read `ctx.resumeInputs[id]`)
    * resume with the user's response. Shared by child contexts via propagation.
+   *
+   * Taken from the events rather than from `rehydrated`, because that view is
+   * scoped to this workflow's direct children: an interrupt raised deeper — by
+   * a `ctx.runNode` child, or inside a nested workflow — is keyed out of it,
+   * and its answer would never reach the node waiting on it.
    */
-  private applyResumeInputs(
-    ctx: NodeContext,
-    rehydrated: Map<string, RehydratedNode>,
-  ): void {
-    for (const node of rehydrated.values()) {
-      for (const [interruptId, response] of node.resolvedResponses) {
-        ctx.resumeInputs[interruptId] = response;
-      }
+  private applyResumeInputs(ctx: NodeContext, runEvents: Event[]): void {
+    for (const [interruptId, response] of resolvedInterruptResponses(
+      runEvents,
+    )) {
+      ctx.resumeInputs[interruptId] = response;
     }
   }
 

--- a/core/test/agents/user_input_request_test.ts
+++ b/core/test/agents/user_input_request_test.ts
@@ -77,16 +77,6 @@ describe('getUserInputRequests', () => {
     });
   });
 
-  it('reads the schema from a session that recorded it as `responseSchema`', () => {
-    // The spelling adk-js wrote before it aligned with adk-python's
-    // `response_schema`; sessions holding it must still resume and render.
-    const [request] = getUserInputRequests(
-      requestInputEvent('i1', {responseSchema: {type: 'object'}}),
-    );
-
-    expect(request.responseSchema).toEqual({type: 'object'});
-  });
-
   it('summarizes a request for a credential', () => {
     const authConfig = {
       authScheme: {type: 'apiKey', in: 'header', name: 'X-Api-Key'},

--- a/core/test/agents/user_input_request_test.ts
+++ b/core/test/agents/user_input_request_test.ts
@@ -62,7 +62,7 @@ describe('getUserInputRequests', () => {
     const [request] = getUserInputRequests(
       requestInputEvent('i1', {
         payload: {draft: 'hello'},
-        responseSchema: {type: 'object'},
+        response_schema: {type: 'object'},
       }),
     );
 
@@ -75,6 +75,16 @@ describe('getUserInputRequests', () => {
       payload: {draft: 'hello'},
       responseSchema: {type: 'object'},
     });
+  });
+
+  it('reads the schema from a session that recorded it as `responseSchema`', () => {
+    // The spelling adk-js wrote before it aligned with adk-python's
+    // `response_schema`; sessions holding it must still resume and render.
+    const [request] = getUserInputRequests(
+      requestInputEvent('i1', {responseSchema: {type: 'object'}}),
+    );
+
+    expect(request.responseSchema).toEqual({type: 'object'});
   });
 
   it('summarizes a request for a credential', () => {

--- a/core/test/tools/request_input_tool_test.ts
+++ b/core/test/tools/request_input_tool_test.ts
@@ -14,6 +14,17 @@ describe('requestInputTool', () => {
     expect(declaration?.description).toContain('Presents a custom message');
   });
 
+  it('asks the model for the schema under the key clients read', () => {
+    // Same spelling a workflow `RequestInput` uses on the wire, so a client
+    // renders a reply form for either kind of pause.
+    const declaration = requestInputTool._getDeclaration();
+
+    expect(Object.keys(declaration?.parameters?.properties ?? {})).toEqual([
+      'message',
+      'response_schema',
+    ]);
+  });
+
   it('sets skipSummarization flag on execution', async () => {
     const mockActions = createEventActions();
     const mockContext = {actions: mockActions} as unknown as Context;

--- a/core/test/workflow/dynamic_resume_test.ts
+++ b/core/test/workflow/dynamic_resume_test.ts
@@ -11,7 +11,10 @@ import {InMemorySessionService} from '../../src/sessions/in_memory_session_servi
 import {NodeContext} from '../../src/workflow/node_context.js';
 import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
 import {RequestInput} from '../../src/workflow/request_input.js';
-import {hasRequestInputFunctionCall} from '../../src/workflow/utils/hitl_utils.js';
+import {
+  getRequestInputInterruptIds,
+  hasRequestInputFunctionCall,
+} from '../../src/workflow/utils/hitl_utils.js';
 import {Workflow} from '../../src/workflow/workflow.js';
 import {WorkflowAgent} from '../../src/workflow/workflow_agent.js';
 
@@ -170,5 +173,85 @@ describe('Phase 5b-cont — dynamic (ctx.runNode) resume via the Runner', () => 
     expect(askRuns).toBe(1);
     expect(turn2.some(hasRequestInputFunctionCall)).toBe(false);
     expect(turn2.some((e) => e.output === 'decided:yes')).toBe(true);
+  });
+
+  it("answers a graph node's dynamic child from a structured reply", async () => {
+    // The shape `samples/workflows/dynamic/human_input` has: a graph node
+    // driving an interactive child through `ctx.runNode`, so the interrupt is
+    // raised a level below the workflow's own children. The workflow's
+    // rehydrated view is keyed to its DIRECT children, so a reply addressed to
+    // that deeper interrupt used to be dropped — the child re-ran, minted a
+    // fresh interrupt id, and asked again on every turn. Plain text got
+    // through (it is mapped to the pending interrupt by the agent), which is
+    // why the handoff test above did not catch this.
+    let askRuns = 0;
+
+    const ask = new FunctionNode(
+      'get_user_approval',
+      () => {
+        askRuns++;
+        return new RequestInput({message: 'Please approve this request'});
+      },
+      {rerunOnResume: false},
+    );
+
+    const handle = new FunctionNode(
+      'handle_process',
+      async (ctx: NodeContext, input: unknown) => {
+        const approval = await ctx.runNode(ask, input);
+        if (approval.interruptIds.length > 0) {
+          return undefined;
+        }
+        return String(approval.output).trim().toLowerCase() === 'yes'
+          ? 'Approved'
+          : 'Denied';
+      },
+      {rerunOnResume: true},
+    );
+
+    const agent = new WorkflowAgent({
+      name: 'root_agent',
+      edges: [['START', handle]],
+    });
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'u1',
+    });
+    const runner = new Runner({appName: 'test_app', agent, sessionService});
+
+    const turn1 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {role: 'user', parts: [{text: 'delete the database'}]},
+      }),
+    );
+    const [interruptId] = turn1.flatMap(getRequestInputInterruptIds);
+    expect(interruptId).toBeDefined();
+
+    // Answer that interrupt by id, the way a UI does.
+    const turn2 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: interruptId,
+                name: 'adk_request_input',
+                response: {result: 'yes'},
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(askRuns).toBe(1);
+    expect(turn2.some(hasRequestInputFunctionCall)).toBe(false);
+    expect(turn2.some((e) => e.output === 'Approved')).toBe(true);
   });
 });

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -23,10 +23,10 @@ import {
   getRequestInputInterruptIds,
   hasAuthCredential,
   hasRequestInputFunctionCall,
+  interruptResponseMismatch,
   processAuthResume,
   REQUEST_INPUT_FUNCTION_CALL_NAME,
   responseSchemasByInterruptId,
-  validateInterruptResponse,
 } from '../../src/workflow/utils/hitl_utils.js';
 import {unwrapResponse} from '../../src/workflow/utils/rehydration_utils.js';
 
@@ -207,61 +207,67 @@ describe('responseSchemasByInterruptId', () => {
   });
 });
 
-describe('validateInterruptResponse', () => {
+describe('interruptResponseMismatch', () => {
   const objectSchema = toJsonSchema(z4.object({userResponse: z4.string()}));
 
   it('accepts a reply matching the declared schema', () => {
-    expect(() =>
-      validateInterruptResponse('i1', {userResponse: 'yes'}, objectSchema),
-    ).not.toThrow();
+    expect(
+      interruptResponseMismatch('i1', {userResponse: 'yes'}, objectSchema),
+    ).toBeUndefined();
   });
 
-  it('rejects a reply in the wrong shape, naming the interrupt', () => {
+  it('reports a reply in the wrong shape, naming the interrupt', () => {
     // The `{response: x}` envelope a client reaches for instead of `{result: x}`:
     // it is not unwrapped, so the whole object arrives as the node's input.
-    expect(() =>
-      validateInterruptResponse('i1', {response: '21'}, objectSchema),
-    ).toThrow(/reply to interrupt 'i1' does not match/i);
+    expect(
+      interruptResponseMismatch('i1', {response: '21'}, objectSchema),
+    ).toMatch(/reply to interrupt 'i1' does not match/i);
   });
 
   it('explains how a structured reply is expected to look', () => {
-    expect(() =>
-      validateInterruptResponse('i1', {response: '21'}, objectSchema),
-    ).toThrow(/\{result: <value>\}/);
+    expect(
+      interruptResponseMismatch('i1', {response: '21'}, objectSchema),
+    ).toMatch(/\{result: <value>\}/);
+  });
+
+  it('says the interrupt can be answered again', () => {
+    expect(
+      interruptResponseMismatch('i1', {response: '21'}, objectSchema),
+    ).toMatch(/still waiting/i);
   });
 
   it('passes through when the interrupt declared no schema', () => {
-    expect(() =>
-      validateInterruptResponse('i1', {anything: true}, undefined),
-    ).not.toThrow();
+    expect(
+      interruptResponseMismatch('i1', {anything: true}, undefined),
+    ).toBeUndefined();
   });
 
   it('passes through when the schema cannot be compiled', () => {
-    expect(() =>
-      validateInterruptResponse('i1', 'anything', {
+    expect(
+      interruptResponseMismatch('i1', 'anything', {
         $ref: 'https://example.com/unresolvable.json',
       }),
-    ).not.toThrow();
+    ).toBeUndefined();
   });
 
   it('lets a bare-text reply through an object schema, as plain text does', () => {
-    expect(() =>
-      validateInterruptResponse(
+    expect(
+      interruptResponseMismatch(
         'i1',
         unwrapResponse({result: 'the museum and the lunch'}),
         objectSchema,
       ),
-    ).not.toThrow();
+    ).toBeUndefined();
   });
 
   it('checks the unwrapped value, so {result: x} satisfies a bare schema', () => {
     const stringSchema = toJsonSchema(z4.string());
-    expect(() =>
-      validateInterruptResponse(
+    expect(
+      interruptResponseMismatch(
         'i1',
         unwrapResponse({result: '21'}),
         stringSchema,
       ),
-    ).not.toThrow();
+    ).toBeUndefined();
   });
 });

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -85,7 +85,7 @@ describe('createRequestInputEvent', () => {
       interruptId: 'i1',
       message: 'pick',
       payload: {x: 1},
-      responseSchema: null,
+      response_schema: null,
     });
     expect(event.longRunningToolIds).toEqual(['i1']);
     expect(hasRequestInputFunctionCall(event)).toBe(true);
@@ -100,7 +100,7 @@ describe('createRequestInputEvent', () => {
       string,
       unknown
     >;
-    expect(args.responseSchema).toMatchObject({type: 'object'});
+    expect(args['response_schema']).toMatchObject({type: 'object'});
   });
 
   it('converts a Zod v3 responseSchema to a JSON schema', () => {
@@ -111,7 +111,7 @@ describe('createRequestInputEvent', () => {
       string,
       unknown
     >;
-    expect(args.responseSchema).toMatchObject({type: 'object'});
+    expect(args['response_schema']).toMatchObject({type: 'object'});
   });
 
   it('converts a genai Schema responseSchema to a JSON schema', () => {
@@ -126,10 +126,29 @@ describe('createRequestInputEvent', () => {
     >;
     // Emitted in the same JSON Schema dialect as a Zod responseSchema, so a
     // client reading this field does not have to handle two type spellings.
-    expect(args.responseSchema).toEqual({
+    expect(args['response_schema']).toEqual({
       type: 'object',
       properties: {answer: {type: 'string'}},
     });
+  });
+
+  it('names the schema arg the way clients read it', () => {
+    // Snake_case among camelCase neighbours, matching adk-python's
+    // `create_request_input_event`. The dev UI builds its reply form from
+    // `args.response_schema`; under any other spelling it silently falls back
+    // to a chat box, and the user answers a structured prompt with free text.
+    const args = firstFunctionCall(
+      createRequestInputEvent(
+        new RequestInput({responseSchema: z4.object({answer: z4.string()})}),
+      ),
+    )?.args as Record<string, unknown>;
+
+    expect(Object.keys(args)).toEqual([
+      'interruptId',
+      'payload',
+      'message',
+      'response_schema',
+    ]);
   });
 });
 
@@ -190,6 +209,30 @@ describe('responseSchemasByInterruptId', () => {
 
     expect(responseSchemasByInterruptId([event]).has('i1')).toBe(false);
   });
+
+  it('recovers a schema recorded under the older `responseSchema` key', () => {
+    // A session written before the key aligned with adk-python still has to
+    // resume, schema check included.
+    const event: Event = {
+      ...createRequestInputEvent(new RequestInput({interruptId: 'i1'})),
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: REQUEST_INPUT_FUNCTION_CALL_NAME,
+              id: 'i1',
+              args: {interruptId: 'i1', responseSchema: {type: 'object'}},
+            },
+          },
+        ],
+      },
+    };
+
+    expect(responseSchemasByInterruptId([event]).get('i1')).toEqual({
+      type: 'object',
+    });
+  });
 });
 
 describe('validateInterruptResponse', () => {
@@ -226,6 +269,20 @@ describe('validateInterruptResponse', () => {
       validateInterruptResponse('i1', 'anything', {
         $ref: 'https://example.com/unresolvable.json',
       }),
+    ).not.toThrow();
+  });
+
+  it('lets a bare-text reply through an object schema, as plain text does', () => {
+    // `{result: <text>}` is what a client with only a chat box sends — the dev
+    // UI does exactly this when it cannot render a form. Rejecting it would
+    // refuse the same answer the plain-text path accepts, and would keep
+    // refusing it: the reply stays in the session and is re-checked forever.
+    expect(() =>
+      validateInterruptResponse(
+        'i1',
+        unwrapResponse({result: 'the museum and the lunch'}),
+        objectSchema,
+      ),
     ).not.toThrow();
   });
 

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -209,30 +209,6 @@ describe('responseSchemasByInterruptId', () => {
 
     expect(responseSchemasByInterruptId([event]).has('i1')).toBe(false);
   });
-
-  it('recovers a schema recorded under the older `responseSchema` key', () => {
-    // A session written before the key aligned with adk-python still has to
-    // resume, schema check included.
-    const event: Event = {
-      ...createRequestInputEvent(new RequestInput({interruptId: 'i1'})),
-      content: {
-        role: 'model',
-        parts: [
-          {
-            functionCall: {
-              name: REQUEST_INPUT_FUNCTION_CALL_NAME,
-              id: 'i1',
-              args: {interruptId: 'i1', responseSchema: {type: 'object'}},
-            },
-          },
-        ],
-      },
-    };
-
-    expect(responseSchemasByInterruptId([event]).get('i1')).toEqual({
-      type: 'object',
-    });
-  });
 });
 
 describe('validateInterruptResponse', () => {

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -133,10 +133,6 @@ describe('createRequestInputEvent', () => {
   });
 
   it('names the schema arg the way clients read it', () => {
-    // Snake_case among camelCase neighbours, matching adk-python's
-    // `create_request_input_event`. The dev UI builds its reply form from
-    // `args.response_schema`; under any other spelling it silently falls back
-    // to a chat box, and the user answers a structured prompt with free text.
     const args = firstFunctionCall(
       createRequestInputEvent(
         new RequestInput({responseSchema: z4.object({answer: z4.string()})}),
@@ -249,10 +245,6 @@ describe('validateInterruptResponse', () => {
   });
 
   it('lets a bare-text reply through an object schema, as plain text does', () => {
-    // `{result: <text>}` is what a client with only a chat box sends — the dev
-    // UI does exactly this when it cannot render a form. Rejecting it would
-    // refuse the same answer the plain-text path accepts, and would keep
-    // refusing it: the reply stays in the session and is re-checked forever.
     expect(() =>
       validateInterruptResponse(
         'i1',

--- a/core/test/workflow/resume_test.ts
+++ b/core/test/workflow/resume_test.ts
@@ -123,10 +123,6 @@ describe('Phase 5b — rehydration utility', () => {
     });
 
     it('resolves a free-text reply wrapped as {result: …}', () => {
-      // What a client sends when all it can offer is a chat box. The node
-      // receives the text as-is, exactly as on the plain-text path; refusing
-      // it would also brick the session, since the recorded reply is
-      // re-checked on every later turn.
       const states = reconstructNodeStates(
         eventsWithReply({result: 'museum and lunch'}),
       );

--- a/core/test/workflow/resume_test.ts
+++ b/core/test/workflow/resume_test.ts
@@ -140,6 +140,62 @@ describe('Phase 5b — rehydration utility', () => {
         reconstructNodeStates(eventsWithReply({response: '21'})),
       ).toThrow(/reply to interrupt 'gate-1' does not match/i);
     });
+
+    describe('after a rejected reply', () => {
+      /** A rejected reply, followed by whatever the user tried next. */
+      function eventsWithRetry(retry: Event): Event[] {
+        return [...eventsWithReply({response: '21'}), retry];
+      }
+
+      it('stops rejecting once the turn that carried it has passed', () => {
+        // The reply stays in the session for good. Re-throwing on every replay
+        // is what used to make one malformed answer end the session.
+        const retry = createEvent({
+          author: 'user',
+          content: {role: 'user', parts: [{text: 'museum and lunch'}]},
+        });
+
+        expect(() =>
+          reconstructNodeStates(eventsWithRetry(retry)),
+        ).not.toThrow();
+      });
+
+      it('leaves the interrupt unresolved, so the next answer still lands', () => {
+        const retry = createEvent({
+          author: 'user',
+          content: {role: 'user', parts: [{text: 'museum and lunch'}]},
+        });
+
+        const gate = reconstructNodeStates(eventsWithRetry(retry)).get('gate');
+
+        expect(gate?.interruptIds.has('gate-1')).toBe(true);
+        expect(gate?.resolvedResponses.has('gate-1')).toBe(false);
+      });
+
+      it('accepts a corrected structured reply for the same interrupt', () => {
+        const retry = createEvent({
+          author: 'user',
+          content: {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'gate-1',
+                  name: 'adk_request_input',
+                  response: {userResponse: 'museum and lunch'},
+                },
+              },
+            ],
+          },
+        });
+
+        const states = reconstructNodeStates(eventsWithRetry(retry));
+
+        expect(states.get('gate')?.resolvedResponses.get('gate-1')).toEqual({
+          userResponse: 'museum and lunch',
+        });
+      });
+    });
   });
 
   it('recovers structured output and interrupt input after a DB serialization round-trip', () => {

--- a/core/test/workflow/resume_test.ts
+++ b/core/test/workflow/resume_test.ts
@@ -122,6 +122,20 @@ describe('Phase 5b — rehydration utility', () => {
       });
     });
 
+    it('resolves a free-text reply wrapped as {result: …}', () => {
+      // What a client sends when all it can offer is a chat box. The node
+      // receives the text as-is, exactly as on the plain-text path; refusing
+      // it would also brick the session, since the recorded reply is
+      // re-checked on every later turn.
+      const states = reconstructNodeStates(
+        eventsWithReply({result: 'museum and lunch'}),
+      );
+
+      expect(states.get('gate')?.resolvedResponses.get('gate-1')).toBe(
+        'museum and lunch',
+      );
+    });
+
     it('rejects the wrong envelope instead of passing it to the next node', () => {
       // `{response: x}` is not the `{result: x}` envelope, so it is not
       // unwrapped; before this check it reached the successor whole and

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -411,7 +411,7 @@ describe('cli_run', () => {
                   interruptId: 'interrupt-1',
                   message: 'Enter a number:',
                   payload: {draft: 'hi'},
-                  responseSchema: {type: 'object'},
+                  response_schema: {type: 'object'},
                 },
               },
             },

--- a/samples/workflows/README.md
+++ b/samples/workflows/README.md
@@ -85,9 +85,14 @@ shapes and the difference matters:
 `{result: …}` is the only envelope that gets unwrapped. Any other object is
 handed to the next node exactly as sent — which is what makes a structured
 reply carrying an object (`{userResponse: …}` in `payload_and_schema`) work. If
-the interrupt declared a `responseSchema`, a structured reply is checked
-against it and a mismatch fails loudly; if it declared none, whatever you send
-is what the next node receives.
+the interrupt declared a `responseSchema`, a reply carrying an _object_ is
+checked against it and a mismatch fails loudly; a bare value inside
+`{result: …}` counts as plain text and is not checked; if the interrupt
+declared none, whatever you send is what the next node receives.
+
+The schema itself travels on the interrupt as
+`functionCall.args.response_schema` (snake_case, matching adk-python), which is
+what the dev UI reads to render a form for the reply.
 
 ## Samples
 

--- a/samples/workflows/README.md
+++ b/samples/workflows/README.md
@@ -86,9 +86,10 @@ shapes and the difference matters:
 handed to the next node exactly as sent — which is what makes a structured
 reply carrying an object (`{userResponse: …}` in `payload_and_schema`) work. If
 the interrupt declared a `responseSchema`, a reply carrying an _object_ is
-checked against it and a mismatch fails loudly; a bare value inside
-`{result: …}` counts as plain text and is not checked; if the interrupt
-declared none, whatever you send is what the next node receives.
+checked against it and a mismatch fails loudly — the interrupt stays open, so
+your next reply answers it; a bare value inside `{result: …}` counts as plain
+text and is not checked; if the interrupt declared none, whatever you send is
+what the next node receives.
 
 The schema itself travels on the interrupt as
 `functionCall.args.response_schema` (snake_case, matching adk-python), which is


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

Answering the `human_input/payload_and_schema` sample in the dev UI fails. The
reply comes back as `The reply to interrupt '…' does not match the
responseSchema it declared: Invalid input: expected object, received string`,
and every later turn in that session fails the same way — the session cannot be
recovered.

Three things go wrong, in sequence:

1. **The schema travels under a key no client reads.**
   `createRequestInputEvent` wrote the JSON Schema as `args.responseSchema`, but
   the wire spelling is `response_schema`. adk-python's
   `create_request_input_event` dumps the request by alias (`interruptId`,
   `payload`, `message`) and then sets `response_schema` explicitly, and that
   mixed-case shape is what clients parse: the dev UI builds its reply form from
   `args.response_schema`. Finding nothing there, it falls back to a plain chat
   box — so the user answers a structured prompt with free text.

2. **That free text is then held to the schema.** The dev UI wraps a typed reply
   as `{result: <text>}`, which unwraps to a bare string, and the check compared
   that string to the object schema. The plain-text path is exempt from the
   check by contract; this is the same answer in an envelope, so exempting only
   one of them rejects the reply the other accepts.

3. **A rejected reply ends the session, not just the turn.** The reply stays in
   the session, rehydration replays the whole event list on every invocation,
   and the check threw the moment it reached that reply again. No retry could
   get past it — not a corrected structured reply, not plain text.

4. **A reply never reaches a node below the workflow's own children.**
   `samples/workflows/dynamic/human_input` never accepts an approval from a UI:
   answer "yes" and it asks again, with a fresh interrupt id, forever. That
   sample has a graph node driving an interactive child through `ctx.runNode`,
   so the interrupt is raised a level deeper than the workflow's children.
   `applyResumeInputs` sourced `ctx.resumeInputs` from the rehydrated node map,
   which is scoped to DIRECT children (nested workflows reuse node names), so
   the grandchild's resolved reply was keyed out of it — the child re-ran and
   minted a new `RequestInput`. Plain text hid this, since `WorkflowAgent` maps
   a text turn onto the pending interrupt id whatever the depth; only a client
   answering by interrupt id hit it.

`requestInputTool` has the same key mismatch as (1) on the other producer of
`adk_request_input` calls, so a model-raised pause gets no form either.

**Solution:**

- Emit the schema as `response_schema`, matching adk-python and what clients
  read. The dev UI now renders a form from it and replies with
  `{userResponse: …}`, which satisfies the schema.
- Treat a reply that unwraps to a bare scalar as plain text and skip the check,
  so the chat-box answer is accepted exactly as a text turn is.
- Report the mismatch instead of throwing on sight: `interruptResponseMismatch`
  returns the message, and both callers throw for the turn being processed
  (the reply is in the newest user event, so the client can still act on it)
  and skip it on every replay after. A skipped reply resolves nothing, so the
  interrupt goes back to pending and the next answer lands whichever shape it
  takes.
- Read resume inputs from the run's events via `resolvedInterruptResponses`, a
  flat interrupt id -> value map with no notion of depth — the right shape,
  since interrupt ids are unique and the reply belongs to whoever raised it.
  Node state stays scoped as it was.
- Rename `requestInputTool`'s parameter to `response_schema` so both producers
  agree.

What the check exists for is unaffected: a reply carrying an *object* is still
validated, so a client that wraps its answer as `{response: x}` instead of
`{result: x}` still fails loudly rather than delivering the whole envelope to
the next node as a stringified `[object Object]`. It now ends the turn rather
than the session, and the message says so.

Only the wire arg changed. The TypeScript API — `RequestInput.responseSchema`
and `UserInputRequest.responseSchema` — stays camelCase. No compatibility
fallback for the old key: the workflow feature is unreleased, so no session in
the wild carries it.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npm run test:unit` → **229 files, 3261 tests passed**. `npm run ts:check`,
`npm run lint` and `prettier --check` are clean, and the workflow integration
suites (37 files, 84 tests) pass.

Added coverage:

- `core/test/workflow/hitl_test.ts` — the emitted args are exactly
  `interruptId`, `payload`, `message`, `response_schema`; a bare-text reply
  passes an object schema; the mismatch message names the interrupt and says it
  can be answered again.
- `core/test/workflow/resume_test.ts` — a `{result: <text>}` reply resolves the
  interrupt; the wrong `{response: x}` envelope still throws on the turn it
  arrives; after that turn it stops throwing, leaves the interrupt unresolved,
  and a corrected structured reply for the same interrupt resolves it.
- `core/test/workflow/dynamic_resume_test.ts` — a graph node's `ctx.runNode`
  child is answered by a structured reply addressed to its interrupt id: the
  child does not re-run, no second interrupt is raised, and the run completes.
  Verified to fail without the fix.
- `core/test/tools/request_input_tool_test.ts` — the tool declares
  `message` + `response_schema`.

**Manual End-to-End (E2E) Tests:**

```bash
npm run build
npx adk web samples/workflows/human_input --port 8000
# create a session, send "Lisbon", then answer the interrupt
```

All four reply shapes behave correctly (before this change, the first errored
and left the session unusable):

| Reply | Result |
| --- | --- |
| `{"result": "then the museum and the lunch"}` (dev UI chat box) | ✅ `Noted. Building the final itinerary around: then the museum and the lunch` |
| `{"userResponse": "then the museum and the lunch"}` (dev UI form) | ✅ same |
| plain text turn | ✅ same |
| `{"response": "…"}` (wrong envelope) | ❌ rejected, as intended |

And a session survives a rejected reply — both retries below were dead ends
before:

| After a `{"response": "oops"}` rejection | Result |
| --- | --- |
| plain text `museum and lunch` | ✅ `Noted. Building the final itinerary around: museum and lunch` |
| corrected `{"userResponse": "museum and lunch"}` | ✅ same |

`samples/workflows/dynamic/human_input`, answering by interrupt id
(`{"result": "yes"}`), served with `npx adk web samples/workflows/dynamic`:

| Turn | Before | After |
| --- | --- | --- |
| reply "yes" to the approval | ↻ asks again, new interrupt id, forever | ✅ `Approved` |

The interrupt event now carries
`"response_schema": {"$schema": …, "type": "object", "properties": {"userResponse": {"type": "string"}}, …}`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

### Additional context

The dev UI is a prebuilt adk-web bundle (`dev/dist/browser`); the
`args.response_schema` read is in its long-running-call component, which
renders a form when the schema is an object with properties and falls back to a
chat box otherwise.

One inconsistency deliberately left: `getPendingUserInputRequests` in
`agents/user_input_request.ts` still counts any `functionResponse` as an answer,
including a rejected one, so it can report "not waiting" where the engine says
otherwise. It is an inspection helper with no access to the declared schemas,
and its only caller (the interactive CLI) never sends structured replies.

