### PR TITLE
fix(workflow): record which nodes an output answers for

### DIFF
--- a/core/src/events/event.ts
+++ b/core/src/events/event.ts
@@ -44,8 +44,19 @@ export interface NodeInfo {
   /** The workflow node path that produced this event (e.g. `wf.child.0`). */
   path?: string;
 
-  /** The node run id this event's output should be attributed to. */
-  outputFor?: string;
+  /**
+   * The node paths this event's output serves as the output for: the emitting
+   * node first, then any ancestor that delegated its own output to it.
+   *
+   * A node that runs a child with `useAsOutput` takes the child's output as its
+   * own, so one event is the result for several nodes at once. Recording that
+   * on the event is what lets a resumed run tell which nodes already produced a
+   * result, instead of re-running an ancestor whose output only ever existed on
+   * a descendant's event.
+   *
+   * Mirrors adk-python's `node_info.output_for`, which is likewise a list.
+   */
+  outputFor?: string[];
 
   /**
    * Whether the event's textual content should be promoted to the node's

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -67,6 +67,14 @@ export class NodeContext {
   readonly channel: AsyncQueue<Event>;
   readonly nodePath: string;
   readonly runId: string;
+
+  /**
+   * Node paths whose output this node's output also becomes: its parent's if
+   * the parent ran it with `useAsOutput`, plus whatever the parent was standing
+   * in for. Stamped onto every output event as `nodeInfo.outputFor`, so a
+   * resumed run can tell that an ancestor already has a result.
+   */
+  outputForAncestors: readonly string[] = [];
   readonly actions: EventActions;
   resumeInputs: Record<string, unknown>;
   isolationScope?: string;

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -179,6 +179,15 @@ async function runChildNode({
   });
   // Propagate the dynamic scheduler down; a nested Workflow overrides it.
   child.scheduler = parent.scheduler;
+  // A parent that takes this child's output as its own is standing in for it,
+  // so the child's output event answers for both — and for whatever the parent
+  // was already standing in for.
+  if (options.useAsOutput) {
+    child.outputForAncestors = [
+      parent.nodePath,
+      ...parent.outputForAncestors,
+    ].filter((path) => path !== '');
+  }
 
   const nodeState =
     callerNodeState ??
@@ -534,6 +543,9 @@ function enrichEvent({
   }
   // Engine-owned: always stamp the true node path (see doc above).
   event.nodeInfo = {...(event.nodeInfo ?? {}), path: child.nodePath};
+  if (event.output !== undefined) {
+    event.nodeInfo.outputFor = [child.nodePath, ...child.outputForAncestors];
+  }
   if (branch !== undefined && event.branch === undefined) {
     event.branch = branch;
   }

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -1473,7 +1473,7 @@ describe('VertexAiSessionService', () => {
         invocationId: 'inv-1',
         output: {score: 7},
         route: 'approved',
-        nodeInfo: {path: 'wf.reviewer', outputFor: '1'},
+        nodeInfo: {path: 'wf.reviewer', outputFor: ['wf.reviewer']},
         isolationScope: 'wf:evt_1',
         actions: {agentState: {input: 'draft'}, endOfAgent: true},
       });
@@ -1483,7 +1483,10 @@ describe('VertexAiSessionService', () => {
 
       expect(event.output).toEqual({score: 7});
       expect(event.route).toBe('approved');
-      expect(event.nodeInfo).toEqual({path: 'wf.reviewer', outputFor: '1'});
+      expect(event.nodeInfo).toEqual({
+        path: 'wf.reviewer',
+        outputFor: ['wf.reviewer'],
+      });
       expect(event.isolationScope).toBe('wf:evt_1');
       expect(event.actions.agentState).toEqual({input: 'draft'});
       expect(event.actions.endOfAgent).toBe(true);

--- a/core/test/workflow/event_model_test.ts
+++ b/core/test/workflow/event_model_test.ts
@@ -18,7 +18,11 @@ describe('Phase 0 — workflow event-model extensions', () => {
       author: 'node_a',
       output: {value: 42},
       route: 'question',
-      nodeInfo: {path: 'wf.node_a', outputFor: 'run_1', messageAsOutput: true},
+      nodeInfo: {
+        path: 'wf.node_a',
+        outputFor: ['wf.node_a'],
+        messageAsOutput: true,
+      },
       isolationScope: 'wf:evt_123',
       actions: {agentState: {status: 3}, endOfAgent: true},
     });
@@ -36,7 +40,11 @@ describe('Phase 0 — workflow event-model extensions', () => {
       author: 'node_a',
       output: {value: 42},
       route: 'question',
-      nodeInfo: {path: 'wf.node_a', outputFor: 'run_1', messageAsOutput: true},
+      nodeInfo: {
+        path: 'wf.node_a',
+        outputFor: ['wf.node_a'],
+        messageAsOutput: true,
+      },
       isolationScope: 'wf:evt_123',
       actions: {agentState: {status: 3}, endOfAgent: true},
     });
@@ -44,9 +52,9 @@ describe('Phase 0 — workflow event-model extensions', () => {
     const snake = transformToSnakeCaseEvent(ev);
     // Verify Python-compatible key names on the wire.
     expect(snake['node_info']).toBeDefined();
-    expect((snake['node_info'] as Record<string, unknown>)['output_for']).toBe(
-      'run_1',
-    );
+    expect(
+      (snake['node_info'] as Record<string, unknown>)['output_for'],
+    ).toEqual(['wf.node_a']);
     expect(
       (snake['node_info'] as Record<string, unknown>)['message_as_output'],
     ).toBe(true);
@@ -57,7 +65,7 @@ describe('Phase 0 — workflow event-model extensions', () => {
 
     const back = transformToCamelCaseEvent(snake);
     expect(back.nodeInfo?.path).toBe('wf.node_a');
-    expect(back.nodeInfo?.outputFor).toBe('run_1');
+    expect(back.nodeInfo?.outputFor).toEqual(['wf.node_a']);
     expect(back.nodeInfo?.messageAsOutput).toBe(true);
     expect(back.isolationScope).toBe('wf:evt_123');
     expect(back.route).toBe('question');

--- a/core/test/workflow/node_execution_test.ts
+++ b/core/test/workflow/node_execution_test.ts
@@ -364,3 +364,48 @@ describe('retry backoff cancellation', () => {
     expect(isInvocationAbortedError(err)).toBe(true);
   });
 });
+
+describe('outputFor — which nodes an output answers for', () => {
+  it('names the emitting node on its own output event', async () => {
+    const node = new FnNode('solo', () => 'done');
+    const {events} = await driveNode(node);
+
+    const withOutput = events.filter((e) => e.output !== undefined);
+    expect(withOutput).toHaveLength(1);
+    expect(withOutput[0].nodeInfo?.outputFor).toEqual(['solo']);
+  });
+
+  it('names the ancestors that took the output as their own', async () => {
+    // `useAsOutput` makes the parent stand in for the child, so the child's one
+    // event is the result for both. A resumed run reads this to tell that the
+    // parent already has an output, even though no event was authored by it.
+    const inner = new FnNode('inner', () => 'value');
+    const outer = new FnNode('outer', async (ctx) => {
+      await ctx.runNode(inner, null, {useAsOutput: true});
+      return undefined;
+    });
+
+    const {events} = await driveNode(outer);
+
+    const withOutput = events.filter((e) => e.output !== undefined);
+    expect(withOutput).toHaveLength(1);
+    expect(withOutput[0].nodeInfo?.path).toBe('outer.inner');
+    expect(withOutput[0].nodeInfo?.outputFor).toEqual(['outer.inner', 'outer']);
+  });
+
+  it('leaves it off an event that carries no output', async () => {
+    const node = new FnNode('quiet', (ctx) => {
+      ctx.emit(
+        createEvent({author: 'quiet', content: {parts: [{text: 'hi'}]}}),
+      );
+      return undefined;
+    });
+
+    const {events} = await driveNode(node);
+    const textOnly = events.filter((e) => e.output === undefined);
+    expect(textOnly.length).toBeGreaterThan(0);
+    for (const event of textOnly) {
+      expect(event.nodeInfo?.outputFor).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`nodeInfo.outputFor` was declared and never written — dead since the workflow port. It was also declared *wrong*: `string`, documented as "the node run id this event's output should be attributed to", where adk-python's `output_for` is a list of node **paths**. #649 then pinned the singular shape in a session round-trip test, so the divergence was on its way to being load-bearing.

What the field is actually for: a node that runs a child with `useAsOutput` takes the child's output as its own, so one event is the result for several nodes at once. Without recording that, nothing downstream can tell an ancestor already produced a result — its output only ever existed on a descendant's event, authored by the descendant.

**Solution:**

Build the chain where the delegation happens (`executeChildNode`, alongside the branch and isolation scope it already derives), and stamp it in `enrichEvent`, next to the node path — the other piece of provenance the engine owns rather than trusting a node for. Only events carrying output get it; a text-only event answers for nobody.

Three tests: the emitting node names itself, a `useAsOutput` chain names the ancestor too (`['outer.inner', 'outer']`), and a text-only event has no `outputFor`.

**This is the write half, deliberately.** The read half — teaching rehydration that an ancestor listed in `outputFor` already has its output, so a resumed run does not re-run it — is a separate change. Getting the recorded shape right first is the point: it is what goes into persisted sessions.

### Testing Plan

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
npm run ts:check           clean
npm run test:unit          3289 passed
npm run test:integration   211 passed | 8 skipped
```

Three existing assertions pinned the old `string` shape and now pin the list — including the Vertex session round-trip from #649, which is exactly the one that would have cemented it.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Type-level breaking for anyone reading `nodeInfo.outputFor`, though nothing wrote it before, so no runtime value changes shape. Belongs in the 2.0 in #629.