### PR TITLE
test(workflows): treat the Python samples as the golden they claim to be

### DIFF
--- a/tests/integration/workflows/_harness/hitl.ts
+++ b/tests/integration/workflows/_harness/hitl.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Helpers for answering a HITL interrupt the way a client does: with a function
+ * response addressed to the id the framework generated for it, which is only
+ * known once the previous turn has run.
+ */
+
+import {Event, getFunctionCalls} from '@google/adk';
+import {Content} from '@google/genai';
+
+/** The id of the last pending call to `name` across the turns run so far. */
+export function pendingCallId(turns: Event[][], name: string): string {
+  const ids = turns
+    .flat()
+    .flatMap((e) => getFunctionCalls(e))
+    .filter((c) => c.name === name)
+    .map((c) => c.id)
+    .filter((id): id is string => !!id);
+  if (ids.length === 0) {
+    throw new Error(`No pending ${name} call to answer.`);
+  }
+  return ids[ids.length - 1];
+}
+
+/** Builds the function-response turn that answers a pending interrupt. */
+export function answer(
+  name: string,
+  response: Record<string, unknown>,
+): (turns: Event[][]) => Content {
+  return (turns) => ({
+    role: 'user',
+    parts: [
+      {functionResponse: {id: pendingCallId(turns, name), name, response}},
+    ],
+  });
+}
+
+/** Whether any event in the turn marks the invocation as paused. */
+export function isPaused(events: Event[]): boolean {
+  return events.some((e) => (e.longRunningToolIds?.length ?? 0) > 0);
+}
+
+/** All text parts of the given events, concatenated. */
+export function joinedText(events: Event[]): string {
+  return events
+    .flatMap((e) => e.content?.parts ?? [])
+    .map((p) => p.text ?? '')
+    .join(' ');
+}

--- a/tests/integration/workflows/_harness/sample_harness.ts
+++ b/tests/integration/workflows/_harness/sample_harness.ts
@@ -13,7 +13,7 @@
  * calls the live model and writes that fixture.
  */
 
-import {Event, InMemoryRunner, RunConfig, RunnableRoot} from '@google/adk';
+import {App, Event, InMemoryRunner, RunConfig, RunnableRoot} from '@google/adk';
 import {Content} from '@google/genai';
 import {existsSync, readFileSync, writeFileSync} from 'node:fs';
 import path from 'node:path';
@@ -62,8 +62,15 @@ function loadSamplesEnv(): void {
   }
 }
 
-/** A single user turn: plain text or a full `Content` (e.g. function response). */
-export type SampleTurn = string | Content;
+/**
+ * A single user turn: plain text, a full `Content` (e.g. a function response),
+ * or a function that builds one from the turns already run — which is how a
+ * HITL sample answers an interrupt whose id the framework generated.
+ */
+export type SampleTurn =
+  | string
+  | Content
+  | ((previousTurns: Event[][]) => string | Content);
 
 /** Specification of a sample run. */
 export interface SampleSpec {
@@ -71,6 +78,12 @@ export interface SampleSpec {
   name: string;
   /** The real `rootAgent` imported from the sample module. */
   rootAgent: RunnableRoot;
+  /**
+   * The sample's `App`, for samples that ship one (e.g. because they need
+   * `ResumabilityConfig`). When set it is what the runner is built from, so the
+   * sample is exercised exactly as its module declares it.
+   */
+  app?: App;
   /** User turns to send, in order (one session, so later turns resume). */
   turns: SampleTurn[];
   /** Optional run config (e.g. `plainTextToolConfirmation` for HITL samples). */
@@ -83,10 +96,11 @@ export interface SampleSpec {
   offline?: boolean;
 }
 
-function toContent(turn: SampleTurn): Content {
-  return typeof turn === 'string'
-    ? {role: 'user', parts: [{text: turn}]}
-    : turn;
+function toContent(turn: SampleTurn, previousTurns: Event[][]): Content {
+  const resolved = typeof turn === 'function' ? turn(previousTurns) : turn;
+  return typeof resolved === 'string'
+    ? {role: 'user', parts: [{text: resolved}]}
+    : resolved;
 }
 
 /**
@@ -120,12 +134,12 @@ export async function runSample(spec: SampleSpec): Promise<Event[][]> {
   });
 
   try {
-    const runner = new InMemoryRunner({
-      agent: spec.rootAgent,
-      appName: spec.rootAgent.name,
-    });
+    const appName = spec.app?.name ?? spec.rootAgent.name;
+    const runner = spec.app
+      ? new InMemoryRunner({app: spec.app})
+      : new InMemoryRunner({agent: spec.rootAgent, appName});
     const session = await runner.sessionService.createSession({
-      appName: spec.rootAgent.name,
+      appName,
       userId: 'u1',
     });
 
@@ -135,7 +149,7 @@ export async function runSample(spec: SampleSpec): Promise<Event[][]> {
       for await (const event of runner.runAsync({
         userId: 'u1',
         sessionId: session.id,
-        newMessage: toContent(turn),
+        newMessage: toContent(turn, perTurn),
         runConfig: spec.runConfig,
       })) {
         events.push(event);
@@ -144,13 +158,31 @@ export async function runSample(spec: SampleSpec): Promise<Event[][]> {
     }
 
     if (recording) {
-      const calls = drainRecordedCalls();
-      writeFileSync(file, JSON.stringify(calls, null, 2) + '\n');
+      appendFixture(file, drainRecordedCalls());
     }
     return perTurn;
   } finally {
     restoreRecordReplay();
   }
+}
+
+/**
+ * Fixtures this process has already truncated. A sample with several scenarios
+ * calls `runSample` once per `it()` against one fixture file, so only the first
+ * write of a record run replaces it; the rest append. Without this the last
+ * scenario's calls would be the only ones recorded and every other scenario
+ * would miss on replay.
+ */
+const truncatedFixtures = new Set<string>();
+
+function appendFixture(file: string, calls: RecordedCall[]): void {
+  let existing: RecordedCall[] = [];
+  if (truncatedFixtures.has(file) && existsSync(file)) {
+    existing = JSON.parse(readFileSync(file, 'utf8')) as RecordedCall[];
+  }
+  truncatedFixtures.add(file);
+  const merged = [...existing, ...calls];
+  writeFileSync(file, JSON.stringify(merged, null, 2) + '\n');
 }
 
 /** Flattens per-turn events into one list. */

--- a/tests/integration/workflows/agent_in_workflow/agent.ts
+++ b/tests/integration/workflows/agent_in_workflow/agent.ts
@@ -3,18 +3,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/agent_in_workflow/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Agent in a workflow: a `task`-mode `LlmAgent` (`intake_agent`) chats to collect
  * a structured identity and completes via `finish_task`; a function node routes
  * on the result (retry the intake, or proceed); and a second `LlmAgent`
- * (`generate_instruction`) uses a `require_confirmation` tool. Faithful port of
- * Python `contributing/samples/workflows/agent_in_workflow`.
+ * (`generate_instruction`) uses a `require_confirmation` tool. One-to-one port
+ * of Python `contributing/samples/workflows/agent_in_workflow/agent.py`.
  *
  * REQUIRES an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/agent_in_workflow/agent.ts
+ *   npm run sample -- tests/integration/workflows/agent_in_workflow/agent.ts
  * Provide a name + phone (use "Jane Doe" to pass the identity check). The
  * `find_orders` tool pauses for confirmation before running.
  */
@@ -32,13 +29,13 @@ import {z} from 'zod';
 
 const patientIdentity = z.object({
   name: z.string().describe("The patient's full name."),
-  phoneNumber: z.string().describe("The patient's phone number."),
+  phone_number: z.string().describe("The patient's phone number."),
 });
 type PatientIdentity = z.infer<typeof patientIdentity>;
 
-/** Emits a plain display message (Python `Event(message=...)`). */
+/** Python's `Event(message=...)` content shape (role `user`). */
 const message = (text: string) =>
-  createEvent({content: {role: 'model', parts: [{text}]}});
+  createEvent({content: {role: 'user', parts: [{text}]}});
 
 // A task-mode agent: it chats to gather the identity and calls finish_task with
 // the structured result, which becomes this node's output.
@@ -61,7 +58,7 @@ const checkIdentity = node(
       return createEvent({
         route: 'retry',
         content: {
-          role: 'model',
+          role: 'user',
           parts: [
             {
               text: `Could not find matching records for ${identity.name}. Let's try again.`,
@@ -78,7 +75,7 @@ const checkIdentity = node(
 // A tool that requires confirmation before it runs (HITL).
 const findOrders = new FunctionTool({
   name: 'find_orders',
-  description: "Finds the patient's lab orders.",
+  description: 'Finds orders for the patient.',
   execute: () => ['CBC (Complete Blood Count)', 'Lipid Panel'],
   requireConfirmation: true,
 });
@@ -86,9 +83,10 @@ const findOrders = new FunctionTool({
 const generateInstruction = new LlmAgent({
   name: 'generate_instruction',
   model: 'gemini-2.5-flash',
-  instruction: `You MUST call the find_orders tool to get the patient's actual
-orders. Do not invent orders. After the tool returns, list the orders found and
-then generate a concise instruction about how to prepare based on those orders.`,
+  instruction: `
+Use the find_orders tool to get the patient's orders.
+List the orders found, and then generate a concise instruction about how to prepare based on those orders.
+`,
   tools: [findOrders],
 });
 
@@ -96,14 +94,6 @@ export const rootAgent = new Workflow({
   name: 'task_in_workflow',
   edges: [
     ['START', intakeAgent, checkIdentity],
-    [
-      checkIdentity,
-      {
-        retry: intakeAgent,
-        // generate_instruction re-runs on resume so its tool-confirmation can
-        // resolve after the user approves the find_orders call.
-        [DEFAULT_ROUTE]: node(generateInstruction, {rerunOnResume: true}),
-      },
-    ],
+    [checkIdentity, {retry: intakeAgent, [DEFAULT_ROUTE]: generateInstruction}],
   ],
 });

--- a/tests/integration/workflows/agent_in_workflow/agent_in_workflow_test.ts
+++ b/tests/integration/workflows/agent_in_workflow/agent_in_workflow_test.ts
@@ -7,38 +7,95 @@
 /**
  * Runs the real `agent_in_workflow` sample: a task-mode LlmAgent collects an
  * identity via finish_task, a node routes on it, and a second LlmAgent uses a
- * require_confirmation tool (approved here by a plain-text reply, per the CLI
- * opt-in).
+ * require_confirmation tool. Scenarios mirror the Python goldens
+ * `contributing/samples/workflows/agent_in_workflow/tests/*.json`.
+ *
+ * Only the single-turn path runs green; the multi-turn and resume paths are
+ * skipped with the divergence they hit spelled out below.
  */
 
 import {getFunctionCalls} from '@google/adk';
 import {describe, expect, it} from 'vitest';
+import {answer, isPaused, joinedText} from '../_harness/hitl.js';
 import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
+const approve = answer('adk_request_confirmation', {
+  confirmed: true,
+  payload: {},
+});
+const decline = answer('adk_request_confirmation', {
+  confirmed: false,
+  payload: {},
+});
+
 describe('workflow sample: agent_in_workflow (task mode + confirmation)', () => {
-  it('collects identity, gates a tool on confirmation, then lists orders', async () => {
+  it('collects the identity, greets, and gates the tool on confirmation', async () => {
+    const perTurn = await runSample({
+      name: 'agent_in_workflow',
+      rootAgent,
+      turns: ['I am Jane Doe, my phone number is 555-1234'],
+    });
+    const [turn1] = perTurn;
+
+    expect(
+      turn1.flatMap((e) => getFunctionCalls(e)).map((c) => c.name),
+    ).toContain('finish_task');
+    expect(authors(turn1).has('intake_agent')).toBe(true);
+
+    expect(turn1.map((e) => e.route).filter(Boolean)).toEqual([]);
+    expect(joinedText(turn1)).toContain(
+      'Hello Jane Doe! Let me look up your orders.',
+    );
+
+    const calls = turn1.flatMap((e) => getFunctionCalls(e)).map((c) => c.name);
+    expect(calls).toContain('find_orders');
+    expect(calls).toContain('adk_request_confirmation');
+    expect(isPaused(turn1)).toBe(true);
+  }, 120000);
+
+  it.skip('lists the orders once the tool confirmation is approved', async () => {
+    const perTurn = await runSample({
+      name: 'agent_in_workflow',
+      rootAgent,
+      turns: ['I am Jane Doe, my phone number is 555-1234', approve],
+    });
+    const events = allEvents(perTurn);
+    expect(joinedText(events)).toContain('CBC (Complete Blood Count)');
+  }, 120000);
+
+  it.skip('reports the rejection when the confirmation is declined', async () => {
+    const perTurn = await runSample({
+      name: 'agent_in_workflow',
+      rootAgent,
+      turns: ['I am Jane Doe, my phone number is 555-1234', decline],
+    });
+    expect(joinedText(allEvents(perTurn))).toContain('rejected');
+  }, 120000);
+
+  it.skip('collects the identity across several turns', async () => {
+    const perTurn = await runSample({
+      name: 'agent_in_workflow',
+      rootAgent,
+      turns: ['go', 'Jane Doe', '555-1234', approve],
+    });
+    expect(authors(allEvents(perTurn)).has('generate_instruction')).toBe(true);
+  }, 180000);
+
+  it.skip('routes back to intake when the name does not match', async () => {
     const perTurn = await runSample({
       name: 'agent_in_workflow',
       rootAgent,
       turns: [
-        'My full name is Jane Doe and my phone number is 555-123-4567.',
-        'yes',
+        'I am John Doe, my phone number is 555-1234',
+        'Jane Doe, 555-1234',
+        approve,
       ],
-      // The find_orders tool requires confirmation; let a plain-text "yes"
-      // approve it (the interactive CLI opt-in).
-      runConfig: {plainTextToolConfirmation: true},
     });
     const events = allEvents(perTurn);
-
-    // The task-mode intake agent and the instruction agent both ran.
-    expect(authors(events).has('intake_agent')).toBe(true);
-    expect(authors(events).has('generate_instruction')).toBe(true);
-
-    // The confirmation-gated tool was ultimately called.
-    const calledFindOrders = events
-      .flatMap((e) => getFunctionCalls(e))
-      .some((c) => c.name === 'find_orders');
-    expect(calledFindOrders).toBe(true);
-  });
+    expect(events.map((e) => e.route).filter(Boolean)).toContain('retry');
+    expect(joinedText(events)).toContain(
+      'Could not find matching records for John Doe.',
+    );
+  }, 180000);
 });

--- a/tests/integration/workflows/agent_in_workflow/model_responses.json
+++ b/tests/integration/workflows/agent_in_workflow/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "5859bea69bb556da",
-    "instructionAgnosticKey": "dd892124f5572b7f",
+    "key": "4fa8f397250ab824",
+    "instructionAgnosticKey": "3a761bc70a4b684e",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "My full name is Jane Doe and my phone number is 555-123-4567."
+              "text": "I am Jane Doe, my phone number is 555-1234"
             }
           ]
         },
@@ -16,7 +16,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "My full name is Jane Doe and my phone number is 555-123-4567."
+              "text": "I am Jane Doe, my phone number is 555-1234"
             }
           ]
         }
@@ -36,14 +36,14 @@
                       "type": "STRING",
                       "description": "The patient's full name."
                     },
-                    "phoneNumber": {
+                    "phone_number": {
                       "type": "STRING",
                       "description": "The patient's phone number."
                     }
                   },
                   "required": [
                     "name",
-                    "phoneNumber"
+                    "phone_number"
                   ]
                 }
               }
@@ -65,10 +65,10 @@
                 "functionCall": {
                   "name": "finish_task",
                   "args": {
-                    "name": "Jane Doe",
-                    "phoneNumber": "555-123-4567"
+                    "phone_number": "555-1234",
+                    "name": "Jane Doe"
                   },
-                  "id": "adk-6453bae6-378a-46c3-bea0-149eda8e2788"
+                  "id": "adk-18e2b23f-d850-491f-b7ac-349573590968"
                 }
               }
             ]
@@ -77,36 +77,36 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 216,
-        "candidatesTokenCount": 19,
-        "totalTokenCount": 293,
+        "promptTokenCount": 206,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 272,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 216
+            "tokenCount": 206
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 19
+            "tokenCount": 17
           }
         ],
-        "thoughtsTokenCount": 58
+        "thoughtsTokenCount": 49
       }
     }
   },
   {
-    "key": "4d654d41f3ce18f9",
-    "instructionAgnosticKey": "8e897ba6e57b4dc7",
+    "key": "1a51e880b664a1a9",
+    "instructionAgnosticKey": "e041756c62222956",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "My full name is Jane Doe and my phone number is 555-123-4567."
+              "text": "I am Jane Doe, my phone number is 555-1234"
             }
           ]
         },
@@ -114,7 +114,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "My full name is Jane Doe and my phone number is 555-123-4567."
+              "text": "I am Jane Doe, my phone number is 555-1234"
             }
           ]
         },
@@ -125,7 +125,7 @@
               "text": "For context:"
             },
             {
-              "text": "[intake_agent] called tool `finish_task` with parameters: {\"name\":\"Jane Doe\",\"phoneNumber\":\"555-123-4567\"}"
+              "text": "[intake_agent] called tool `finish_task` with parameters: {\"phone_number\":\"555-1234\",\"name\":\"Jane Doe\"}"
             }
           ]
         },
@@ -153,13 +153,13 @@
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\nYou MUST call the find_orders tool to get the patient's actual\norders. Do not invent orders. After the tool returns, list the orders found and\nthen generate a concise instruction about how to prepare based on those orders.",
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\n\nUse the find_orders tool to get the patient's orders.\nList the orders found, and then generate a concise instruction about how to prepare based on those orders.\n",
         "tools": [
           {
             "functionDeclarations": [
               {
                 "name": "find_orders",
-                "description": "Finds the patient's lab orders.",
+                "description": "Finds orders for the patient.",
                 "parameters": {
                   "type": "OBJECT",
                   "properties": {}
@@ -183,7 +183,7 @@
                 "functionCall": {
                   "name": "find_orders",
                   "args": {},
-                  "id": "adk-d98f5307-6330-4235-8fc9-e2f66312d763"
+                  "id": "adk-979e2633-064e-4077-91df-8433807d7dcc"
                 }
               }
             ]
@@ -192,14 +192,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 212,
+        "promptTokenCount": 182,
         "candidatesTokenCount": 3,
-        "totalTokenCount": 274,
+        "totalTokenCount": 251,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 212
+            "tokenCount": 182
           }
         ],
         "candidatesTokensDetails": [
@@ -208,152 +208,7 @@
             "tokenCount": 3
           }
         ],
-        "thoughtsTokenCount": 59
-      }
-    }
-  },
-  {
-    "key": "8de2f3f109b60cc4",
-    "instructionAgnosticKey": "9db7eb5a9e2222a1",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "My full name is Jane Doe and my phone number is 555-123-4567."
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "My full name is Jane Doe and my phone number is 555-123-4567."
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[intake_agent] called tool `finish_task` with parameters: {\"name\":\"Jane Doe\",\"phoneNumber\":\"555-123-4567\"}"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[intake_agent] tool `finish_task` returned result: {\"result\":\"Task completed.\"}"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[check_identity] said: Hello Jane Doe! Let me look up your orders."
-            }
-          ]
-        },
-        {
-          "role": "model",
-          "parts": [
-            {
-              "functionCall": {
-                "name": "find_orders",
-                "args": {}
-              }
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "yes"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[check_identity] said: Hello Jane Doe! Let me look up your orders."
-            }
-          ]
-        }
-      ],
-      "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\nYou MUST call the find_orders tool to get the patient's actual\norders. Do not invent orders. After the tool returns, list the orders found and\nthen generate a concise instruction about how to prepare based on those orders.",
-        "tools": [
-          {
-            "functionDeclarations": [
-              {
-                "name": "find_orders",
-                "description": "Finds the patient's lab orders.",
-                "parameters": {
-                  "type": "OBJECT",
-                  "properties": {}
-                }
-              }
-            ]
-          }
-        ],
-        "labels": {
-          "adk_agent_name": "generate_instruction"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "functionCall": {
-                  "name": "find_orders",
-                  "args": {},
-                  "id": "adk-0edc0e06-18d6-49aa-86b3-8850e2e3f9bf"
-                }
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 237,
-        "candidatesTokenCount": 3,
-        "totalTokenCount": 281,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 237
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 3
-          }
-        ],
-        "thoughtsTokenCount": 41
+        "thoughtsTokenCount": 66
       }
     }
   }

--- a/tests/integration/workflows/auth_api_key/agent.ts
+++ b/tests/integration/workflows/auth_api_key/agent.ts
@@ -3,15 +3,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/auth_api_key/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Auth API Key: a FunctionNode with API-key authentication. The `fetch_weather`
  * node declares an `authConfig`, so the framework pauses the workflow and
  * requests a credential before running it; once supplied, the node runs with the
- * credential available in session state. Faithful port of Python
- * `contributing/samples/workflows/auth_api_key`.
+ * credential available in session state. One-to-one port of Python
+ * `contributing/samples/workflows/auth_api_key/agent.py`.
  *
  * The node is `rerunOnResume: true` so that, on resume, it re-runs its body
  * (storing the provided credential and fetching), rather than short-circuiting.
@@ -20,7 +17,7 @@
  * There is no such helper here; the framework stores the credential at
  * `temp:<credentialKey>` in state (see AuthHandler), which the node reads.
  *
- * Run:  npm run sample -- samples/workflows/auth_api_key/agent.ts
+ * Run:  npm run sample -- tests/integration/workflows/auth_api_key/agent.ts
  * Turn 1: any message -> the workflow requests an API key.
  * Turn 2: type any API key value; the node runs and echoes it back (masked).
  */
@@ -53,7 +50,7 @@ interface Weather {
   city: string;
   temperature: string;
   condition: string;
-  apiKeyUsed: string;
+  api_key_used: string;
 }
 
 // Fetches weather data using the authenticated API key.
@@ -70,7 +67,7 @@ const fetchWeather = node(
       city: 'San Francisco',
       temperature: '18C',
       condition: 'Sunny',
-      apiKeyUsed: masked,
+      api_key_used: masked,
     };
   },
   {name: 'fetch_weather', authConfig, rerunOnResume: true},
@@ -81,12 +78,12 @@ const summarize = node(
   (_ctx: NodeContext, weather: Weather) =>
     createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [
           {
             text:
               `Weather for ${weather.city}: ${weather.temperature}, ` +
-              `${weather.condition}. (Authenticated with key: ${weather.apiKeyUsed})`,
+              `${weather.condition}. (Authenticated with key: ${weather.api_key_used})`,
           },
         ],
       },

--- a/tests/integration/workflows/auth_api_key/auth_api_key_test.ts
+++ b/tests/integration/workflows/auth_api_key/auth_api_key_test.ts
@@ -6,30 +6,69 @@
 
 /**
  * Runs the real `auth_api_key` sample (offline): a node declares an API-key
- * authConfig, so the workflow pauses to request a credential before running it.
+ * authConfig, so the workflow pauses to request a credential before running it,
+ * then resumes once the credential is supplied. Turns and expectations mirror
+ * the Python golden `contributing/samples/workflows/auth_api_key/tests/go.json`.
  */
 
-import {Event} from '@google/adk';
+import {Event, getFunctionCalls} from '@google/adk';
+import {Content} from '@google/genai';
 import {describe, expect, it} from 'vitest';
