### PR TITLE
refactor(samples): stop wrapping agents that ctx.runNode() now accepts

### DIFF
--- a/samples/workflows/dynamic/data_handling/agent.ts
+++ b/samples/workflows/dynamic/data_handling/agent.ts
@@ -20,13 +20,11 @@
 
 import {LlmAgent, node, NodeContext, WorkflowAgent} from '@google/adk';
 
-const draftAgent = node(
-  new LlmAgent({
-    name: 'draft_agent',
-    model: 'gemini-flash-latest',
-    instruction: 'Write a short draft for the user request.',
-  }),
-);
+const draftAgent = new LlmAgent({
+  name: 'draft_agent',
+  model: 'gemini-flash-latest',
+  instruction: 'Write a short draft for the user request.',
+});
 
 const formatFunctionNode = node(
   (_ctx: NodeContext, rawDraft: string) =>

--- a/samples/workflows/dynamic/loop_route/agent.ts
+++ b/samples/workflows/dynamic/loop_route/agent.ts
@@ -30,14 +30,11 @@ import {LlmAgent, node, NodeContext, WorkflowAgent} from '@google/adk';
 /** Safety bound on the refine loop. */
 const MAX_FIX_ROUNDS = 3;
 
-const coderAgent = node(
-  new LlmAgent({
-    name: 'generator_agent',
-    model: 'gemini-flash-latest',
-    instruction:
-      'Write TypeScript code for the user request. Output code only.',
-  }),
-);
+const coderAgent = new LlmAgent({
+  name: 'generator_agent',
+  model: 'gemini-flash-latest',
+  instruction: 'Write TypeScript code for the user request. Output code only.',
+});
 
 /** Simulates a compile / lint pass. Empty findings means "clean". */
 const compileLintCheck = node(
@@ -54,15 +51,13 @@ const compileLintCheck = node(
   {name: 'lint_reviewer'},
 );
 
-const fixerAgent = node(
-  new LlmAgent({
-    name: 'fixer_agent',
-    model: 'gemini-flash-latest',
-    instruction: `Refactor current code {code}.
-        Based on compile & lint review: {findings}
-        Output code only.`,
-  }),
-);
+const fixerAgent = new LlmAgent({
+  name: 'fixer_agent',
+  model: 'gemini-flash-latest',
+  instruction: `Refactor current code {code}.
+      Based on compile & lint review: {findings}
+      Output code only.`,
+});
 
 const codeWorkflow = node(
   async (ctx: NodeContext, userRequest: string) => {

--- a/samples/workflows/dynamic/sequence_route/agent.ts
+++ b/samples/workflows/dynamic/sequence_route/agent.ts
@@ -26,13 +26,11 @@ const cityTimeSchema = z.object({
 });
 type CityTime = z.infer<typeof cityTimeSchema>;
 
-const cityGeneratorAgent = node(
-  new LlmAgent({
-    name: 'city_generator_agent',
-    model: 'gemini-flash-latest',
-    instruction: 'Return the name of a random city. Return only the name.',
-  }),
-);
+const cityGeneratorAgent = new LlmAgent({
+  name: 'city_generator_agent',
+  model: 'gemini-flash-latest',
+  instruction: 'Return the name of a random city. Return only the name.',
+});
 
 /** Simulates returning the current time in a specified city. */
 const cityTimeFunction = node(


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Since #683, `ctx.runNode()` takes what an edge takes, so an agent handed to it no longer needs `node()` around it. Four wrappers in the `dynamic/` samples existed only to satisfy the old signature:

```ts
const draftAgent = node(new LlmAgent({...}));   // before
const draftAgent = new LlmAgent({...});         // after
```

These are the samples the docs pages show, so the wrapper was teaching readers a step the API no longer asks for.

**Solution:**

Dropped in `data_handling` (`draft_agent`), `loop_route` (`generator_agent`, `fixer_agent`) and `sequence_route` (`city_generator_agent`).

The wrapper stays wherever it still carries something: `sequence_route`'s `city_report_agent` has an `inputSchema`, and every function node keeps the snake_case name the graph reports. Nothing else in the samples changes.

### Testing Plan

**Unit Tests:**

- [x] All tests pass locally — `tests/integration/docs_samples` 27 passed, `ts:check:samples` clean, eslint + prettier clean.

**Manual End-to-End (E2E) Tests:**

All three touched samples were run against a live `gemini-flash-latest`, plus the full 26-sample sweep (30 runs): **30 pass, 0 fail**.

**Node names are unchanged**, which is the thing worth checking here — `runNode` builds the same wrapper internally that `node()` built explicitly, so the events still come from `draft_agent`, `generator_agent`, `fixer_agent` and `city_generator_agent`:

```
[city_generator_agent]: Reykjavik
[city_time_function]: {"timeInfo":"10:10 AM","city":"Reykjavik"}
[city_report_agent]: The current time in Reykjavik is 10:10 AM.
```

That matters for #677, which asserts on those author names and records fixtures keyed by request content — both unaffected.