### PR TITLE
feat(dev): serve the agent structure graph the dev UI's graph tab asks for

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -43,6 +43,14 @@ import {
   setupTelemetry,
 } from '../utils/telemetry_utils.js';
 import {getAgentGraphAsDot, getWorkflowHighlights} from './agent_graph.js';
+import {
+  collectSubWorkflows,
+  GraphTarget,
+  navigateToNode,
+  serializeAgent,
+  serializeAppInfo,
+} from './app_info.js';
+import {renderStructureGraphAsDot} from './structure_graph.js';
 
 /**
  * Environment variable holding the shared bearer token used to authenticate
@@ -270,28 +278,38 @@ export class AdkApiServer {
       }
     });
 
-    app.get('/debug/trace/:eventId', (req: Request, res: Response) => {
-      try {
-        const eventId = req.params['eventId'];
-        const eventDict = this.traceDict[eventId];
+    // Both prefixes resolve to the same trace store: the dev UI asks under
+    // `/dev/apps/<app>/`, while `adk api_server` clients use the bare path.
+    // Traces are keyed by event and session id alone, so the app name in the
+    // UI's path is not needed to answer.
+    app.get(
+      ['/debug/trace/:eventId', '/dev/apps/:appName/debug/trace/:eventId'],
+      (req: Request, res: Response) => {
+        try {
+          const eventId = req.params['eventId'];
+          const eventDict = this.traceDict[eventId];
 
-        if (!eventDict) {
-          return res.status(404).json({error: 'Trace not found'});
+          if (!eventDict) {
+            return res.status(404).json({error: 'Trace not found'});
+          }
+
+          return res.json(eventDict);
+        } catch (e) {
+          const error = `Failed to get trace: ${e}`;
+
+          res.status(500).json({error});
+          this.logger.error(error);
+
+          return;
         }
-
-        return res.json(eventDict);
-      } catch (e) {
-        const error = `Failed to get trace: ${e}`;
-
-        res.status(500).json({error});
-        this.logger.error(error);
-
-        return;
-      }
-    });
+      },
+    );
 
     app.get(
-      '/debug/trace/session/:sessionId',
+      [
+        '/debug/trace/session/:sessionId',
+        '/dev/apps/:appName/debug/trace/session/:sessionId',
+      ],
       (req: Request, res: Response) => {
         try {
           const sessionId = req.params['sessionId'];
@@ -402,6 +420,90 @@ export class AdkApiServer {
           });
         } catch (e) {
           const error = `Failed to get agent graph: ${e}`;
+
+          res.status(500).json({error});
+          this.logger.error(error);
+          return;
+        }
+      },
+    );
+
+    // ---------------------- Agent structure graph endpoints ------------------
+    // The dev UI's graph tab reads the app's structure from these two, under a
+    // `/dev` prefix that marks them as debug-UI-only (adk-python registers the
+    // same pair in `dev_server.py`).
+    app.get(
+      '/dev/apps/:appName/build_graph',
+      async (req: Request, res: Response) => {
+        const appName = req.params['appName'];
+        try {
+          const rootAgent = await this.loadRootTarget(appName);
+          if (!rootAgent) {
+            return res.status(404).json({error: `App not found: ${appName}`});
+          }
+
+          return res.json(serializeAppInfo(appName, rootAgent));
+        } catch (e) {
+          const error = `Failed to get app info: ${e}`;
+
+          res.status(500).json({error});
+          this.logger.error(error);
+          return;
+        }
+      },
+    );
+
+    app.get(
+      '/dev/apps/:appName/build_graph_image',
+      async (req: Request, res: Response) => {
+        const appName = req.params['appName'];
+        try {
+          const rootAgent = await this.loadRootTarget(appName);
+          if (!rootAgent) {
+            return res.status(404).json({error: `App not found: ${appName}`});
+          }
+
+          const darkMode = String(req.query['dark_mode']) === 'true';
+          const nodePath =
+            typeof req.query['node'] === 'string' ? req.query['node'] : '';
+
+          const target = nodePath
+            ? navigateToNode(rootAgent, nodePath)
+            : rootAgent;
+          if (!target) {
+            return res.status(404).json({error: `Node not found: ${nodePath}`});
+          }
+
+          // One DOT per level, keyed by path, so the UI can preload the whole
+          // app in a single request and re-render instantly as the user
+          // navigates. A level that owns no workflow graph — a plain agent tree
+          // — is drawn whole at its own path, which is why the requested level
+          // is always present.
+          const levels = collectSubWorkflows(target, nodePath);
+          if (!levels.has(nodePath)) {
+            levels.set(nodePath, target);
+          }
+
+          const results: Record<string, {dotSrc: string}> = {};
+          for (const [path, level] of levels) {
+            results[path] = {
+              dotSrc: renderStructureGraphAsDot(
+                serializeAgent(level),
+                darkMode,
+              ),
+            };
+          }
+
+          // `dotSrc` for the requested level alongside the map: the UI reads
+          // the map when it preloads every level, but reads `o.dotSrc` on the
+          // single-level fetch it falls back to when a level is missing from
+          // that preload. Returning only the map leaves that fallback blank.
+          return res.json({
+            ...results,
+            dotSrc: results[nodePath]?.dotSrc,
+          });
+        } catch (e) {
+          const error = `Failed to get app graph image: ${e}`;
 
           res.status(500).json({error});
           this.logger.error(error);
@@ -1030,6 +1132,28 @@ export class AdkApiServer {
         resolve();
       });
     });
+  }
+
+  /**
+   * Loads an app's root agent for the structure-graph endpoints, or returns
+   * undefined when no app goes by that name.
+   *
+   * Membership is checked against `listAgents()` rather than by matching the
+   * loader's error text, so an app that exists but throws while loading still
+   * surfaces as a 500 with its real cause instead of a misleading 404.
+   */
+  private async loadRootTarget(
+    appName: string,
+  ): Promise<GraphTarget | undefined> {
+    const apps = await this.agentLoader.listAgents();
+    if (!apps.includes(appName)) {
+      return undefined;
+    }
+
+    await using agentFile = await this.agentLoader.getAgentFile(appName);
+    const loaded = await agentFile.load();
+
+    return isApp(loaded) ? loaded.rootAgent : loaded;
   }
 
   private async getRunner(

--- a/dev/src/server/app_info.ts
+++ b/dev/src/server/app_info.ts
@@ -1,0 +1,340 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseAgent,
+  BaseNode,
+  DEFAULT_ROUTE,
+  RouteValue,
+  Workflow,
+  Graph as WorkflowGraph,
+  isBaseAgent,
+  isBaseTool,
+  isGraphWorkflowAgent,
+  isLlmAgent,
+} from '@google/adk';
+
+/**
+ * Anything the dev UI's structure graph can sit on: an agent, or a node of a
+ * workflow graph. The two are interchangeable at every level — a workflow node
+ * can wrap an agent, and an agent can be a workflow — so navigation and
+ * serialization both work over the union rather than over `BaseAgent` alone.
+ */
+export type GraphTarget = BaseAgent | BaseNode;
+
+/** A workflow graph edge, as the dev UI's live workflow view reads it. */
+export interface SerializedEdge {
+  from_node: SerializedNodeRef;
+  to_node: SerializedNodeRef;
+  route?: string | string[];
+}
+
+/**
+ * Edge endpoints are shallow on purpose: the UI reads only `name`/`type` off
+ * them, and serializing them in full would repeat every nested subtree once per
+ * incident edge.
+ */
+export interface SerializedNodeRef {
+  name: string;
+  type: string;
+}
+
+/**
+ * An agent or node in the form the dev UI consumes. Keys are snake_case to
+ * match adk-python's `serialize_agent`, which is the contract the shared
+ * adk-web bundle was built against.
+ */
+export interface SerializedAgent {
+  name: string;
+  type: string;
+  description?: string;
+  model?: string;
+  rerun_on_resume?: boolean;
+  agent?: SerializedAgent;
+  sub_agents?: SerializedAgent[];
+  tools?: SerializedNodeRef[];
+  graph?: {nodes: SerializedAgent[]; edges: SerializedEdge[]};
+}
+
+/** The `build_graph` payload — adk-python's `serialize_app_info`. */
+export interface AppInfo {
+  name: string;
+  root_agent: SerializedAgent;
+  readme?: string;
+}
+
+const WORKFLOW_START_NODE_NAME = '__START__';
+
+/**
+ * Reads a field off a node structurally. The dev server loads the user's agent
+ * module, which may resolve its own copy of `@google/adk`, so `instanceof` is
+ * not dependable here — the same reason `agent_graph.ts` classifies nodes by
+ * shape.
+ */
+function getField(target: GraphTarget, field: string): unknown {
+  return (target as unknown as Record<string, unknown>)[field];
+}
+
+function isWorkflowGraph(value: unknown): value is WorkflowGraph {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as WorkflowGraph).nodes) &&
+    Array.isArray((value as WorkflowGraph).edges)
+  );
+}
+
+/**
+ * The {@link Workflow} a target holds, if any: either a `WorkflowAgent`'s
+ * adapted workflow or a workflow used directly as a node. Mirrors
+ * `agent_graph.ts`'s `asWorkflow` so the JSON tree and the DOT agree on what
+ * counts as a workflow.
+ */
+function asWorkflow(target: GraphTarget): Workflow | undefined {
+  if (isGraphWorkflowAgent(target)) {
+    return target.workflow;
+  }
+
+  const isWorkflowShaped =
+    isWorkflowGraph(getField(target, 'graph')) ||
+    typeof getField(target, 'dynamicEntry') === 'function';
+
+  return isWorkflowShaped ? (target as Workflow) : undefined;
+}
+
+/** The agent a node wraps, if it wraps one (e.g. an `LLMAgentWrapper`). */
+function wrappedAgent(target: GraphTarget): BaseAgent | undefined {
+  const agent = getField(target, 'agent');
+
+  return isBaseAgent(agent) ? agent : undefined;
+}
+
+/**
+ * Classifies a target for the UI's icon and label switch.
+ *
+ * Only the vocabulary the UI knows is emitted — `start`, `workflow`, `agent`,
+ * `tool`, `join`, `function`. A composite agent (sequential, loop, parallel) is
+ * an `agent`: the UI has no glyph of its own for those, and a type it does not
+ * recognize draws with no icon at all.
+ */
+function targetType(target: GraphTarget): string {
+  if (target.name === WORKFLOW_START_NODE_NAME) {
+    return 'start';
+  }
+  if (asWorkflow(target)) {
+    return 'workflow';
+  }
+  if (wrappedAgent(target) || isBaseAgent(target)) {
+    return 'agent';
+  }
+  if (isBaseTool(getField(target, 'tool'))) {
+    return 'tool';
+  }
+  if ((target as BaseNode).requiresAllPredecessors) {
+    return 'join';
+  }
+
+  return 'function';
+}
+
+/**
+ * The children of a target, in the order the UI resolves a path segment
+ * against them (`graph.nodes`, then `sub_agents`).
+ *
+ * Exported because `build_graph_image` navigates the *live* tree rather than
+ * the serialized one — the DOT is produced from real agents and workflows —
+ * and both walks have to agree on which names exist at which path.
+ */
+export function childTargets(target: GraphTarget): GraphTarget[] {
+  const workflow = asWorkflow(target);
+  if (workflow) {
+    return [...(workflow.graph?.nodes ?? [])];
+  }
+
+  const agent =
+    wrappedAgent(target) ?? (isBaseAgent(target) ? target : undefined);
+
+  return agent ? [...agent.subAgents] : [];
+}
+
+function serializeRoute(
+  route: RouteValue | RouteValue[] | null | undefined,
+): string | string[] | undefined {
+  if (route == null) {
+    return undefined;
+  }
+
+  const labels = (Array.isArray(route) ? route : [route]).map((value) =>
+    value === DEFAULT_ROUTE ? 'default' : String(value),
+  );
+
+  return labels.length === 1 ? labels[0] : labels;
+}
+
+function serializeNodeRef(node: BaseNode): SerializedNodeRef {
+  return {name: node.name, type: targetType(node)};
+}
+
+function serializeGraph(graph: WorkflowGraph): {
+  nodes: SerializedAgent[];
+  edges: SerializedEdge[];
+} {
+  return {
+    nodes: graph.nodes.map((node) => serializeAgent(node)),
+    edges: graph.edges.map((edge) => {
+      const route = serializeRoute(edge.route);
+
+      return {
+        from_node: serializeNodeRef(edge.fromNode),
+        to_node: serializeNodeRef(edge.toNode),
+        ...(route !== undefined ? {route} : {}),
+      };
+    }),
+  };
+}
+
+/**
+ * Serializes an agent or workflow node into the dev UI's JSON tree.
+ *
+ * A workflow keeps its structure in `graph.edges`, not in `subAgents` — a naive
+ * `sub_agents` walk reports an empty tree for every workflow — so a workflow is
+ * emitted under `graph` and everything else under `sub_agents`.
+ */
+export function serializeAgent(target: GraphTarget): SerializedAgent {
+  const type = targetType(target);
+  const description = target.description || undefined;
+  const serialized: SerializedAgent = {
+    name: target.name,
+    type,
+    ...(description ? {description} : {}),
+  };
+
+  if (isLlmAgent(target)) {
+    if (typeof target.model === 'string' && target.model) {
+      serialized.model = target.model;
+    }
+
+    // `tools`, not `canonicalTools()`: the async form resolves toolsets by
+    // calling out to their providers, which a structure request should not do.
+    // A toolset therefore contributes nothing here — it has no name until it is
+    // resolved into the tools it holds.
+    const tools = target.tools
+      .map((tool) => (tool as {name?: unknown})?.name)
+      .filter((name): name is string => typeof name === 'string' && !!name)
+      .map((name) => ({name, type: 'tool'}));
+    if (tools.length) {
+      serialized.tools = tools;
+    }
+  }
+
+  const rerunOnResume = getField(target, 'rerunOnResume');
+  if (typeof rerunOnResume === 'boolean') {
+    serialized.rerun_on_resume = rerunOnResume;
+  }
+
+  const workflow = asWorkflow(target);
+  if (workflow) {
+    // A dynamic workflow (`dynamicEntry`) has no static graph to expand, so it
+    // is left as a leaf rather than given an empty `graph` the UI would offer
+    // as navigable.
+    if (workflow.graph) {
+      serialized.graph = serializeGraph(workflow.graph);
+    }
+
+    return serialized;
+  }
+
+  const agent = wrappedAgent(target);
+  if (agent) {
+    serialized.agent = serializeAgent(agent);
+  }
+
+  const subAgents = (agent ?? (isBaseAgent(target) ? target : undefined))
+    ?.subAgents;
+  if (subAgents?.length) {
+    serialized.sub_agents = subAgents.map((sub) => serializeAgent(sub));
+  }
+
+  return serialized;
+}
+
+/** Builds the `build_graph` payload for an app. */
+export function serializeAppInfo(
+  name: string,
+  root: GraphTarget,
+  readme?: string,
+): AppInfo {
+  return {
+    name,
+    root_agent: serializeAgent(root),
+    ...(readme ? {readme} : {}),
+  };
+}
+
+/**
+ * Resolves a `parent/child/grandchild` path against the live tree.
+ *
+ * Paths the UI sends are relative to the root agent and exclude its name, but a
+ * leading root name is tolerated because the UI builds some paths from
+ * breadcrumbs that include it — the same allowance adk-python's
+ * `_navigate_to_node` makes.
+ */
+export function navigateToNode(
+  root: GraphTarget,
+  nodePath: string,
+): GraphTarget | undefined {
+  const parts = nodePath.split('/').filter((part) => part !== '');
+  let current: GraphTarget = root;
+
+  const startIndex = parts[0] === root.name ? 1 : 0;
+  for (const part of parts.slice(startIndex)) {
+    const child = childTargets(current).find((candidate) => {
+      const agent = wrappedAgent(candidate);
+
+      return candidate.name === part || agent?.name === part;
+    });
+
+    if (!child) {
+      return undefined;
+    }
+
+    current = child;
+  }
+
+  return current;
+}
+
+/**
+ * Every workflow at or below `root`, keyed by its path relative to `basePath`.
+ *
+ * The dev UI preloads one DOT per level in a single request and then renders
+ * whichever level the user has navigated to, so only targets that own a graph
+ * are worth an entry; plain agent trees are drawn whole at their root.
+ */
+export function collectSubWorkflows(
+  root: GraphTarget,
+  basePath = '',
+): Map<string, GraphTarget> {
+  const workflows = new Map<string, GraphTarget>();
+
+  const visit = (target: GraphTarget, path: string) => {
+    if (asWorkflow(target)?.graph) {
+      workflows.set(path, target);
+    }
+
+    for (const child of childTargets(target)) {
+      if (child.name === WORKFLOW_START_NODE_NAME) {
+        continue;
+      }
+
+      visit(child, path ? `${path}/${child.name}` : child.name);
+    }
+  };
+
+  visit(root, basePath);
+
+  return workflows;
+}