-import {authors, runSample} from '../_harness/sample_harness.js';
+import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
 const isPaused = (events: Event[]): boolean =>
   events.some((e) => (e.longRunningToolIds?.length ?? 0) > 0);
 
+/** The credential reply, keyed by the interrupt id (the credential key). */
+const credential: Content = {
+  role: 'user',
+  parts: [
+    {
+      functionResponse: {
+        id: 'weather_api_key',
+        name: 'adk_request_credential',
+        response: {result: '12345678'},
+      },
+    },
+  ],
+};
+
 describe('workflow sample: auth_api_key', () => {
-  it('pauses to request a credential before the authenticated node runs', async () => {
+  it('pauses for a credential, then runs the node with it', async () => {
     const perTurn = await runSample({
       name: 'auth_api_key',
       rootAgent,
-      turns: ['What is the weather?'],
+      turns: ['go', credential],
       offline: true,
     });
-    const [turn1] = perTurn;
+    const [turn1, turn2] = perTurn;
 
-    // The workflow pauses on turn 1 requesting the API-key credential; the
-    // authenticated node has not produced weather output yet.
     expect(isPaused(turn1)).toBe(true);
+    const request = turn1
+      .flatMap((e) => getFunctionCalls(e))
+      .find((c) => c.name === 'adk_request_credential');
+    expect(request).toBeDefined();
     expect(authors(turn1).has('summarize')).toBe(false);
+
+    const weather = allEvents([turn2]).find(
+      (e) => e.author === 'fetch_weather' && e.output !== undefined,
+    );
+    expect(weather?.output).toEqual({
+      city: 'San Francisco',
+      temperature: '18C',
+      condition: 'Sunny',
+      api_key_used: '1234****',
+    });
+
+    const summary = allEvents([turn2])
+      .filter((e) => e.author === 'summarize')
+      .flatMap((e) => e.content?.parts ?? [])
+      .map((p) => p.text ?? '')
+      .join('');
+    expect(summary).toBe(
+      'Weather for San Francisco: 18C, Sunny. (Authenticated with key: 1234****)',
+    );
+    expect(isPaused(turn2)).toBe(false);
   });
 });

--- a/tests/integration/workflows/auth_oauth/agent.ts
+++ b/tests/integration/workflows/auth_oauth/agent.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OAuth Authentication sample: FunctionNode with GitHub OAuth2 token request.
+ * One-to-one port of Python
+ * `contributing/samples/workflows/auth_oauth/agent.py`.
+ *
+ * Demonstrates how to use `authConfig` with GitHub OAuth2 on a FunctionNode to
+ * pause the workflow, request an OAuth token from the user, and use it to list
+ * the user's GitHub repositories.
+ *
+ * Flow:
+ *   1. User sends any message to start the workflow.
+ *   2. The `list_github_repos` node pauses and requests GitHub OAuth
+ *      credentials.
+ *   3. The user provides the credentials (after logging in to GitHub).
+ *   4. The node runs, calls the GitHub API to list repos, and returns the list.
+ *   5. The `display_result` node displays the repository names.
+ *
+ * TypeScript note: Python reads the credential via `ctx.get_auth_response(cfg)`.
+ * `NodeContext` has no such helper; the framework stores the exchanged
+ * credential at `temp:<credentialKey>` in state (see `AuthHandler`), which the
+ * node reads instead. Same as `auth_api_key`; see the gap report.
+ *
+ * Sample queries:
+ *   - "start"
+ *   - "list my repos"
+ */
+
+import {
+  AuthConfig,
+  AuthCredential,
+  AuthCredentialTypes,
+  AuthScheme,
+  createEvent,
+  node,
+  NodeContext,
+  Workflow,
+} from '@google/adk';
+
+const CREDENTIAL_KEY = 'github_oauth_token';
+
+const authConfig: AuthConfig = {
+  authScheme: {
+    type: 'oauth2',
+    flows: {
+      authorizationCode: {
+        authorizationUrl: 'https://github.com/login/oauth/authorize',
+        tokenUrl: 'https://github.com/login/oauth/access_token',
+        scopes: {
+          user: 'Read user profile',
+          repo: 'Access public repositories',
+        },
+      },
+    },
+  } as AuthScheme,
+  rawAuthCredential: {
+    authType: AuthCredentialTypes.OAUTH2,
+    oauth2: {
+      clientId: process.env['GITHUB_CLIENT_ID'] ?? 'YOUR_GITHUB_CLIENT_ID',
+      clientSecret:
+        process.env['GITHUB_CLIENT_SECRET'] ?? 'YOUR_GITHUB_CLIENT_SECRET',
+    },
+  },
+  credentialKey: CREDENTIAL_KEY,
+};
+
+interface RepoResult {
+  status: 'Success' | 'Error';
+  repos?: string[];
+  message?: string;
+}
+
+/** Fetches GitHub repositories for the authenticated user. */
+const listGithubRepos = node(
+  async (ctx: NodeContext): Promise<RepoResult> => {
+    const cred = ctx.state.get<AuthCredential>('temp:' + CREDENTIAL_KEY);
+    const accessToken = cred?.oauth2?.accessToken;
+
+    if (!accessToken) {
+      return {status: 'Error', message: 'No access token found'};
+    }
+
+    const headers = {
+      Authorization: `Bearer ${accessToken}`,
+      'User-Agent': 'ADK-Sample-Agent',
+      Accept: 'application/json',
+    };
+
+    try {
+      const response = await fetch('https://api.github.com/user/repos', {
+        headers,
+      });
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+      const reposData = (await response.json()) as Array<{name: string}>;
+      return {status: 'Success', repos: reposData.map((repo) => repo.name)};
+    } catch (e) {
+      return {
+        status: 'Error',
+        message: `Failed to fetch repos: ${e instanceof Error ? e.message : e}`,
+      };
+    }
+  },
+  {name: 'list_github_repos', authConfig, rerunOnResume: true},
+);
+
+/** Displays the result of accessing the resource. */
+const displayResult = node(
+  function* (_ctx: NodeContext, nodeInput: RepoResult) {
+    const text =
+      nodeInput.status === 'Success'
+        ? `Successfully fetched repositories: ${(nodeInput.repos ?? []).join(', ')}`
+        : `Failed to fetch repositories. Error: ${nodeInput.message ?? 'Unknown error'}`;
+    yield createEvent({content: {role: 'user', parts: [{text}]}});
+  },
+  {name: 'display_result'},
+);
+
+export const rootAgent = new Workflow({
+  name: 'auth_oauth',
+  edges: [['START', listGithubRepos, displayResult]],
+});

--- a/tests/integration/workflows/auth_oauth/auth_oauth_test.ts
+++ b/tests/integration/workflows/auth_oauth/auth_oauth_test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Runs the real `auth_oauth` sample (offline): a node declares a GitHub OAuth2
+ * authConfig, so the workflow pauses and asks the user to complete the consent
+ * flow before running.
+ *
+ * Only turn 1 is covered. The resumed node calls `https://api.github.com` for
+ * real, and the harness mocks the model only — it does not intercept HTTP — so
+ * a turn-2 assertion would need a live token and a network round trip.
+ */
+
+import {Event, getFunctionCalls} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {authors, runSample} from '../_harness/sample_harness.js';
+import {rootAgent} from './agent.js';
+
+const isPaused = (events: Event[]): boolean =>
+  events.some((e) => (e.longRunningToolIds?.length ?? 0) > 0);
+
+describe('workflow sample: auth_oauth', () => {
+  it('pauses for OAuth consent with a GitHub authorization URL', async () => {
+    const perTurn = await runSample({
+      name: 'auth_oauth',
+      rootAgent,
+      turns: ['list my repos'],
+      offline: true,
+    });
+    const [turn1] = perTurn;
+
+    expect(isPaused(turn1)).toBe(true);
+    expect(authors(turn1).has('display_result')).toBe(false);
+
+    const request = turn1
+      .flatMap((e) => getFunctionCalls(e))
+      .find((c) => c.name === 'adk_request_credential');
+    expect(request).toBeDefined();
+
+    const args = request?.args as {
+      authConfig?: {exchangedAuthCredential?: {oauth2?: {authUri?: string}}};
+    };
+    const authUri = args?.authConfig?.exchangedAuthCredential?.oauth2?.authUri;
+    expect(authUri).toBeDefined();
+    expect(authUri!).toContain('https://github.com/login/oauth/authorize');
+    expect(authUri!).toContain('response_type=code');
+    const scope = new URL(authUri!).searchParams.get('scope');
+    expect(scope?.split(' ').sort()).toEqual(['repo', 'user']);
+  });
+});

--- a/tests/integration/workflows/dynamic_fan_out_fan_in/agent.ts
+++ b/tests/integration/workflows/dynamic_fan_out_fan_in/agent.ts
@@ -3,17 +3,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/dynamic_fan_out_fan_in/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Dynamic fan-out / fan-in: an orchestrator node splits a comma-separated input
  * into topics, fans out a worker LlmAgent per topic via `ctx.runNode()`, waits
- * for all of them, and aggregates the results into a table. Faithful port of
- * Python `contributing/samples/workflows/dynamic_fan_out_fan_in`.
+ * for all of them, and aggregates the results into a table. One-to-one port of
+ * Python `contributing/samples/workflows/dynamic_fan_out_fan_in/agent.py`.
  *
  * Requires an API key (calls a live model). Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/dynamic_fan_out_fan_in/agent.ts
+ *   npm run sample -- tests/integration/workflows/dynamic_fan_out_fan_in/agent.ts
  * Enter a comma-separated list of topics, e.g. "space, oceans, volcanoes".
  */
 
@@ -26,7 +23,6 @@ const generator = new LlmAgent({
   instruction:
     'Write a catchy one-line headline about the topic provided in the user message.',
 });
-const generatorNode = node(generator);
 
 const orchestrator = node(
   async function* (ctx: NodeContext, nodeInput: string) {
@@ -37,17 +33,14 @@ const orchestrator = node(
       .filter((t) => t.length > 0);
     yield createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [{text: `Processing ${topics.length} topics in parallel.`}],
       },
     });
 
     // Fan-out: schedule a dynamic node for each topic.
-    const tasks = topics.map((topic, i) =>
-      ctx.runNode(generatorNode, topic, {
-        useSubBranch: true,
-        runId: `gen-${i}`,
-      }),
+    const tasks = topics.map((topic) =>
+      ctx.runNode(generator, topic, {useSubBranch: true}),
     );
 
     // Wait for all tasks to complete.
@@ -62,7 +55,7 @@ const orchestrator = node(
     });
 
     yield createEvent({
-      content: {role: 'model', parts: [{text: aggregated}]},
+      content: {role: 'user', parts: [{text: aggregated}]},
     });
   },
   {name: 'orchestrator', rerunOnResume: true},

--- a/tests/integration/workflows/dynamic_fan_out_fan_in/dynamic_fan_out_fan_in_test.ts
+++ b/tests/integration/workflows/dynamic_fan_out_fan_in/dynamic_fan_out_fan_in_test.ts
@@ -5,35 +5,48 @@
  */
 
 /**
- * Runs the real `dynamic_fan_out_fan_in` sample: an orchestrator splits a
- * comma-separated input, fans out a worker agent per topic via `ctx.runNode()`
- * (concurrent, closure-captured), then aggregates. Exercises both the global
- * model seam and the fingerprint matcher under concurrency.
+ * Runs the real `dynamic_fan_out_fan_in` sample: the orchestrator splits the
+ * input, fans a worker agent out per topic via `ctx.runNode`, and renders the
+ * results as a table. Python ships no golden for this sample; the turn is the
+ * one its README suggests.
  */
 
 import {describe, expect, it} from 'vitest';
-import {allEvents, runSample} from '../_harness/sample_harness.js';
+import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
+const TOPICS = ['AI', 'Cloud Computing', 'Quantum Computing'];
+
 describe('workflow sample: dynamic_fan_out_fan_in', () => {
-  it('fans a worker agent out across topics and aggregates', async () => {
+  it('fans out one worker per topic and aggregates into a table', async () => {
     const perTurn = await runSample({
       name: 'dynamic_fan_out_fan_in',
       rootAgent,
-      turns: ['space, oceans, volcanoes'],
+      turns: [TOPICS.join(', ')],
     });
     const events = allEvents(perTurn);
 
-    // The worker agent ran once per topic (concurrent, distinct fingerprints).
-    const generatorEvents = events.filter((e) => e.author === 'generator');
-    expect(generatorEvents.length).toBeGreaterThanOrEqual(3);
+    expect(authors(events).has('generator')).toBe(true);
+    const headlines = events.filter(
+      (e) => e.author === 'generator' && e.content?.parts?.length,
+    );
+    expect(headlines).toHaveLength(TOPICS.length);
 
-    // The orchestrator emitted an aggregated table over all topics.
-    const orchestratorText = events
-      .filter((e) => e.author === 'orchestrator')
+    const texts = events
       .flatMap((e) => e.content?.parts ?? [])
-      .map((p) => p.text ?? '')
-      .join(' ');
-    expect(orchestratorText).toContain('Aggregated Headlines');
-  });
+      .map((p) => p.text ?? '');
+    expect(texts).toContain('Processing 3 topics in parallel.');
+
+    const table = texts.find((t) => t.startsWith('### Aggregated Headlines'));
+    expect(table).toBeDefined();
+    for (const topic of TOPICS) {
+      const row = table!
+        .split('\n')
+        .find((line) => line.startsWith(`| ${topic} |`));
+      expect(row, `row for ${topic}`).toBeDefined();
+      const headline = row!.split('|')[2].trim();
+      expect(headline.length).toBeGreaterThan(0);
+      expect(headline).not.toBe('undefined');
+    }
+  }, 120000);
 });

--- a/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
+++ b/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "893fe50fb5617951",
-    "instructionAgnosticKey": "b07208311518b7db",
+    "key": "f9bb8dcf0415f757",
+    "instructionAgnosticKey": "c5961d15bc449f56",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "space, oceans, volcanoes"
+              "text": "AI, Cloud Computing, Quantum Computing"
             }
           ]
         },
@@ -16,7 +16,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "volcanoes"
+              "text": "AI"
             }
           ]
         },
@@ -46,7 +46,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Deep, Fiery, Infinite: Oceans, Volcanoes, Space."
+                "text": "AI, Cloud, Quantum: The Ultimate Tech Trifecta."
               }
             ]
           },
@@ -55,8 +55,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 54,
-        "candidatesTokenCount": 14,
-        "totalTokenCount": 958,
+        "candidatesTokenCount": 12,
+        "totalTokenCount": 430,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -67,23 +67,98 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
+            "tokenCount": 12
+          }
+        ],
+        "thoughtsTokenCount": 364
+      }
+    }
+  },
+  {
+    "key": "7faf7d4e0cbe2a36",
+    "instructionAgnosticKey": "4a31d3b714eb27f2",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "AI, Cloud Computing, Quantum Computing"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Cloud Computing"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[orchestrator] said: Processing 3 topics in parallel."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message.",
+        "labels": {
+          "adk_agent_name": "generator"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "AI, Cloud, Quantum: The Tech Trinity Forging Our Future."
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 55,
+        "candidatesTokenCount": 14,
+        "totalTokenCount": 985,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 55
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
             "tokenCount": 14
           }
         ],
-        "thoughtsTokenCount": 890
+        "thoughtsTokenCount": 916
       }
     }
   },
   {
-    "key": "4a0fb6899c30134c",
-    "instructionAgnosticKey": "7da08d4d351e7485",
+    "key": "2105595e08af2b48",
+    "instructionAgnosticKey": "3be2874c299f0acb",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "space, oceans, volcanoes"
+              "text": "AI, Cloud Computing, Quantum Computing"
             }
           ]
         },
@@ -91,7 +166,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "space"
+              "text": "Quantum Computing"
             }
           ]
         },
@@ -121,7 +196,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Space, Oceans, Volcanoes: Unearthing the Universe's Wildest Wonders."
+                "text": "AI, Cloud, Quantum: Forging the Future of Computing."
               }
             ]
           },
@@ -129,98 +204,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 52,
-        "candidatesTokenCount": 18,
-        "totalTokenCount": 939,
+        "promptTokenCount": 55,
+        "candidatesTokenCount": 13,
+        "totalTokenCount": 1296,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 52
+            "tokenCount": 55
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 18
+            "tokenCount": 13
           }
         ],
-        "thoughtsTokenCount": 869
-      }
-    }
-  },
-  {
-    "key": "e22d71fa47fcc401",
-    "instructionAgnosticKey": "5569d5644985d09c",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "space, oceans, volcanoes"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "oceans"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[orchestrator] said: Processing 3 topics in parallel."
-            }
-          ]
-        }
-      ],
-      "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generator\".\n\nWrite a catchy one-line headline about the topic provided in the user message.",
-        "labels": {
-          "adk_agent_name": "generator"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "From Earth's fiery heart to the cosmic expanse: Space, Oceans, Volcanoes."
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 53,
-        "candidatesTokenCount": 18,
-        "totalTokenCount": 1096,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 53
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 18
-          }
-        ],
-        "thoughtsTokenCount": 1025
+        "thoughtsTokenCount": 1228
       }
     }
   }

--- a/tests/integration/workflows/dynamic_nodes/agent.ts
+++ b/tests/integration/workflows/dynamic_nodes/agent.ts
@@ -3,69 +3,76 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/dynamic_nodes/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
 
 /**
- * Dynamic nodes: an imperative `dynamicEntry` drives LlmAgents with
- * `ctx.runNode` in a loop until the generated headline is tech-related, instead
- * of a static edge graph. Faithful port of Python
- * `contributing/samples/workflows/dynamic_nodes`.
+ * Dynamic nodes: a single `orchestrate` node drives two LlmAgents imperatively
+ * with `ctx.runNode` in a loop until the generated headline is graded
+ * tech-related. One-to-one port of Python
+ * `contributing/samples/workflows/dynamic_nodes/agent.py`.
  *
- * The loop is bounded (`MAX_ATTEMPTS`) so an off-topic input can't spin forever
- * making live model calls.
+ * A node that calls `ctx.runNode` must be declared `rerunOnResume: true`, the
+ * same requirement Python's README states for `@node(rerun_on_resume=True)`.
  *
  * Requires an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/dynamic_nodes/agent.ts
+ *   npm run sample -- tests/integration/workflows/dynamic_nodes/agent.ts
  */
 
-import {LlmAgent, node, NodeContext, Workflow} from '@google/adk';
+import {createEvent, LlmAgent, node, NodeContext, Workflow} from '@google/adk';
 import {z} from 'zod';
 
 const feedbackSchema = z.object({
-  grade: z.enum(['tech-related', 'unrelated']),
-  feedback: z.string(),
+  grade: z
+    .enum(['tech-related', 'unrelated'])
+    .describe(
+      'Decide if the headline is related to technology or software engineering.',
+    ),
+  feedback: z
+    .string()
+    .describe(
+      'If the headline is unrelated to technology, provide feedback on how to make it more tech-focused.',
+    ),
 });
 
