### PR TITLE
docs(workflow): describe what a JoinNode barrier actually waits for

### DIFF
--- a/core/test/workflow/workflow_test.ts
+++ b/core/test/workflow/workflow_test.ts
@@ -95,6 +95,21 @@ describe('Phase 2 — Workflow orchestration', () => {
     expect(output).toEqual({A: 'A(x)', B: 'B(x)'});
   });
 
+  it('releases the barrier when a predecessor completes without an output, keying it undefined', async () => {
+    const a = new FnNode('A', (_c, input) => `A(${input})`);
+    const silent = new FnNode('silent', () => undefined);
+    const join = new JoinNode({name: 'join'});
+    const wf = new Workflow({
+      name: 'fan_wf_silent',
+      edges: [['START', [a, silent], join]],
+    });
+
+    const {output} = await driveWorkflow(wf, 'x');
+
+    expect(output).toEqual({A: 'A(x)', silent: undefined});
+    expect(Object.keys(output as object).sort()).toEqual(['A', 'silent']);
+  });
+
   it('rejects an unconditional cycle at construction', () => {
     const a = new FnNode('cyc_a', (_c, i) => i);
     const b = new FnNode('cyc_b', (_c, i) => i);

--- a/samples/workflows/routes/fan_out_join/agent.ts
+++ b/samples/workflows/routes/fan_out_join/agent.ts
@@ -11,9 +11,12 @@
  * A `JoinNode` is a fan-in barrier: it waits for EVERY predecessor to finish and
  * then hands the next node an object keyed by predecessor node name.
  *
- * Caution: a JoinNode proceeds only once all upstream nodes have produced an
- * output. If one fails to produce output the join is stuck and the workflow
- * stops — give any node feeding a join a failsafe output (or a `retryConfig`).
+ * Caution: the barrier waits for every predecessor to COMPLETE, not to produce
+ * an output. A predecessor that finishes without one still releases the join,
+ * and arrives in the record as its name mapped to `undefined` — so reading a
+ * field off it throws somewhere downstream, far from the node that skipped it.
+ * Give anything feeding a join an output of its own, and a `retryConfig` if it
+ * can fail; treat a missing one as a bug rather than as a pause.
  *
  * Run (offline, no API key):
  *   npm run sample -- samples/workflows/routes/fan_out_join/agent.ts


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Last finding from bug-bashing the graph-workflow docs samples. The
`routes/fan_out_join` header says:

> a JoinNode proceeds only once all upstream nodes have produced an output. If
> one fails to produce output the join is stuck and the workflow stops

Neither half is true. Probed with a predecessor that emits display content and
no output:

```
[after_join]: JOIN FIRED keys=[task_a,task_b_no_output] task_b=undefined
```

The barrier releases when every predecessor reaches `COMPLETED`
(`workflow.ts:570`); a predecessor that completes without an output releases it
too and lands in the record as its name mapped to `undefined`.

This matters because the documented failure is the *opposite* of the real one. A
reader who believes the header expects a hang and goes looking for a stall. What
actually happens is a successor reading a field off `undefined` and throwing
somewhere downstream, far from the node that skipped its output.

**Solution:**

Documentation, plus a regression test — deliberately not a behaviour change.

I went in expecting to change the engine, on the grounds that a silent
`undefined` is worse than a visible stall. adk-python builds the same record the
same way:

```python
outputs = {p: loop_state.node_outputs.get(p) for p in predecessors}
```

over predecessors it has already checked are `COMPLETED` (`_workflow.py:791-797`)
— `.get` yields `None` for a missing one, exactly as the TypeScript yields
`undefined`. So this is faithful parity rather than a TS defect, and making the
barrier wait on output (or fail the run) would put the two languages' graph
semantics out of step for a case neither treats as an error. That seems like the
wrong trade for a docs bug, but it is a judgement call and I am happy to be
overruled — the engine change is small if you want it.

The header now describes the real barrier and keeps the actionable half of the
old advice: give anything feeding a join an output of its own, and treat a
missing one as a bug rather than as a pause.

### Testing Plan

**Unit Tests:**

- [x] I have added a unit test — `workflow_test.ts` pins that a predecessor
      completing without an output releases the barrier and is keyed
      `undefined`, so the header and the engine cannot drift apart again.
- [x] All unit tests pass locally — `unit:core` **2983 passed** (213 files).
- [x] Integration — `tests/integration/workflows` 37 files, 84 passed.

**Manual End-to-End (E2E) Tests:**

Reproduced with a three-branch fan-out whose middle branch emits `content` only;
the join fired with `{task_a: 'HELLO WORLD'}` and `task_b_no_output` present but
`undefined`. `npm run ts:check:samples` is clean.