--- a/dev/src/server/structure_graph.ts
+++ b/dev/src/server/structure_graph.ts
@@ -1,0 +1,358 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Color, Digraph, Edge, Node, toDot} from 'ts-graphviz';
+
+import {SerializedAgent, SerializedEdge} from './app_info.js';
+
+/**
+ * Renders ONE level of an app's structure, for the dev UI's graph tab.
+ *
+ * This is deliberately not `agent_graph.ts`, which draws the whole tree with
+ * nested workflows as recursive clusters — the right picture for the per-event
+ * graph, where the point is to highlight a path through everything at once.
+ * The graph tab instead shows a single level and lets the user click into a
+ * sub-workflow, so a sub-workflow has to be one node here rather than an
+ * expanded cluster. adk-python splits the same two jobs across `agent_graph.py`
+ * and `graph_visualization.py`; this mirrors the latter.
+ *
+ * The node ids matter: the UI binds its click handler to `g.node` elements and
+ * matches each one's `<title>` against a bare child name, so nodes are keyed by
+ * name — a qualified `parent.child` id would render but never be clickable.
+ */
+
+const START_NODE_NAME = '__START__';
+const END_NODE_NAME = '__END__';
+
+interface Palette {
+  background: Color;
+  nodeFill: Color;
+  nodeBorder: Color;
+  nodeText: Color;
+  edge: Color;
+  edgeText: Color;
+  startFill: Color;
+  startBorder: Color;
+  endFill: Color;
+  endBorder: Color;
+}
+
+const DARK_PALETTE: Palette = {
+  background: '#0F172A',
+  nodeFill: '#1E293B',
+  nodeBorder: '#475569',
+  nodeText: '#F8FAFC',
+  edge: '#94A3B8',
+  edgeText: '#CBD5E1',
+  startFill: '#059669',
+  startBorder: '#047857',
+  endFill: '#DC2626',
+  endBorder: '#B91C1C',
+};
+
+const LIGHT_PALETTE: Palette = {
+  background: '#F8FAFC',
+  nodeFill: '#FFFFFF',
+  nodeBorder: '#94A3B8',
+  nodeText: '#0F172A',
+  edge: '#64748B',
+  edgeText: '#475569',
+  startFill: '#10B981',
+  startBorder: '#059669',
+  endFill: '#EF4444',
+  endBorder: '#DC2626',
+};
+
+/** Glyph and accent per node type, matching the legend the dev UI draws. */
+const ICONS: Record<string, {icon: string; color: string}> = {
+  agent: {icon: '✦', color: '#42A5F5'},
+  workflow: {icon: '⊷', color: '#9333EA'},
+  function: {icon: 'ƒ', color: '#10B981'},
+  join: {icon: '⌵', color: '#F59E0B'},
+  tool: {icon: '🔧', color: '#6B7280'},
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** A tool edge is synthesized here, so it is marked rather than serialized. */
+interface LevelEdge extends SerializedEdge {
+  isToolEdge?: boolean;
+}
+
+/**
+ * Flattens a plain agent tree into nodes and edges. A level that owns no
+ * workflow graph — an `LlmAgent` and its sub-agents — has no `graph` to draw,
+ * so its hierarchy becomes the graph.
+ */
+function agentTreeAsGraph(level: SerializedAgent): {
+  nodes: SerializedAgent[];
+  edges: LevelEdge[];
+} {
+  // A dynamic workflow reaches here too: it builds its nodes as it runs, so it
+  // has no static graph and stands alone as a single node of its own type.
+  const nodes: SerializedAgent[] = [
+    {name: level.name, type: level.type || 'agent', tools: level.tools},
+  ];
+  const edges: LevelEdge[] = [];
+
+  const walk = (agent: SerializedAgent, parentName: string) => {
+    for (const sub of agent.sub_agents ?? []) {
+      if (!sub.name) {
+        continue;
+      }
+
+      nodes.push({name: sub.name, type: sub.type || 'agent', tools: sub.tools});
+      edges.push({
+        from_node: {name: parentName, type: 'agent'},
+        to_node: {name: sub.name, type: sub.type || 'agent'},
+      });
+      walk(sub, sub.name);
+    }
+  };
+
+  walk(level, level.name);
+
+  return {nodes, edges};
+}
+
+/** Adds one node per tool, plus a dashed edge from its owner. */
+function injectTools(nodes: SerializedAgent[], edges: LevelEdge[]) {
+  const toolNodes = new Map<string, SerializedAgent>();
+
+  for (const node of nodes) {
+    if (!node.name || node.name === START_NODE_NAME) {
+      continue;
+    }
+
+    for (const tool of node.tools ?? []) {
+      if (!tool.name) {
+        continue;
+      }
+
+      if (!toolNodes.has(tool.name)) {
+        toolNodes.set(tool.name, {name: tool.name, type: tool.type || 'tool'});
+      }
+
+      edges.push({
+        from_node: {name: node.name, type: node.type},
+        to_node: {name: tool.name, type: tool.type || 'tool'},
+        isToolEdge: true,
+      });
+    }
+  }
+
+  for (const tool of toolNodes.values()) {
+    if (!nodes.some((node) => node.name === tool.name)) {
+      nodes.push(tool);
+    }
+  }
+}
+
+function nodeLabel(name: string, type: string, noDefault: boolean): string {
+  const iconData = ICONS[type];
+  if (!iconData) {
+    return name;
+  }
+
+  const {icon, color} = iconData;
+  const label =
+    `<FONT COLOR="${color}" POINT-SIZE="14">${icon}</FONT> ` + escapeHtml(name);
+
+  // A router with no fallback route silently drops every input that matches
+  // none of its branches, so the drawn node says so.
+  return noDefault
+    ? `<${label}<br/><br/><FONT POINT-SIZE="10">⚠️ [NO DEFAULT]</FONT>>`
+    : `<${label}>`;
+}
+
+/**
+ * Renders a level to DOT.
+ *
+ * @param level The agent or workflow to draw, as serialized by `app_info`.
+ * @param darkMode Whether to draw with the dark palette.
+ */
+export function renderStructureGraphAsDot(
+  level: SerializedAgent,
+  darkMode = false,
+): string {
+  const palette = darkMode ? DARK_PALETTE : LIGHT_PALETTE;
+  const isWorkflow = !!level.graph;
+  const {nodes, edges} = isWorkflow
+    ? {
+        nodes: [...(level.graph?.nodes ?? [])],
+        edges: [...(level.graph?.edges ?? [])] as LevelEdge[],
+      }
+    : agentTreeAsGraph(level);
+
+  injectTools(nodes, edges);
+
+  const dot = new Digraph(level.name, {
+    bgcolor: palette.background,
+    pad: 0.5,
+    nodesep: 0.5,
+    ranksep: 0.8,
+    fontname: 'Helvetica',
+    splines: 'spline',
+  });
+
+  dot.attributes.node.apply({
+    shape: 'rect',
+    style: 'rounded,filled',
+    fillcolor: palette.nodeFill,
+    color: palette.nodeBorder,
+    penwidth: 1.5,
+    fontname: 'Helvetica',
+    fontcolor: palette.nodeText,
+    fontsize: 12,
+    margin: '0.25,0.15',
+  });
+
+  dot.attributes.edge.apply({
+    color: palette.edge,
+    penwidth: 1.2,
+    fontname: 'Helvetica',
+    fontcolor: palette.edgeText,
+    fontsize: 10,
+    arrowhead: 'vee',
+    arrowsize: 0.7,
+  });
+
+  const flowEdges = edges.filter((edge) => !edge.isToolEdge);
+
+  for (const node of nodes) {
+    const name = node.name;
+    // START is drawn from the edge that leaves it, so it keeps its own style.
+    if (!name || name === START_NODE_NAME) {
+      continue;
+    }
+
+    const outgoing = flowEdges.filter((edge) => edge.from_node?.name === name);
+    const isConditional = outgoing.some((edge) => !!edge.route);
+    const hasDefault = outgoing.some(
+      (edge) => !edge.route || edge.route === 'default',
+    );
+    const type = node.type || 'node';
+    const label = nodeLabel(name, type, isConditional && !hasDefault);
+    const tooltip = type.charAt(0).toUpperCase() + type.slice(1);
+
+    if (isConditional) {
+      dot.addNode(
+        new Node(name, {
+          label,
+          tooltip,
+          shape: 'diamond',
+          style: 'filled',
+          height: 1.2,
+          width: 0.8,
+          margin: '0.0,0.0',
+        }),
+      );
+    } else if (type === 'join') {
+      dot.addNode(
+        new Node(name, {
+          label,
+          tooltip,
+          shape: 'oval',
+          style: 'filled',
+          margin: '0.05,0.05',
+        }),
+      );
+    } else if (type === 'tool') {
+      dot.addNode(
+        new Node(name, {label, tooltip, style: 'rounded,filled,dashed'}),
+      );
+    } else {
+      dot.addNode(new Node(name, {label, tooltip, style: 'rounded,filled'}));
+    }
+  }
+
+  let startDrawn = false;
+  for (const edge of edges) {
+    const from = edge.from_node?.name;
+    const to = edge.to_node?.name;
+    if (!from || !to) {
+      continue;
+    }
+
+    if (from === START_NODE_NAME && !startDrawn) {
+      startDrawn = true;
+      dot.addNode(
+        new Node(START_NODE_NAME, {
+          label: 'START',
+          shape: 'oval',
+          style: 'filled',
+          fillcolor: palette.startFill,
+          color: palette.startBorder,
+          fontcolor: palette.nodeText,
+          fontname: 'Helvetica-Bold',
+          width: 0.9,
+          fixedsize: true,
+        }),
+      );
+    }
+
+    if (edge.isToolEdge) {
+      dot.addEdge(
+        new Edge([new Node(from), new Node(to)], {
+          style: 'dashed',
+          color: palette.edge,
+        }),
+      );
+
+      continue;
+    }
+
+    const route = Array.isArray(edge.route)
+      ? edge.route.join(', ')
+      : edge.route;
+    dot.addEdge(
+      new Edge([new Node(from), new Node(to)], {
+        ...(route ? {label: `  ${route}`} : {}),
+      }),
+    );
+  }
+
+  // A workflow's terminal nodes are joined to an END marker so the exits of a
+  // branching graph are visible; an agent tree has no such notion.
+  const terminals = nodes
+    .map((node) => node.name)
+    .filter(
+      (name) =>
+        !!name &&
+        name !== START_NODE_NAME &&
+        name !== END_NODE_NAME &&
+        nodes.find((node) => node.name === name)?.type !== 'tool' &&
+        !flowEdges.some((edge) => edge.from_node?.name === name),
+    );
+
+  if (isWorkflow && terminals.length) {
+    dot.addNode(
+      new Node(END_NODE_NAME, {
+        label: 'END',
+        shape: 'oval',
+        style: 'filled',
+        fillcolor: palette.endFill,
+        color: palette.endBorder,
+        fontcolor: palette.nodeText,
+        fontname: 'Helvetica-Bold',
+        width: 0.9,
+        fixedsize: true,
+      }),
+    );
+
+    for (const terminal of terminals) {
+      dot.addEdge(new Edge([new Node(terminal), new Node(END_NODE_NAME)]));
+    }
+  }
+
+  return toDot(dot);
+}

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -21,6 +21,7 @@ import {
   node,
   Runner,
   Session,
+  Workflow,
   WorkflowAgent,
 } from '@google/adk';
 import {ReadableSpan} from '@opentelemetry/sdk-trace-base';
@@ -894,6 +895,44 @@ describe('AdkWebServer', () => {
       expect(response.data).toHaveLength(1);
       expect(response.data![0].name).toBe('call_llm');
     });
+
+    // The dev UI asks for traces under `/dev/apps/<app>/`; the same store
+    // answers, since a trace is keyed by event and session id alone.
+    it('serves the same traces under the dev UI prefix', async () => {
+      (server as unknown as {traceDict: {[key: string]: unknown}}).traceDict[
+        'event2'
+      ] = {some: 'prefixed trace'};
+      const mockSpan = {
+        name: 'call_llm',
+        spanContext: () => ({traceId: 'trace2', spanId: 'span2'}),
+        startTime: [1, 0],
+        endTime: [2, 0],
+        attributes: {'gcp.vertex.agent.session_id': 'session2'},
+        parentSpanContext: undefined,
+      } as unknown as ReadableSpan;
+      (
+        server as unknown as {
+          memoryExporter: {
+            export: (
+              spans: ReadableSpan[],
+              resultCallback: (result: {code: number}) => void,
+            ) => void;
+          };
+        }
+      ).memoryExporter.export([mockSpan], () => {});
+
+      const event = await client.get<{some: string}>(
+        '/dev/apps/testApp/debug/trace/event2',
+      );
+      const session = await client.get<{name: string}[]>(
+        '/dev/apps/testApp/debug/trace/session/session2',
+      );
+
+      expect(event.status).toBe(200);
+      expect(event.data).toEqual({some: 'prefixed trace'});
+      expect(session.status).toBe(200);
+      expect(session.data![0].name).toBe('call_llm');
+    });
   });
 
   describe('Graph', () => {
@@ -1011,6 +1050,218 @@ describe('AdkWebServer', () => {
       } catch (e: unknown) {
         expect((e as {response: {status: number}}).response.status).toBe(404);
       }
+    });
+  });
+
+  describe('Structure graph', () => {
+    /** Points the loader at `agent` for the rest of the test. */
+    function loadInstead(agent: unknown) {
+      agentLoader.getAgentFile = (() =>
+        Promise.resolve({
+          load: () => Promise.resolve(agent),
+          async [Symbol.asyncDispose](): Promise<void> {
+            return;
+          },
+        })) as unknown as AgentLoader['getAgentFile'];
+    }
+
+    /** A workflow nesting another workflow, to exercise per-level paths. */
+    function nestedWorkflowAgent() {
+      const inner = new Workflow({
+        name: 'inner',
+        edges: [['START', node(async () => 'b', {name: 'inner_step'})]],
+      });
+
+      return new WorkflowAgent({
+        name: 'outer',
+        edges: [['START', node(async () => 'a', {name: 'outer_step'}), inner]],
+      });
+    }
+
+    describe('build_graph', () => {
+      it('serializes the agent tree, its tools and its sub-agents', async () => {
+        const child = new LlmAgent({name: 'child', description: 'a child'});
+        loadInstead(
+          new LlmAgent({
+            name: 'parent',
+            tools: [
+              new FunctionTool({
+                name: 'lookup',
+                description: 'lookup',
+                execute: async () => 'ok',
+              }),
+            ],
+            subAgents: [child],
+          }),
+        );
+
+        const response = await client.get<{
+          name: string;
+          root_agent: {
+            name: string;
+            type: string;
+            tools?: Array<{name: string}>;
+            sub_agents?: Array<{name: string}>;
+          };
+        }>('/dev/apps/testApp/build_graph');
+
+        expect(response.status).toBe(200);
+        expect(response.data?.name).toBe('testApp');
+        expect(response.data?.root_agent.name).toBe('parent');
+        expect(response.data?.root_agent.type).toBe('agent');
+        expect(response.data?.root_agent.tools).toEqual([
+          {name: 'lookup', type: 'tool'},
+        ]);
+        expect(response.data?.root_agent.sub_agents).toEqual([
+          expect.objectContaining({name: 'child', description: 'a child'}),
+        ]);
+      });
+
+      // A workflow keeps its structure in its edges, so a serializer that only
+      // walks `subAgents` reports an empty tree for it — the same trap the DOT
+      // renderer hit before it learned to walk `edges`.
+      it('serializes a workflow from its edges rather than its sub-agents', async () => {
+        loadInstead(nestedWorkflowAgent());
+
+        const response = await client.get<{
+          root_agent: {
+            name: string;
+            type: string;
+            graph?: {
+              nodes: Array<{name: string; type: string}>;
+              edges: Array<{
+                from_node: {name: string};
+                to_node: {name: string};
+              }>;
+            };
+          };
+        }>('/dev/apps/testApp/build_graph');
+
+        expect(response.status).toBe(200);
+        const root = response.data!.root_agent;
+        expect(root.type).toBe('workflow');
+        expect(root.graph?.nodes.map((n) => n.name)).toEqual([
+          '__START__',
+          'outer_step',
+          'inner',
+        ]);
+        expect(root.graph?.nodes.find((n) => n.name === 'inner')?.type).toBe(
+          'workflow',
+        );
+        expect(
+          root.graph?.edges.map((e) => [e.from_node.name, e.to_node.name]),
+        ).toEqual([
+          ['__START__', 'outer_step'],
+          ['outer_step', 'inner'],
+        ]);
+      });
+
+      it('returns 404 for an app that does not exist', async () => {
+        await expect(
+          client.get('/dev/apps/nope/build_graph'),
+        ).rejects.toMatchObject({response: {status: 404}});
+      });
+    });
+
+    describe('build_graph_image', () => {
+      it('returns the DOT for the app, keyed by level and at the top level', async () => {
+        const response = await client.get<
+          Record<string, unknown> & {dotSrc?: string}
+        >('/dev/apps/testApp/build_graph_image');
+
+        expect(response.status).toBe(200);
+        // The UI preloads every level from the map, but reads `dotSrc` on the
+        // single-level fetch it falls back to, so both have to be present.
+        expect(response.data?.dotSrc).toContain('digraph');
+        expect(response.data?.['']).toEqual({
+          dotSrc: expect.stringContaining('testAgent'),
+        });
+      });
+
+      // The click handler matches a node's `<title>` against a bare child name,
+      // so a qualified `parent.child` id would render but never be clickable.
+      it('names nodes so the UI can match them to a child', async () => {
+        loadInstead(nestedWorkflowAgent());
+
+        const response = await client.get<{dotSrc: string}>(
+          '/dev/apps/testApp/build_graph_image',
+        );
+
+        expect(response.data?.dotSrc).toContain('"outer_step"');
+        expect(response.data?.dotSrc).toContain('"inner"');
+        expect(response.data?.dotSrc).not.toContain('"outer.outer_step"');
+      });
+
+      it('returns one entry per nested workflow, keyed by its path', async () => {
+        loadInstead(nestedWorkflowAgent());
+
+        const response = await client.get<Record<string, {dotSrc: string}>>(
+          '/dev/apps/testApp/build_graph_image',
+        );
+
+        expect(Object.keys(response.data!).sort()).toEqual([
+          '',
+          'dotSrc',
+          'inner',
+        ]);
+        expect(response.data!['inner'].dotSrc).toContain('inner_step');
+        expect(response.data!['inner'].dotSrc).not.toContain('outer_step');
+      });
+
+      it('returns just the requested level for a node path', async () => {
+        loadInstead(nestedWorkflowAgent());
+
+        const response = await client.get<
+          Record<string, unknown> & {dotSrc?: string}
+        >('/dev/apps/testApp/build_graph_image?node=inner');
+
+        expect(Object.keys(response.data!).sort()).toEqual(['dotSrc', 'inner']);
+        expect(response.data?.dotSrc).toContain('inner_step');
+      });
+
+      it('draws each theme with its own palette', async () => {
+        const light = await client.get<{dotSrc: string}>(
+          '/dev/apps/testApp/build_graph_image?dark_mode=false',
+        );
+        const dark = await client.get<{dotSrc: string}>(
+          '/dev/apps/testApp/build_graph_image?dark_mode=true',
+        );
+
+        expect(light.data?.dotSrc).toContain('bgcolor = "#F8FAFC"');
+        expect(dark.data?.dotSrc).toContain('bgcolor = "#0F172A"');
+      });
+
+      // A dynamic workflow builds its nodes as it runs, so it has no static
+      // graph to expand. It still has to draw as something.
+      it('draws a dynamic workflow as a single node', async () => {
+        loadInstead(
+          new WorkflowAgent(
+            new Workflow({
+              name: 'dynamic_flow',
+              dynamicEntry: async () => 'done',
+            }),
+          ),
+        );
+
+        const response = await client.get<{dotSrc: string}>(
+          '/dev/apps/testApp/build_graph_image',
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.dotSrc).toContain('"dynamic_flow"');
+      });
+
+      it('returns 404 for an app that does not exist', async () => {
+        await expect(
+          client.get('/dev/apps/nope/build_graph_image'),
+        ).rejects.toMatchObject({response: {status: 404}});
+      });
+
+      it('returns 404 for a node path that resolves to nothing', async () => {
+        await expect(
+          client.get('/dev/apps/testApp/build_graph_image?node=ghost'),
+        ).rejects.toMatchObject({response: {status: 404}});
+      });
     });
   });
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