-const generateHeadline = node(
-  new LlmAgent({
-    name: 'generate_headline',
-    model: 'gemini-2.5-flash',
-    instruction: `
+const generateHeadline = new LlmAgent({
+  name: 'generate_headline',
+  model: 'gemini-2.5-flash',
+  instruction: `
     Write a headline about the topic "{topic}".
     If feedback is provided, take it into account.
     The feedback: {feedback?}
     `,
-  }),
-);
+});
 
-const evaluateHeadline = node(
-  new LlmAgent({
-    name: 'evaluate_headline',
-    model: 'gemini-2.5-flash',
-    instruction:
-      'Grade whether the headline is related to technology or software engineering.',
-    outputSchema: feedbackSchema,
-    outputKey: 'feedback',
-  }),
+const evaluateHeadline = new LlmAgent({
+  name: 'evaluate_headline',
+  model: 'gemini-2.5-flash',
+  instruction: `
+    Grade whether the headline is related to technology or software engineering.
+    `,
+  outputSchema: feedbackSchema,
+  outputKey: 'feedback',
+});
+
+const orchestrate = node(
+  async function* (ctx: NodeContext, nodeInput: string) {
+    ctx.state.set('topic', nodeInput);
+    yield createEvent({});
+
+    for (;;) {
+      const headline = (await ctx.runNode(generateHeadline)).output as string;
+      const feedback = feedbackSchema.parse(
+        (await ctx.runNode(evaluateHeadline, headline)).output,
+      );
+      if (feedback.grade === 'tech-related') {
+        yield headline;
+        break;
+      }
+    }
+  },
+  {name: 'orchestrate', rerunOnResume: true},
 );
 
 export const rootAgent = new Workflow({
   name: 'root_agent',
-  // Imperative entry: drive the child nodes directly via `ctx.runNode()`
-  // rather than a static edge graph (mutually exclusive with `edges`).
-  dynamicEntry: async (ctx: NodeContext, nodeInput: unknown) => {
-    ctx.state.set('topic', nodeInput as string);
-
-    const MAX_ATTEMPTS = 5;
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      const headline = (await ctx.runNode(generateHeadline)).output as string;
-      const feedback = (await ctx.runNode(evaluateHeadline, headline))
-        .output as {grade: string};
-      if (feedback.grade === 'tech-related') {
-        return headline;
-      }
-    }
-    return `Gave up after ${MAX_ATTEMPTS} attempts (headline never graded tech-related).`;
-  },
+  edges: [['START', orchestrate]],
 });

--- a/tests/integration/workflows/dynamic_nodes/dynamic_nodes_test.ts
+++ b/tests/integration/workflows/dynamic_nodes/dynamic_nodes_test.ts
@@ -5,10 +5,10 @@
  */
 
 /**
- * Runs the real `samples/workflows/dynamic_nodes` agent with recorded model
- * responses. Its LlmAgents are captured inside a `dynamicEntry` closure and are
- * unreachable by static traversal — so this proves the registry-level model
- * injection reaches every agent, however it is wired.
+ * Runs the real `dynamic_nodes` sample: one `orchestrate` node drives two agents
+ * with `ctx.runNode` until the headline grades tech-related. Turn mirrors the
+ * Python golden `contributing/samples/workflows/dynamic_nodes/tests/flower.json`,
+ * which deliberately uses a non-tech topic so the loop iterates.
  */
 
 import {describe, expect, it} from 'vitest';
@@ -21,22 +21,34 @@ import {
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: dynamic_nodes', () => {
-  it('drives closure-captured agents via dynamicEntry to a final headline', async () => {
+  it('loops until the generated headline is graded tech-related', async () => {
     const perTurn = await runSample({
       name: 'dynamic_nodes',
       rootAgent,
-      turns: ['the ocean'],
+      turns: ['flower'],
     });
     const events = allEvents(perTurn);
 
-    // Both closure-captured agents ran (reached only via ctx.runNode).
-    expect(authors(events).has('generate_headline')).toBe(true);
-    expect(authors(events).has('evaluate_headline')).toBe(true);
+    expect(events.map((e) => e.actions?.stateDelta ?? {})).toContainEqual({
+      topic: 'flower',
+    });
 
-    // The bounded loop terminates with a string output (a headline, or the
-    // "gave up" message).
-    const output = finalOutput(events);
-    expect(typeof output).toBe('string');
-    expect((output as string).length).toBeGreaterThan(0);
-  });
+    const who = authors(events);
+    expect(who.has('generate_headline')).toBe(true);
+    expect(who.has('evaluate_headline')).toBe(true);
+
+    const headlines = events.filter((e) => e.author === 'generate_headline');
+    expect(headlines.length).toBeGreaterThanOrEqual(2);
+    const grades = events
+      .filter((e) => e.author === 'evaluate_headline' && e.output !== undefined)
+      .map((e) => (e.output as {grade: string}).grade);
+    expect(grades.length).toBe(headlines.length);
+    expect(grades[grades.length - 1]).toBe('tech-related');
+    expect(grades.slice(0, -1).every((g) => g === 'unrelated')).toBe(true);
+
+    const lastHeadline = (headlines[headlines.length - 1].content?.parts ?? [])
+      .map((p) => p.text ?? '')
+      .join('');
+    expect(finalOutput(events)).toBe(lastHeadline);
+  }, 120000);
 });

--- a/tests/integration/workflows/dynamic_nodes/model_responses.json
+++ b/tests/integration/workflows/dynamic_nodes/model_responses.json
@@ -1,20 +1,20 @@
 [
   {
-    "key": "0112f342bd840a3d",
-    "instructionAgnosticKey": "dba6770d80737da2",
+    "key": "ba32ce85868d31a6",
+    "instructionAgnosticKey": "d5b3da4b095b2f9e",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "the ocean"
+              "text": "flower"
             }
           ]
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"the ocean\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
         "labels": {
           "adk_agent_name": "generate_headline"
         }
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
+                "text": "Blooming Beauty: The Timeless Allure of Flowers"
               }
             ]
           },
@@ -35,192 +35,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 48,
-        "candidatesTokenCount": 15,
-        "totalTokenCount": 102,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 48
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 15
-          }
-        ],
-        "thoughtsTokenCount": 39
-      }
-    }
-  },
-  {
-    "key": "b4a7114387b0d365",
-    "instructionAgnosticKey": "fbe12ea2ada9d29d",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "the ocean"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: \"Beneath the Surface: Unveiling the Ocean's Secrets\""
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
-            }
-          ]
-        }
-      ],
-      "config": {
-        "responseSchema": {
-          "type": "OBJECT",
-          "properties": {
-            "grade": {
-              "type": "STRING",
-              "enum": [
-                "tech-related",
-                "unrelated"
-              ]
-            },
-            "feedback": {
-              "type": "STRING"
-            }
-          },
-          "required": [
-            "grade",
-            "feedback"
-          ]
-        },
-        "responseMimeType": "application/json",
-        "systemInstruction": "Grade whether the headline is related to technology or software engineering.",
-        "labels": {
-          "adk_agent_name": "evaluate_headline"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "{\"grade\": \"unrelated\", \"feedback\": \"The headline is about ocean exploration and discovery, not technology or software engineering.\"}"
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 66,
-        "candidatesTokenCount": 27,
-        "totalTokenCount": 148,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 66
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 27
-          }
-        ],
-        "thoughtsTokenCount": 55
-      }
-    }
-  },
-  {
-    "key": "35f70f2d232d2a3d",
-    "instructionAgnosticKey": "ac107cad3eb60ad5",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "the ocean"
-            }
-          ]
-        },
-        {
-          "role": "model",
-          "parts": [
-            {
-              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[evaluate_headline] said: {\"grade\": \"unrelated\", \"feedback\": \"The headline is about ocean exploration and discovery, not technology or software engineering.\"}"
-            }
-          ]
-        }
-      ],
-      "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"the ocean\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"The headline is about ocean exploration and discovery, not technology or software engineering.\"}\n    ",
-        "labels": {
-          "adk_agent_name": "generate_headline"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "Deep Dive into Code: Software Engineering for Ocean Innovation"
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 138,
+        "promptTokenCount": 46,
         "candidatesTokenCount": 10,
-        "totalTokenCount": 1282,
+        "totalTokenCount": 87,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 138
+            "tokenCount": 46
           }
         ],
         "candidatesTokensDetails": [
@@ -229,20 +51,20 @@
             "tokenCount": 10
           }
         ],
-        "thoughtsTokenCount": 1134
+        "thoughtsTokenCount": 31
       }
     }
   },
   {
-    "key": "b426c322f8f0086d",
-    "instructionAgnosticKey": "ad38f7ee02479dc9",
+    "key": "dca2d3a7772916d9",
+    "instructionAgnosticKey": "81cb6cad2d7fab34",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "the ocean"
+              "text": "flower"
             }
           ]
         },
@@ -253,7 +75,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_headline] said: \"Beneath the Surface: Unveiling the Ocean's Secrets\""
+              "text": "[generate_headline] said: Blooming Beauty: The Timeless Allure of Flowers"
             }
           ]
         },
@@ -261,34 +83,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "\"Beneath the Surface: Unveiling the Ocean's Secrets\""
-            }
-          ]
-        },
-        {
-          "role": "model",
-          "parts": [
-            {
-              "text": "{\"grade\": \"unrelated\", \"feedback\": \"The headline is about ocean exploration and discovery, not technology or software engineering.\"}"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: Deep Dive into Code: Software Engineering for Ocean Innovation"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Deep Dive into Code: Software Engineering for Ocean Innovation"
+              "text": "Blooming Beauty: The Timeless Allure of Flowers"
             }
           ]
         }
@@ -302,10 +97,12 @@
               "enum": [
                 "tech-related",
                 "unrelated"
-              ]
+              ],
+              "description": "Decide if the headline is related to technology or software engineering."
             },
             "feedback": {
-              "type": "STRING"
+              "type": "STRING",
+              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
             }
           },
           "required": [
@@ -314,7 +111,7 @@
           ]
         },
         "responseMimeType": "application/json",
-        "systemInstruction": "Grade whether the headline is related to technology or software engineering.",
+        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
         "labels": {
           "adk_agent_name": "evaluate_headline"
         }
@@ -327,7 +124,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\"grade\": \"tech-related\", \"feedback\": \"The headline explicitly mentions 'Software Engineering' and 'Code,' directly indicating its relevance to technology and software engineering. The 'Ocean Innovation' part describes the application domain, but the core subject remains software engineering.\"}"
+                "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}"
               }
             ]
           },
@@ -335,23 +132,230 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 123,
-        "candidatesTokenCount": 54,
-        "totalTokenCount": 270,
+        "promptTokenCount": 92,
+        "candidatesTokenCount": 70,
+        "totalTokenCount": 324,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 123
+            "tokenCount": 92
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 54
+            "tokenCount": 70
           }
         ],
-        "thoughtsTokenCount": 93
+        "thoughtsTokenCount": 162
+      }
+    }
+  },
+  {
+    "key": "6c72bb0fcdd7042b",
+    "instructionAgnosticKey": "a133bf8d41cdf97c",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "flower"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Blooming Beauty: The Timeless Allure of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Blooming Beauty: The Timeless Allure of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[evaluate_headline] said: {\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}\n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "AI's Floral Revolution: Designing Digital Blooms"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 212,
+        "candidatesTokenCount": 9,
+        "totalTokenCount": 936,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 212
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9
+          }
+        ],
+        "thoughtsTokenCount": 715
+      }
+    }
+  },
+  {
+    "key": "23c78a6f3b150214",
+    "instructionAgnosticKey": "20036aed37d9d4a2",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "flower"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[generate_headline] said: Blooming Beauty: The Timeless Allure of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Blooming Beauty: The Timeless Allure of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[generate_headline] said: AI's Floral Revolution: Designing Digital Blooms"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "AI's Floral Revolution: Designing Digital Blooms"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ],
+              "description": "Decide if the headline is related to technology or software engineering."
+            },
+            "feedback": {
+              "type": "STRING",
+              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "{\"grade\": \"tech-related\", \"feedback\": \"This headline is highly tech-related, specifically mentioning 'AI' and 'Digital Blooms,' which are key concepts in artificial intelligence and digital design/software.\"}"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 190,
+        "candidatesTokenCount": 44,
+        "totalTokenCount": 416,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 190
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 44
+          }
+        ],
+        "thoughtsTokenCount": 182
       }
     }
   }

--- a/tests/integration/workflows/fan_out_fan_in/agent.ts
+++ b/tests/integration/workflows/fan_out_fan_in/agent.ts
@@ -3,15 +3,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/fan_out_fan_in/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Fan-out / fan-in: run three functions in parallel on the same input, join
- * their outputs, and aggregate. Faithful port of Python
- * `contributing/samples/workflows/fan_out_fan_in`.
+ * their outputs, and aggregate. One-to-one port of Python
+ * `contributing/samples/workflows/fan_out_fan_in/agent.py`.
  *
- * Run (offline):  npm run sample -- samples/workflows/fan_out_fan_in/agent.ts
+ * Run (offline):  npm run sample -- tests/integration/workflows/fan_out_fan_in/agent.ts
  */
 
 import {createEvent, JoinNode, node, NodeContext, Workflow} from '@google/adk';
@@ -33,7 +30,7 @@ const aggregate = node(
   async function* (_c: NodeContext, results: Record<string, unknown>) {
     yield createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [
           {
             text:

--- a/tests/integration/workflows/fan_out_fan_in/fan_out_fan_in_test.ts
+++ b/tests/integration/workflows/fan_out_fan_in/fan_out_fan_in_test.ts
@@ -6,7 +6,9 @@
 
 /**
  * Runs the real `fan_out_fan_in` sample (offline): three functions run in
- * parallel on the same input, joined and aggregated.
+ * parallel on the same input, joined and aggregated. Turn and expectations
+ * mirror the Python golden
+ * `contributing/samples/workflows/fan_out_fan_in/tests/go.json`.
  */
 
 import {describe, expect, it} from 'vitest';
@@ -18,24 +20,34 @@ describe('workflow sample: fan_out_fan_in', () => {
     const perTurn = await runSample({
       name: 'fan_out_fan_in',
       rootAgent,
-      turns: ['hello'],
+      turns: ['go'],
       offline: true,
     });
     const events = allEvents(perTurn);
 
-    // All three parallel branches ran.
     expect(authors(events).has('make_uppercase')).toBe(true);
     expect(authors(events).has('count_characters')).toBe(true);
     expect(authors(events).has('reverse_string')).toBe(true);
 
-    // The aggregate node combined all three results.
+    const outputOf = (author: string) =>
+      events.find((e) => e.author === author && e.output !== undefined)?.output;
+    expect(outputOf('make_uppercase')).toBe('GO');
+    expect(outputOf('count_characters')).toBe(2);
+    expect(outputOf('reverse_string')).toBe('og');
+
+    expect(outputOf('join_for_results')).toEqual({
+      make_uppercase: 'GO',
+      count_characters: 2,
+      reverse_string: 'og',
+    });
+
     const text = events
       .filter((e) => e.author === 'aggregate')
       .flatMap((e) => e.content?.parts ?? [])
       .map((p) => p.text ?? '')
-      .join(' ');
-    expect(text).toContain('Uppercase: HELLO');
-    expect(text).toContain('Character Count: 5');
-    expect(text).toContain('Reversed: olleh');
+      .join('');
+    expect(text).toBe(
+      'Uppercase: GO\n\nCharacter Count: 2\n\nReversed: og\n\n',
+    );
   });
 });

--- a/tests/integration/workflows/loop/agent.ts
+++ b/tests/integration/workflows/loop/agent.ts
@@ -3,15 +3,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/loop/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Loop: generate a headline, grade it, and route back until it is tech-related.
- * Faithful port of Python `contributing/samples/workflows/loop`.
+ * One-to-one port of Python
+ * `contributing/samples/workflows/loop/agent.py`.
  *
  * Requires an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/loop/agent.ts
+ *   npm run sample -- tests/integration/workflows/loop/agent.ts
  * Enter a topic, e.g. "the ocean" (loops until the headline is tech-related).
  */
 

--- a/tests/integration/workflows/loop/loop_test.ts
+++ b/tests/integration/workflows/loop/loop_test.ts
@@ -7,27 +7,67 @@
 /**
  * Runs the real `loop` sample: a graph-level cycle that generates a headline,
  * grades it, and routes back to generation until it is graded tech-related.
+ * Both turns mirror the Python goldens
+ * `contributing/samples/workflows/loop/tests/{computer,flower}.json`: a
+ * tech topic exits on the first pass, a non-tech one traverses the cycle.
  */
 
 import {describe, expect, it} from 'vitest';
 import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
+function grades(events: ReturnType<typeof allEvents>): string[] {
+  return events
+    .filter((e) => e.author === 'evaluate_headline' && e.output !== undefined)
+    .map((e) => (e.output as {grade: string}).grade);
+}
+
 describe('workflow sample: loop', () => {
-  it('generates and grades headlines around the cyclic edge', async () => {
+  it('exits after one pass when the topic is already tech-related', async () => {
     const perTurn = await runSample({
       name: 'loop',
       rootAgent,
-      turns: ['quantum computing'],
+      turns: ['computer'],
     });
     const events = allEvents(perTurn);
 
-    // Both agents in the cycle ran at least once.
+    expect(events.map((e) => e.actions?.stateDelta ?? {})).toContainEqual({
+      topic: 'computer',
+    });
     expect(authors(events).has('generate_headline')).toBe(true);
-    expect(authors(events).has('evaluate_headline')).toBe(true);
+    expect(grades(events)).toEqual(['tech-related']);
+    expect(events.filter((e) => e.author === 'generate_headline')).toHaveLength(
+      1,
+    );
+    expect(events.map((e) => e.route).filter(Boolean)).toEqual([
+      'tech-related',
+    ]);
+  }, 120000);
 
-    // A route was emitted by the routing node (either back to generate, or out).
-    const routed = events.some((e) => e.route !== undefined);
-    expect(routed).toBe(true);
-  });
+  it('routes back around the cycle when the headline is unrelated', async () => {
+    const perTurn = await runSample({
+      name: 'loop',
+      rootAgent,
+      turns: ['flower'],
+    });
+    const events = allEvents(perTurn);
+
+    const passes = events.filter((e) => e.author === 'generate_headline');
+    const allGrades = grades(events);
+
+    expect(passes.length).toBeGreaterThanOrEqual(2);
+    expect(allGrades.length).toBe(passes.length);
+    expect(allGrades[allGrades.length - 1]).toBe('tech-related');
+    expect(allGrades.slice(0, -1).every((g) => g === 'unrelated')).toBe(true);
+
+    const routes = events.map((e) => e.route).filter(Boolean);
+    expect(routes.filter((r) => r === 'unrelated')).toHaveLength(
+      passes.length - 1,
+    );
+
+    const feedbackDelta = events
+      .map((e) => e.actions?.stateDelta ?? {})
+      .find((d) => 'feedback' in d);
+    expect(feedbackDelta).toBeDefined();
+  }, 120000);
 });

--- a/tests/integration/workflows/loop/model_responses.json
+++ b/tests/integration/workflows/loop/model_responses.json
@@ -1,20 +1,20 @@
 [
   {
-    "key": "5fc04152f12fe2c0",
-    "instructionAgnosticKey": "2fc1b852b548f499",
+    "key": "234de0df3136b92f",
+    "instructionAgnosticKey": "6b5d07c2a8e674bd",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "quantum computing"
+              "text": "computer"
             }
           ]
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"quantum computing\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"computer\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
         "labels": {
           "adk_agent_name": "generate_headline"
         }
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Quantum Computing: The Next Frontier in Technology"
+                "text": "The Computer Revolution: Shaping Our Digital Future"
               }
             ]
           },
@@ -35,14 +35,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 48,
+        "promptTokenCount": 46,
         "candidatesTokenCount": 8,
-        "totalTokenCount": 75,
+        "totalTokenCount": 594,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 48
+            "tokenCount": 46
           }
         ],
         "candidatesTokensDetails": [
@@ -51,20 +51,20 @@
             "tokenCount": 8
           }
         ],
-        "thoughtsTokenCount": 19
+        "thoughtsTokenCount": 540
       }
     }
   },
   {
-    "key": "9da3434b6aa989f8",
-    "instructionAgnosticKey": "163205064812ed4e",
+    "key": "09142a2f4182a0ef",
+    "instructionAgnosticKey": "5601a53640996e24",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "quantum computing"
+              "text": "computer"
             }
           ]
         },
@@ -75,7 +75,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_headline] said: Quantum Computing: The Next Frontier in Technology"
+              "text": "[generate_headline] said: The Computer Revolution: Shaping Our Digital Future"
             }
           ]
         },
@@ -83,7 +83,367 @@
           "role": "user",
           "parts": [
             {
-              "text": "Quantum Computing: The Next Frontier in Technology"
+              "text": "The Computer Revolution: Shaping Our Digital Future"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ],
+              "description": "Decide if the headline is related to technology or software engineering."
+            },
+            "feedback": {
+              "type": "STRING",
+              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "{\n  \"grade\": \"tech-related\",\n  \"feedback\": \"\"\n}"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 88,
+        "candidatesTokenCount": 19,
+        "totalTokenCount": 328,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 88
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 19
+          }
+        ],
+        "thoughtsTokenCount": 221
+      }
+    }
+  },
+  {
+    "key": "ba32ce85868d31a6",
+    "instructionAgnosticKey": "d5b3da4b095b2f9e",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "flower"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Blooming Beauty: The Enduring Charm of Flowers"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 46,
+        "candidatesTokenCount": 9,
+        "totalTokenCount": 74,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 46
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9
+          }
+        ],
+        "thoughtsTokenCount": 19
+      }
+    }
+  },
+  {
+    "key": "d1adcca1e879897f",
+    "instructionAgnosticKey": "cfe2236122cc6b85",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "flower"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[generate_headline] said: Blooming Beauty: The Enduring Charm of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Blooming Beauty: The Enduring Charm of Flowers"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ],
+              "description": "Decide if the headline is related to technology or software engineering."
+            },
+            "feedback": {
+              "type": "STRING",
+              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 90,
+        "candidatesTokenCount": 90,
+        "totalTokenCount": 371,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 90
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 90
+          }
+        ],
+        "thoughtsTokenCount": 191
+      }
+    }
+  },
+  {
+    "key": "3ba3628b133649b7",
+    "instructionAgnosticKey": "6b5d3e51a69f808a",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "flower"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Blooming Beauty: The Enduring Charm of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Blooming Beauty: The Enduring Charm of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[evaluate_headline] said: {\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}\n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "AI-Powered Petals: How Technology is Redefining Flower Cultivation"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 250,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 696,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 250
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 15
+          }
+        ],
+        "thoughtsTokenCount": 431
+      }
+    }
+  },
+  {
+    "key": "1158f54ecb2f7e2f",
+    "instructionAgnosticKey": "4996630b58425479",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "flower"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[generate_headline] said: Blooming Beauty: The Enduring Charm of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Blooming Beauty: The Enduring Charm of Flowers"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[generate_headline] said: AI-Powered Petals: How Technology is Redefining Flower Cultivation"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "AI-Powered Petals: How Technology is Redefining Flower Cultivation"
             }
           ]
         }
@@ -132,14 +492,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 89,
+        "promptTokenCount": 220,
         "candidatesTokenCount": 12,
-        "totalTokenCount": 286,
+        "totalTokenCount": 340,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 89
+            "tokenCount": 220
           }
         ],
         "candidatesTokensDetails": [
@@ -148,7 +508,7 @@
             "tokenCount": 12
           }
         ],
-        "thoughtsTokenCount": 185
+        "thoughtsTokenCount": 108
       }
     }
   }

--- a/tests/integration/workflows/loop_self/agent.ts
+++ b/tests/integration/workflows/loop_self/agent.ts
@@ -3,47 +3,58 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/loop_self/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Loop-self: a node routes back to itself until it guesses the target number.
- * Faithful port of Python `contributing/samples/workflows/loop_self`.
+ * One-to-one port of Python
+ * `contributing/samples/workflows/loop_self/agent.py`.
  *
- * Run (offline):  npm run sample -- samples/workflows/loop_self/agent.ts
+ * TypeScript note: Python's `guess_number(target_number: int)` binds
+ * `target_number` from state by parameter name. `FunctionNode` in TypeScript
+ * has a fixed `(ctx, input)` signature, so the value is read via `ctx.state`.
+ *
+ * Run (offline):  npm run sample -- tests/integration/workflows/loop_self/agent.ts
  * Enter a number between 0 and 10.
  */
 
 import {createEvent, node, NodeContext, Workflow} from '@google/adk';
 
+/** Python's `Event(message=...)` content shape (role `user`). */
+const message = (text: string) =>
+  createEvent({content: {role: 'user', parts: [{text}]}});
+
+/**
+ * Python's `int(node_input)`: tolerates surrounding whitespace and a sign, and
+ * throws on anything else — `parseInt` would silently accept "3abc".
+ */
+function parseIntStrict(value: string): number {
+  const text = String(value).trim();
+  if (!/^[+-]?\d+$/.test(text)) {
+    throw new Error(`invalid literal for int() with base 10: '${value}'`);
+  }
+  return Number(text);
+}
+
 const validateInput = node(
   function* (ctx: NodeContext, nodeInput: string) {
-    const parsed = parseInt(String(nodeInput).trim(), 10);
-    if (Number.isNaN(parsed) || parsed > 10 || parsed < 0) {
-      yield createEvent({
-        content: {
-          role: 'model',
-          parts: [{text: 'Please provide a number between 0 and 10.'}],
-        },
-      });
+    const parsedNumber = parseIntStrict(nodeInput);
+    if (parsedNumber > 10 || parsedNumber < 0) {
+      yield message('Please provide a number between 0 and 10.');
       throw new Error('Invalid input.');
+    } else {
+      ctx.state.set('target_number', parsedNumber);
+      yield createEvent({});
     }
-    ctx.state.set('target_number', parsed);
   },
   {name: 'validate_input'},
 );
 
 const guessNumber = node(
   function* (ctx: NodeContext) {
-    const target = ctx.state.get<number>('target_number');
+    const targetNumber = ctx.state.get<number>('target_number');
     const guess = Math.floor(Math.random() * 11);
-    yield createEvent({
-      content: {role: 'model', parts: [{text: `Guessing ${guess}...`}]},
-    });
-    if (guess === target) {
-      yield createEvent({
-        content: {role: 'model', parts: [{text: 'Correct!'}]},
-      });
+    yield message(`Guessing ${guess}...`);
+    if (guess === targetNumber) {
+      yield message('Correct!');
     } else {
       yield createEvent({route: 'guessed_wrong'});
     }

--- a/tests/integration/workflows/loop_self/loop_self_test.ts
+++ b/tests/integration/workflows/loop_self/loop_self_test.ts
@@ -5,8 +5,10 @@
  */
 
 /**
- * Runs the real `loop_self` sample (offline): a node routes back to itself until
- * it guesses the target number. `Math.random` is seeded for reproducibility.
+ * Runs the real `loop_self` sample (offline): a node routes back to itself
+ * until its random guess matches the target. Turn mirrors the Python golden
+ * `contributing/samples/workflows/loop_self/tests/3.json`, which mocks the RNG
+ * to a fixed sequence; here `Math.random` is replaced by a seeded PRNG.
  */
 
 import {afterEach, describe, expect, it, vi} from 'vitest';
@@ -14,26 +16,46 @@ import {mulberry32} from '../_harness/rng.js';
 import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
-describe('workflow sample: loop_self', () => {
-  afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
-  it('loops back to itself until it guesses the target', async () => {
+describe('workflow sample: loop_self', () => {
+  it('guesses repeatedly around the self-edge until it is correct', async () => {
     vi.spyOn(Math, 'random').mockImplementation(mulberry32(1));
 
     const perTurn = await runSample({
       name: 'loop_self',
       rootAgent,
-      turns: ['7'],
+      turns: ['3'],
       offline: true,
     });
     const events = allEvents(perTurn);
 
-    // The self-looping node ran (guessing), and eventually announced success.
     expect(authors(events).has('guess_number')).toBe(true);
-    const text = events
+
+    const texts = events
       .flatMap((e) => e.content?.parts ?? [])
       .map((p) => p.text ?? '')
-      .join(' ');
-    expect(text).toContain('Correct!');
+      .filter(Boolean);
+    const guesses = texts.filter((t) => t.startsWith('Guessing '));
+
+    expect(guesses.length).toBeGreaterThan(1);
+    expect(texts).toContain('Correct!');
+    const wrongRoutes = events.filter((e) => e.route === 'guessed_wrong');
+    expect(wrongRoutes).toHaveLength(guesses.length - 1);
+
+    expect(guesses[guesses.length - 1]).toBe('Guessing 3...');
+  });
+
+  it('rejects a non-numeric input the way Python int() does', async () => {
+    await expect(
+      runSample({
+        name: 'loop_self',
+        rootAgent,
+        turns: ['3abc'],
+        offline: true,
+      }),
+    ).rejects.toThrow(/invalid literal for int\(\)/);
   });
 });

--- a/tests/integration/workflows/message/agent.ts
+++ b/tests/integration/workflows/message/agent.ts
@@ -3,15 +3,20 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/message/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
 
 /**
  * Message: the many ways a node can emit display messages — plain string,
  * multi-modal (text + inline image), multiple messages, and streamed partial
- * chunks. Faithful port of Python `contributing/samples/workflows/message`.
+ * chunks. One-to-one port of Python
+ * `contributing/samples/workflows/message/agent.py`.
  *
- * Run (offline):  npm run sample -- samples/workflows/message/agent.ts
+ * Python builds these with `Event(message=...)`, which routes the payload
+ * through `t_content` and so produces `role: "user"` content. TS has no
+ * `message` shorthand on `createEvent`, so the role is spelled out to keep the
+ * emitted events identical to Python's.
+ *
+ * Run (offline):
+ *   npm run sample -- tests/integration/workflows/message/agent.ts
  */
 
 import {createEvent, node, Workflow} from '@google/adk';
@@ -22,15 +27,23 @@ const RED_SQUARE_PNG =
   '7fz/z+ZQtapwmrJc8QklmjBIgZJgIZMiAIl9KYbhjx4fgwosbNxgMrF0+4uhgHnYDM6' +
   'AzQHJeg5HYtyHFfgy2AztN/5tZWfrBtVzkl4DzfQkEPd+cEkAAAAASUVORK5CYII=';
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/** Mirrors Python's `sleep_if_not_pytest`: the sample paces itself when run
+ * interactively, but must not burn wall-clock inside the test suite. */
+async function sleepIfNotUnderTest(seconds: number): Promise<void> {
+  if (process.env['VITEST_WORKER_ID'] !== undefined) return;
+  await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+
+/** Python's `Event(message=...)` content shape. */
+const message = (text: string) => ({
+  role: 'user',
+  parts: [{text}],
+});
 
 const sendString = node(
   async function* () {
     yield createEvent({
-      content: {
-        role: 'model',
-        parts: [{text: '#1 This is a simple string message.'}],
-      },
+      content: message('#1 This is a simple string message.'),
     });
   },
   {name: 'send_string'},
@@ -40,9 +53,13 @@ const sendMultimodal = node(
   async function* () {
     yield createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [
-          {text: '#2 Here is a multi-modal message with an inline image:'},
+          {
+            text:
+              '#2 Here is a multi-modal message with an inline image (red' +
+              ' circle):',
+          },
           {inlineData: {data: RED_SQUARE_PNG, mimeType: 'image/png'}},
         ],
       },
@@ -53,34 +70,48 @@ const sendMultimodal = node(
 
 const multipleMessages = node(
   async function* () {
-    const msg = (text: string) =>
-      createEvent({content: {role: 'model', parts: [{text}]}});
-    yield msg('#3 Multiple messages');
-    await sleep(300);
-    yield msg('Processing step 1...');
-    await sleep(300);
-    yield msg('Processing step 2...');
-    await sleep(300);
-    yield msg('Done processing.');
+    yield createEvent({content: message('#3 Multiple messages')});
+    await sleepIfNotUnderTest(1.0);
+
+    yield createEvent({content: message('Processing step 1...')});
+    await sleepIfNotUnderTest(1.0);
+
+    yield createEvent({content: message('Processing step 2...')});
+    await sleepIfNotUnderTest(1.0);
+
+    yield createEvent({content: message('Done processing.')});
   },
   {name: 'multiple_messages'},
 );
 
+/**
+ * Demonstrates streaming by sending a sentence in chunks.
+ * The `partial: true` flag tells the UI that this is part of an ongoing
+ * message. Partial events are not written to the session, so the node ends by
+ * yielding the assembled sentence once as a non-partial event.
+ */
 const streamSentence = node(
   async function* () {
-    yield createEvent({
-      content: {role: 'model', parts: [{text: '#4 Starting to stream...'}]},
-    });
+    yield createEvent({content: message('#4 Starting to stream...')});
     const sentence =
-      'This is a streaming message sent in chunks. ' +
-      'You can stream markdown too.';
+      'This is a streaming message sent in chunks.\n' +
+      '\n' +
+      'You can stream in markdown as well. For example, the table below:\n' +
+      '\n' +
+      '| Header 1 | Header 2 |\n' +
+      '|----------|----------|\n' +
+      '| Cell 1   | Cell 2   |\n' +
+      '| Cell 3   | Cell 4   |\n';
+
     for (let i = 0; i < sentence.length; i += 5) {
       yield createEvent({
         partial: true,
-        content: {role: 'model', parts: [{text: sentence.slice(i, i + 5)}]},
+        content: message(sentence.slice(i, i + 5)),
       });
-      await sleep(100);
+      await sleepIfNotUnderTest(0.2);
     }
+
+    yield createEvent({content: message(sentence)});
   },
   {name: 'stream_sentence'},
 );

--- a/tests/integration/workflows/message/message_test.ts
+++ b/tests/integration/workflows/message/message_test.ts
@@ -4,14 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** Runs the real `message` sample (offline): the many ways a node emits messages. */
+/**
+ * Runs the real `message` sample (offline): the ways a node can emit display
+ * messages. Turn and expectations mirror the Python golden
+ * `contributing/samples/workflows/message/tests/go.json`, which pins the eight
+ * non-partial events (partial chunks are deliberately not persisted).
+ */
 
 import {describe, expect, it} from 'vitest';
 import {allEvents, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
+const STREAMED_SENTENCE =
+  'This is a streaming message sent in chunks.\n' +
+  '\n' +
+  'You can stream in markdown as well. For example, the table below:\n' +
+  '\n' +
+  '| Header 1 | Header 2 |\n' +
+  '|----------|----------|\n' +
+  '| Cell 1   | Cell 2   |\n' +
+  '| Cell 3   | Cell 4   |\n';
+
 describe('workflow sample: message', () => {
-  it('emits string, multimodal, multiple, and streamed messages', async () => {
+  it('emits string, multimodal, multiple and streamed messages', async () => {
     const perTurn = await runSample({
       name: 'message',
       rootAgent,
@@ -19,17 +34,36 @@ describe('workflow sample: message', () => {
       offline: true,
     });
     const events = allEvents(perTurn);
-    const parts = events.flatMap((e) => e.content?.parts ?? []);
 
-    // Plain string message.
-    expect(parts.some((p) => p.text?.includes('simple string message'))).toBe(
-      true,
-    );
-    // Multi-modal message with an inline image.
-    expect(parts.some((p) => p.inlineData?.mimeType === 'image/png')).toBe(
-      true,
-    );
-    // Streamed partial chunks were emitted.
-    expect(events.some((e) => e.partial === true)).toBe(true);
+    const texts = events
+      .filter((e) => !e.partial)
+      .flatMap((e) => e.content?.parts ?? [])
+      .map((p) => p.text)
+      .filter((t): t is string => !!t);
+
+    expect(texts).toEqual([
+      '#1 This is a simple string message.',
+      '#2 Here is a multi-modal message with an inline image (red circle):',
+      '#3 Multiple messages',
+      'Processing step 1...',
+      'Processing step 2...',
+      'Done processing.',
+      '#4 Starting to stream...',
+      STREAMED_SENTENCE,
+    ]);
+
+    const inline = events
+      .flatMap((e) => e.content?.parts ?? [])
+      .find((p) => p.inlineData);
+    expect(inline?.inlineData?.mimeType).toBe('image/png');
+
+    const partials = events.filter((e) => e.partial);
+    expect(partials.length).toBe(Math.ceil(STREAMED_SENTENCE.length / 5));
+    expect(
+      partials
+        .flatMap((e) => e.content?.parts ?? [])
+        .map((p) => p.text ?? '')
+        .join(''),
+    ).toBe(STREAMED_SENTENCE);
   });
 });

--- a/tests/integration/workflows/multi_triggers/agent.ts
+++ b/tests/integration/workflows/multi_triggers/agent.ts
@@ -3,14 +3,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/multi_triggers/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Multi-triggers: a node with several predecessors runs once per incoming
- * trigger. Faithful port of Python `contributing/samples/workflows/multi_triggers`.
+ * trigger. One-to-one port of Python
+ * `contributing/samples/workflows/multi_triggers/agent.py`.
  *
- * Run (offline):  npm run sample -- samples/workflows/multi_triggers/agent.ts
+ * Run (offline):  npm run sample -- tests/integration/workflows/multi_triggers/agent.ts
  */
 
 import {createEvent, node, NodeContext, Workflow} from '@google/adk';
@@ -31,7 +29,7 @@ const sendMessage = node(
   async function* (_c: NodeContext, nodeInput: unknown) {
     yield createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [{text: `Triggered for input: ${nodeInput}`}],
       },
     });

--- a/tests/integration/workflows/multi_triggers/multi_triggers_test.ts
+++ b/tests/integration/workflows/multi_triggers/multi_triggers_test.ts
@@ -5,8 +5,10 @@
  */
 
 /**
- * Runs the real `multi_triggers` sample (offline): a node with several
- * predecessors runs once per incoming trigger.
+ * Runs the real `multi_triggers` sample (offline): one successor node is
+ * triggered once per upstream branch, each with that branch's payload. Turn and
+ * expectations mirror the Python golden
+ * `contributing/samples/workflows/multi_triggers/tests/go.json`.
  */
 
 import {describe, expect, it} from 'vitest';
@@ -14,22 +16,27 @@ import {allEvents, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: multi_triggers', () => {
-  it('runs the downstream node once per predecessor trigger', async () => {
+  it('fires the successor once per triggering branch', async () => {
     const perTurn = await runSample({
       name: 'multi_triggers',
       rootAgent,
-      turns: ['abc'],
+      turns: ['go'],
       offline: true,
     });
     const events = allEvents(perTurn);
 
-    // send_message has three predecessors, so it fires three times.
-    const triggered = events.filter((e) => e.author === 'send_message');
-    expect(triggered.length).toBe(3);
-    expect(
-      triggered.every((e) =>
-        (e.content?.parts ?? []).some((p) => p.text?.includes('Triggered for')),
-      ),
-    ).toBe(true);
+    const texts = events
+      .filter((e) => e.author === 'send_message')
+      .flatMap((e) => e.content?.parts ?? [])
+      .map((p) => p.text ?? '');
+
+    expect(texts).toHaveLength(3);
+    expect(texts.sort()).toEqual(
+      [
+        'Triggered for input: GO',
+        'Triggered for input: 2',
+        'Triggered for input: og',
+      ].sort(),
+    );
   });
 });

--- a/tests/integration/workflows/nested_workflow/agent.ts
+++ b/tests/integration/workflows/nested_workflow/agent.ts
@@ -3,16 +3,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/nested_workflow/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Nested workflow: a sub-Workflow used as a node, running in parallel with an
- * agent, joined and aggregated. Faithful port of Python
- * `contributing/samples/workflows/nested_workflow`.
+ * agent, joined and aggregated. One-to-one port of Python
+ * `contributing/samples/workflows/nested_workflow/agent.py`.
  *
  * Requires an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/nested_workflow/agent.ts
+ *   npm run sample -- tests/integration/workflows/nested_workflow/agent.ts
  * Enter a 4-digit year, e.g. "1955".
  */
 
@@ -31,13 +28,14 @@ const processInput = node(
     if (!match) {
       yield createEvent({
         content: {
-          role: 'model',
+          role: 'user',
           parts: [{text: 'Please provide a valid 4-digit year (e.g., 1955).'}],
         },
       });
       throw new Error('Invalid year format.');
     }
     ctx.state.set('year', match[0]);
+    yield createEvent({});
   },
   {name: 'process_input'},
 );
@@ -85,7 +83,7 @@ const aggregateResults = node(
       `${nodeInput['find_famous_person']}\n\n` +
       '## Historical Event:\n\n' +
       `${nodeInput['find_historical_event']}`;
-    yield createEvent({content: {role: 'model', parts: [{text: combined}]}});
+    yield createEvent({content: {role: 'user', parts: [{text: combined}]}});
   },
   {name: 'aggregate_results'},
 );

--- a/tests/integration/workflows/nested_workflow/model_responses.json
+++ b/tests/integration/workflows/nested_workflow/model_responses.json
@@ -1,20 +1,20 @@
 [
   {
-    "key": "778e1cce4468601d",
-    "instructionAgnosticKey": "6f1092c2fdbac9e3",
+    "key": "5b100c977505f7bd",
+    "instructionAgnosticKey": "68bcd6d8fa3075da",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "1955"
+              "text": "1984"
             }
           ]
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"find_name\".\n\n\n    Find the name of one famous person who was born in this year: 1955.\n    Return ONLY their name, nothing else.\n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"find_name\".\n\n\n    Find the name of one famous person who was born in this year: 1984.\n    Return ONLY their name, nothing else.\n    ",
         "labels": {
           "adk_agent_name": "find_name"
         }
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Bill Gates"
+                "text": "Mark Zuckerberg"
               }
             ]
           },
@@ -37,7 +37,7 @@
       "usageMetadata": {
         "promptTokenCount": 52,
         "candidatesTokenCount": 2,
-        "totalTokenCount": 98,
+        "totalTokenCount": 167,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -51,20 +51,76 @@
             "tokenCount": 2
           }
         ],
-        "thoughtsTokenCount": 44
+        "thoughtsTokenCount": 113
       }
     }
   },
   {
-    "key": "228440ecf0c1e553",
-    "instructionAgnosticKey": "4969c8b07da28a12",
+    "key": "3e840407dc663206",
+    "instructionAgnosticKey": "d165670813341e1d",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "1955"
+              "text": "1984"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"find_historical_event\".\n\n\n    Describe one highly significant historical event that occurred in this year: 1984.\n    Keep the description to 2 sentences.\n    ",
+        "labels": {
+          "adk_agent_name": "find_historical_event"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "In December 1984, the Bhopal disaster occurred in India, where a leak of methyl isocyanate gas from a Union Carbide plant killed thousands immediately and caused long-term health issues for hundreds of thousands more. This industrial catastrophe remains one of the world's worst, raising critical questions about corporate responsibility, industrial safety, and environmental justice."
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 52,
+        "candidatesTokenCount": 70,
+        "totalTokenCount": 302,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 52
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 70
+          }
+        ],
+        "thoughtsTokenCount": 180
+      }
+    }
+  },
+  {
+    "key": "010aa2005042745b",
+    "instructionAgnosticKey": "cb42c8dbd3a6eff9",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "1984"
             }
           ]
         },
@@ -75,7 +131,7 @@
               "text": "For context:"
             },
             {
-              "text": "[find_name] said: Bill Gates"
+              "text": "[find_name] said: Mark Zuckerberg"
             }
           ]
         },
@@ -83,7 +139,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "Bill Gates"
+              "text": "Mark Zuckerberg"
             }
           ]
         }
@@ -102,7 +158,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Bill Gates revolutionized personal computing as the co-founder of Microsoft, turning it into a global software giant that made technology accessible worldwide. His innovative vision and leadership shaped the digital age. Today, he is primarily known for his extensive philanthropic work through the Bill & Melinda Gates Foundation, addressing critical global health and poverty issues."
+                "text": "Mark Zuckerberg is the visionary co-founder and CEO of Meta Platforms, the company behind Facebook. He launched the groundbreaking social media platform from his Harvard dorm room, forever changing how billions connect and interact globally. Today, he continues to drive Meta's ambitious push into the metaverse, aiming to shape the next generation of digital experience."
               }
             ]
           },
@@ -111,7 +167,7 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 51,
-        "candidatesTokenCount": 63,
+        "candidatesTokenCount": 66,
         "totalTokenCount": 245,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
@@ -123,66 +179,10 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 63
-          }
-        ],
-        "thoughtsTokenCount": 131
-      }
-    }
-  },
-  {
-    "key": "e15dc3fa645e73fc",
-    "instructionAgnosticKey": "78053afc62938740",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "1955"
-            }
-          ]
-        }
-      ],
-      "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"find_historical_event\".\n\n\n    Describe one highly significant historical event that occurred in this year: 1955.\n    Keep the description to 2 sentences.\n    ",
-        "labels": {
-          "adk_agent_name": "find_historical_event"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "In 1955, the Montgomery Bus Boycott began after Rosa Parks' refusal to give up her seat on a bus sparked widespread protest against racial segregation. This pivotal act of civil disobedience, led by Martin Luther King Jr., became a foundational event of the American Civil Rights Movement, demonstrating the power of nonviolent resistance."
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 52,
-        "candidatesTokenCount": 66,
-        "totalTokenCount": 583,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 52
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
             "tokenCount": 66
           }
         ],
-        "thoughtsTokenCount": 465
+        "thoughtsTokenCount": 128
       }
     }
   }

--- a/tests/integration/workflows/nested_workflow/nested_workflow_test.ts
+++ b/tests/integration/workflows/nested_workflow/nested_workflow_test.ts
@@ -5,8 +5,9 @@
  */
 
 /**
- * Runs the real `nested_workflow` sample: a sub-Workflow (find name -> bio) runs
- * in parallel with an agent, joined and aggregated.
+ * Runs the real `nested_workflow` sample: a sub-Workflow runs as one node
+ * alongside an agent, joined and aggregated. Turn and expectations mirror the
+ * Python golden `contributing/samples/workflows/nested_workflow/tests/1984.json`.
  */
 
 import {describe, expect, it} from 'vitest';
@@ -14,26 +15,48 @@ import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: nested_workflow', () => {
-  it('runs a sub-workflow in parallel with an agent, then aggregates', async () => {
+  it('runs a sub-workflow and an agent in parallel and aggregates them', async () => {
     const perTurn = await runSample({
       name: 'nested_workflow',
       rootAgent,
-      turns: ['1955'],
+      turns: ['1984'],
     });
     const events = allEvents(perTurn);
 
-    // The sub-workflow's two agents and the parallel agent all ran.
-    expect(authors(events).has('find_name')).toBe(true);
-    expect(authors(events).has('generate_bio')).toBe(true);
-    expect(authors(events).has('find_historical_event')).toBe(true);
+    expect(events.map((e) => e.actions?.stateDelta ?? {})).toContainEqual({
+      year: '1984',
+    });
 
-    // The aggregate node emitted a combined report referencing the year.
-    const aggregateText = events
+    const who = authors(events);
+    expect(who.has('find_name')).toBe(true);
+    expect(who.has('generate_bio')).toBe(true);
+    expect(who.has('find_historical_event')).toBe(true);
+
+    const join = events.find(
+      (e) => e.author === 'join_for_aggregation' && e.output !== undefined,
+    );
+    expect(Object.keys(join?.output as object).sort()).toEqual([
+      'find_famous_person',
+      'find_historical_event',
+    ]);
+
+    const text = events
       .filter((e) => e.author === 'aggregate_results')
       .flatMap((e) => e.content?.parts ?? [])
       .map((p) => p.text ?? '')
-      .join(' ');
-    expect(aggregateText).toContain('1955');
-    expect(aggregateText).toContain('Famous Person Bio');
+      .join('');
+    expect(text).toContain('# Year: 1984');
+    expect(text).toContain('## Famous Person Bio:');
+    expect(text).toContain('## Historical Event:');
+  });
+
+  it('rejects an input with no 4-digit year', async () => {
+    await expect(
+      runSample({
+        name: 'nested_workflow',
+        rootAgent,
+        turns: ['sometime in the eighties'],
+      }),
+    ).rejects.toThrow('Invalid year format.');
   });
 });

--- a/tests/integration/workflows/node_as_tool/agent.ts
+++ b/tests/integration/workflows/node_as_tool/agent.ts
@@ -3,28 +3,29 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/node_as_tool/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
 
 /**
  * Node-as-tool: an `LlmAgent` uses a `Workflow` AND a function node as tools.
  * The framework auto-wraps each as a `NodeTool`, so the model can call them like
- * any other tool; a node may even pause for input (HITL) mid-tool-call. Faithful
- * port of Python `contributing/samples/workflows/node_as_tool`.
+ * any other tool; a node may even pause for input (HITL) mid-tool-call.
+ * One-to-one port of Python
+ * `contributing/samples/workflows/node_as_tool/agent.py`.
  *
  * `customer_lookup_workflow` looks up a customer's tier; `calculate_discount`
  * (a node) streams a status message and, for VIP tiers, raises a `RequestInput`
  * to confirm the discount — pausing the agent until the user responds.
  *
  * REQUIRES an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/node_as_tool/agent.ts
- * Turn 1: "Look up user u123 and tell me my discount."
+ *   npm run sample -- tests/integration/workflows/node_as_tool/agent.ts
+ * Turn 1: "Look up user c123 and tell me my discount."
  * Turn 2 (VIP): resume by answering the confirmation (a function response to the
  * `confirm_vip_discount` interrupt, e.g. via the web UI).
  */
 
 import {
+  App,
   createEvent,
+  createResumabilityConfig,
   LlmAgent,
   node,
   NodeContext,
@@ -34,37 +35,32 @@ import {
 import {z} from 'zod';
 
 const customerLookupArgs = z.object({
-  userId: z.string().describe("The customer's unique identifier."),
+  user_id: z.string().describe("The customer's unique identifier."),
 });
 
-/** Emits a plain display message (Python `Event(message=...)`). */
+/** Python's `Event(message=...)` content shape (role `user`). */
 const message = (text: string) =>
-  createEvent({content: {role: 'model', parts: [{text}]}});
+  createEvent({content: {role: 'user', parts: [{text}]}});
 
-// A node exposed as a tool. It streams an intermediate message and, for VIP
-// tiers, pauses (RequestInput) to confirm the discount. rerunOnResume=true so it
-// re-runs on resume and reads the reply from ctx.resumeInputs.
 const calculateDiscount = node(
   function* (ctx: NodeContext, args: {tier: string}) {
     yield message(`Checking discount rules for tier '${args.tier}'...`);
 
-    const resume = ctx.resumeInputs['confirm_vip_discount'];
+    const resumeInput = ctx.resumeInputs['confirm_vip_discount'];
     if (args.tier.includes('VIP')) {
-      if (resume === undefined) {
+      if (!resumeInput) {
         yield new RequestInput({
           interruptId: 'confirm_vip_discount',
           message: `Apply VIP discount for tier '${args.tier}'?`,
         });
         return;
       }
-      const answer =
-        typeof resume === 'object' && resume !== null
-          ? (resume as {text?: string}).text
-          : resume;
-      // Same affirmative normalization the other HITL samples use.
-      yield ['yes', 'y', 'true', 'approve', 'approved'].includes(
-        String(answer).trim().toLowerCase(),
-      )
+
+      const userResponse =
+        typeof resumeInput === 'object' && resumeInput !== null
+          ? (resumeInput as {text?: string}).text
+          : resumeInput;
+      yield ['yes', 'y', 'true'].includes(String(userResponse).toLowerCase())
         ? '20% off'
         : '5% off (VIP declined)';
     } else {
@@ -73,19 +69,20 @@ const calculateDiscount = node(
   },
   {
     name: 'calculate_discount',
-    description:
-      'Calculates the discount percentage based on the customer tier.',
+    description: 'Calculates the discount percentage based on customer tier.',
     inputSchema: z.object({
-      tier: z.string().describe('The customer membership tier (e.g. VIP).'),
+      tier: z
+        .string()
+        .describe("The customer's membership tier (e.g., VIP, Standard)."),
     }),
+    outputSchema: z.string(),
     rerunOnResume: true,
   },
 );
 
-// A Workflow exposed as a tool: looks up customer status/tier by user_id.
 const lookupCustomerData = node(
-  (_ctx: NodeContext, args: {userId: string}) => ({
-    userId: args.userId,
+  (_ctx: NodeContext, nodeInput: {user_id: string}) => ({
+    user_id: nodeInput.user_id,
     tier: 'Verified VIP Member',
   }),
   {name: 'lookup_customer_data'},
@@ -98,15 +95,20 @@ const customerLookupWorkflow = new Workflow({
   edges: [['START', lookupCustomerData]],
 });
 
-// The agent uses both the Workflow and the node as tools.
 export const rootAgent = new LlmAgent({
   name: 'customer_service_agent',
   model: 'gemini-2.5-flash',
   instruction: `
     You are a customer service assistant.
     1. First, call \`customer_lookup_workflow\` using the user_id to get their membership tier.
-    2. Then, call \`calculate_discount\` with that tier to find out what discount they get.
+    2. Then, call \`calculate_discount\` node with that tier to find out what discount they get.
     Summarize these details for the customer.
     `,
   tools: [customerLookupWorkflow, calculateDiscount],
+});
+
+export const app = new App({
+  name: 'node_as_tool',
+  rootAgent,
+  resumabilityConfig: createResumabilityConfig({isResumable: true}),
 });

--- a/tests/integration/workflows/node_as_tool/model_responses.json
+++ b/tests/integration/workflows/node_as_tool/model_responses.json
@@ -1,20 +1,20 @@
 [
   {
-    "key": "5c12572a300d06ce",
-    "instructionAgnosticKey": "3855f18c9f65f0c3",
+    "key": "d745c2462b709e3f",
+    "instructionAgnosticKey": "cd29e9d8047eef5e",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "Look up user u123 and tell me my discount."
+              "text": "Look up user c123 and tell me my discount."
             }
           ]
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` node with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
         "tools": [
           {
             "functionDeclarations": [
@@ -24,25 +24,25 @@
                 "parameters": {
                   "type": "OBJECT",
                   "properties": {
-                    "userId": {
+                    "user_id": {
                       "type": "STRING",
                       "description": "The customer's unique identifier."
                     }
                   },
                   "required": [
-                    "userId"
+                    "user_id"
                   ]
                 }
               },
               {
                 "name": "calculate_discount",
-                "description": "Calculates the discount percentage based on the customer tier.",
+                "description": "Calculates the discount percentage based on customer tier.",
                 "parameters": {
                   "type": "OBJECT",
                   "properties": {
                     "tier": {
                       "type": "STRING",
-                      "description": "The customer membership tier (e.g. VIP)."
+                      "description": "The customer's membership tier (e.g., VIP, Standard)."
                     }
                   },
                   "required": [
@@ -68,9 +68,9 @@
                 "functionCall": {
                   "name": "customer_lookup_workflow",
                   "args": {
-                    "userId": "u123"
+                    "user_id": "c123"
                   },
-                  "id": "adk-f58be2e3-f696-4d15-8dee-0cee5c320702"
+                  "id": "adk-e49b8903-4128-4665-bf17-af8f9b73509e"
                 }
               }
             ]
@@ -79,36 +79,36 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 154,
-        "candidatesTokenCount": 10,
-        "totalTokenCount": 271,
+        "promptTokenCount": 162,
+        "candidatesTokenCount": 12,
+        "totalTokenCount": 263,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 154
+            "tokenCount": 162
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 10
+            "tokenCount": 12
           }
         ],
-        "thoughtsTokenCount": 107
+        "thoughtsTokenCount": 89
       }
     }
   },
   {
-    "key": "ea80007f6409252c",
-    "instructionAgnosticKey": "0f0a2260e6e894d0",
+    "key": "31758cfb2f2b5c51",
+    "instructionAgnosticKey": "9c901c45de75f6ba",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "Look up user u123 and tell me my discount."
+              "text": "Look up user c123 and tell me my discount."
             }
           ]
         },
@@ -119,7 +119,7 @@
               "functionCall": {
                 "name": "customer_lookup_workflow",
                 "args": {
-                  "userId": "u123"
+                  "user_id": "c123"
                 }
               }
             }
@@ -132,7 +132,7 @@
               "functionResponse": {
                 "name": "customer_lookup_workflow",
                 "response": {
-                  "userId": "u123",
+                  "user_id": "c123",
                   "tier": "Verified VIP Member"
                 }
               }
@@ -141,7 +141,7 @@
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` node with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
         "tools": [
           {
             "functionDeclarations": [
@@ -151,25 +151,25 @@
                 "parameters": {
                   "type": "OBJECT",
                   "properties": {
-                    "userId": {
+                    "user_id": {
                       "type": "STRING",
                       "description": "The customer's unique identifier."
                     }
                   },
                   "required": [
-                    "userId"
+                    "user_id"
                   ]
                 }
               },
               {
                 "name": "calculate_discount",
-                "description": "Calculates the discount percentage based on the customer tier.",
+                "description": "Calculates the discount percentage based on customer tier.",
                 "parameters": {
                   "type": "OBJECT",
                   "properties": {
                     "tier": {
                       "type": "STRING",
-                      "description": "The customer membership tier (e.g. VIP)."
+                      "description": "The customer's membership tier (e.g., VIP, Standard)."
                     }
                   },
                   "required": [
@@ -197,7 +197,7 @@
                   "args": {
                     "tier": "Verified VIP Member"
                   },
-                  "id": "adk-c050f74b-0a29-4720-86a2-fde8da23cb6b"
+                  "id": "adk-f6ee1e8a-2716-4b6f-9a4e-0dc93a9450fb"
                 }
               }
             ]
@@ -206,14 +206,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 178,
+        "promptTokenCount": 190,
         "candidatesTokenCount": 7,
-        "totalTokenCount": 185,
+        "totalTokenCount": 269,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 178
+            "tokenCount": 190
           }
         ],
         "candidatesTokensDetails": [
@@ -221,20 +221,21 @@
             "modality": "TEXT",
             "tokenCount": 7
           }
-        ]
+        ],
+        "thoughtsTokenCount": 72
       }
     }
   },
   {
-    "key": "028f0c7b0f0252ef",
-    "instructionAgnosticKey": "a7d31ef585c10ae6",
+    "key": "106beb6c3c01fe20",
+    "instructionAgnosticKey": "2c0ec1ce41d3014e",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "Look up user u123 and tell me my discount."
+              "text": "Look up user c123 and tell me my discount."
             }
           ]
         },
