### PR TITLE
StreamingMode.BIDI is accepted but has no effect — silently degrades to NONE with no error or warning

### DIFF
--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -22,7 +22,7 @@ export enum StreamingMode {
   SSE = 'sse',
   /**
    * Bidirectional streaming. Not yet supported; passing this value to
-   * {@link createRunConfig} throws. Use {@link StreamingMode.SSE} for token
+   * `createRunConfig` throws. Use {@link StreamingMode.SSE} for token
    * streaming.
    */
   BIDI = 'bidi',
@@ -60,7 +60,7 @@ export interface RunConfig {
   /**
    * Streaming mode. Supported values are {@link StreamingMode.NONE} and
    * {@link StreamingMode.SSE}. {@link StreamingMode.BIDI} is not yet
-   * supported and is rejected by {@link createRunConfig}.
+   * supported and is rejected by `createRunConfig`.
    */
   streamingMode?: StreamingMode;
 

--- a/core/src/agents/run_config.ts
+++ b/core/src/agents/run_config.ts
@@ -20,6 +20,11 @@ import {logger} from '../utils/logger.js';
 export enum StreamingMode {
   NONE = 'none',
   SSE = 'sse',
+  /**
+   * Bidirectional streaming. Not yet supported; passing this value to
+   * {@link createRunConfig} throws. Use {@link StreamingMode.SSE} for token
+   * streaming.
+   */
   BIDI = 'bidi',
 }
 
@@ -53,7 +58,9 @@ export interface RunConfig {
   supportCfc?: boolean;
 
   /**
-   * Streaming mode, None or StreamingMode.SSE or StreamingMode.BIDI.
+   * Streaming mode. Supported values are {@link StreamingMode.NONE} and
+   * {@link StreamingMode.SSE}. {@link StreamingMode.BIDI} is not yet
+   * supported and is rejected by {@link createRunConfig}.
    */
   streamingMode?: StreamingMode;
 
@@ -123,8 +130,10 @@ export interface RunConfig {
  * @param params - Optional partial {@link RunConfig} overriding defaults.
  * @returns A merged {@link RunConfig} object.
  * @throws {Error} When `params.maxLlmCalls` exceeds `Number.MAX_SAFE_INTEGER`.
+ * @throws {Error} When `params.streamingMode` is {@link StreamingMode.BIDI}.
  */
 export function createRunConfig(params: Partial<RunConfig> = {}) {
+  validateStreamingMode(params.streamingMode);
   return {
     saveInputBlobsAsArtifacts: false,
     supportCfc: false,
@@ -134,6 +143,14 @@ export function createRunConfig(params: Partial<RunConfig> = {}) {
     ...params,
     maxLlmCalls: validateMaxLlmCalls(params.maxLlmCalls ?? 500),
   };
+}
+
+function validateStreamingMode(streamingMode?: StreamingMode): void {
+  if (streamingMode === StreamingMode.BIDI) {
+    throw new Error(
+      'StreamingMode.BIDI is not supported; use StreamingMode.SSE.',
+    );
+  }
 }
 
 function validateMaxLlmCalls(value: number): number {

--- a/core/test/agents/run_config_test.ts
+++ b/core/test/agents/run_config_test.ts
@@ -45,9 +45,10 @@ describe('createRunConfig', () => {
     expect(config.maxLlmCalls).toBe(100);
   });
 
-  it('accepts StreamingMode.BIDI', () => {
-    const config = createRunConfig({streamingMode: StreamingMode.BIDI});
-    expect(config.streamingMode).toBe(StreamingMode.BIDI);
+  it('throws when streamingMode is StreamingMode.BIDI', () => {
+    expect(() => createRunConfig({streamingMode: StreamingMode.BIDI})).toThrow(
+      'StreamingMode.BIDI is not supported; use StreamingMode.SSE.',
+    );
   });
 
   it('logs a warning when maxLlmCalls is 0', () => {


### PR DESCRIPTION
Fixes #676.

## What changed
- `core/src/agents/run_config.ts`
- `core/test/agents/run_config_test.ts`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.