### PR TITLE
fix(sessions): stop a late event commit rolling a state key back

### DIFF
--- a/core/src/events/event_actions.ts
+++ b/core/src/events/event_actions.ts
@@ -5,6 +5,7 @@
  */
 
 import {AuthConfig} from '../auth/auth_tool.js';
+import {carryDeltaStamps} from '../sessions/state_write_order.js';
 import {ToolConfirmation} from '../tools/tool_confirmation.js';
 
 /**
@@ -127,6 +128,9 @@ export function mergeEventActions(
 
     if (source.stateDelta) {
       Object.assign(result.stateDelta, source.stateDelta);
+      // The merged map is a new object; carry the write order with the entries
+      // so a late commit can still tell it has been superseded.
+      carryDeltaStamps(source.stateDelta, result.stateDelta);
     }
     if (source.artifactDelta) {
       Object.assign(result.artifactDelta, source.artifactDelta);

--- a/core/src/sessions/base_session_service.ts
+++ b/core/src/sessions/base_session_service.ts
@@ -10,6 +10,7 @@ import {Event} from '../events/event.js';
 
 import {CompositeSessionKey, Session} from './session.js';
 import {State} from './state.js';
+import {carryDeltaStamps, shouldApplyDeltaWrite} from './state_write_order.js';
 
 /**
  * The configuration of getting a session.
@@ -196,6 +197,15 @@ export abstract class BaseSessionService {
       if (key.startsWith(State.TEMP_PREFIX)) {
         continue;
       }
+      // Commits lag the writes they carry, and events arrive here in the order
+      // they were streamed rather than the order their writes happened.
+      // Applying an entry that a newer write already superseded would roll the
+      // key back until that newer event commits in turn; skip it instead.
+      if (
+        !shouldApplyDeltaWrite(session.state, event.actions.stateDelta, key)
+      ) {
+        continue;
+      }
       // `session.state` is not always a null-prototype map — a caller can hand
       // us a session whose state is a plain object literal — and on a plain
       // object `state['__proto__'] = value` reaches the inherited `__proto__`
@@ -230,6 +240,9 @@ export function trimTempDeltaState(event: Event): Event {
     }
   }
 
+  // The rebuilt map is a different object, so the write order recorded against
+  // the old one has to come with it or the commit loses its ordering.
+  carryDeltaStamps(stateDelta, filteredStateDelta);
   event.actions.stateDelta = filteredStateDelta;
   return event;
 }

--- a/core/src/sessions/state.ts
+++ b/core/src/sessions/state.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {recordStateWrite} from './state_write_order.js';
+
 /**
  * A state mapping that maintains the current value and the pending-commit
  * delta.
@@ -49,6 +51,9 @@ export class State {
   set(key: string, value: unknown) {
     this.value[key] = value;
     this.delta[key] = value;
+    // Stamp the write so that committing this delta later cannot roll the key
+    // back over a newer write. See `state_write_order.ts`.
+    recordStateWrite(this.value, this.delta, key);
   }
 
   /**
@@ -74,6 +79,9 @@ export class State {
     // This should be revised while working on the parallel tool execution.
     Object.assign(this.delta, delta);
     Object.assign(this.value, delta);
+    for (const key of Object.keys(delta)) {
+      recordStateWrite(this.value, this.delta, key);
+    }
   }
 
   /**

--- a/core/src/sessions/state_write_order.ts
+++ b/core/src/sessions/state_write_order.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Write ordering for session state, so that a state delta committed late cannot
+ * roll a key back to an older value.
+ *
+ * `session.state` is written from two directions during a run. A writer — a
+ * workflow node's `ctx.state`, a tool, a callback — sets a key immediately, and
+ * that same write is also recorded in an event's `actions.stateDelta`, which
+ * the session service re-applies when it commits that event. Commits lag
+ * execution, so re-applying an earlier writer's delta can overwrite a later
+ * writer's value:
+ *
+ *   a: set('attempts', 0)
+ *   b: get -> 0, set('attempts', 1)
+ *   commit(a) re-applies attempts=0        <- rolls back b's write
+ *   c: get -> 0                            <- wrong; b already set 1
+ *   commit(b) re-applies attempts=1        <- rolls forward, too late
+ *
+ * Every write takes a tick off one monotonic clock. A key's stamp on a state
+ * object is the newest write that reached it; a key's stamp on a delta is the
+ * write that put it there. Applying a delta entry that is older than the key's
+ * current stamp would move it backwards, so it is skipped — `commit(a)` above
+ * becomes a no-op and `c` reads 1.
+ *
+ * Stamps live in WeakMaps keyed by object identity, so nothing is added to the
+ * state or the delta themselves: they never serialize, never reach a session
+ * backend, and cost nothing once the objects are collected. A delta entry with
+ * no stamp — one built by hand, or read back from a persisted session — is
+ * applied unconditionally, exactly as it was before.
+ */
+
+/** Monotonic write counter, shared by every state writer in the process. */
+let writeClock = 0;
+
+/** For each state object, the stamp of the newest write to each of its keys. */
+const stateStamps = new WeakMap<object, Map<string, number>>();
+
+/** For each delta object, the stamp of the write that produced each entry. */
+const deltaStamps = new WeakMap<object, Map<string, number>>();
+
+function stampsFor(
+  registry: WeakMap<object, Map<string, number>>,
+  target: object,
+): Map<string, number> {
+  let stamps = registry.get(target);
+  if (!stamps) {
+    stamps = new Map();
+    registry.set(target, stamps);
+  }
+  return stamps;
+}
+
+/**
+ * Records a direct write of `key` into `state`, and — when the same write is
+ * being recorded in `delta` for later commit — stamps it there too, so the
+ * commit can tell whether it has since been superseded.
+ */
+export function recordStateWrite(
+  state: object,
+  delta: object | undefined,
+  key: string,
+): void {
+  const stamp = ++writeClock;
+  stampsFor(stateStamps, state).set(key, stamp);
+  if (delta && delta !== state) {
+    stampsFor(deltaStamps, delta).set(key, stamp);
+  }
+}
+
+/**
+ * Copies the stamp `delta` holds for `key` onto `state`, for a writer that
+ * mirrors one logical write into more than one state object (a workflow node
+ * writes through to `session.state` as well as to its own view). Both objects
+ * then carry the same stamp, so neither can roll the other back.
+ */
+export function adoptDeltaStamp(
+  state: object,
+  delta: object,
+  key: string,
+): void {
+  const stamp = deltaStamps.get(delta)?.get(key);
+  if (stamp !== undefined) {
+    stampsFor(stateStamps, state).set(key, stamp);
+  }
+}
+
+/**
+ * Whether committing `key` from `delta` into `state` should go ahead, recording
+ * the write when it should.
+ *
+ * Returns false only when the delta entry is stamped and a newer write to that
+ * key has already landed — the rollback this module exists to prevent.
+ */
+export function shouldApplyDeltaWrite(
+  state: object,
+  delta: object,
+  key: string,
+): boolean {
+  const written = deltaStamps.get(delta)?.get(key);
+  const current = stateStamps.get(state)?.get(key);
+  if (written !== undefined && current !== undefined && current > written) {
+    return false;
+  }
+  stampsFor(stateStamps, state).set(key, written ?? ++writeClock);
+  return true;
+}
+
+/**
+ * Carries the stamp for one key from one delta object to another.
+ *
+ * A delta is copied several times between the write and the commit — a node
+ * drains its pending entries into a fresh map, `createEventActions` copies that
+ * into the event, `trimTempDeltaState` rebuilds it again — and each copy is a
+ * new object, so the stamps have to be carried with it. An entry that arrives
+ * at the commit unstamped is applied unconditionally, which is the old
+ * behaviour, so a missed hop degrades rather than breaks.
+ */
+export function carryDeltaStamp(from: object, to: object, key: string): void {
+  const stamp = deltaStamps.get(from)?.get(key);
+  if (stamp !== undefined) {
+    stampsFor(deltaStamps, to).set(key, stamp);
+  }
+}
+
+/** {@link carryDeltaStamp} for every key `from` carries a stamp for. */
+export function carryDeltaStamps(from: object, to: object): void {
+  const stamps = deltaStamps.get(from);
+  if (!stamps) {
+    return;
+  }
+  const carried = stampsFor(deltaStamps, to);
+  for (const [key, stamp] of stamps) {
+    carried.set(key, stamp);
+  }
+}

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -128,11 +128,12 @@ export class NodeContext {
     this.isolationScope = opts.isolationScope;
     this.actions = opts.actions ?? createEventActions();
     // Writes via `ctx.state` accumulate into `actions.stateDelta`, mirroring
-    // Python's `ctx.state` -> `ctx.actions.state_delta` behaviour.
-    this._state = new NodeStateView(
-      invocationOverlay(opts.invocationContext),
-      this.actions.stateDelta,
+    // Python's `ctx.state` -> `ctx.actions.state_delta` behaviour, and land in
+    // `session.state` at once so a reader outside the workflow — an agent
+    // resolving a `{key}` instruction, a callback, a tool — sees them.
+    this._state = new State(
       opts.invocationContext.session.state,
+      this.actions.stateDelta,
     );
   }
 
@@ -178,12 +179,10 @@ export class NodeContext {
    * applied by the time this runs: the node runner builds the child invocation
    * context with the node's scope, so it is present on the object returned.
    *
-   * That leaves the node's own `state` view, which layers this node's pending
-   * delta over an invocation-wide overlay. Nodes read through it; an agent
-   * reads `session.state`. The two agree because every write through the view
-   * is also written through to the session — see `NodeStateView` below — and
-   * the agent-node cases in `core/test/workflow/state_consistency_test.ts` pin
-   * that.
+   * That leaves the node's own `state`, which is this node's pending delta over
+   * `session.state` — the same thing an agent reads, so the two cannot
+   * disagree. The agent-node cases in
+   * `core/test/workflow/state_consistency_test.ts` pin that.
    */
   getInvocationContext(): InvocationContext {
     return this.invocationContext;
@@ -291,114 +290,5 @@ function assertCustomRunId(
         `ids are "1", "2", "3" per node; give a custom id a non-numeric ` +
         `part, e.g. '${nodeName}-${runId}'.`,
     );
-  }
-}
-
-/**
- * Per-invocation record of every `ctx.state` write made by the nodes of one
- * invocation, keyed by the session's live state object.
- *
- * `session.state` object identity is stable for the duration of a turn (the
- * session services mutate it in place, and hand out a fresh object per
- * `getSession`), so the WeakMap entry naturally scopes to one turn.
- *
- * The `invocationId` guard covers *sequential* reuse of one state object: a
- * later invocation replaces the entry rather than inheriting the earlier one's
- * writes. It does not let two *live* invocations share a state object — they
- * would evict each other's entry and fall back to reading committed state.
- * Nothing does that today: `getSession` hands out a fresh state object per
- * turn, and a sub-invocation (`AgentTool`) re-fetches the session, so it keys a
- * different entry.
- */
-const invocationOverlays = new WeakMap<
-  Record<string, unknown>,
-  {invocationId: string; values: Record<string, unknown>}
->();
-
-/** Returns the write overlay for `ic`'s invocation, creating it on first use. */
-function invocationOverlay(ic: InvocationContext): Record<string, unknown> {
-  const sessionState = ic.session.state;
-  const existing = invocationOverlays.get(sessionState);
-  if (existing && existing.invocationId === ic.invocationId) {
-    return existing.values;
-  }
-  const created = {invocationId: ic.invocationId, values: {}};
-  invocationOverlays.set(sessionState, created);
-  return created.values;
-}
-
-/**
- * The state view a workflow node sees: its own pending delta, then the
- * invocation's write overlay, then the session's committed state.
- *
- * The overlay exists to keep node-to-node reads honest. `session.state` is
- * mutated from two directions during a run: nodes write through it
- * immediately, while the runner separately re-applies each event's
- * `actions.stateDelta` as it commits that event — and that commit lags node
- * execution. Re-applying an earlier node's delta therefore rolls back a later
- * node's write, and any node reading in that window observes the stale value:
- *
- *   a: set('attempts', 0)
- *   b: get -> 0, set('attempts', 1)
- *   commit(a) re-applies attempts=0        <- rolls back b's write
- *   c: get -> 0                            <- wrong; b already set 1
- *   commit(b) re-applies attempts=1        <- rolls forward, too late
- *
- * Reads are served from the overlay, which only ever moves forward, so `c`
- * sees `1`. Writes still land in `session.state` as well, so consumers that
- * read it directly — notably `{key}` instruction templating in an agent node —
- * behave exactly as before.
- *
- * Two gaps remain. They are mirror images of each other, share the root cause
- * above, and are both only really fixable at the source (version-stamping keys
- * as the session services apply a delta), so neither is closed here:
- *
- * - Workflow writes still reach an outside reader out of order. `session.state`
- *   is written through *and* re-applied by the event commit, so an agent
- *   resolving `{key}` for a key two nodes wrote can observe the stale value
- *   inside the same window.
- * - Outside writes no longer reach a workflow reader. Once a node writes `k`,
- *   every later read of `k` in this invocation is served from the overlay, so a
- *   tool or callback that writes `k` straight to `session.state` mid-run is
- *   invisible to those reads for the rest of the invocation. Before the overlay
- *   they saw it, subject to the rollback race being fixed.
- */
-class NodeStateView extends State {
-  constructor(
-    overlay: Record<string, unknown>,
-    delta: Record<string, unknown>,
-    private readonly committed: Record<string, unknown>,
-  ) {
-    super(overlay, delta);
-  }
-
-  override get<T>(key: string, defaultValue?: T): T | undefined {
-    if (super.has(key)) {
-      return super.get<T>(key, defaultValue);
-    }
-    return key in this.committed ? (this.committed[key] as T) : defaultValue;
-  }
-
-  override has(key: string): boolean {
-    return super.has(key) || key in this.committed;
-  }
-
-  // Both of `State`'s write paths (`set` and `update`) keep writing through to
-  // the session, so readers of `session.state` (agent instruction templates,
-  // callbacks, tools) see the write immediately, as they did before the overlay
-  // existed.
-
-  override set(key: string, value: unknown): void {
-    super.set(key, value);
-    this.committed[key] = value;
-  }
-
-  override update(delta: Record<string, unknown>): void {
-    super.update(delta);
-    Object.assign(this.committed, delta);
-  }
-
-  override toRecord(): Record<string, unknown> {
-    return {...this.committed, ...super.toRecord()};
   }
 }

--- a/core/src/workflow/nodes/function_node.ts
+++ b/core/src/workflow/nodes/function_node.ts
@@ -6,6 +6,7 @@
 
 import {AuthConfig} from '../../auth/auth_tool.js';
 import {createEvent, Event, isEvent} from '../../events/event.js';
+import {carryDeltaStamp} from '../../sessions/state_write_order.js';
 import {BaseNode, BaseNodeConfig, isContent, toContent} from '../base_node.js';
 import {NodeContext} from '../node_context.js';
 import {
@@ -173,6 +174,9 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
       if (!shadow.has(key) || shadow.get(key) !== value) {
         delta[key] = value;
         shadow.set(key, value);
+        // Carry the write order onto the drained copy, reading the stamp as it
+        // stands now — this is the write that this event reports.
+        carryDeltaStamp(ctx.actions.stateDelta, delta, key);
       }
     }
     return Object.keys(delta).length > 0 ? delta : undefined;

--- a/core/test/workflow/state_consistency_test.ts
+++ b/core/test/workflow/state_consistency_test.ts
@@ -131,6 +131,42 @@ describe('workflow state consistency across nodes', () => {
     expect(state['attempts']).toBe(1);
   });
 
+  it('never rolls a key back in session.state itself', async () => {
+    // The overlay keeps *node* reads honest, but everything else reads
+    // `session.state` directly — an agent resolving a `{key}` instruction, a
+    // callback, a tool. Re-applying `a`'s delta after `b` had written used to
+    // roll the key back there for as long as it took `b`'s event to commit, so
+    // a reader in that window saw 0. Writes are ordered now, so the stale
+    // commit is dropped and the key only ever moves forward.
+    const seen: Array<number | undefined> = [];
+    const watch = (ctx: NodeContext) =>
+      seen.push(ctx.invocationContext.session.state['attempts'] as number);
+
+    const a = new FunctionNode('a', (ctx: NodeContext) => {
+      ctx.state.set('attempts', 0);
+      return 'a';
+    });
+    const b = new FunctionNode('b', (ctx: NodeContext) => {
+      ctx.state.set('attempts', (ctx.state.get<number>('attempts') ?? -1) + 1);
+      watch(ctx);
+      return 'b';
+    });
+    // Reads either side of a tick: the stale commit lands between them.
+    const c = new FunctionNode('c', async (ctx: NodeContext) => {
+      watch(ctx);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      watch(ctx);
+      return 'c';
+    });
+
+    const {state} = await runOnce(
+      new WorkflowAgent({name: 'no_rollback_wf', edges: [['START', a, b, c]]}),
+    );
+
+    expect(seen).toEqual([1, 1, 1]);
+    expect(state['attempts']).toBe(1);
+  });
+
   it('survives a long read-modify-write chain', async () => {
     const reads: number[] = [];
     const bump = (name: string) =>
@@ -329,13 +365,14 @@ describe('workflow state consistency across nodes', () => {
     expect(reads[reads.length - 1]).toBe(state['attempts']);
   });
 
-  it('serves a second invocation over the same session from committed state', () => {
-    // The overlay is keyed by the session's live state object, so sequential
-    // invocations that reuse one session object must not inherit each other's
-    // writes — that is what the invocation-id guard is for.
-    const ic1 = createIc();
+  it('shows a node what someone outside the workflow wrote mid-run', () => {
+    // A node reads `session.state` directly, so a tool, a callback or an agent
+    // that writes a key straight to it mid-run is visible to every later node.
+    // The write overlay this used to be served from was invisible to outside
+    // writers, which shadowed them for the rest of the invocation.
+    const ic = createIc();
     const channel = new AsyncQueue<Event>();
-    const mkCtx = (ic = ic1) =>
+    const mkCtx = () =>
       new NodeContext({
         invocationContext: ic,
         channel,
@@ -343,24 +380,16 @@ describe('workflow state consistency across nodes', () => {
         runId: 'root',
       });
 
-    mkCtx().state.set('k', 'from-inv-1');
-    // Stand in for the runner re-applying a stale delta to the live session
-    // state while the invocation is still running.
-    ic1.session.state['k'] = 'stale';
+    mkCtx().state.set('k', 'from-a-node');
+    expect(mkCtx().state.get('k')).toBe('from-a-node');
 
-    // Same invocation: the overlay wins, which is the whole point of the fix.
-    expect(mkCtx().state.get('k')).toBe('from-inv-1');
-
-    // Next invocation on the same session object: fresh overlay, so the read
-    // falls through to committed state rather than the previous run's write.
-    const ic2 = ic1.clone({invocationId: 'inv-2'});
-    expect(ic2.session.state).toBe(ic1.session.state);
-    expect(mkCtx(ic2).state.get('k')).toBe('stale');
+    ic.session.state['k'] = 'from-outside';
+    expect(mkCtx().state.get('k')).toBe('from-outside');
   });
 
-  it('does not leak one invocation\u2019s overlay into another session', async () => {
-    // The overlay is keyed by the session's live state object and guarded by
-    // invocation id, so a second, unrelated run starts from a clean slate.
+  it('does not leak one run\u2019s writes into another session', async () => {
+    // Node writes land in the session they were made against and nowhere else,
+    // so a second, unrelated run starts from a clean slate.
     const seen: Array<number | undefined> = [];
     const bump = new FunctionNode('bump', (ctx: NodeContext) => {
       const next = (ctx.state.get<number>('count') ?? 0) + 1;


### PR DESCRIPTION
## What

`session.state` is written from two directions during a run and the two could disagree. A writer — a workflow node's `ctx.state`, a tool, a callback — sets a key immediately, and the same write is recorded in an event's `actions.stateDelta`, which the session service re-applies when it commits that event. Commits lag execution, so re-applying an earlier writer's delta overwrote a later writer's value:

```
a: set('attempts', 0)
b: get -> 0, set('attempts', 1)
commit(a) re-applies attempts=0        <- rolls back b's write
c: get -> 0                            <- wrong; b already set 1
commit(b) re-applies attempts=1        <- rolls forward, too late
```

Every write now takes a tick off one monotonic clock (`core/src/sessions/state_write_order.ts`). A key's stamp on a state object is the newest write that reached it; a key's stamp on a delta is the write that put it there. A commit whose entry is older than the key's current stamp is dropped, so `commit(a)` is a no-op and `c` reads 1.

## Why it is safe

Stamps live in `WeakMap`s keyed by object identity, so nothing is added to the state or the delta: they never serialize and never reach a session backend. An unstamped entry — one built by hand, or read back from a persisted session — is applied unconditionally, exactly as before, so a missed hop degrades rather than breaks.

## This was known

`NodeContext` carried a per-invocation write overlay that served *node* reads from a value that only moves forward. Its comment described this exact scenario, named version-stamping as the real fix, and listed the two gaps the overlay could not close:

- workflow writes still reached an outside reader (an agent resolving `{key}`, a callback, a tool) out of order;
- outside writes no longer reached a workflow reader at all — once a node wrote a key, the overlay shadowed it for the rest of the invocation.

Fixing it at the source closes both, and the overlay goes with them: with `session.state` monotonic, a node reads its own pending delta over the session like every other reader, and `NodeStateView` collapses into a plain `State`.

## How it surfaced

Removing `LLMAgentWrapper` (M3, follow-up PR). Its unconditional `await appendEvent(nodeInput)` before running the agent happened to park an agent node's first read past the bad window, so the case in `state_consistency_test.ts` written to catch this — *"a delta re-applied by the runner's event commit mid-run would show up as a rollback here"* — passed for the wrong reason.

## Tests

- New: `never rolls a key back in session.state itself` — reads `session.state` directly either side of a tick, the window the stale commit lands in. Fails on `main` with `[1, 0, 1]`.
- New: `shows a node what someone outside the workflow wrote mid-run` — the second gap, replacing the unit test of the overlay's invocation-id guard.
- `npm run test:unit` 3292 passed, `npm run test:integration` 211 passed, `tsc --noEmit` and `ts:check:samples` clean.

Agent session: `ses_0065207a1ffe1w57QSfIfumWSD`