@@ -245,7 +246,7 @@
               "functionCall": {
                 "name": "customer_lookup_workflow",
                 "args": {
-                  "userId": "u123"
+                  "user_id": "c123"
                 }
               }
             }
@@ -258,7 +259,7 @@
               "functionResponse": {
                 "name": "customer_lookup_workflow",
                 "response": {
-                  "userId": "u123",
+                  "user_id": "c123",
                   "tier": "Verified VIP Member"
                 }
               }
@@ -272,7 +273,7 @@
               "text": "For context:"
             },
             {
-              "text": "[lookup_customer_data] said: {\"userId\":\"u123\",\"tier\":\"Verified VIP Member\"}"
+              "text": "[lookup_customer_data] said: {\"user_id\":\"c123\",\"tier\":\"Verified VIP Member\"}"
             }
           ]
         },
@@ -304,7 +305,7 @@
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"customer_service_agent\".\n\n\n    You are a customer service assistant.\n    1. First, call `customer_lookup_workflow` using the user_id to get their membership tier.\n    2. Then, call `calculate_discount` node with that tier to find out what discount they get.\n    Summarize these details for the customer.\n    ",
         "tools": [
           {
             "functionDeclarations": [
@@ -314,25 +315,25 @@
                 "parameters": {
                   "type": "OBJECT",
                   "properties": {
-                    "userId": {
+                    "user_id": {
                       "type": "STRING",
                       "description": "The customer's unique identifier."
                     }
                   },
                   "required": [
-                    "userId"
+                    "user_id"
                   ]
                 }
               },
               {
                 "name": "calculate_discount",
-                "description": "Calculates the discount percentage based on the customer tier.",
+                "description": "Calculates the discount percentage based on customer tier.",
                 "parameters": {
                   "type": "OBJECT",
                   "properties": {
                     "tier": {
                       "type": "STRING",
-                      "description": "The customer membership tier (e.g. VIP)."
+                      "description": "The customer's membership tier (e.g., VIP, Standard)."
                     }
                   },
                   "required": [
@@ -355,7 +356,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Your membership tier is \"Verified VIP Member\" and your discount is 20% off."
+                "text": "Your discount for user c123, who is a Verified VIP Member, is 20% off."
               }
             ]
           },
@@ -363,23 +364,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 219,
-        "candidatesTokenCount": 19,
-        "totalTokenCount": 291,
+        "promptTokenCount": 233,
+        "candidatesTokenCount": 23,
+        "totalTokenCount": 371,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 219
+            "tokenCount": 233
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 19
+            "tokenCount": 23
           }
         ],
-        "thoughtsTokenCount": 53
+        "thoughtsTokenCount": 115
       }
     }
   }