None open for this.

**2. Or, if no issue exists, describe the change:**

**Problem:**

The dev UI's graph tab has never drawn anything. Selecting an app and clicking the
`account_tree` toolbar button shows *"Agent structure graph not available."*, because
the UI calls two endpoints the TypeScript server does not implement:

```
404 GET /dev/apps/<app>/build_graph
404 GET /dev/apps/<app>/build_graph_image?dark_mode=false
```

This is **not** the gap #654 closed. That fixed the per-event graph
(`.../events/<id>/graph`), which still works and is untouched here; the graph tab
simply asks elsewhere. adk-python serves both routes from `cli/dev_server.py`, and the
adk-web bundle is shared between the two runtimes, so the gap shows up as a broken tab
rather than a design difference.

**Solution:**

Two new endpoints, plus the pieces TypeScript was missing behind them.

`build_graph` needed an **app-info serializer**, which had no TypeScript equivalent: the
agent tree as JSON. The catch is that a workflow keeps its structure in `edges`, not in
`subAgents`, so a naive `sub_agents` walk reports an empty tree — the same trap #654 hit
on the DOT side. `app_info.ts` handles both shapes, and also does node-path navigation
for `?node=`.

`build_graph_image` returns one DOT per level, keyed by path, so the UI can preload a
whole app in a single request.

