### PR TITLE
fix(build): retry the ADK Web download instead of failing the build

### DIFF
--- a/dev/build.js
+++ b/dev/build.js
@@ -56,11 +56,11 @@ function downloadFile(url, dest) {
       }
 
       if (response.statusCode !== 200) {
-        reject(
-          new Error(
-            `Failed to get '${url}' (status code: ${response.statusCode})`,
-          ),
+        const err = new Error(
+          `Failed to get '${url}' (status code: ${response.statusCode})`,
         );
+        err.retryable = false;
+        reject(err);
         return;
       }
 
@@ -76,9 +76,37 @@ function downloadFile(url, dest) {
     });
 
     request.on('error', (err) => {
+      err.retryable = true;
       unlink(dest, () => reject(err));
     });
   });
+}
+
+const DOWNLOAD_ATTEMPTS = 3;
+const DOWNLOAD_RETRY_DELAY_MS = 2000;
+
+async function downloadFileWithRetry(url, dest) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await downloadFile(url, dest);
+    } catch (err) {
+      if (err.retryable === false || attempt >= DOWNLOAD_ATTEMPTS) {
+        throw new Error(
+          `Failed to download ADK Web assets: ${err.message}. The build needs ` +
+            `${url}; retry, or place the zip at ${zipCachePath} to build ` +
+            `offline.`,
+          {cause: err},
+        );
+      }
+      console.warn(
+        `[ADK Build] Download failed (attempt ${attempt}/${DOWNLOAD_ATTEMPTS}): ` +
+          `${err.message}. Retrying...`,
+      );
+      await new Promise((r) =>
+        setTimeout(r, DOWNLOAD_RETRY_DELAY_MS * attempt),
+      );
+    }
+  }
 }
 
 function unzipFile(zipPath, destDir) {
@@ -113,7 +141,7 @@ async function ensureBrowserAssets() {
       }
       const url = `https://github.com/google/adk-web/releases/download/${ADK_WEB_VERSION}/adk-web-browser.zip`;
       const tempZipPath = `${zipCachePath}.tmp`;
-      await downloadFile(url, tempZipPath);
+      await downloadFileWithRetry(url, tempZipPath);
       await rename(tempZipPath, zipCachePath);
       console.log(
         `[ADK Build] Downloaded and cached ADK Web ${ADK_WEB_VERSION}.`,


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Every build downloads the adk-web zip from GitHub releases, and a single transport error takes the whole build down:

```
[ADK Build] ADK Web zip not cached. Fetching v1.0.0 from GitHub...
Build failed: Error: socket hang up
    code: 'ECONNRESET'
```

That failed all three `run-tests` jobs on #691, a PR touching three sample files. In the same window it also failed a run on **main** ([31659998316](https://github.com/google/adk-js/actions/runs/31659998316)) with the identical error, so this is not specific to any change — CI is one flaky connection away from red on anything.

**Solution:**

Retry three times with a widening delay (2s, 4s).

Transport errors only. A bad HTTP status means the version tag is wrong or the release is gone, which retrying cannot fix, so those still fail on the first attempt rather than spending three round trips to print the same thing. The failure message now also names the cache path, since dropping the zip there is how you build with no network at all.

### Testing Plan

**Unit Tests:**

- [x] All unit tests pass locally — `unit:dev` 287 passed.

**Manual End-to-End (E2E) Tests:**

Both paths exercised against a cleared cache:

*Transport failure* (URL pointed at an unreachable host) — retries, then fails with a message naming the cache path:

```
[ADK Build] Download failed (attempt 1/3): connect ECONNREFUSED 127.0.0.1:1. Retrying...
[ADK Build] Download failed (attempt 2/3): connect ECONNREFUSED 127.0.0.1:1. Retrying...
Build failed: Failed to download ADK Web assets: connect ECONNREFUSED 127.0.0.1:1.
  The build needs https://127.0.0.1:1/adk-web-browser.zip; retry, or place the zip
  at dev/.cache/adk-web-v1.0.0.zip to build offline.
```

*Bad release tag* (`v0.0.0-does-not-exist`) — **zero** retry attempts, fails immediately.

Normal build unaffected: `npm run build` restores all 104 browser assets.