--- a/tests/integration/workflows/node_as_tool/node_as_tool_test.ts
+++ b/tests/integration/workflows/node_as_tool/node_as_tool_test.ts
@@ -8,50 +8,50 @@
  * Runs the real `node_as_tool` sample: an LlmAgent uses a Workflow and a node as
  * tools (auto-wrapped as NodeTools). The discount node raises a RequestInput
  * mid-tool-call (HITL); the next turn answers it and the tool result flows back
- * to the model.
+ * to the model. Turns and expectations mirror the Python golden
+ * `contributing/samples/workflows/node_as_tool/tests/go.json`, including its
+ * `{"text": "yes"}` reply shape and the App-level resumability the sample needs.
  */
 
 import {getFunctionCalls, getFunctionResponses} from '@google/adk';
-import {Content} from '@google/genai';
 import {describe, expect, it} from 'vitest';
+import {answer, joinedText} from '../_harness/hitl.js';
 import {allEvents, runSample} from '../_harness/sample_harness.js';
-import {rootAgent} from './agent.js';
+import {app, rootAgent} from './agent.js';
 
 describe('workflow sample: node_as_tool (HITL mid-tool)', () => {
   it('calls node/workflow tools and resumes a mid-tool interrupt', async () => {
-    // Turn 2 answers the node-tool's RequestInput (fixed interruptId).
-    const resume: Content = {
-      role: 'user',
-      parts: [
-        {
-          functionResponse: {
-            id: 'confirm_vip_discount',
-            name: 'adk_request_input',
-            response: {result: 'yes'},
-          },
-        },
-      ],
-    };
-
     const perTurn = await runSample({
       name: 'node_as_tool',
       rootAgent,
-      turns: ['Look up user u123 and tell me my discount.', resume],
+      app,
+      turns: [
+        'Look up user c123 and tell me my discount.',
+        answer('adk_request_input', {text: 'yes'}),
+      ],
     });
     const [turn1, turn2] = perTurn;
 
-    // Turn 1: the model calls the lookup tool and the discount node-tool, which
-    // raises a RequestInput interrupt.
     const turn1Calls = turn1
       .flatMap((e) => getFunctionCalls(e))
       .map((c) => c.name);
     expect(turn1Calls).toContain('customer_lookup_workflow');
     expect(turn1Calls).toContain('adk_request_input');
 
+    const lookup = turn1
+      .flatMap((e) => getFunctionResponses(e))
+      .find((fr) => fr.name === 'customer_lookup_workflow');
+    expect(JSON.stringify(lookup?.response)).toContain('Verified VIP Member');
+    expect(JSON.stringify(lookup?.response)).toContain('user_id');
+
+    expect(joinedText(turn1)).toContain(
+      "Checking discount rules for tier 'Verified VIP Member'...",
+    );
+
     // Turn 2: the node-tool re-runs with the answer and returns the VIP discount.
     const discount = allEvents([turn2])
       .flatMap((e) => getFunctionResponses(e))
       .find((fr) => fr.name === 'calculate_discount');
     expect(JSON.stringify(discount?.response)).toContain('20% off');
-  });
+  }, 120000);
 });

--- a/tests/integration/workflows/node_output/agent.ts
+++ b/tests/integration/workflows/node_output/agent.ts
@@ -3,16 +3,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/node_output/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Node output styles: a raw string, an explicit `Event({output})`, a
- * schema-typed LlmAgent output, and a downstream node consuming it. Faithful
- * port of Python `contributing/samples/workflows/node_output`.
+ * schema-typed LlmAgent output, and a downstream node consuming it. One-to-one
+ * port of Python `contributing/samples/workflows/node_output/agent.py`.
  *
  * Requires an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/node_output/agent.ts
+ *   npm run sample -- tests/integration/workflows/node_output/agent.ts
  */
 
 import {createEvent, LlmAgent, node, NodeContext, Workflow} from '@google/adk';
@@ -50,7 +47,7 @@ const consumePydanticOutput = node(
     `Title: ${nodeInput.title}\n` +
     `Description: ${nodeInput.description}\n` +
     `Category: ${nodeInput.category}`,
-  {name: 'consume_pydantic_output'},
+  {name: 'consume_pydantic_output', inputSchema: topicDetails},
 );
 
 export const rootAgent = new Workflow({

--- a/tests/integration/workflows/node_output/model_responses.json
+++ b/tests/integration/workflows/node_output/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "9770890d07d83c14",
-    "instructionAgnosticKey": "5583ad5423f13dc1",
+    "key": "e2e6a68125810d7f",
+    "instructionAgnosticKey": "c59e48dcc910513c",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "ocean exploration"
+              "text": "go"
             }
           ]
         },
@@ -19,7 +19,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_string_output] said: Processed input: ocean exploration"
+              "text": "[generate_string_output] said: Processed input: go"
             }
           ]
         },
@@ -27,7 +27,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "Event wrapped output: Processed input: ocean exploration"
+              "text": "Event wrapped output: Processed input: go"
             }
           ]
         }
@@ -69,7 +69,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\n  \"title\": \"Abyssal Archives: Unearthing the Ocean's Hidden History and Future Secrets\",\n  \"description\": \"Explore how cutting-edge ocean exploration technologies are not only discovering new life forms and geological wonders in the deep sea, but also revealing forgotten histories and providing critical insights into the future of Earth's climate and biodiversity.\",\n  \"category\": \"Marine Science & Future Discovery\"\n}"
+                "text": "{\n  \"title\": \"Just Go: Embracing the Journey of Action and Discovery\",\n  \"description\": \"A deep dive into the philosophy of taking the first step, overcoming inertia, and finding liberation in the act of beginning, whether it's a new project, a personal goal, or an adventure.\",\n  \"category\": \"Personal Growth\"\n}"
               }
             ]
           },
@@ -77,23 +77,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 71,
-        "candidatesTokenCount": 88,
-        "totalTokenCount": 443,
+        "promptTokenCount": 68,
+        "candidatesTokenCount": 76,
+        "totalTokenCount": 676,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 71
+            "tokenCount": 68
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 88
+            "tokenCount": 76
           }
         ],
-        "thoughtsTokenCount": 284
+        "thoughtsTokenCount": 532
       }
     }
   }

--- a/tests/integration/workflows/node_output/node_output_test.ts
+++ b/tests/integration/workflows/node_output/node_output_test.ts
@@ -5,35 +5,47 @@
  */
 
 /**
- * Runs the real `node_output` sample: raw-string, Event({output}), and a
- * schema-typed LlmAgent output consumed by a downstream node.
+ * Runs the real `node_output` sample: the four ways a node can produce output,
+ * chained. Turn and expectations mirror the Python golden
+ * `contributing/samples/workflows/node_output/tests/go.json`.
  */
 
 import {describe, expect, it} from 'vitest';
-import {
-  allEvents,
-  authors,
-  finalOutput,
-  runSample,
-} from '../_harness/sample_harness.js';
+import {allEvents, finalOutput, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: node_output', () => {
-  it('threads a schema-typed LLM output into the consuming node', async () => {
+  it('threads each output style into the next node', async () => {
     const perTurn = await runSample({
       name: 'node_output',
       rootAgent,
-      turns: ['ocean exploration'],
+      turns: ['go'],
     });
     const events = allEvents(perTurn);
 
-    // The schema-typed LLM node ran.
-    expect(authors(events).has('generate_pydantic_output')).toBe(true);
+    const outputOf = (author: string) =>
+      events.find((e) => e.author === author && e.output !== undefined)?.output;
 
-    // The final node rendered the structured fields it received.
-    const output = finalOutput(events);
-    expect(typeof output).toBe('string');
-    expect(output as string).toContain('Received Pydantic Model!');
-    expect(output as string).toContain('Title:');
+    expect(outputOf('generate_string_output')).toBe('Processed input: go');
+    expect(outputOf('generate_event_output')).toBe(
+      'Event wrapped output: Processed input: go',
+    );
+
+    const topic = outputOf('generate_pydantic_output') as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(topic).sort()).toEqual([
+      'category',
+      'description',
+      'title',
+    ]);
+
+    expect(finalOutput(events)).toBe(
+      'Received Pydantic Model!\n' +
+        `Title: ${topic['title']}\n` +
+        `Description: ${topic['description']}\n` +
+        `Category: ${topic['category']}`,
+    );
   });
 });

--- a/tests/integration/workflows/parallel_worker/agent.ts
+++ b/tests/integration/workflows/parallel_worker/agent.ts
@@ -3,17 +3,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/parallel_worker/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Parallel worker: an LlmAgent generates related topics, each is uppercased and
  * explained by a parallel worker (a function and an agent with
- * `parallelWorker: true`), then results are aggregated. Faithful port of Python
- * `contributing/samples/workflows/parallel_worker`.
+ * `parallelWorker: true`), then results are aggregated. One-to-one port of
+ * Python `contributing/samples/workflows/parallel_worker/agent.py`.
  *
  * Requires an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/parallel_worker/agent.ts
+ *   npm run sample -- tests/integration/workflows/parallel_worker/agent.ts
  * Enter a topic, e.g. "databases".
  */
 
@@ -45,7 +42,7 @@ const makeUpperCase = node(
   function* (_c: NodeContext, nodeInput: string) {
     yield nodeInput.toUpperCase();
   },
-  {name: 'make_upper_case', parallelWorker: true, maxParallelWorkers: 2},
+  {name: 'make_upper_case', parallelWorker: true},
 );
 
 const explainTopic = node(
@@ -53,19 +50,17 @@ const explainTopic = node(
     name: 'explain_topic',
     model: 'gemini-2.5-flash',
     instruction:
-      'Explain how the following topic relates to the original topic: "{topic}".',
+      'Explain how the following topic relates the the original topic: "{topic}".',
     outputSchema: z.object({topic: z.string(), explanation: z.string()}),
   }),
-  // Bound concurrency (at most 2 live model calls at once), demonstrating the
-  // `maxParallelWorkers` field the README advertises.
-  {parallelWorker: true, maxParallelWorkers: 2},
+  {parallelWorker: true},
 );
 
 const aggregate = node(
   (_c: NodeContext, nodeInput: TopicExplanation[]) =>
     createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [
           {
             text: nodeInput

--- a/tests/integration/workflows/parallel_worker/model_responses.json
+++ b/tests/integration/workflows/parallel_worker/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "cd9270015161d3d2",
-    "instructionAgnosticKey": "4264aed4e3cdf2d9",
+    "key": "92014c360cbc0a50",
+    "instructionAgnosticKey": "0c04e22ff5342701",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "databases"
+              "text": "flower"
             }
           ]
         }
@@ -21,7 +21,7 @@
           }
         },
         "responseMimeType": "application/json",
-        "systemInstruction": "Given the specific topic \"databases\", generate a list of 3 related topics.",
+        "systemInstruction": "Given the specific topic \"flower\", generate a list of 3 related topics.",
         "labels": {
           "adk_agent_name": "find_related_topics"
         }
@@ -31,41 +31,47 @@
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "[\"SQL\", \"NoSQL\", \"Data Warehousing\"]"
+                "text": "[\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
         "promptTokenCount": 19,
-        "candidatesTokenCount": 12,
-        "totalTokenCount": 185,
+        "candidatesTokenCount": 21,
+        "totalTokenCount": 133,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
             "tokenCount": 19
           }
         ],
-        "thoughtsTokenCount": 154,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 21
+          }
+        ],
+        "thoughtsTokenCount": 93
       }
     }
   },
   {
-    "key": "e3bca3321aba963d",
-    "instructionAgnosticKey": "6e24d936094013e3",
+    "key": "57f651819556f230",
+    "instructionAgnosticKey": "5851154691d9ee9f",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "databases"
+              "text": "flower"
             }
           ]
         },
@@ -76,7 +82,7 @@
               "text": "For context:"
             },
             {
-              "text": "[find_related_topics] said: [\"SQL\", \"NoSQL\", \"Data Warehousing\"]"
+              "text": "[find_related_topics] said: [\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
             }
           ]
         },
@@ -84,24 +90,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "SQL"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[make_upper_case] said: SQL"
-            },
-            {
-              "text": "[make_upper_case] said: NOSQL"
-            },
-            {
-              "text": "[make_upper_case] said: DATA WAREHOUSING"
+              "text": "BOTANY"
             }
           ]
         }
@@ -123,7 +112,7 @@
           ]
         },
         "responseMimeType": "application/json",
-        "systemInstruction": "Explain how the following topic relates to the original topic: \"databases\".",
+        "systemInstruction": "Explain how the following topic relates the the original topic: \"flower\".",
         "labels": {
           "adk_agent_name": "explain_topic"
         }
@@ -133,41 +122,47 @@
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\n  \"topic\": \"SQL\",\n  \"explanation\": \"SQL (Structured Query Language) is the standard language used for managing and manipulating relational databases. It is fundamental to interacting with, defining, and querying data stored in many types of databases.\"\n}"
+                "text": "{\n  \"topic\": \"BOTANY\",\n  \"explanation\": \"Botany is the scientific study of plants, and flowers are the reproductive structures of many plant species. Therefore, the study of flowers, their structure, function, classification, and evolution, is a core component of botany.\"\n}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 83,
-        "candidatesTokenCount": 54,
-        "totalTokenCount": 171,
+        "promptTokenCount": 57,
+        "candidatesTokenCount": 62,
+        "totalTokenCount": 153,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 83
+            "tokenCount": 57
           }
         ],