The levels are drawn by a **new flat renderer** rather than by `agent_graph.ts`. Reusing
the existing generator was the obvious plan, and it does not work: `agent_graph.ts` draws
a nested workflow as a recursive *cluster* with a qualified `parent.child` id, while the
UI binds its click handler to `g.node` elements and matches each one's `<title>` against
a *bare* child name. A cluster is never a `g.node`, so every sub-workflow would render
and none would be clickable — and drawing the whole tree at once leaves nothing to
navigate into anyway. A level now draws its sub-workflows as single nodes keyed by name,
which is what makes drilling in work.

adk-python splits these same two jobs across `agent_graph.py` (per-event, recursive) and
`graph_visualization.py` (per-level, flat); this mirrors that split, including its
palettes, glyphs and START/END markers — so the picture finally matches the legend the UI
draws beside it (`✦ Agent  ⊷ Workflow  ƒ Function  ⌵ Join  🔧 Tool`).

**One deliberate divergence from adk-python**, called out for review: the response carries
`dotSrc` for the requested level *alongside* the path-keyed map. The UI reads the map when
preloading every level, but reads `o.dotSrc` on the single-level fetch it falls back to
when a level is missing from that preload — which is exactly what happens two levels deep,
because it re-keys a preloaded `a/b` as `b`. Returning only the map, as adk-python does,
leaves that fallback blank. The extra key is ignored by the map reader, so it is additive.