-        "thoughtsTokenCount": 34,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 62
+          }
+        ],
+        "thoughtsTokenCount": 34
       }
     }
   },
   {
-    "key": "3b2b3199b7187a30",
-    "instructionAgnosticKey": "3691cf3130333b0a",
+    "key": "74227dc97594ce04",
+    "instructionAgnosticKey": "77607772828009d0",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "databases"
+              "text": "flower"
             }
           ]
         },
@@ -178,7 +173,7 @@
               "text": "For context:"
             },
             {
-              "text": "[find_related_topics] said: [\"SQL\", \"NoSQL\", \"Data Warehousing\"]"
+              "text": "[find_related_topics] said: [\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
             }
           ]
         },
@@ -186,24 +181,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "NOSQL"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[make_upper_case] said: SQL"
-            },
-            {
-              "text": "[make_upper_case] said: NOSQL"
-            },
-            {
-              "text": "[make_upper_case] said: DATA WAREHOUSING"
+              "text": "GARDENING"
             }
           ]
         }
@@ -225,7 +203,7 @@
           ]
         },
         "responseMimeType": "application/json",
-        "systemInstruction": "Explain how the following topic relates to the original topic: \"databases\".",
+        "systemInstruction": "Explain how the following topic relates the the original topic: \"flower\".",
         "labels": {
           "adk_agent_name": "explain_topic"
         }
@@ -235,41 +213,47 @@
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"topic\": \"NOSQL\", \"explanation\": \"NoSQL (originally referring to 'non-SQL' or 'not only SQL') is a category of databases that provides a mechanism for storage and retrieval of data that is modeled in means other than the tabular relations used in traditional relational databases (which typically use SQL). While traditional databases are primarily relational, NoSQL databases encompass a wide variety of database technologies developed in response to the demands of modern web applications, big data, and real-time data processing. They are often chosen for their flexibility, scalability, and performance with specific data models, such as document, key-value, wide-column, or graph stores, making them a direct alternative or complement to SQL databases within the broader domain of 'databases'.\"}"
+                "text": "{\n  \"topic\": \"GARDENING\",\n  \"explanation\": \"Gardening is the practice of cultivating and caring for plants, including flowers. Flowers are a primary focus in many gardens, grown for their aesthetic beauty, fragrance, or for purposes like cutting or attracting pollinators. Therefore, gardening is the activity directly involving the planting, growing, and maintenance of flowers.\"\n}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 84,
-        "candidatesTokenCount": 154,
-        "totalTokenCount": 309,
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 78,
+        "totalTokenCount": 172,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 84
+            "tokenCount": 58
           }
         ],
-        "thoughtsTokenCount": 71,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 78
+          }
+        ],
+        "thoughtsTokenCount": 36
       }
     }
   },
   {
-    "key": "e1c11a98f2b06d10",
-    "instructionAgnosticKey": "a577040a3abddd36",
+    "key": "077708ea225d7754",
+    "instructionAgnosticKey": "98824ea692e191ff",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "databases"
+              "text": "flower"
             }
           ]
         },
@@ -280,7 +264,7 @@
               "text": "For context:"
             },
             {
-              "text": "[find_related_topics] said: [\"SQL\", \"NoSQL\", \"Data Warehousing\"]"
+              "text": "[find_related_topics] said: [\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
             }
           ]
         },
@@ -288,24 +272,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "For context:"
-            },
-            {
-              "text": "[make_upper_case] said: SQL"
-            },
-            {
-              "text": "[make_upper_case] said: NOSQL"
-            },
-            {
-              "text": "[make_upper_case] said: DATA WAREHOUSING"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "DATA WAREHOUSING"
+              "text": "POLLINATION"
             }
           ]
         }
@@ -327,7 +294,7 @@
           ]
         },
         "responseMimeType": "application/json",
-        "systemInstruction": "Explain how the following topic relates to the original topic: \"databases\".",
+        "systemInstruction": "Explain how the following topic relates the the original topic: \"flower\".",
         "labels": {
           "adk_agent_name": "explain_topic"
         }
@@ -337,28 +304,34 @@
       "candidates": [
         {
           "content": {
+            "role": "model",
             "parts": [
               {
-                "text": "{\"topic\":\"DATA WAREHOUSING\",\"explanation\":\"DATA WAREHOUSING is a specialized type of database system designed for analytical processing rather than transactional operations. While databases focus on storing and retrieving current data for day-to-day operations, data warehouses consolidate and store historical data from multiple operational databases to support business intelligence activities, reporting, and data analysis. They are structured differently, often using star or snowflake schemas, to optimize for complex queries and aggregations across large datasets, making them a crucial application and extension of database technology.\"}"
+                "text": "{\n  \"topic\": \"POLLINATION\",\n  \"explanation\": \"Pollination is a vital process directly involving flowers. It is the transfer of pollen, typically from the anther to the stigma of a flower, which enables fertilization and the production of seeds and fruits. Flowers are the reproductive organs of many plants, specifically evolved to attract pollinators (like insects or birds) or to facilitate wind pollination, making them central to the entire pollination mechanism.\"\n}"
               }
-            ],
-            "role": "model"
+            ]
           },
           "finishReason": "STOP"
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 87,
-        "candidatesTokenCount": 108,
-        "totalTokenCount": 345,
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 94,
+        "totalTokenCount": 191,
+        "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 87
+            "tokenCount": 58
           }
         ],
-        "thoughtsTokenCount": 150,
-        "serviceTier": "standard"
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 94
+          }
+        ],
+        "thoughtsTokenCount": 39
       }
     }
   }

--- a/tests/integration/workflows/parallel_worker/parallel_worker_test.ts
+++ b/tests/integration/workflows/parallel_worker/parallel_worker_test.ts
@@ -5,10 +5,10 @@
  */
 
 /**
- * Runs the real `samples/workflows/parallel_worker` agent with recorded model
- * responses. The per-item worker LlmAgent fires several model calls
- * concurrently, so this exercises the fingerprint matcher's order/concurrency
- * independence.
+ * Runs the real `parallel_worker` sample: a topic list is fanned out across a
+ * per-item function worker and a per-item agent worker, then aggregated. Turn
+ * and expectations mirror the Python golden
+ * `contributing/samples/workflows/parallel_worker/tests/flower.json`.
  */
 
 import {describe, expect, it} from 'vitest';
@@ -16,29 +16,49 @@ import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: parallel_worker', () => {
-  it('maps a worker agent across items concurrently and aggregates', async () => {
+  it('maps both workers across the generated topics and aggregates', async () => {
     const perTurn = await runSample({
       name: 'parallel_worker',
       rootAgent,
-      turns: ['databases'],
+      turns: ['flower'],
     });
     const events = allEvents(perTurn);
 
-    // The generator agent and the aggregate node ran.
+    expect(events.map((e) => e.actions?.stateDelta ?? {})).toContainEqual({
+      topic: 'flower',
+    });
     expect(authors(events).has('find_related_topics')).toBe(true);
-    expect(authors(events).has('aggregate')).toBe(true);
 
-    // The worker agent ran for multiple items (concurrent model calls, each
-    // matched to its own recorded response by request fingerprint).
-    const explainEvents = events.filter((e) => e.author === 'explain_topic');
-    expect(explainEvents.length).toBeGreaterThanOrEqual(2);
+    const topics = events.find(
+      (e) => e.author === 'find_related_topics' && e.output !== undefined,
+    )?.output as string[];
+    expect(topics.length).toBeGreaterThanOrEqual(3);
 
-    // The aggregate node emits a human-readable summary (a message, not output).
-    const aggregateText = events
+    const uppercased = events
+      .filter((e) => e.author === 'make_upper_case' && e.output !== undefined)
+      .map((e) => e.output)
+      .filter((o) => typeof o === 'string') as string[];
+    expect(uppercased.sort()).toEqual(
+      topics.map((t) => t.toUpperCase()).sort(),
+    );
+
+    const explanations = events
+      .filter((e) => e.author === 'explain_topic' && e.output !== undefined)
+      .map((e) => e.output)
+      .filter(
+        (o): o is {topic: string; explanation: string} =>
+          !Array.isArray(o) && typeof o === 'object' && o !== null,
+      );
+    expect(explanations).toHaveLength(topics.length);
+
+    const text = events
       .filter((e) => e.author === 'aggregate')
       .flatMap((e) => e.content?.parts ?? [])
       .map((p) => p.text ?? '')
-      .join(' ');
-    expect(aggregateText.length).toBeGreaterThan(0);
-  });
+      .join('');
+    expect(text.split('\n\n---\n\n')).toHaveLength(topics.length);
+    for (const item of explanations) {
+      expect(text).toContain(`${item.topic}: ${item.explanation}`);
+    }
+  }, 120000);
 });

--- a/tests/integration/workflows/request_input/agent.ts
+++ b/tests/integration/workflows/request_input/agent.ts
@@ -3,22 +3,19 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/request_input/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Human-in-the-loop (two-node pattern). An LlmAgent drafts a reply to a customer
  * complaint; `request_human_review` pauses the workflow (RequestInput) and, on
  * resume, its successor `handle_human_review` receives the human's reply as its
  * input and routes on it (approve / reject / feedback-to-revise). Faithful port
- * of Python `contributing/samples/workflows/request_input`.
+ * of Python `contributing/samples/workflows/request_input/agent.py`.
  *
  * The two-node split relies on `rerun_on_resume=false` semantics: the node that
  * raised the interrupt does NOT re-run on resume; instead it completes with the
  * resume value as its output, which feeds the next node.
  *
  * REQUIRES an API key (draft_email calls a live model). Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/request_input/agent.ts
+ *   npm run sample -- tests/integration/workflows/request_input/agent.ts
  * Turn 1: type a complaint. Turn 2: type "approve", "reject", or feedback text.
  */
 
@@ -31,9 +28,9 @@ import {
   Workflow,
 } from '@google/adk';
 
-/** Emits a plain display message (Python `Event(message=...)`). */
+/** Python's `Event(message=...)` content shape (role `user`). */
 const message = (text: string) =>
-  createEvent({content: {role: 'model', parts: [{text}]}});
+  createEvent({content: {role: 'user', parts: [{text}]}});
 
 // Takes the initial customer complaint and seeds it into workflow state.
 const processInput = node(
@@ -71,13 +68,10 @@ const requestHumanReview = node(
 // Receives the human's reply (the resume value) as its input and routes on it.
 const handleHumanReview = node(
   (ctx: NodeContext, nodeInput: string) => {
-    // Normalize the reply (case/whitespace) before matching, so "Approve" or
-    // "approve " don't fall through to the revise branch.
-    const reply = String(nodeInput).trim().toLowerCase();
-    if (reply === 'reject') {
+    if (nodeInput === 'reject') {
       return createEvent({route: 'rejected'});
     }
-    if (reply === 'approve') {
+    if (nodeInput === 'approve') {
       return createEvent({route: 'approved'});
     }
     ctx.state.set('feedback', nodeInput);

--- a/tests/integration/workflows/request_input/model_responses.json
+++ b/tests/integration/workflows/request_input/model_responses.json
@@ -1,20 +1,20 @@
 [
   {
-    "key": "2286e7d95f2f2225",
-    "instructionAgnosticKey": "dc9308db164b54da",
+    "key": "2bb5ba2af14c8a1f",
+    "instructionAgnosticKey": "7d399be2c6c4129c",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "The product I bought broke after a day."
+              "text": "phone broke"
             }
           ]
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"The product I bought broke after a day.\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"phone broke\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
         "labels": {
           "adk_agent_name": "draft_email"
         }
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Subject: We're Sorry to Hear About Your Product Issue - Let's Make It Right\n\nDear [Customer Name],\n\nThank you for reaching out to us. I am truly sorry to hear that the product you purchased broke after just one day. We understand how frustrating and disappointing this must be, and it's certainly not the experience we want our customers to have with our products.\n\nWe are committed to providing high-quality items, and we want to help resolve this for you as quickly as possible.\n\nTo assist you efficiently, could you please provide us with the following information?\n\n*   Your order number or proof of purchase\n*   The name of the product you purchased\n*   A brief description of how the product broke (e.g., what happened, what part broke)\n*   Any photos or videos of the damaged product, if available (this can often help us understand the issue faster)\n\nOnce we have this information, we will be able to review your case and discuss the best resolution, whether that's a replacement, a refund, or a repair, according to our warranty policy.\n\nWe genuinely appreciate your patience and cooperation as we work to resolve this for you. Please reply to this email with the details requested, and we'll get right on it.\n\nSincerely,\n\nThe [Your Company Name] Team"
+                "text": "Subject: Re: Your recent inquiry regarding your phone\n\nDear Valued Customer,\n\nThank you for reaching out to us. I'm very sorry to hear that your phone has broken. I understand how frustrating and inconvenient this can be, and we're here to help.\n\nTo assist you best, could you please provide a few more details about what happened? Specifically, it would be helpful if you could tell us:\n\n*   **What is the model of your phone?** (e.g., iPhone 12, Samsung Galaxy S23, etc.)\n*   **What exactly happened to it?** (e.g., screen cracked, stopped turning on, dropped in water, etc.)\n*   **When did this occur?**\n*   **Have you tried any troubleshooting steps already?**\n\nOnce we have a better understanding of the situation, we can guide you through the next steps, which may include troubleshooting, repair options, warranty information, or potential replacement options.\n\nPlease reply to this email with the details, or if you prefer to speak with someone directly, you can call our support team at [Your Support Phone Number] during business hours.\n\nWe look forward to helping you resolve this as quickly as possible.\n\nSincerely,\n\n[Your Name/Support Team Name]\n[Your Company Name]\n[Your Company Website (Optional)]"
               }
             ]
           },
@@ -35,23 +35,79 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 71,
-        "candidatesTokenCount": 276,
-        "totalTokenCount": 810,
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 282,
+        "totalTokenCount": 580,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 71
+            "tokenCount": 58
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 276
+            "tokenCount": 282
           }
         ],
-        "thoughtsTokenCount": 463
+        "thoughtsTokenCount": 240
+      }
+    }
+  },
+  {
+    "key": "2bb5ba2af14c8a1f",
+    "instructionAgnosticKey": "7d399be2c6c4129c",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "phone broke"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"phone broke\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Subject: Regarding Your Phone Issue - We're Here to Help!\n\nDear [Customer Name],\n\nThank you for reaching out to us. We're very sorry to hear that your phone has broken, and we understand how frustrating this can be.\n\nTo help us best assist you, could you please provide a few more details?\n\n*   **What is the make and model of your phone?** (e.g., iPhone 15, Samsung Galaxy S23)\n*   **When did the phone break, and what happened?** (e.g., dropped it, screen stopped working, won't turn on, water damage)\n*   **When and where did you purchase the phone?** (This helps us check warranty status.)\n\nOnce we have this information, we can better advise you on the next steps, whether it's troubleshooting, warranty service, repair options, or a replacement.\n\nPlease reply to this email with the details, or feel free to call us directly at [Your Company Phone Number] if you'd prefer to discuss it over the phone. Our support team is available [Hours of Operation, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to helping you resolve this as quickly as possible.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 279,
+        "totalTokenCount": 546,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 58
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 279
+          }
+        ],
+        "thoughtsTokenCount": 209
       }
     }
   }

--- a/tests/integration/workflows/request_input/request_input_test.ts
+++ b/tests/integration/workflows/request_input/request_input_test.ts
@@ -5,42 +5,72 @@
  */
 
 /**
- * Runs the real `samples/workflows/request_input` agent with recorded model
- * responses across two turns: it drafts an email (live model), pauses for human
- * review (HITL interrupt), then resumes from a plain-text "approve" reply.
+ * Runs the real `request_input` sample (two-node HITL): an agent drafts a reply,
+ * `request_human_review` pauses, and its successor routes on the human's reply.
+ * Scenarios mirror the Python goldens
+ * `contributing/samples/workflows/request_input/tests/{phone_broke,phone_broke_reject}.json`.
  */
 
-import {Event} from '@google/adk';
 import {describe, expect, it} from 'vitest';
+import {answer, isPaused, joinedText} from '../_harness/hitl.js';
 import {authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
-function isPaused(events: Event[]): boolean {
-  return events.some((e) => (e.longRunningToolIds?.length ?? 0) > 0);
-}
-
-function joinedText(events: Event[]): string {
-  return events
-    .flatMap((e) => e.content?.parts ?? [])
-    .map((p) => p.text ?? '')
-    .join(' ');
-}
-
 describe('workflow sample: request_input (HITL)', () => {
-  it('drafts, pauses for review, and resumes on a plain-text approval', async () => {
+  it('drafts, pauses for review, and sends on approval', async () => {
     const perTurn = await runSample({
       name: 'request_input',
       rootAgent,
-      turns: ['The product I bought broke after a day.', 'approve'],
+      turns: ['phone broke', answer('adk_request_input', {result: 'approve'})],
     });
     const [turn1, turn2] = perTurn;
 
-    // Turn 1: the draft agent ran and the workflow paused for human review.
     expect(authors(turn1).has('draft_email')).toBe(true);
     expect(isPaused(turn1)).toBe(true);
 
-    // Turn 2: the plain-text "approve" resumed the workflow to the send branch.
-    expect(joinedText(turn2).toLowerCase()).toContain('approved');
+    expect(turn2.map((e) => e.route).filter(Boolean)).toEqual(['approved']);
+    expect(authors(turn2).has('send_email')).toBe(true);
+    expect(joinedText(turn2)).toContain(
+      'Draft approved and sent successfully.',
+    );
     expect(isPaused(turn2)).toBe(false);
-  });
+  }, 120000);
+
+  it('rejects the draft', async () => {
+    const perTurn = await runSample({
+      name: 'request_input',
+      rootAgent,
+      turns: ['phone broke', answer('adk_request_input', {result: 'reject'})],
+    });
+    const [, turn2] = perTurn;
+
+    expect(turn2.map((e) => e.route).filter(Boolean)).toEqual(['rejected']);
+    expect(joinedText(turn2)).toContain('Draft rejected.');
+    expect(isPaused(turn2)).toBe(false);
+  }, 120000);
+
+  it.skip('revises on feedback, then sends on approval', async () => {
+    const perTurn = await runSample({
+      name: 'request_input',
+      rootAgent,
+      turns: [
+        'phone broke',
+        answer('adk_request_input', {result: 'shorter'}),
+        answer('adk_request_input', {result: 'approve'}),
+      ],
+    });
+    const [, turn2, turn3] = perTurn;
+
+    expect(turn2.map((e) => e.route).filter(Boolean)).toEqual(['revise']);
+    expect(turn2.map((e) => e.actions?.stateDelta ?? {})).toContainEqual({
+      feedback: 'shorter',
+    });
+    expect(authors(turn2).has('draft_email')).toBe(true);
+    expect(isPaused(turn2)).toBe(true);
+
+    expect(turn3.map((e) => e.route).filter(Boolean)).toEqual(['approved']);
+    expect(joinedText(turn3)).toContain(
+      'Draft approved and sent successfully.',
+    );
+  }, 120000);
 });

--- a/tests/integration/workflows/request_input_advanced/agent.ts
+++ b/tests/integration/workflows/request_input_advanced/agent.ts
@@ -3,24 +3,23 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/request_input_advanced/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
 
 /**
  * Advanced human-in-the-loop with structured schemas. An LlmAgent extracts a
  * structured time-off request; `evaluate_request` auto-approves short requests
  * (<= 1 day) and otherwise pauses for manager approval (RequestInput carrying a
- * response schema). `process_decision` renders the outcome. Faithful port of
- * Python `contributing/samples/workflows/request_input_advanced`.
+ * response schema). `process_decision` renders the outcome. One-to-one port of
+ * Python `contributing/samples/workflows/request_input_advanced/agent.py`.
  *
- * The manager-approval branch uses `rerun_on_resume=false`: evaluate_request
- * does not re-run on resume; its output becomes the manager's decision, which
- * feeds process_decision.
+ * The manager-approval branch uses `rerunOnResume: false` (the default):
+ * evaluate_request does not re-run on resume; its output becomes the manager's
+ * decision, which feeds process_decision.
  *
  * REQUIRES an API key (process_request calls a live model). Set GEMINI_API_KEY:
- *   npm run sample -- samples/workflows/request_input_advanced/agent.ts
- * Turn 1: e.g. "I need 3 days off next week for a family trip".
- * Turn 2 (only if > 1 day): type "yes" or "no" to approve/deny.
+ *   npm run sample -- tests/integration/workflows/request_input_advanced/agent.ts
+ * Turn 1: e.g. "2 sick days".
+ * Turn 2 (only if > 1 day): reply with the structured decision, e.g.
+ * `{"approved": true}`.
  */
 
 import {
@@ -34,20 +33,26 @@ import {
 import {z} from 'zod';
 
 const timeOffRequestSchema = z.object({
-  days: z.number().describe('Number of days requested.'),
+  days: z.number().int().describe('Number of days requested.'),
   reason: z.string().describe('Reason for the time off.'),
 });
 type TimeOffRequest = z.infer<typeof timeOffRequestSchema>;
 
-const timeOffDecisionSchema = z.object({
-  approved: z.boolean().describe('Whether the time off is approved.'),
-  approvedDays: z.number().nullish().describe('Number of days approved.'),
-});
+const timeOffDecisionSchema = z
+  .object({
+    approved: z.boolean().describe('Whether the time off is approved.'),
+    approved_days: z
+      .number()
+      .int()
+      .nullish()
+      .describe('Number of days approved.'),
+  })
+  .describe('The structured response we expect back from the human manager.');
 type TimeOffDecision = z.infer<typeof timeOffDecisionSchema>;
 
-/** Emits a plain display message (Python `Event(message=...)`). */
+/** Python's `Event(message=...)` content shape (role `user`). */
 const message = (text: string) =>
-  createEvent({content: {role: 'model', parts: [{text}]}});
+  createEvent({content: {role: 'user', parts: [{text}]}});
 
 const processRequest = new LlmAgent({
   name: 'process_request',
@@ -64,15 +69,11 @@ const processRequest = new LlmAgent({
 // expected response schema.
 const evaluateRequest = node(
   (
-    ctx: NodeContext,
+    _ctx: NodeContext,
     request: TimeOffRequest,
   ): TimeOffDecision | RequestInput => {
-    // Persist the request so process_decision can read it back (TypeScript has
-    // no signature-based state injection like Python's `request` parameter).
-    ctx.state.set('request', request);
-
     if (request.days <= 1) {
-      return {approved: true, approvedDays: request.days};
+      return {approved: true};
     }
     return new RequestInput({
       interruptId: 'manager_approval',
@@ -85,35 +86,19 @@ const evaluateRequest = node(
 );
 
 const processDecision = node(
-  (ctx: NodeContext, nodeInput: TimeOffDecision | string) => {
-    const request = ctx.state.get<TimeOffRequest>('request');
-    const decision = normalizeDecision(nodeInput);
+  (ctx: NodeContext, nodeInput: TimeOffDecision) => {
+    const request = ctx.state.get<TimeOffRequest>('request')!;
 
-    if (decision.approved) {
-      const approvedDays = decision.approvedDays ?? request?.days ?? 0;
+    if (nodeInput.approved) {
+      const approvedDays = nodeInput.approved_days ?? request.days;
       return message(
-        `Time Off Approved! ${approvedDays} out of ${request?.days ?? approvedDays} days granted.`,
+        `Time Off Approved! ${approvedDays} out of ${request.days} days granted.`,
       );
     }
     return message('Time Off Denied.');
   },
-  {name: 'process_decision'},
+  {name: 'process_decision', inputSchema: timeOffDecisionSchema},
 );
-
-/**
- * Accepts either a structured {@link TimeOffDecision} (auto-approve path or a
- * structured resume) or a plain-string reply typed by an interactive user
- * (e.g. "yes"/"no"), and normalizes it to a decision.
- */
-function normalizeDecision(input: TimeOffDecision | string): TimeOffDecision {
-  if (typeof input === 'string') {
-    const yes = ['yes', 'y', 'true', 'approve', 'approved'].includes(
-      input.trim().toLowerCase(),
-    );
-    return {approved: yes};
-  }
-  return input;
-}
 
 export const rootAgent = new Workflow({
   name: 'request_input_advanced',

--- a/tests/integration/workflows/request_input_advanced/model_responses.json
+++ b/tests/integration/workflows/request_input_advanced/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "cd00e10c2b9ea2c8",
-    "instructionAgnosticKey": "a6cfda2775c1b821",
+    "key": "075ada6d0639573f",
+    "instructionAgnosticKey": "fe44a59739a4f475",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "I need 3 days off next week for a family trip."
+              "text": "1 sick day"
             }
           ]
         },
@@ -16,7 +16,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "I need 3 days off next week for a family trip."
+              "text": "1 sick day"
             }
           ]
         }
@@ -26,7 +26,9 @@
           "type": "OBJECT",
           "properties": {
             "days": {
-              "type": "NUMBER",
+              "type": "INTEGER",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991,
               "description": "Number of days requested."
             },
             "reason": {
@@ -53,7 +55,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\"days\": 3, \"reason\": \"family trip\"}"
+                "text": "{\"days\": 1, \"reason\": \"sick\"}"
               }
             ]
           },
@@ -61,14 +63,98 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 63,
-        "candidatesTokenCount": 13,
-        "totalTokenCount": 115,
+        "promptTokenCount": 45,
+        "candidatesTokenCount": 12,
+        "totalTokenCount": 108,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 63
+            "tokenCount": 45
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 12
+          }
+        ],
+        "thoughtsTokenCount": 51
+      }
+    }
+  },
+  {
+    "key": "e05c319f8df062fe",
+    "instructionAgnosticKey": "ec90e37d89e9eb1d",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "2 sick days"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "2 sick days"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "days": {
+              "type": "INTEGER",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991,
+              "description": "Number of days requested."
+            },
+            "reason": {
+              "type": "STRING",
+              "description": "Reason for the time off."
+            }
+          },
+          "required": [
+            "days",
+            "reason"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Extract the number of days and the reason from the user's natural language time off request.",
+        "labels": {
+          "adk_agent_name": "process_request"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "{\"days\": 2, \"reason\": \"sick days\"}"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 45,
+        "candidatesTokenCount": 13,
+        "totalTokenCount": 109,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 45
           }
         ],
         "candidatesTokensDetails": [
@@ -77,7 +163,7 @@
             "tokenCount": 13
           }
         ],
-        "thoughtsTokenCount": 39
+        "thoughtsTokenCount": 51
       }
     }
   }

--- a/tests/integration/workflows/request_input_advanced/request_input_advanced_test.ts
+++ b/tests/integration/workflows/request_input_advanced/request_input_advanced_test.ts
@@ -5,39 +5,80 @@
  */
 
 /**
- * Runs the real `request_input_advanced` sample: an LlmAgent extracts a
- * structured time-off request; short requests auto-approve, longer ones pause
- * for manager approval (structured RequestInput), resumed here by plain text.
+ * Runs the real `request_input_advanced` sample: an agent extracts a structured
+ * time-off request; short requests are auto-approved and longer ones pause for a
+ * manager decision declared by a response schema. Scenarios mirror the Python
+ * golden
+ * `contributing/samples/workflows/request_input_advanced/tests/2_sick_days.json`.
  */
 
-import {Event} from '@google/adk';
+import {getFunctionCalls} from '@google/adk';
 import {describe, expect, it} from 'vitest';
+import {answer, isPaused, joinedText} from '../_harness/hitl.js';
 import {authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
-const isPaused = (events: Event[]): boolean =>
-  events.some((e) => (e.longRunningToolIds?.length ?? 0) > 0);
-
-const joinedText = (events: Event[]): string =>
-  events
-    .flatMap((e) => e.content?.parts ?? [])
-    .map((p) => p.text ?? '')
-    .join(' ');
-
-describe('workflow sample: request_input_advanced (HITL)', () => {
-  it('extracts the request, pauses for approval, and resumes on "yes"', async () => {
+describe('workflow sample: request_input_advanced (structured HITL)', () => {
+  it('auto-approves a single day without asking the manager', async () => {
     const perTurn = await runSample({
       name: 'request_input_advanced',
       rootAgent,
-      turns: ['I need 3 days off next week for a family trip.', 'yes'],
+      turns: ['1 sick day'],
     });
-    const [turn1, turn2] = perTurn;
+    const [turn1] = perTurn;
 
-    // The extractor agent ran, and a >1-day request paused for approval.
     expect(authors(turn1).has('process_request')).toBe(true);
-    expect(isPaused(turn1)).toBe(true);
+    const request = turn1
+      .map((e) => e.actions?.stateDelta ?? {})
+      .find((d) => 'request' in d)?.['request'] as {
+      days: number;
+      reason: string;
+    };
+    expect(request.days).toBe(1);
+    expect(request.reason.toLowerCase()).toContain('sick');
 
-    // The plain-text "yes" approved the request.
-    expect(joinedText(turn2)).toContain('Approved');
-  });
+    expect(isPaused(turn1)).toBe(false);
+    expect(joinedText(turn1)).toContain(
+      'Time Off Approved! 1 out of 1 days granted.',
+    );
+  }, 120000);
+
+  it('pauses for a manager decision, advertising the response schema', async () => {
+    const perTurn = await runSample({
+      name: 'request_input_advanced',
+      rootAgent,
+      turns: ['2 sick days'],
+    });
+    const [turn1] = perTurn;
+
+    expect(isPaused(turn1)).toBe(true);
+    const call = turn1
+      .flatMap((e) => getFunctionCalls(e))
+      .find((c) => c.name === 'adk_request_input');
+    expect(call?.args?.['message']).toBe(
+      'Please review this time off request.',
+    );
+    expect(JSON.stringify(call?.args?.['payload'])).toContain('"days":2');
+    expect(JSON.stringify(call?.args)).toContain('approved_days');
+    expect(JSON.stringify(call?.args)).toContain(
+      'The structured response we expect back from the human manager.',
+    );
+  }, 120000);
+
+  it.skip('renders the decision from a structured resume', async () => {
+    const perTurn = await runSample({
+      name: 'request_input_advanced',
+      rootAgent,
+      turns: [
+        '2 sick days',
+        answer('adk_request_input', {result: '{"approved": true}'}),
+      ],
+    });
+    const [, turn2] = perTurn;
+
+    expect(joinedText(turn2)).toContain(
+      'Time Off Approved! 2 out of 2 days granted.',
+    );
+    expect(isPaused(turn2)).toBe(false);
+  }, 120000);
 });

--- a/tests/integration/workflows/request_input_rerun/agent.ts
+++ b/tests/integration/workflows/request_input_rerun/agent.ts
@@ -3,18 +3,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/request_input_rerun/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Human-in-the-loop (single-node, rerun-on-resume). An LlmAgent drafts a reply;
  * one `human_review` node both raises the RequestInput and, because it is marked
  * `rerunOnResume: true`, RE-RUNS on resume to consume the reply (via
- * `ctx.resumeInputs`) and route. Faithful port of Python
- * `contributing/samples/workflows/request_input_rerun`.
+ * `ctx.resumeInputs`) and route. One-to-one port of Python
+ * `contributing/samples/workflows/request_input_rerun/agent.py`.
  *
  * REQUIRES an API key (draft_email calls a live model). Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/request_input_rerun/agent.ts
+ *   npm run sample -- tests/integration/workflows/request_input_rerun/agent.ts
  * Turn 1: type a complaint. Turn 2: type "approve", "reject", or feedback text.
  */
 
@@ -27,9 +24,9 @@ import {
   Workflow,
 } from '@google/adk';
 
-/** Emits a plain display message (Python `Event(message=...)`). */
+/** Python's `Event(message=...)` content shape (role `user`). */
 const message = (text: string) =>
-  createEvent({content: {role: 'model', parts: [{text}]}});
+  createEvent({content: {role: 'user', parts: [{text}]}});
 
 // Takes the initial customer complaint and seeds it into workflow state.
 const processInput = node(
@@ -65,13 +62,10 @@ const humanReview = node(
       });
     }
 
-    // Normalize the reply (case/whitespace) before matching, so "Approve" or
-    // "approve " don't fall through to the revise branch.
-    const reply = String(resumeInput).trim().toLowerCase();
-    if (reply === 'reject') {
+    if (resumeInput === 'reject') {
       return createEvent({route: 'rejected'});
     }
-    if (reply === 'approve') {
+    if (resumeInput === 'approve') {
       return createEvent({route: 'approved'});
     }
     ctx.state.set('feedback', resumeInput);

--- a/tests/integration/workflows/request_input_rerun/model_responses.json
+++ b/tests/integration/workflows/request_input_rerun/model_responses.json
@@ -1,20 +1,20 @@
 [
   {
-    "key": "98b25193a6c2de82",
-    "instructionAgnosticKey": "684e2888794c2394",
+    "key": "2bb5ba2af14c8a1f",
+    "instructionAgnosticKey": "7d399be2c6c4129c",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "My order never arrived and support is ignoring me."
+              "text": "phone broke"
             }
           ]
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"My order never arrived and support is ignoring me.\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"phone broke\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
         "labels": {
           "adk_agent_name": "draft_email"
         }
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Subject: We're so sorry about your order and the lack of response - Let's fix this immediately\n\nDear Customer,\n\nPlease accept my sincerest apologies for the frustration and inconvenience you've experienced. It is completely unacceptable that your order has not arrived, and I am truly sorry to hear that you feel ignored by our support team. That is not the level of service we aim to provide, and I understand how disheartening that must be.\n\nI want to assure you that I am personally looking into this right away. To help me investigate your order status and resolve this for you as quickly as possible, could you please provide me with your:\n\n*   **Order Number:**\n*   **Email Address used for the order:**\n*   **(Optional, but helpful) Date of Purchase:**\n\nOnce I have this information, I will immediately:\n1.  Trace your shipment.\n2.  Review all previous support interactions.\n3.  Work directly with our logistics and support teams to find out exactly what happened and why your previous inquiries went unanswered.\n\nYou can expect to hear back from me within [e.g., 4-8 business hours / 24 hours] with a full update and a proposed resolution. My priority is to get this resolved for you quickly and to ensure you receive your order or a full refund, along with a proper explanation.\n\nThank you for your patience as we rectify this. Please feel free to reply directly to this email with the requested details or any further questions you may have.\n\nSincerely,\n\n[Your Name/Customer Service Manager]\n[Your Title]\n[Your Company]"
+                "text": "Subject: Regarding Your Recent Report - Phone Issue\n\nDear [Customer Name],\n\nThank you for reaching out to us. We're very sorry to hear that your phone is broken, and we understand how frustrating that can be.\n\nTo help us understand the situation better and assist you as quickly as possible, could you please provide us with a few more details? Specifically, it would be very helpful if you could tell us:\n\n1.  **What model of phone is it?** (e.g., iPhone 13, Samsung Galaxy S22, etc.)\n2.  **When did you purchase the phone?** (An approximate date is fine if you don't have the exact one)\n3.  **Can you describe what happened when it broke?** (e.g., dropped it, stopped working suddenly, screen cracked, won't turn on, water damage, etc.)\n4.  **Do you have any warranty or protection plans associated with the device?**\n\nOnce we have this information, we'll be able to guide you through the next steps, which may include troubleshooting, repair options, or potential replacement under warranty.\n\nPlease reply to this email with the details requested. Alternatively, if you prefer to speak with someone, you can call our support team at [Your Phone Number] during our business hours of [Business Hours, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to helping you resolve this issue promptly.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
               }
             ]
           },
@@ -35,23 +35,79 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 73,
-        "candidatesTokenCount": 337,
-        "totalTokenCount": 615,
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 323,
+        "totalTokenCount": 796,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 73
+            "tokenCount": 58
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 337
+            "tokenCount": 323
           }
         ],
-        "thoughtsTokenCount": 205
+        "thoughtsTokenCount": 415
+      }
+    }
+  },
+  {
+    "key": "2bb5ba2af14c8a1f",
+    "instructionAgnosticKey": "7d399be2c6c4129c",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "phone broke"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"phone broke\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Subject: Regarding Your Recent Phone Issue - How Can We Help?\n\nDear Valued Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone has broken, and we understand how frustrating and disruptive this can be. Please accept our sincerest apologies for the inconvenience this has caused.\n\nTo help us assist you best and find the quickest resolution, could you please provide us with a few more details? Specifically, it would be very helpful if you could tell us:\n\n*   What is the **model of your phone**?\n*   When did you **purchase it**? (This helps us check warranty status)\n*   Could you please describe **what happened** and **what exactly is broken or not working**? (e.g., screen cracked, not turning on, water damage, etc.)\n\nOnce we have this information, we can better advise you on the next steps, which may include troubleshooting, repair options, or exploring warranty coverage.\n\nIn the meantime, you can also visit our support page for common issues and warranty information here: [Link to Your Company's Support/Warranty Page]\n\nWe are committed to helping you get this resolved as quickly as possible. Please reply to this email with the details requested, or if you prefer to speak with someone directly, you can contact our support team at [Your Phone Number] or start a live chat on our website at [Link to Live Chat].\n\nThank you for your patience as we work to assist you.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 322,
+        "totalTokenCount": 1284,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 58
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 322
+          }
+        ],
+        "thoughtsTokenCount": 904
       }
     }
   }

--- a/tests/integration/workflows/request_input_rerun/request_input_rerun_test.ts
+++ b/tests/integration/workflows/request_input_rerun/request_input_rerun_test.ts
@@ -5,38 +5,64 @@
  */
 
 /**
- * Runs the real `request_input_rerun` sample: a single node raises the
- * RequestInput and, because it is `rerunOnResume: true`, re-runs on resume to
- * consume the reply and route.
+ * Runs the real `request_input_rerun` sample (single-node HITL): one
+ * `human_review` node both raises the interrupt and, because it is
+ * `rerunOnResume`, re-runs to consume the reply. Scenarios mirror the Python
+ * golden
+ * `contributing/samples/workflows/request_input_rerun/tests/phone_broke.json`.
  */
 
-import {Event} from '@google/adk';
 import {describe, expect, it} from 'vitest';
+import {answer, isPaused, joinedText} from '../_harness/hitl.js';
 import {authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
-const isPaused = (events: Event[]): boolean =>
-  events.some((e) => (e.longRunningToolIds?.length ?? 0) > 0);
-
-const joinedText = (events: Event[]): string =>
-  events
-    .flatMap((e) => e.content?.parts ?? [])
-    .map((p) => p.text ?? '')
-    .join(' ');
-
 describe('workflow sample: request_input_rerun (HITL)', () => {
-  it('drafts, pauses, and re-runs the node on approval', async () => {
+  it('re-runs the review node on resume and sends on approval', async () => {
     const perTurn = await runSample({
       name: 'request_input_rerun',
       rootAgent,
-      turns: ['My order never arrived and support is ignoring me.', 'approve'],
+      turns: ['phone broke', answer('adk_request_input', {result: 'approve'})],
     });
     const [turn1, turn2] = perTurn;
 
     expect(authors(turn1).has('draft_email')).toBe(true);
     expect(isPaused(turn1)).toBe(true);
 
-    expect(joinedText(turn2).toLowerCase()).toContain('approved');
+    expect(authors(turn2).has('human_review')).toBe(true);
+    expect(turn2.map((e) => e.route).filter(Boolean)).toEqual(['approved']);
+    expect(joinedText(turn2)).toContain(
+      'Draft approved and sent successfully.',
+    );
     expect(isPaused(turn2)).toBe(false);
-  });
+  }, 120000);
+
+  it('rejects the draft', async () => {
+    const perTurn = await runSample({
+      name: 'request_input_rerun',
+      rootAgent,
+      turns: ['phone broke', answer('adk_request_input', {result: 'reject'})],
+    });
+    const [, turn2] = perTurn;
+
+    expect(turn2.map((e) => e.route).filter(Boolean)).toEqual(['rejected']);
+    expect(joinedText(turn2)).toContain('Draft rejected.');
+  }, 120000);
+
+  it.skip('re-runs the review node to revise, then approves', async () => {
+    const perTurn = await runSample({
+      name: 'request_input_rerun',
+      rootAgent,
+      turns: [
+        'phone broke',
+        answer('adk_request_input', {result: 'shorter'}),
+        answer('adk_request_input', {result: 'approve'}),
+      ],
+    });
+    const [, turn2, turn3] = perTurn;
+
+    expect(turn2.map((e) => e.route).filter(Boolean)).toEqual(['revise']);
+    expect(isPaused(turn2)).toBe(true);
+    expect(turn3.map((e) => e.route).filter(Boolean)).toEqual(['approved']);
+  }, 120000);
 });

--- a/tests/integration/workflows/retry/agent.ts
+++ b/tests/integration/workflows/retry/agent.ts
@@ -3,30 +3,38 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/retry/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Retry: a mock task fails randomly (~70%) and is retried per its RetryConfig,
- * using `ctx.attemptCount`. Faithful port of Python
- * `contributing/samples/workflows/retry`.
+ * using `ctx.attemptCount`. One-to-one port of Python
+ * `contributing/samples/workflows/retry/agent.py`.
  *
- * Run (offline):  npm run sample -- samples/workflows/retry/agent.ts
+ * Run (offline):
+ *   npm run sample -- tests/integration/workflows/retry/agent.ts
  */
 
 import {createEvent, node, NodeContext, Workflow} from '@google/adk';
+
+/**
+ * Stands in for Python's `urllib.error.HTTPError`, so the failure event carries
+ * the same `errorCode`/`errorMessage` the Python sample produces.
+ */
+function httpError(code: number, msg: string): Error {
+  const error = new Error(`HTTP Error ${code}: ${msg}`);
+  error.name = 'HTTPError';
+  return error;
+}
 
 const getWeather = node(
   async function* (ctx: NodeContext) {
     yield createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [{text: `Getting weather... attempt ${ctx.attemptCount}`}],
       },
     });
     if (Math.random() < 0.7) {
       // 70% chance of failure
-      throw new Error('HTTP 500: Internal Server Error');
+      throw httpError(500, 'Internal Server Error');
     }
     yield 'sunny';
   },
@@ -36,7 +44,7 @@ const getWeather = node(
 const reportWeather = node(
   async function* (_c: NodeContext, weather: string) {
     yield createEvent({
-      content: {role: 'model', parts: [{text: `The weather is ${weather}`}]},
+      content: {role: 'user', parts: [{text: `The weather is ${weather}`}]},
     });
   },
   {name: 'report_weather'},

--- a/tests/integration/workflows/retry/retry_test.ts
+++ b/tests/integration/workflows/retry/retry_test.ts
@@ -5,42 +5,53 @@
  */
 
 /**
- * Runs the real `retry` sample (offline): a node fails randomly (~70%) and is
- * retried per its RetryConfig. `Math.random` is seeded so the run is
- * reproducible (and eventually succeeds within maxAttempts).
+ * Runs the real `retry` sample (offline): a flaky node is retried per its
+ * RetryConfig until it succeeds. Turn mirrors the Python golden
+ * `contributing/samples/workflows/retry/tests/go.json`, which mocks
+ * `random.random` to force exactly three attempts; here `Math.random` is
+ * seeded to a value that produces the same three attempts.
+ *
+ * The seed cannot be chosen to reproduce Python's exact draws: the engine's
+ * event-id generator draws from `Math.random` too (8 draws per event), so the
+ * sample's own draws are interleaved with it.
  */
 
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import {mulberry32} from '../_harness/rng.js';
-import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
+import {allEvents, finalOutput, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
-describe('workflow sample: retry', () => {
-  afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
-  it('retries the flaky node until it succeeds', async () => {
-    vi.spyOn(Math, 'random').mockImplementation(mulberry32(7));
+describe('workflow sample: retry', () => {
+  it('retries the failing node and reports the weather once it succeeds', async () => {
+    vi.spyOn(Math, 'random').mockImplementation(mulberry32(2));
 
     const perTurn = await runSample({
       name: 'retry',
       rootAgent,
-      turns: ['what is the weather?'],
+      turns: ['go'],
       offline: true,
     });
     const events = allEvents(perTurn);
 
-    // The node was attempted more than once (a retry happened) ...
-    const attempts = events.filter((e) =>
-      (e.content?.parts ?? []).some((p) => p.text?.includes('Getting weather')),
-    );
-    expect(attempts.length).toBeGreaterThanOrEqual(2);
-
-    // ... and ultimately succeeded, feeding the reporter node.
-    expect(authors(events).has('report_weather')).toBe(true);
-    const text = events
+    const texts = events
       .flatMap((e) => e.content?.parts ?? [])
       .map((p) => p.text ?? '')
-      .join(' ');
-    expect(text).toContain('The weather is sunny');
-  });
+      .filter(Boolean);
+
+    expect(
+      texts.filter((t) => t.startsWith('Getting weather... attempt')),
+    ).toEqual([
+      'Getting weather... attempt 1',
+      'Getting weather... attempt 2',
+      'Getting weather... attempt 3',
+    ]);
+    expect(finalOutput(events)).toBe('sunny');
+    expect(texts).toContain('The weather is sunny');
+
+    expect(events.filter((e) => e.errorCode !== undefined)).toHaveLength(0);
+  }, 30000);
 });

--- a/tests/integration/workflows/route/agent.ts
+++ b/tests/integration/workflows/route/agent.ts
@@ -3,18 +3,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/route/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Route: an LlmAgent classifies the input into a category, a routing node emits
  * that category as the route, and the matching branch (an LlmAgent, or a
- * function for the fallback) handles it. Faithful port of Python
- * `contributing/samples/workflows/route`.
+ * function for the fallback) handles it. One-to-one port of Python
+ * `contributing/samples/workflows/route/agent.py`.
  *
  * REQUIRES an API key (classification and answers call a live model). Set
  * GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/route/agent.ts
+ *   npm run sample -- tests/integration/workflows/route/agent.ts
  * Try "What is ADK?" (question) or "ADK is great." (statement).
  */
 
@@ -65,7 +62,7 @@ const handleOther = node(
   () =>
     createEvent({
       content: {
-        role: 'model',
+        role: 'user',
         parts: [
           {text: 'Sorry I can only answer questions or comment on statements.'},
         ],

--- a/tests/integration/workflows/route/model_responses.json
+++ b/tests/integration/workflows/route/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "e2ef67caafcbd841",
-    "instructionAgnosticKey": "c115d001eab3ef66",
+    "key": "7158435b179f11ee",
+    "instructionAgnosticKey": "5dd683d81fe3734a",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "What is ADK?"
+              "text": "who are you"
             }
           ]
         }
@@ -31,7 +31,7 @@
           ]
         },
         "responseMimeType": "application/json",
-        "systemInstruction": "Based on this input, decide which category it belongs to: What is ADK?",
+        "systemInstruction": "Based on this input, decide which category it belongs to: who are you",
         "labels": {
           "adk_agent_name": "classify_input"
         }
@@ -52,14 +52,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 29,
+        "promptTokenCount": 25,
         "candidatesTokenCount": 6,
-        "totalTokenCount": 67,
+        "totalTokenCount": 63,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 29
+            "tokenCount": 25
           }
         ],
         "candidatesTokensDetails": [
@@ -73,15 +73,15 @@
     }
   },
   {
-    "key": "d1fcb02355443296",
-    "instructionAgnosticKey": "468125998cc36437",
+    "key": "f2b4cd3df00d7860",
+    "instructionAgnosticKey": "91bb24ccd3a5ed98",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "What is ADK?"
+              "text": "who are you"
             }
           ]
         },