Also included: the trace endpoints are now registered under the `/dev/apps/<app>/` prefix
the UI uses. That was a prefix mismatch rather than a missing feature — a trace is keyed by
event and session id alone, so both paths answer from the same store.

Out of scope and still 404ing: `builder`, `eval_sets`, `eval_results`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

11 new tests in `dev/test/server/adk_api_server_test.ts` covering both routes: agent-tree
and workflow serialization, a workflow serialized from its edges, bare node ids, one entry
per nested workflow, `?node=` returning a single level, per-theme palettes, a dynamic
workflow with no static graph, and 404s for an unknown app and an unresolvable node path.
One more covers the trace prefix.

```
npx vitest run --project unit:core --project unit:dev
  Test Files  230 passed (230)
       Tests  3303 passed (3303)

npx vitest run --project integration
  Test Files  74 passed (74)
       Tests  211 passed | 8 skipped (219)
```

`--project e2e` was not run: it makes live model calls.

**Manual End-to-End (E2E) Tests:**

```bash
npm run build
node dev/dist/esm/cli_entrypoint.js web samples/workflows/routes --port 8123
# open http://localhost:8123, pick an app, click the account_tree toolbar button
```

Driven through real Chrome (puppeteer-core) against `samples/workflows/routes`:

- All six samples render — `sequence`, `branches`, `fan_out_join`, `function_node`,
  `loop_escalation`, `nested_workflow`. No error panel.
- `loop_escalation` draws its back-edge (`refine → critic`) with both route labels
  (`REVISE`, `DONE`), and its router as a diamond flagged `⚠️ [NO DEFAULT]`.
- `nested_workflow`: `workflow_B` and `workflow_C` are the clickable nodes; clicking
  `workflow_B` pushes the breadcrumb to `nested_workflow › parent_workflow › workflow_B`
  and re-renders that level (`b_title_case`, `b_frame`). `?node=workflow_B` returns the
  same level.
- Both themes draw: the UI requests `dark_mode=true` and `dark_mode=false`, and toggling
  the theme re-renders (`bgcolor` `#0F172A` / `#F8FAFC`).
- No `build_graph` or `build_graph_image` 404s in the network log.
- A plain `LlmAgent` tree (root + two sub-agents + a tool) renders as an agent tree with
  the tool on a dashed edge.

Happy to attach screenshots of the dark and light renders if useful.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Noticed while working here, left alone deliberately: `agent_graph.ts` draws clusters with
`bgcolor: #ffffff` and `#cccccc` text, so the per-event graph is near-white text on white
in dark mode. It predates this change (an existing test pins `fillcolor = "#ffffff"`) and
fixing it is a visual change to a different surface, so it belongs in its own PR.

Reference: adk-python `cli/dev_server.py` (`build_graph` / `build_graph_image`,
`_navigate_to_node`, `_get_all_sub_workflows`), `cli/utils/graph_serialization.py` and
`cli/utils/graph_visualization.py`.