@@ -98,7 +98,7 @@
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"answer_question\".\n\nAnswer the question: What is ADK?",
+        "systemInstruction": "You are an agent. Your internal name is \"answer_question\".\n\nAnswer the question: who are you",
         "labels": {
           "adk_agent_name": "answer_question"
         }
@@ -111,7 +111,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "\"ADK\" can stand for several different things, depending on the context. Here are the most common interpretations:\n\n1.  **Application Development Kit (ADK):** This is a generic term referring to a set of software development tools that allows for the creation of applications for a certain software package, platform, hardware device, or operating system. It's very similar to an SDK (Software Development Kit) and often includes compilers, debuggers, libraries, APIs, documentation, and sample code.\n2.  **Android Development Kit:** While the official term is usually **Android SDK (Software Development Kit)**, \"ADK\" might sometimes be informally used to refer to the tools and resources for developing applications for the Android platform. There was also a specific \"Android ADK\" (Android Open Accessory Development Kit) for connecting hardware accessories to Android devices.\n3.  **Adirondack Park / Mountains:** Often abbreviated as \"ADK,\" this refers to a large protected area in northeastern New York State, known for its mountains, lakes, and forests. People might use \"ADK\" when talking about hiking, camping, or the region in general.\n4.  **Appliance Development Kit:** In the context of embedded systems or IoT (Internet of Things), an ADK might refer to tools used to develop software for specific smart appliances or connected devices.\n\nTo know exactly what \"ADK\" means in a specific situation, you usually need more context."
+                "text": "I am a large language model, trained by Google."
               }
             ]
           },
@@ -119,23 +119,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 45,
-        "candidatesTokenCount": 300,
-        "totalTokenCount": 648,
+        "promptTokenCount": 41,
+        "candidatesTokenCount": 11,
+        "totalTokenCount": 85,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 45
+            "tokenCount": 41
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 300
+            "tokenCount": 11
           }
         ],
-        "thoughtsTokenCount": 303
+        "thoughtsTokenCount": 33
       }
     }
   }

--- a/tests/integration/workflows/route/route_test.ts
+++ b/tests/integration/workflows/route/route_test.ts
@@ -5,47 +5,36 @@
  */
 
 /**
- * Runs the real `samples/workflows/route` agent with recorded model responses:
- * an LlmAgent classifies the input and the workflow routes to the matching
- * branch.
+ * Runs the real `route` sample: an agent classifies the input and a routing node
+ * dispatches to the matching branch. Turn and expectations mirror the Python
+ * golden `contributing/samples/workflows/route/tests/who_are_you.json`.
  */
 
-import {Event} from '@google/adk';
 import {describe, expect, it} from 'vitest';
 import {allEvents, authors, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
-/** The route(s) emitted by the routing node across events. */
-function routes(events: Event[]): string[] {
-  const out: string[] = [];
-  for (const event of events) {
-    if (typeof event.route === 'string') out.push(event.route);
-    else if (Array.isArray(event.route)) out.push(...event.route.map(String));
-  }
-  return out;
-}
-
 describe('workflow sample: route', () => {
-  it('classifies the input and dispatches to exactly one branch', async () => {
+  it('classifies the input and runs only the matching branch', async () => {
     const perTurn = await runSample({
       name: 'route',
       rootAgent,
-      turns: ['What is ADK?'],
+      turns: ['who are you'],
     });
     const events = allEvents(perTurn);
 
-    // The classifier ran and a single category was routed.
-    expect(authors(events).has('classify_input')).toBe(true);
-    const routed = routes(events);
-    expect(routed.length).toBe(1);
-    expect(['question', 'statement', 'other']).toContain(routed[0]);
+    const deltas = events.map((e) => e.actions?.stateDelta ?? {});
+    expect(deltas).toContainEqual({input: 'who are you'});
 
-    // The branch matching the routed category is the one that handled it.
-    const branchByRoute: Record<string, string> = {
-      question: 'answer_question',
-      statement: 'comment_on_statement',
-      other: 'handle_other',
-    };
-    expect(authors(events).has(branchByRoute[routed[0]])).toBe(true);
+    const category = deltas.find((d) => 'category' in d)?.['category'];
+    expect(category).toEqual({category: 'question'});
+
+    const routes = events.map((e) => e.route).filter((r) => r !== undefined);
+    expect(routes).toEqual(['question']);
+
+    const who = authors(events);
+    expect(who.has('answer_question')).toBe(true);
+    expect(who.has('comment_on_statement')).toBe(false);
+    expect(who.has('handle_other')).toBe(false);
   });
 });

--- a/tests/integration/workflows/sequence/agent.ts
+++ b/tests/integration/workflows/sequence/agent.ts
@@ -3,17 +3,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/sequence/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * Simple sequential workflow with LLM agents: the first agent names a random
  * fruit, and its output feeds the second agent, which describes a health benefit
- * of that fruit. Faithful port of Python
- * `contributing/samples/workflows/sequence`.
+ * of that fruit. One-to-one port of Python
+ * `contributing/samples/workflows/sequence/agent.py`.
  *
  * REQUIRES an API key (both nodes call a live model). Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/sequence/agent.ts
+ *   npm run sample -- tests/integration/workflows/sequence/agent.ts
  */
 
 import {LlmAgent, Workflow} from '@google/adk';

--- a/tests/integration/workflows/sequence/model_responses.json
+++ b/tests/integration/workflows/sequence/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "fe3c05c052fff445",
-    "instructionAgnosticKey": "e2299668e57ebcb1",
+    "key": "9a4363ea0fe135a2",
+    "instructionAgnosticKey": "b2a784f7e90793f2",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "Give me a fruit fact"
+              "text": "go"
             }
           ]
         },
@@ -16,7 +16,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "Give me a fruit fact"
+              "text": "go"
             }
           ]
         }
@@ -35,7 +35,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "I cannot provide a fruit fact. I can only provide the name of a random fruit."
+                "text": "Grape"
               }
             ]
           },
@@ -43,36 +43,36 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 45,
-        "candidatesTokenCount": 18,
-        "totalTokenCount": 103,
+        "promptTokenCount": 37,
+        "candidatesTokenCount": 2,
+        "totalTokenCount": 63,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 45
+            "tokenCount": 37
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 18
+            "tokenCount": 2
           }
         ],
-        "thoughtsTokenCount": 40
+        "thoughtsTokenCount": 24
       }
     }
   },
   {
-    "key": "6fee2a727c1ea777",
-    "instructionAgnosticKey": "3506ab9a2bab86b7",
+    "key": "774281fdd2b8ca86",
+    "instructionAgnosticKey": "8312b27786d22e92",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "Give me a fruit fact"
+              "text": "go"
             }
           ]
         },
@@ -80,7 +80,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "Give me a fruit fact"
+              "text": "go"
             }
           ]
         },
@@ -91,7 +91,7 @@
               "text": "For context:"
             },
             {
-              "text": "[generate_fruit_agent] said: I cannot provide a fruit fact. I can only provide the name of a random fruit."
+              "text": "[generate_fruit_agent] said: Grape"
             }
           ]
         },
@@ -99,7 +99,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "I cannot provide a fruit fact. I can only provide the name of a random fruit."
+              "text": "Grape"
             }
           ]
         }
@@ -118,7 +118,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Here's a health benefit about an apple:\n\n**Apples are a good source of dietary fiber, which can help promote healthy digestion and regulate blood sugar levels.**"
+                "text": "Grapes are rich in antioxidants, particularly resveratrol, which can help protect your heart and blood vessels."
               }
             ]
           },
@@ -126,23 +126,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 85,
-        "candidatesTokenCount": 34,
-        "totalTokenCount": 212,
+        "promptTokenCount": 44,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 90,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 85
+            "tokenCount": 44
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 34
+            "tokenCount": 20
           }
         ],
-        "thoughtsTokenCount": 93
+        "thoughtsTokenCount": 26
       }
     }
   }

--- a/tests/integration/workflows/sequence/sequence_test.ts
+++ b/tests/integration/workflows/sequence/sequence_test.ts
@@ -5,8 +5,9 @@
  */
 
 /**
- * Runs the real `samples/workflows/sequence` agent with recorded model
- * responses: two LlmAgents chained in a workflow.
+ * Runs the real `sequence` sample: the first agent names a random fruit and the
+ * second describes a health benefit of it. Turn mirrors the Python golden
+ * `contributing/samples/workflows/sequence/tests/go.json`.
  */
 
 import {describe, expect, it} from 'vitest';
@@ -19,21 +20,31 @@ import {
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: sequence', () => {
-  it('chains two LLM agents, surfacing the second agent output', async () => {
+  it('feeds the first agent output into the second', async () => {
     const perTurn = await runSample({
       name: 'sequence',
       rootAgent,
-      turns: ['Give me a fruit fact'],
+      turns: ['go'],
     });
     const events = allEvents(perTurn);
 
-    // Both agents in the chain ran.
     expect(authors(events).has('generate_fruit_agent')).toBe(true);
     expect(authors(events).has('generate_benefit_agent')).toBe(true);
 
-    // The workflow's final output is a non-empty string (the second response).
-    const output = finalOutput(events);
-    expect(typeof output).toBe('string');
-    expect((output as string).length).toBeGreaterThan(0);
+    const fruit = events
+      .find((e) => e.author === 'generate_fruit_agent')
+      ?.content?.parts?.map((p) => p.text ?? '')
+      .join('')
+      .trim();
+    expect(fruit).toBeTruthy();
+    expect(fruit!.split(/\s+/).length).toBeLessThanOrEqual(3);
+
+    const benefit = finalOutput(events);
+    expect(typeof benefit).toBe('string');
+    const benefitText = String(benefit);
+    expect(benefitText.length).toBeGreaterThan(0);
+    expect(benefitText.toLowerCase()).toContain(
+      fruit!.toLowerCase().replace(/[^a-z]/gi, ''),
+    );
   });
 });

--- a/tests/integration/workflows/state/agent.ts
+++ b/tests/integration/workflows/state/agent.ts
@@ -3,16 +3,16 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/state/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
- * State: several ways to read/write shared workflow state. Faithful port of
- * Python `contributing/samples/workflows/state`. (Python's final node reads a
- * state value by automatic parameter injection; TypeScript reads it explicitly
- * via `ctx.state`.)
+ * State: several ways to read/write shared workflow state. One-to-one port of
+ * Python `contributing/samples/workflows/state/agent.py`.
  *
- * Run (offline):  npm run sample -- samples/workflows/state/agent.ts
+ * TypeScript note: Python's `read_state_via_param` reads a state value by
+ * automatic parameter-name injection. `FunctionNode` in TypeScript has a fixed
+ * `(ctx, input)` signature, so the value is read explicitly via `ctx.state`.
+ * See the gap report.
+ *
+ * Run (offline):  npm run sample -- tests/integration/workflows/state/agent.ts
  */
 
 import {node, NodeContext, Workflow} from '@google/adk';
@@ -24,7 +24,6 @@ function processInitialInput(ctx: NodeContext, nodeInput: string): string {
 }
 
 function updateStateViaEvent(ctx: NodeContext, nodeInput: string): void {
-  // Implicitly update the shared workflow state (Python yields Event(state=)).
   ctx.state.set('uppercased_text', nodeInput.toUpperCase());
 }
 

--- a/tests/integration/workflows/state/state_test.ts
+++ b/tests/integration/workflows/state/state_test.ts
@@ -4,26 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** Runs the real `state` sample (offline): read/write shared workflow state. */
+/**
+ * Runs the real `state` sample (offline): read/write shared workflow state.
+ * Turn and expectations mirror the Python golden
+ * `contributing/samples/workflows/state/tests/go.json`.
+ */
 
 import {describe, expect, it} from 'vitest';
 import {allEvents, finalOutput, runSample} from '../_harness/sample_harness.js';
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: state', () => {
-  it('threads values through ctx.state across nodes', async () => {
+  it('threads values through state across nodes', async () => {
     const perTurn = await runSample({
       name: 'state',
       rootAgent,
-      turns: ['hello world'],
+      turns: ['go'],
       offline: true,
     });
-    const output = finalOutput(allEvents(perTurn));
+    const events = allEvents(perTurn);
 
-    expect(typeof output).toBe('string');
-    expect(output as string).toContain('Final Result:');
-    // Uppercased value + the original are both threaded through state.
-    expect(output as string).toContain('HELLO WORLD');
-    expect(output as string).toContain('Original was: hello world');
+    const deltas = events
+      .map((e) => e.actions?.stateDelta ?? {})
+      .filter((d) => Object.keys(d).length > 0);
+    expect(deltas).toEqual([
+      {original_text: 'go'},
+      {uppercased_text: 'GO'},
+      {appended_text: 'GO (Original was: go)'},
+    ]);
+
+    expect(finalOutput(events)).toBe('Final Result: GO (Original was: go)!');
   });
 });

--- a/tests/integration/workflows/use_as_output/agent.ts
+++ b/tests/integration/workflows/use_as_output/agent.ts
@@ -3,28 +3,23 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-// Vendored copy of samples/workflows/use_as_output/agent.ts so this integration test
-// is self-contained; keep it in sync with the sample.
-
 /**
  * use_as_output: an orchestrator runs a sub-agent with `useAsOutput`, so the
- * sub-agent's result becomes the node's output. Faithful port of Python
- * `contributing/samples/workflows/use_as_output`.
+ * sub-agent's result becomes the node's output. One-to-one port of Python
+ * `contributing/samples/workflows/use_as_output/agent.py`.
  *
  * Requires an API key. Set GEMINI_API_KEY, then:
- *   npm run sample -- samples/workflows/use_as_output/agent.ts
+ *   npm run sample -- tests/integration/workflows/use_as_output/agent.ts
  * Paste some text to summarize.
  */
 
 import {LlmAgent, node, NodeContext, Workflow} from '@google/adk';
 
-const summarizer = node(
-  new LlmAgent({
-    name: 'summarizer',
-    model: 'gemini-2.5-flash',
-    instruction: 'Summarize the following text in one sentence.',
-  }),
-);
+const summarizer = new LlmAgent({
+  name: 'summarizer',
+  model: 'gemini-2.5-flash',
+  instruction: 'Summarize the following text in one sentence.',
+});
 
 const orchestrate = node(
   async (ctx: NodeContext, nodeInput: string) => {

--- a/tests/integration/workflows/use_as_output/model_responses.json
+++ b/tests/integration/workflows/use_as_output/model_responses.json
@@ -1,14 +1,14 @@
 [
   {
-    "key": "8069171463b0c7a3",
-    "instructionAgnosticKey": "28b9e67bda5ca5eb",
+    "key": "4d165d7296a857c7",
+    "instructionAgnosticKey": "6dd9a37e6d1e4f74",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "The quick brown fox jumps over the lazy dog, repeatedly, all day."
+              "text": "go"
             }
           ]
         },
@@ -16,7 +16,7 @@
           "role": "user",
           "parts": [
             {
-              "text": "The quick brown fox jumps over the lazy dog, repeatedly, all day."
+              "text": "go"
             }
           ]
         }
@@ -35,7 +35,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "The quick brown fox repeatedly jumps over the lazy dog throughout the day."
+                "text": "The provided text is too short and does not contain enough information to summarize."
               }
             ]
           },
@@ -43,23 +43,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 53,
-        "candidatesTokenCount": 14,
-        "totalTokenCount": 96,
+        "promptTokenCount": 25,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 68,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 53
+            "tokenCount": 25
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 14
+            "tokenCount": 15
           }
         ],
-        "thoughtsTokenCount": 29
+        "thoughtsTokenCount": 28
       }
     }
   }

--- a/tests/integration/workflows/use_as_output/use_as_output_test.ts
+++ b/tests/integration/workflows/use_as_output/use_as_output_test.ts
@@ -5,8 +5,10 @@
  */
 
 /**
- * Runs the real `use_as_output` sample: an orchestrator runs a summarizer
- * sub-node with `useAsOutput`, then a finalize node wraps that output.
+ * Runs the real `use_as_output` sample: an orchestrator node delegates to a
+ * summarizer with `useAsOutput`, so the child's result becomes the node's
+ * output. Turn mirrors the Python golden
+ * `contributing/samples/workflows/use_as_output/tests/go.json`.
  */
 
 import {describe, expect, it} from 'vitest';
@@ -19,22 +21,34 @@ import {
 import {rootAgent} from './agent.js';
 
 describe('workflow sample: use_as_output', () => {
-  it('promotes the sub-node result and wraps it in the final node', async () => {
+  it("promotes the child's result to the delegating node's output", async () => {
     const perTurn = await runSample({
       name: 'use_as_output',
       rootAgent,
-      turns: [
-        'The quick brown fox jumps over the lazy dog, repeatedly, all day.',
-      ],
+      turns: ['go'],
     });
     const events = allEvents(perTurn);
 
-    // The summarizer sub-node ran (reached via ctx.runNode with useAsOutput).
     expect(authors(events).has('summarizer')).toBe(true);
 
-    // The finalize node wrapped the promoted summary as the workflow output.
-    const output = finalOutput(events);
-    expect(typeof output).toBe('string');
-    expect(output as string).toMatch(/^final: /);
-  });
+    const summary = events.find((e) => e.author === 'summarizer');
+    expect(summary?.nodeInfo?.messageAsOutput).toBe(true);
+    const summaryText = (summary?.content?.parts ?? [])
+      .map((p) => p.text ?? '')
+      .join('');
+
+    const orchestrate = events.find((e) => e.author === 'orchestrate');
+    expect(orchestrate?.output).toBe(summaryText);
+
+    expect(finalOutput(events)).toBe(`final: ${summaryText}`);
+
+    expect(summary?.nodeInfo?.outputFor).toEqual([
+      summary?.nodeInfo?.path,
+      orchestrate?.nodeInfo?.path,
+    ]);
+
+    expect(
+      events.filter((e) => e.output === summaryText).map((e) => e.author),
+    ).toEqual(['summarizer', 'orchestrate']);
+  }, 60000);
 });


### PR DESCRIPTION
Every one of the 21 workflow sample ports under `tests/integration/workflows` says it is a faithful port of `contributing/samples/workflows/<name>`, and every one of them had drifted. The tests also used their own input turns rather than the ones the Python goldens pin, and asserted little beyond "this author produced an event", so the branch each sample exists to demonstrate — the revise loop, the retry route, the cycle, the decline path — was never exercised.

Realigned against `adk-python@18903cad`. **91 passing, 7 skipped, 0 failing.**

## Ports match the Python source again

Restored instructions verbatim (down to `parallel_worker`'s `relates the the` typo), snake_case schema fields that are visible on the wire (`phone_number`, `api_key_used`, `approved_days`, `user_id`), Python's raw reply matching in the HITL samples, its unbounded loops, its `HTTPError`, and the `App` + `ResumabilityConfig` that `node_as_tool` calls required. Dropped additions Python does not have: `maxParallelWorkers`, explicit `runId`s, and a plain-string decision path that turned a typo'd approval into a denial.

Worst offenders: `dynamic_nodes` had replaced the named `orchestrate` node with an anonymous `dynamicEntry` (losing node identity and `rerunOnResume`) and Python's `while True` with a 5-attempt cap that returned a novel "Gave up after 5 attempts" string the workflow could otherwise never produce; `message` never emitted the assembled non-partial event, so nothing it streamed was persisted at all.

Also: all 22 headers claimed to be a "vendored copy of `samples/workflows/<name>/agent.ts`" — none of those files exist.

## Tests assert the goldens' values

Same input turns (`go`, `flower`, `1984`, `who are you`, `2 sick days`, `phone broke`, `3`), and the values the goldens pin: `fan_out_fan_in`'s join payload, `state`'s per-node deltas, `multi_triggers`' per-branch messages, `message`'s eight persisted events, `route`'s classification, `loop`'s cycle, `use_as_output`'s `outputFor` promotion.

Branches that had no coverage at all now do: `loop`'s flower cycle, `request_input`'s reject, `auth_api_key`'s resume and masking, `nested_workflow`'s error path, `loop_self`'s non-numeric input, `request_input_advanced`'s auto-approve.

## New and not ported

`auth_oauth` is ported (it had nothing). `loop_config` is not: it is YAML-driven, and TypeScript has no `agent_class: Workflow`, no `edges` field and no function/code reference resolution, so there is nothing to port it onto. Upstream Python marks its own sample non-runnable.

## Fixtures

Every model response re-recorded against a live model. The old `sequence` fixture had the fruit agent refusing to answer and the next agent hallucinating a fruit from nothing — which the assertions happily passed.

## The seven skips

Skipped rather than asserted green, each naming the divergence it hits and the golden it should have matched. They are the point of the exercise, not leftovers:

| Skip | Divergence |
|---|---|
| `request_input`, `request_input_rerun` revise | **The HITL revise loop never terminates.** On resume the node emits `route: 'revise'` but the engine re-invokes the same node with the same resume input instead of routing to its target; `draft_email` is never re-run. Reproduced with no model calls: ~87k iterations in 40s. Python's `phone_broke.json` reaches `draft_email@2`. |
| `agent_in_workflow` approve / decline | Tool confirmation inside an agent node does not resume — `generate_instruction` never continues and the tool never returns its orders. Python's `go_approve.json` needs no extra flags. |
| `agent_in_workflow` multi-turn / retry | A task-mode agent that needs a second user turn throws `ended without calling finish_task`. That is the sample's stated job, and three Python goldens depend on it. |
| `request_input_advanced` structured resume | Python resumes with a JSON *string* and coerces it from the parameter annotation; TS's `inputSchema` only validates, so `parseWithSchema` rejects it with "expected object, received string". |

Two more divergences are asserted as current behaviour rather than skipped, so they cannot change unnoticed: `retry` emits no error event per failed attempt (Python's golden pins two `HTTPError` events), and `use_as_output` emits the delegated output twice (Python suppresses the delegating node's copy).

Separately, and not addressed here: workflow `LlmAgent` nodes run with `includeContents: 'default'`, while Python forces `'none'` for single-turn nodes (`_llm_agent_wrapper.py:386-389`). The user turn therefore reaches the model twice — the `use_as_output` summarizer replied *"the single word \"gogo\""*. It is a one-line fix but it changes every workflow agent's prompt, so it wants its own change and a re-record.

## Harness

Samples may supply an `App`; record mode appends so one fixture holds several scenarios; and a turn may be a function of the turns already run, so a HITL test can answer the interrupt id the framework generated instead of inventing one.
