### PR TITLE
feat(core): add ExecuteBashTool and BashToolPolicy

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -257,6 +257,20 @@ export type {
 } from './tools/base_tool.js';
 export {BaseToolset, isBaseToolset} from './tools/base_toolset.js';
 export type {ToolPredicate} from './tools/base_toolset.js';
+export {
+  BashTool,
+  BashToolPolicy,
+  ExecuteBashTool,
+  isBashTool,
+  isExecuteBashTool,
+} from './tools/bash_tool.js';
+export type {
+  BashToolErrorResult,
+  BashToolPolicyOptions,
+  BashToolResult,
+  BashToolSuccessResult,
+  ExecuteBashToolOptions,
+} from './tools/bash_tool.js';
 export {ConsolidateContextTool} from './tools/consolidate_context_tool.js';
 export {
   ENTERPRISE_WEB_SEARCH,

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -257,20 +257,6 @@ export type {
 } from './tools/base_tool.js';
 export {BaseToolset, isBaseToolset} from './tools/base_toolset.js';
 export type {ToolPredicate} from './tools/base_toolset.js';
-export {
-  BashTool,
-  BashToolPolicy,
-  ExecuteBashTool,
-  isBashTool,
-  isExecuteBashTool,
-} from './tools/bash_tool.js';
-export type {
-  BashToolErrorResult,
-  BashToolPolicyOptions,
-  BashToolResult,
-  BashToolSuccessResult,
-  ExecuteBashToolOptions,
-} from './tools/bash_tool.js';
 export {ConsolidateContextTool} from './tools/consolidate_context_tool.js';
 export {
   ENTERPRISE_WEB_SEARCH,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -54,6 +54,21 @@ export {
   validateSkillDir,
 } from './skills/loader.js';
 export {
+  BashTool,
+  BashToolPolicy,
+  ExecuteBashTool,
+  isBashTool,
+  isBashToolPolicy,
+  isExecuteBashTool,
+} from './tools/bash_tool.js';
+export type {
+  BashToolErrorResult,
+  BashToolPolicyOptions,
+  BashToolResult,
+  BashToolSuccessResult,
+  ExecuteBashToolOptions,
+} from './tools/bash_tool.js';
+export {
   RunSkillInlineScriptErrorCode,
   RunSkillInlineScriptTool,
 } from './tools/skill/run_skill_inline_script_tool.js';

--- a/core/src/tools/bash_tool.ts
+++ b/core/src/tools/bash_tool.ts
@@ -1,0 +1,374 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionDeclaration, Type} from '@google/genai';
+import {spawn} from 'node:child_process';
+import * as path from 'node:path';
+import {BaseTool, RunAsyncToolRequest} from './base_tool.js';
+
+/**
+ * Configuration options for BashToolPolicy.
+ */
+export interface BashToolPolicyOptions {
+  /**
+   * Allowed command prefixes. Use `['*']` (default) to allow all commands,
+   * or list specific prefixes (e.g. `['git', 'ls', 'cat']`).
+   */
+  allowedCommandPrefixes?: string[];
+
+  /**
+   * Blocked operators or substrings in commands (e.g. `['rm -rf', '>', '|']`).
+   */
+  blockedOperators?: string[];
+
+  /**
+   * Command execution timeout in seconds. Default is 30 seconds.
+   */
+  timeoutSeconds?: number;
+
+  /**
+   * Maximum memory in bytes for the process (optional policy metadata).
+   */
+  maxMemoryBytes?: number;
+
+  /**
+   * Maximum file size in bytes (optional policy metadata).
+   */
+  maxFileSizeBytes?: number;
+
+  /**
+   * Maximum child processes (optional policy metadata).
+   */
+  maxChildProcesses?: number;
+}
+
+/**
+ * Configuration policy for allowed bash commands and resource limits.
+ */
+export class BashToolPolicy {
+  readonly allowedCommandPrefixes: readonly string[];
+  readonly blockedOperators: readonly string[];
+  readonly timeoutSeconds: number;
+  readonly maxMemoryBytes?: number;
+  readonly maxFileSizeBytes?: number;
+  readonly maxChildProcesses?: number;
+
+  constructor(options: BashToolPolicyOptions = {}) {
+    this.allowedCommandPrefixes = Object.freeze([
+      ...(options.allowedCommandPrefixes ?? ['*']),
+    ]);
+    this.blockedOperators = Object.freeze([
+      ...(options.blockedOperators ?? []),
+    ]);
+    this.timeoutSeconds = options.timeoutSeconds ?? 30;
+    this.maxMemoryBytes = options.maxMemoryBytes;
+    this.maxFileSizeBytes = options.maxFileSizeBytes;
+    this.maxChildProcesses = options.maxChildProcesses;
+  }
+}
+
+/**
+ * Validates a bash command against the permitted prefixes and blocked operators.
+ */
+function validateCommand(
+  command: string,
+  policy: BashToolPolicy,
+): string | undefined {
+  const stripped = command.trim();
+  if (!stripped) {
+    return 'Command is required.';
+  }
+
+  for (const op of policy.blockedOperators) {
+    if (command.includes(op)) {
+      return `Command contains blocked operator: ${op}`;
+    }
+  }
+
+  if (policy.allowedCommandPrefixes.includes('*')) {
+    return undefined;
+  }
+
+  for (const prefix of policy.allowedCommandPrefixes) {
+    if (stripped.startsWith(prefix)) {
+      return undefined;
+    }
+  }
+
+  const allowed = policy.allowedCommandPrefixes.join(', ');
+  return `Command blocked. Permitted prefixes are: ${allowed}`;
+}
+
+/**
+ * Options for configuring ExecuteBashTool.
+ */
+export interface ExecuteBashToolOptions {
+  /**
+   * Working directory for bash command execution. Defaults to `process.cwd()`.
+   */
+  workspace?: string;
+
+  /**
+   * Configuration policy for allowed commands, blocked operators, and timeouts.
+   */
+  policy?: BashToolPolicy | BashToolPolicyOptions;
+
+  /**
+   * Custom tool name. Defaults to `'execute_bash'`.
+   */
+  name?: string;
+
+  /**
+   * Custom description for the tool.
+   */
+  description?: string;
+
+  /**
+   * Whether this tool requires user confirmation before executing commands.
+   * Defaults to true (matching Python ADK ExecuteBashTool).
+   */
+  requireConfirmation?: boolean;
+
+  /**
+   * Custom shell command path (e.g. `'bash'`, `'/bin/zsh'`, `'powershell'`).
+   */
+  shellCommandPath?: string;
+}
+
+/**
+ * Result payload returned when bash command finishes successfully.
+ */
+export interface BashToolSuccessResult {
+  stdout: string;
+  stderr: string;
+  returncode: number | null;
+}
+
+/**
+ * Result payload returned when bash command fails or is rejected.
+ */
+export interface BashToolErrorResult {
+  error: string;
+  stdout?: string;
+  stderr?: string;
+  returncode?: number | null;
+}
+
+/**
+ * Union result of bash execution.
+ */
+export type BashToolResult = BashToolSuccessResult | BashToolErrorResult;
+
+const EXECUTE_BASH_TOOL_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.executeBashTool',
+);
+
+/**
+ * Tool to execute a validated bash command within a workspace directory.
+ */
+export class ExecuteBashTool extends BaseTool {
+  readonly [EXECUTE_BASH_TOOL_SIGNATURE_SYMBOL] = true;
+
+  private readonly workspace: string;
+  private readonly policy: BashToolPolicy;
+  private readonly requireConfirmation: boolean;
+  private readonly shellCommandPath?: string;
+
+  constructor(options: ExecuteBashToolOptions = {}) {
+    const policy =
+      options.policy instanceof BashToolPolicy
+        ? options.policy
+        : new BashToolPolicy(options.policy);
+
+    const name = options.name ?? 'execute_bash';
+    const allowedHint = policy.allowedCommandPrefixes.includes('*')
+      ? 'any command'
+      : `commands matching prefixes: ${policy.allowedCommandPrefixes.join(', ')}`;
+    const description =
+      options.description ??
+      `Executes a bash command with the working directory set to the workspace. Allowed: ${allowedHint}. All commands require user confirmation.`;
+
+    super({name, description});
+
+    this.workspace = path.resolve(options.workspace ?? process.cwd());
+    this.policy = policy;
+    this.requireConfirmation = options.requireConfirmation ?? true;
+    this.shellCommandPath = options.shellCommandPath;
+  }
+
+  override _getDeclaration(): FunctionDeclaration {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          command: {
+            type: Type.STRING,
+            description: 'The bash command to execute.',
+          },
+        },
+        required: ['command'],
+      },
+    };
+  }
+
+  override async runAsync(req: RunAsyncToolRequest): Promise<BashToolResult> {
+    const rawCommand = req.args?.command;
+    const command = typeof rawCommand === 'string' ? rawCommand : '';
+
+    if (!command || !command.trim()) {
+      return {error: 'Command is required.'};
+    }
+
+    // Static validation against policy.
+    const validationError = validateCommand(command, this.policy);
+    if (validationError) {
+      return {error: validationError};
+    }
+
+    // Check human-in-the-Loop confirmation if enabled.
+    if (this.requireConfirmation) {
+      const toolContext = req.toolContext;
+      if (!toolContext?.toolConfirmation) {
+        if (toolContext?.functionCallId) {
+          toolContext.requestConfirmation({
+            hint: `Please approve or reject the bash command: ${command}`,
+          });
+        }
+        if (toolContext?.actions) {
+          toolContext.actions.skipSummarization = true;
+        }
+        return {
+          error:
+            'This tool call requires confirmation, please approve or reject.',
+        };
+      }
+
+      if (!toolContext.toolConfirmation.confirmed) {
+        return {error: 'This tool call is rejected.'};
+      }
+    }
+
+    // Execute subprocess.
+    return this.executeProcess(command);
+  }
+
+  private executeProcess(command: string): Promise<BashToolResult> {
+    return new Promise((resolve) => {
+      const isWindows = process.platform === 'win32';
+      const shell = this.shellCommandPath ?? (isWindows ? 'cmd.exe' : 'bash');
+      const shellArgs = isWindows ? ['/D', '/c', command] : ['-c', command];
+
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(shell, shellArgs, {
+          cwd: this.workspace,
+          timeout: this.policy.timeoutSeconds * 1000,
+          killSignal: 'SIGKILL',
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        resolve({
+          error: `Execution failed: ${message}`,
+          stdout: '<no stdout captured>',
+          stderr: '<no stderr captured>',
+        });
+        return;
+      }
+
+      let stdout = '';
+      let stderr = '';
+      let timedOut = false;
+
+      if (child.stdout) {
+        child.stdout.on('data', (chunk) => {
+          stdout += chunk.toString();
+        });
+      }
+
+      if (child.stderr) {
+        child.stderr.on('data', (chunk) => {
+          stderr += chunk.toString();
+        });
+      }
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      if (this.policy.timeoutSeconds > 0) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            // Ignore process kill errors if already exited
+          }
+        }, this.policy.timeoutSeconds * 1000);
+      }
+
+      child.on('error', (err) => {
+        if (timer) clearTimeout(timer);
+        resolve({
+          error: `Execution failed: ${err.message}`,
+          stdout: stdout || '<no stdout captured>',
+          stderr: stderr || '<no stderr captured>',
+        });
+      });
+
+      child.on('close', (exitCode, signal) => {
+        if (timer) clearTimeout(timer);
+
+        if (timedOut || signal === 'SIGKILL' || signal === 'SIGTERM') {
+          resolve({
+            error: `Command timed out after ${this.policy.timeoutSeconds} seconds.`,
+            stdout: stdout || '<no stdout captured>',
+            stderr: stderr || '<no stderr captured>',
+            returncode: exitCode,
+          });
+          return;
+        }
+
+        resolve({
+          stdout: stdout || '<no stdout captured>',
+          stderr: stderr || '<no stderr captured>',
+          returncode: exitCode,
+        });
+      });
+    });
+  }
+
+  /**
+   * Telemetry hook: returns an error type if the response indicates an error.
+   */
+  _detectErrorInResponse(response: unknown): string | undefined {
+    if (
+      typeof response === 'object' &&
+      response !== null &&
+      'error' in response &&
+      Boolean((response as {error?: unknown}).error)
+    ) {
+      return 'TOOL_ERROR';
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Type guard to check if an object is an instance of ExecuteBashTool.
+ */
+export function isExecuteBashTool(obj: unknown): obj is ExecuteBashTool {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    EXECUTE_BASH_TOOL_SIGNATURE_SYMBOL in obj &&
+    obj[EXECUTE_BASH_TOOL_SIGNATURE_SYMBOL] === true
+  );
+}
+
+/**
+ * Alias of ExecuteBashTool for convenience.
+ */
+export {ExecuteBashTool as BashTool};
+export const isBashTool = isExecuteBashTool;

--- a/core/src/tools/bash_tool.ts
+++ b/core/src/tools/bash_tool.ts
@@ -259,16 +259,11 @@ export class ExecuteBashTool extends BaseTool {
 
   private executeProcess(command: string): Promise<BashToolResult> {
     return new Promise((resolve) => {
-      const isWindows = process.platform === 'win32';
-      const shell = this.shellCommandPath ?? (isWindows ? 'cmd.exe' : 'bash');
-      const shellArgs = isWindows ? ['/D', '/c', command] : ['-c', command];
-
       let child: ReturnType<typeof spawn>;
       try {
-        child = spawn(shell, shellArgs, {
+        child = spawn(command, {
+          shell: this.shellCommandPath || true,
           cwd: this.workspace,
-          timeout: this.policy.timeoutSeconds * 1000,
-          killSignal: 'SIGKILL',
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -305,6 +300,9 @@ export class ExecuteBashTool extends BaseTool {
           } catch {
             // Ignore process kill errors if already exited
           }
+          // Destroy read streams so the timeout close event is promptly triggered on Windows
+          child.stdout?.destroy();
+          child.stderr?.destroy();
         }, this.policy.timeoutSeconds * 1000);
       }
 

--- a/core/src/tools/bash_tool.ts
+++ b/core/src/tools/bash_tool.ts
@@ -5,7 +5,7 @@
  */
 
 import {FunctionDeclaration, Type} from '@google/genai';
-import {spawn} from 'node:child_process';
+import {ChildProcess, spawn} from 'node:child_process';
 import * as path from 'node:path';
 import {BaseTool, RunAsyncToolRequest} from './base_tool.js';
 
@@ -16,45 +16,50 @@ export interface BashToolPolicyOptions {
   /**
    * Allowed command prefixes. Use `['*']` (default) to allow all commands,
    * or list specific prefixes (e.g. `['git', 'ls', 'cat']`).
+   *
+   * Because commands are executed without a shell, a prefix constrains the
+   * program that actually runs: with `['git']` the only binary this tool can
+   * exec is `git`.
    */
   allowedCommandPrefixes?: string[];
 
   /**
    * Blocked operators or substrings in commands (e.g. `['rm -rf', '>', '|']`).
+   *
+   * This is a plain substring match and is defence in depth, not a security
+   * boundary: `rm  -rf` (two spaces) and `rm -fr` do not match `rm -rf`. Use
+   * {@link BashToolPolicyOptions.allowedCommandPrefixes} to constrain what can
+   * run.
    */
   blockedOperators?: string[];
 
   /**
-   * Command execution timeout in seconds. Default is 30 seconds.
+   * Command execution timeout in seconds. Default is 30 seconds. Values of 0
+   * or less disable the timeout.
    */
   timeoutSeconds?: number;
-
-  /**
-   * Maximum memory in bytes for the process (optional policy metadata).
-   */
-  maxMemoryBytes?: number;
-
-  /**
-   * Maximum file size in bytes (optional policy metadata).
-   */
-  maxFileSizeBytes?: number;
-
-  /**
-   * Maximum child processes (optional policy metadata).
-   */
-  maxChildProcesses?: number;
 }
 
+const BASH_TOOL_POLICY_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.bashToolPolicy',
+);
+
 /**
- * Configuration policy for allowed bash commands and resource limits.
+ * Configuration policy for allowed bash commands.
+ *
+ * Note that adk-python's `BashToolPolicy` additionally carries
+ * `max_memory_bytes`, `max_file_size_bytes` and `max_child_processes`, which it
+ * enforces with `setrlimit` in a `preexec_fn`. Node exposes no `setrlimit`
+ * binding, so those fields are deliberately absent here rather than present and
+ * inert.
  */
 export class BashToolPolicy {
+  /** A unique symbol to identify ADK bash tool policies. */
+  readonly [BASH_TOOL_POLICY_SIGNATURE_SYMBOL] = true;
+
   readonly allowedCommandPrefixes: readonly string[];
   readonly blockedOperators: readonly string[];
   readonly timeoutSeconds: number;
-  readonly maxMemoryBytes?: number;
-  readonly maxFileSizeBytes?: number;
-  readonly maxChildProcesses?: number;
 
   constructor(options: BashToolPolicyOptions = {}) {
     this.allowedCommandPrefixes = Object.freeze([
@@ -64,14 +69,24 @@ export class BashToolPolicy {
       ...(options.blockedOperators ?? []),
     ]);
     this.timeoutSeconds = options.timeoutSeconds ?? 30;
-    this.maxMemoryBytes = options.maxMemoryBytes;
-    this.maxFileSizeBytes = options.maxFileSizeBytes;
-    this.maxChildProcesses = options.maxChildProcesses;
   }
 }
 
 /**
- * Validates a bash command against the permitted prefixes and blocked operators.
+ * Type guard to check if an object is an instance of BashToolPolicy.
+ */
+export function isBashToolPolicy(obj: unknown): obj is BashToolPolicy {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    BASH_TOOL_POLICY_SIGNATURE_SYMBOL in obj &&
+    obj[BASH_TOOL_POLICY_SIGNATURE_SYMBOL] === true
+  );
+}
+
+/**
+ * Validates a bash command against the permitted prefixes and blocked
+ * operators.
  */
 function validateCommand(
   command: string,
@@ -82,6 +97,8 @@ function validateCommand(
     return 'Command is required.';
   }
 
+  // Matches upstream: blocked operators are checked against the raw command
+  // while prefixes are checked against the stripped one.
   for (const op of policy.blockedOperators) {
     if (command.includes(op)) {
       return `Command contains blocked operator: ${op}`;
@@ -102,17 +119,145 @@ function validateCommand(
   return `Command blocked. Permitted prefixes are: ${allowed}`;
 }
 
+const TOKENIZER_WHITESPACE = new Set([' ', '\t', '\r', '\n']);
+
+/**
+ * Splits a command string into an argument vector using POSIX shell word
+ * rules, equivalent to Python's `shlex.split(command)`.
+ *
+ * Only quoting and escaping are honoured. There is no expansion of variables,
+ * globs, command substitutions or tildes, and no operator handling: `;`, `|`,
+ * `&&`, `>` and newlines are ordinary characters that end up as literal
+ * arguments. That is what makes
+ * {@link BashToolPolicyOptions.allowedCommandPrefixes} meaningful — the vector
+ * is exec'd directly, so only `argv[0]` ever runs.
+ *
+ * @throws Error if the command ends inside a quote or a trailing escape, using
+ *   the same messages `shlex` raises.
+ */
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let hasToken = false;
+  let i = 0;
+
+  while (i < command.length) {
+    const char = command[i];
+
+    if (char === '\\') {
+      const next = command[i + 1];
+      if (next === undefined) {
+        throw new Error('No escaped character');
+      }
+      // Outside quotes a backslash escapes any single character.
+      current += next;
+      hasToken = true;
+      i += 2;
+      continue;
+    }
+
+    if (char === "'") {
+      const end = command.indexOf("'", i + 1);
+      if (end === -1) {
+        throw new Error('No closing quotation');
+      }
+      // Single quotes are fully literal, including backslashes.
+      current += command.slice(i + 1, end);
+      hasToken = true;
+      i = end + 1;
+      continue;
+    }
+
+    if (char === '"') {
+      i++;
+      let closed = false;
+      while (i < command.length) {
+        const inner = command[i];
+        if (inner === '\\') {
+          const next = command[i + 1];
+          if (next === undefined) {
+            throw new Error('No escaped character');
+          }
+          // Inside double quotes a backslash only escapes `"` and `\`;
+          // anything else keeps the backslash, as in `shlex` posix mode.
+          current += next === '"' || next === '\\' ? next : `\\${next}`;
+          i += 2;
+          continue;
+        }
+        if (inner === '"') {
+          closed = true;
+          i++;
+          break;
+        }
+        current += inner;
+        i++;
+      }
+      if (!closed) {
+        throw new Error('No closing quotation');
+      }
+      hasToken = true;
+      continue;
+    }
+
+    if (TOKENIZER_WHITESPACE.has(char)) {
+      if (hasToken) {
+        tokens.push(current);
+        current = '';
+        hasToken = false;
+      }
+      i++;
+      continue;
+    }
+
+    current += char;
+    hasToken = true;
+    i++;
+  }
+
+  if (hasToken) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+/**
+ * Kills the subprocess group, so a timeout also reaches anything the command
+ * spawned. Equivalent to upstream's `os.killpg(process.pid, SIGKILL)`.
+ */
+function killProcessGroup(child: ChildProcess): void {
+  const pid = child.pid;
+  if (pid === undefined) {
+    return;
+  }
+  try {
+    // A negative pid signals the whole process group.
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    // The group is already gone, or the platform refused; fall back to the
+    // direct child.
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // Already exited.
+    }
+  }
+}
+
 /**
  * Options for configuring ExecuteBashTool.
  */
 export interface ExecuteBashToolOptions {
   /**
-   * Working directory for bash command execution. Defaults to `process.cwd()`.
+   * Working directory for command execution. Defaults to `process.cwd()`.
+   *
+   * This sets the child's `cwd`; it is not a sandbox. A command is still free
+   * to reach any path the calling user can reach by naming it absolutely.
    */
   workspace?: string;
 
   /**
-   * Configuration policy for allowed commands, blocked operators, and timeouts.
+   * Configuration policy for allowed commands, blocked operators, and
+   * timeouts.
    */
   policy?: BashToolPolicy | BashToolPolicyOptions;
 
@@ -129,13 +274,13 @@ export interface ExecuteBashToolOptions {
   /**
    * Whether this tool requires user confirmation before executing commands.
    * Defaults to true (matching Python ADK ExecuteBashTool).
+   *
+   * WARNING: setting this to `false` removes the only human gate in front of
+   * model-authored command execution, and has no counterpart in adk-python,
+   * where confirmation is unconditional. Turn it off only when the policy alone
+   * makes the tool safe for the deployment.
    */
   requireConfirmation?: boolean;
-
-  /**
-   * Custom shell command path (e.g. `'bash'`, `'/bin/zsh'`, `'powershell'`).
-   */
-  shellCommandPath?: string;
 }
 
 /**
@@ -167,7 +312,23 @@ const EXECUTE_BASH_TOOL_SIGNATURE_SYMBOL = Symbol.for(
 );
 
 /**
- * Tool to execute a validated bash command within a workspace directory.
+ * Tool to execute a validated command within a workspace directory.
+ *
+ * The command string is split into an argument vector with POSIX word rules
+ * and exec'd directly — no shell is involved, matching adk-python's
+ * `shlex.split` + `create_subprocess_exec`. Shell operators are therefore
+ * inert: `git status; rm -rf /` tries to exec `git` with the literal arguments
+ * `status;`, `rm`, `-rf`, `/` and fails harmlessly. Pipes, redirection, globs
+ * and variable expansion are not available.
+ *
+ * Known limits, all shared with or inherited from upstream:
+ *
+ * - POSIX only. Like adk-python, this tool refuses to run on Windows rather
+ *   than apply POSIX-shaped rules to `cmd.exe`.
+ * - No resource limits. Upstream caps memory, file size and child processes
+ *   with `setrlimit`; Node exposes no equivalent, so those knobs are absent
+ *   from {@link BashToolPolicy}.
+ * - `workspace` is the child's working directory, not a jail.
  */
 export class ExecuteBashTool extends BaseTool {
   readonly [EXECUTE_BASH_TOOL_SIGNATURE_SYMBOL] = true;
@@ -175,28 +336,34 @@ export class ExecuteBashTool extends BaseTool {
   private readonly workspace: string;
   private readonly policy: BashToolPolicy;
   private readonly requireConfirmation: boolean;
-  private readonly shellCommandPath?: string;
 
   constructor(options: ExecuteBashToolOptions = {}) {
-    const policy =
-      options.policy instanceof BashToolPolicy
-        ? options.policy
-        : new BashToolPolicy(options.policy);
+    const policy = isBashToolPolicy(options.policy)
+      ? options.policy
+      : new BashToolPolicy(options.policy);
 
     const name = options.name ?? 'execute_bash';
+    const requireConfirmation = options.requireConfirmation ?? true;
     const allowedHint = policy.allowedCommandPrefixes.includes('*')
       ? 'any command'
       : `commands matching prefixes: ${policy.allowedCommandPrefixes.join(', ')}`;
+    const confirmationHint = requireConfirmation
+      ? ' All commands require user confirmation.'
+      : '';
     const description =
       options.description ??
-      `Executes a bash command with the working directory set to the workspace. Allowed: ${allowedHint}. All commands require user confirmation.`;
+      `Executes a command with the working directory set to the workspace. ` +
+        `The command is split into an argument vector and executed directly ` +
+        `without a shell, so pipes, redirection, globs, variable expansion ` +
+        `and command separators such as |, >, ; and && are not interpreted ` +
+        `and are passed through as literal arguments. ` +
+        `Allowed: ${allowedHint}.${confirmationHint}`;
 
     super({name, description});
 
     this.workspace = path.resolve(options.workspace ?? process.cwd());
     this.policy = policy;
-    this.requireConfirmation = options.requireConfirmation ?? true;
-    this.shellCommandPath = options.shellCommandPath;
+    this.requireConfirmation = requireConfirmation;
   }
 
   override _getDeclaration(): FunctionDeclaration {
@@ -208,7 +375,7 @@ export class ExecuteBashTool extends BaseTool {
         properties: {
           command: {
             type: Type.STRING,
-            description: 'The bash command to execute.',
+            description: 'The command to execute.',
           },
         },
         required: ['command'],
@@ -230,7 +397,7 @@ export class ExecuteBashTool extends BaseTool {
       return {error: validationError};
     }
 
-    // Check human-in-the-Loop confirmation if enabled.
+    // Check human-in-the-loop confirmation if enabled.
     if (this.requireConfirmation) {
       const toolContext = req.toolContext;
       if (!toolContext?.toolConfirmation) {
@@ -253,17 +420,44 @@ export class ExecuteBashTool extends BaseTool {
       }
     }
 
+    // Upstream refuses non-POSIX platforms outright rather than reason about
+    // a second shell's syntax; the check sits after confirmation there too.
+    if (process.platform === 'win32') {
+      return {error: 'ExecuteBashTool is only supported on POSIX systems.'};
+    }
+
+    let argv: string[];
+    try {
+      argv = tokenizeCommand(command);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        error: `Execution failed: ${message}`,
+        stdout: '<no stdout captured>',
+        stderr: '<no stderr captured>',
+      };
+    }
+
+    if (argv.length === 0 || !argv[0]) {
+      return {error: 'Command is required.'};
+    }
+
     // Execute subprocess.
-    return this.executeProcess(command);
+    return this.executeProcess(argv);
   }
 
-  private executeProcess(command: string): Promise<BashToolResult> {
+  private executeProcess(argv: string[]): Promise<BashToolResult> {
     return new Promise((resolve) => {
-      let child: ReturnType<typeof spawn>;
+      let child: ChildProcess;
       try {
-        child = spawn(command, {
-          shell: this.shellCommandPath || true,
+        child = spawn(argv[0], argv.slice(1), {
           cwd: this.workspace,
+          // Its own process group, so a timeout can signal the whole tree.
+          // Equivalent to upstream's `start_new_session=True`.
+          detached: true,
+          // The command never inherits the agent's stdin: anything that reads
+          // it sees EOF instead of blocking until the timeout.
+          stdio: ['ignore', 'pipe', 'pipe'],
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -278,48 +472,52 @@ export class ExecuteBashTool extends BaseTool {
       let stdout = '';
       let stderr = '';
       let timedOut = false;
+      let settled = false;
 
-      if (child.stdout) {
-        child.stdout.on('data', (chunk) => {
-          stdout += chunk.toString();
-        });
-      }
+      const settle = (result: BashToolResult) => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
 
-      if (child.stderr) {
-        child.stderr.on('data', (chunk) => {
-          stderr += chunk.toString();
-        });
-      }
+      child.stdout?.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+
+      child.stderr?.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
 
       let timer: ReturnType<typeof setTimeout> | undefined;
       if (this.policy.timeoutSeconds > 0) {
         timer = setTimeout(() => {
           timedOut = true;
-          try {
-            child.kill('SIGKILL');
-          } catch {
-            // Ignore process kill errors if already exited
-          }
-          // Destroy read streams so the timeout close event is promptly triggered on Windows
-          child.stdout?.destroy();
-          child.stderr?.destroy();
+          killProcessGroup(child);
         }, this.policy.timeoutSeconds * 1000);
       }
 
+      // Upstream kills the group in a `finally` as well, so a command that
+      // exits normally cannot leave a stray group behind. Doing it on `exit`
+      // also releases any pipe a lingering grandchild still holds, which is
+      // what lets `close` fire.
+      child.on('exit', () => {
+        killProcessGroup(child);
+      });
+
       child.on('error', (err) => {
         if (timer) clearTimeout(timer);
-        resolve({
+        settle({
           error: `Execution failed: ${err.message}`,
           stdout: stdout || '<no stdout captured>',
           stderr: stderr || '<no stderr captured>',
         });
       });
 
-      child.on('close', (exitCode, signal) => {
+      child.on('close', (exitCode) => {
         if (timer) clearTimeout(timer);
 
-        if (timedOut || signal === 'SIGKILL' || signal === 'SIGTERM') {
-          resolve({
+        if (timedOut) {
+          settle({
             error: `Command timed out after ${this.policy.timeoutSeconds} seconds.`,
             stdout: stdout || '<no stdout captured>',
             stderr: stderr || '<no stderr captured>',
@@ -328,7 +526,7 @@ export class ExecuteBashTool extends BaseTool {
           return;
         }
 
-        resolve({
+        settle({
           stdout: stdout || '<no stdout captured>',
           stderr: stderr || '<no stderr captured>',
           returncode: exitCode,

--- a/core/test/tools/bash_tool_test.ts
+++ b/core/test/tools/bash_tool_test.ts
@@ -22,6 +22,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
+/**
+ * Commands are built from the Node binary running the tests so that they work
+ * under both `sh` and `cmd.exe`.
+ */
+const NODE = `"${process.execPath}"`;
+
 function makeContext(
   options: {
     functionCallId?: string;
@@ -55,7 +61,12 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
 
   afterEach(async () => {
     if (tempDir) {
-      await fs.rm(tempDir, {recursive: true, force: true});
+      await fs.rm(tempDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 500,
+      });
     }
   });
 
@@ -164,7 +175,7 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       const tool = new ExecuteBashTool({requireConfirmation: true});
       const context = makeContext();
       const res = await tool.runAsync({
-        args: {command: 'echo "hello"'},
+        args: {command: `${NODE} -e "process.stdout.write('hello')"`},
         toolContext: context,
       });
 
@@ -181,7 +192,7 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
         toolConfirmation: new ToolConfirmation({confirmed: false}),
       });
       const res = await tool.runAsync({
-        args: {command: 'echo "hello"'},
+        args: {command: `${NODE} -e "process.stdout.write('hello')"`},
         toolContext: context,
       });
 
@@ -194,7 +205,9 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
         toolConfirmation: new ToolConfirmation({confirmed: true}),
       });
       const res = (await tool.runAsync({
-        args: {command: 'echo "confirmed execution"'},
+        args: {
+          command: `${NODE} -e "process.stdout.write('confirmed execution')"`,
+        },
         toolContext: context,
       })) as {stdout: string; returncode: number};
 
@@ -207,7 +220,9 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
     it('executes a standard echo command and captures stdout', async () => {
       const tool = new ExecuteBashTool({requireConfirmation: false});
       const res = (await tool.runAsync({
-        args: {command: 'node -e "console.log(\'test output 123\')"'},
+        args: {
+          command: `${NODE} -e "process.stdout.write('test output 123')"`,
+        },
         toolContext: makeContext(),
       })) as {stdout: string; stderr: string; returncode: number};
 
@@ -227,8 +242,7 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
 
       const res = (await tool.runAsync({
         args: {
-          command:
-            "node -e \"console.log(require('node:fs').readFileSync('sample.txt', 'utf8'))\"",
+          command: `${NODE} -e "process.stdout.write(require('node:fs').readFileSync('sample.txt', 'utf8'))"`,
         },
         toolContext: makeContext(),
       })) as {stdout: string; returncode: number};
@@ -241,8 +255,7 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       const tool = new ExecuteBashTool({requireConfirmation: false});
       const res = (await tool.runAsync({
         args: {
-          command:
-            'node -e "process.stderr.write(\'error_in_test_execution\'); process.exit(1)"',
+          command: `${NODE} -e "process.stderr.write('error_in_test_execution'); process.exit(1)"`,
         },
         toolContext: makeContext(),
       })) as {stdout: string; stderr: string; returncode: number};
@@ -258,7 +271,7 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       });
 
       const res = (await tool.runAsync({
-        args: {command: 'node -e "setTimeout(() => {}, 5000)"'},
+        args: {command: `${NODE} -e "setTimeout(() => {}, 5000)"`},
         toolContext: makeContext(),
       })) as {error: string};
 

--- a/core/test/tools/bash_tool_test.ts
+++ b/core/test/tools/bash_tool_test.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BashTool,
+  BashToolPolicy,
+  Context,
+  createSession,
+  ExecuteBashTool,
+  InvocationContext,
+  isBashTool,
+  isExecuteBashTool,
+  LlmAgent,
+  PluginManager,
+  ToolConfirmation,
+} from '@google/adk';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+function makeContext(
+  options: {
+    functionCallId?: string;
+    toolConfirmation?: ToolConfirmation;
+  } = {},
+): Context {
+  const session = createSession({
+    id: 's1',
+    appName: 'app',
+    userId: 'u1',
+  });
+  const invocationContext = new InvocationContext({
+    invocationId: 'inv-1',
+    agent: new LlmAgent({name: 'test-agent', model: 'gemini-2.5-flash'}),
+    session,
+    pluginManager: new PluginManager([]),
+  });
+  return new Context({
+    invocationContext,
+    functionCallId: options.functionCallId ?? 'fc-1',
+    ...options,
+  });
+}
+
+describe('ExecuteBashTool & BashToolPolicy', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adk_bash_tool_test_'));
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, {recursive: true, force: true});
+    }
+  });
+
+  describe('Initialization and Declaration', () => {
+    it('initializes with default options', () => {
+      const tool = new ExecuteBashTool();
+      expect(tool.name).toBe('execute_bash');
+      expect(tool.description).toContain('Executes a bash command');
+      expect(tool.description).toContain('any command');
+      expect(isExecuteBashTool(tool)).toBe(true);
+      expect(isBashTool(tool)).toBe(true);
+      expect(BashTool).toBe(ExecuteBashTool);
+    });
+
+    it('initializes with custom options and policy', () => {
+      const policy = new BashToolPolicy({
+        allowedCommandPrefixes: ['git', 'npm'],
+        blockedOperators: ['|', ';'],
+        timeoutSeconds: 15,
+      });
+      const tool = new ExecuteBashTool({
+        name: 'custom_bash',
+        workspace: tempDir,
+        policy,
+        requireConfirmation: false,
+      });
+      expect(tool.name).toBe('custom_bash');
+      expect(tool.description).toContain('git, npm');
+    });
+
+    it('returns valid function declaration schema', () => {
+      const tool = new ExecuteBashTool();
+      const declaration = tool._getDeclaration();
+      expect(declaration).toBeDefined();
+      expect(declaration?.name).toBe('execute_bash');
+      expect(declaration?.parameters?.type).toBe('OBJECT');
+      expect(declaration?.parameters?.properties?.command).toBeDefined();
+      expect(declaration?.parameters?.required).toEqual(['command']);
+    });
+  });
+
+  describe('Policy Validation', () => {
+    it('returns error when command is empty or whitespace', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: false});
+      const res1 = await tool.runAsync({
+        args: {command: ''},
+        toolContext: makeContext(),
+      });
+      expect(res1).toEqual({error: 'Command is required.'});
+
+      const res2 = await tool.runAsync({
+        args: {command: '   '},
+        toolContext: makeContext(),
+      });
+      expect(res2).toEqual({error: 'Command is required.'});
+    });
+
+    it('blocks commands containing blocked operators', async () => {
+      const tool = new ExecuteBashTool({
+        policy: {blockedOperators: ['rm -rf', '>', '|']},
+        requireConfirmation: false,
+      });
+
+      const res1 = await tool.runAsync({
+        args: {command: 'ls -la | grep test'},
+        toolContext: makeContext(),
+      });
+      expect(res1).toEqual({
+        error: 'Command contains blocked operator: |',
+      });
+
+      const res2 = await tool.runAsync({
+        args: {command: 'rm -rf /tmp/test'},
+        toolContext: makeContext(),
+      });
+      expect(res2).toEqual({
+        error: 'Command contains blocked operator: rm -rf',
+      });
+    });
+
+    it('enforces allowed command prefixes', async () => {
+      const tool = new ExecuteBashTool({
+        policy: {allowedCommandPrefixes: ['git', 'npm run test']},
+        requireConfirmation: false,
+      });
+
+      const resDisallowed = await tool.runAsync({
+        args: {command: 'cat secret.txt'},
+        toolContext: makeContext(),
+      });
+      expect(resDisallowed).toEqual({
+        error: 'Command blocked. Permitted prefixes are: git, npm run test',
+      });
+
+      const resAllowed = await tool.runAsync({
+        args: {command: 'git status'},
+        toolContext: makeContext(),
+      });
+      // Should proceed to execution
+      expect('returncode' in resAllowed).toBe(true);
+    });
+  });
+
+  describe('Confirmation Gate (Human-in-the-Loop)', () => {
+    it('requests confirmation when requireConfirmation is true and context has no confirmation', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: true});
+      const context = makeContext();
+      const res = await tool.runAsync({
+        args: {command: 'echo "hello"'},
+        toolContext: context,
+      });
+
+      expect(res).toEqual({
+        error:
+          'This tool call requires confirmation, please approve or reject.',
+      });
+      expect(context.actions.skipSummarization).toBe(true);
+    });
+
+    it('returns rejected error when user declines confirmation', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: true});
+      const context = makeContext({
+        toolConfirmation: new ToolConfirmation({confirmed: false}),
+      });
+      const res = await tool.runAsync({
+        args: {command: 'echo "hello"'},
+        toolContext: context,
+      });
+
+      expect(res).toEqual({error: 'This tool call is rejected.'});
+    });
+
+    it('executes command when confirmation is approved', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: true});
+      const context = makeContext({
+        toolConfirmation: new ToolConfirmation({confirmed: true}),
+      });
+      const res = (await tool.runAsync({
+        args: {command: 'echo "confirmed execution"'},
+        toolContext: context,
+      })) as {stdout: string; returncode: number};
+
+      expect(res.returncode).toBe(0);
+      expect(res.stdout).toContain('confirmed execution');
+    });
+  });
+
+  describe('Command Execution & Environment', () => {
+    it('executes a standard echo command and captures stdout', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: false});
+      const res = (await tool.runAsync({
+        args: {command: 'node -e "console.log(\'test output 123\')"'},
+        toolContext: makeContext(),
+      })) as {stdout: string; stderr: string; returncode: number};
+
+      expect(res.returncode).toBe(0);
+      expect(res.stdout.trim()).toBe('test output 123');
+      expect(res.stderr).toBe('<no stderr captured>');
+    });
+
+    it('executes command in the specified workspace directory', async () => {
+      const testFilePath = path.join(tempDir, 'sample.txt');
+      await fs.writeFile(testFilePath, 'workspace file content');
+
+      const tool = new ExecuteBashTool({
+        workspace: tempDir,
+        requireConfirmation: false,
+      });
+
+      const res = (await tool.runAsync({
+        args: {
+          command:
+            "node -e \"console.log(require('node:fs').readFileSync('sample.txt', 'utf8'))\"",
+        },
+        toolContext: makeContext(),
+      })) as {stdout: string; returncode: number};
+
+      expect(res.returncode).toBe(0);
+      expect(res.stdout.trim()).toBe('workspace file content');
+    });
+
+    it('captures stderr and non-zero returncode on failure', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: false});
+      const res = (await tool.runAsync({
+        args: {
+          command:
+            'node -e "process.stderr.write(\'error_in_test_execution\'); process.exit(1)"',
+        },
+        toolContext: makeContext(),
+      })) as {stdout: string; stderr: string; returncode: number};
+
+      expect(res.returncode).not.toBe(0);
+      expect(res.stderr).toContain('error_in_test_execution');
+    });
+
+    it('handles command timeouts correctly', async () => {
+      const tool = new ExecuteBashTool({
+        policy: {timeoutSeconds: 1},
+        requireConfirmation: false,
+      });
+
+      const res = (await tool.runAsync({
+        args: {command: 'node -e "setTimeout(() => {}, 5000)"'},
+        toolContext: makeContext(),
+      })) as {error: string};
+
+      expect(res.error).toBe('Command timed out after 1 seconds.');
+    });
+  });
+
+  describe('Telemetry Hook', () => {
+    it('detects tool error in response', () => {
+      const tool = new ExecuteBashTool();
+      expect(tool._detectErrorInResponse({error: 'Failed'})).toBe('TOOL_ERROR');
+      expect(
+        tool._detectErrorInResponse({
+          stdout: 'ok',
+          stderr: '<no stderr captured>',
+          returncode: 0,
+        }),
+      ).toBeUndefined();
+      expect(tool._detectErrorInResponse(null)).toBeUndefined();
+    });
+  });
+});

--- a/core/test/tools/bash_tool_test.ts
+++ b/core/test/tools/bash_tool_test.ts
@@ -12,6 +12,7 @@ import {
   ExecuteBashTool,
   InvocationContext,
   isBashTool,
+  isBashToolPolicy,
   isExecuteBashTool,
   LlmAgent,
   PluginManager,
@@ -23,10 +24,15 @@ import * as path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 /**
- * Commands are built from the Node binary running the tests so that they work
- * under both `sh` and `cmd.exe`.
+ * Commands are built from the Node binary running the tests, quoted so the
+ * tokenizer keeps a path containing spaces in one argument.
  */
-const NODE = `"${process.execPath}"`;
+const NODE = JSON.stringify(process.execPath);
+
+const IS_WINDOWS = process.platform === 'win32';
+
+/** The tool refuses to execute at all off POSIX, as adk-python does. */
+const describeOnPosix = IS_WINDOWS ? describe.skip : describe;
 
 function makeContext(
   options: {
@@ -52,6 +58,17 @@ function makeContext(
   });
 }
 
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 describe('ExecuteBashTool & BashToolPolicy', () => {
   let tempDir: string;
 
@@ -74,7 +91,7 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
     it('initializes with default options', () => {
       const tool = new ExecuteBashTool();
       expect(tool.name).toBe('execute_bash');
-      expect(tool.description).toContain('Executes a bash command');
+      expect(tool.description).toContain('Executes a command');
       expect(tool.description).toContain('any command');
       expect(isExecuteBashTool(tool)).toBe(true);
       expect(isBashTool(tool)).toBe(true);
@@ -97,6 +114,20 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       expect(tool.description).toContain('git, npm');
     });
 
+    it('tells the model that no shell is involved', () => {
+      const declaration = new ExecuteBashTool()._getDeclaration();
+      expect(declaration?.description).toContain('without a shell');
+    });
+
+    it('describes the confirmation gate only when it is enabled', () => {
+      expect(new ExecuteBashTool().description).toContain(
+        'All commands require user confirmation.',
+      );
+      expect(
+        new ExecuteBashTool({requireConfirmation: false}).description,
+      ).not.toContain('confirmation');
+    });
+
     it('returns valid function declaration schema', () => {
       const tool = new ExecuteBashTool();
       const declaration = tool._getDeclaration();
@@ -105,6 +136,29 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       expect(declaration?.parameters?.type).toBe('OBJECT');
       expect(declaration?.parameters?.properties?.command).toBeDefined();
       expect(declaration?.parameters?.required).toEqual(['command']);
+    });
+  });
+
+  describe('Policy Identification', () => {
+    it('identifies policies by brand symbol rather than instanceof', () => {
+      expect(isBashToolPolicy(new BashToolPolicy())).toBe(true);
+      expect(isBashToolPolicy({allowedCommandPrefixes: ['git']})).toBe(false);
+      expect(isBashToolPolicy(null)).toBe(false);
+    });
+
+    it('accepts a branded policy from another copy of the package', () => {
+      // A structural duplicate carrying the same registered symbol, as a
+      // second bundled copy of @google/adk would produce. `instanceof` would
+      // reject this and silently rewrap it.
+      const foreignPolicy = {
+        [Symbol.for('google.adk.bashToolPolicy')]: true,
+        allowedCommandPrefixes: ['git'],
+        blockedOperators: [],
+        timeoutSeconds: 7,
+      } as unknown as BashToolPolicy;
+
+      const tool = new ExecuteBashTool({policy: foreignPolicy});
+      expect(tool.description).toContain('prefixes: git');
     });
   });
 
@@ -147,26 +201,141 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       });
     });
 
-    it('enforces allowed command prefixes', async () => {
+    it('rejects a command outside the allowed prefixes', async () => {
       const tool = new ExecuteBashTool({
-        policy: {allowedCommandPrefixes: ['git', 'npm run test']},
+        policy: {allowedCommandPrefixes: [NODE, 'npm run test']},
         requireConfirmation: false,
       });
 
-      const resDisallowed = await tool.runAsync({
+      const res = await tool.runAsync({
         args: {command: 'cat secret.txt'},
         toolContext: makeContext(),
       });
-      expect(resDisallowed).toEqual({
-        error: 'Command blocked. Permitted prefixes are: git, npm run test',
+      expect(res).toEqual({
+        error: `Command blocked. Permitted prefixes are: ${NODE}, npm run test`,
+      });
+    });
+  });
+
+  describeOnPosix('Allowed Prefixes', () => {
+    it('runs a command matching an allowed prefix', async () => {
+      const tool = new ExecuteBashTool({
+        policy: {allowedCommandPrefixes: [NODE, 'npm run test']},
+        requireConfirmation: false,
       });
 
-      const resAllowed = await tool.runAsync({
-        args: {command: 'git status'},
+      const res = await tool.runAsync({
+        args: {command: `${NODE} --version`},
         toolContext: makeContext(),
       });
-      // Should proceed to execution
-      expect('returncode' in resAllowed).toBe(true);
+      expect('returncode' in res).toBe(true);
+    });
+  });
+
+  describeOnPosix('Shell Metacharacters Are Inert', () => {
+    /**
+     * Each of these passes the prefix allowlist, and under a shell each would
+     * run a second program. The command is exec'd as an argument vector, so the
+     * separator reaches `argv[0]` as a literal string and nothing else runs.
+     */
+    it.each([
+      ['semicolon', ';'],
+      ['logical and', '&&'],
+      ['pipe', '|'],
+      ['newline', '\n'],
+      ['background', '&'],
+    ])(
+      'does not let a %s escape the prefix allowlist',
+      async (_label, separator) => {
+        const marker = path.join(tempDir, 'pwned.txt');
+        const payload = `require('node:fs').writeFileSync('pwned.txt', 'x')`;
+        const tool = new ExecuteBashTool({
+          workspace: tempDir,
+          policy: {allowedCommandPrefixes: [NODE]},
+          requireConfirmation: false,
+        });
+
+        const res = await tool.runAsync({
+          args: {
+            command:
+              `${NODE} -e "process.stdout.write('FIRST')" ` +
+              `${separator} ${NODE} -e "${payload}"`,
+          },
+          toolContext: makeContext(),
+        });
+
+        expect(JSON.stringify(res)).not.toContain('PWNED');
+        expect(await exists(marker)).toBe(false);
+      },
+    );
+
+    it('does not let command substitution run a second program', async () => {
+      const marker = path.join(tempDir, 'pwned.txt');
+      const tool = new ExecuteBashTool({
+        workspace: tempDir,
+        policy: {allowedCommandPrefixes: [NODE]},
+        requireConfirmation: false,
+      });
+
+      await tool.runAsync({
+        args: {
+          command:
+            `${NODE} -e "process.stdout.write('FIRST')" ` +
+            `$(${NODE} -e "require('node:fs').writeFileSync('pwned.txt','x')")`,
+        },
+        toolContext: makeContext(),
+      });
+
+      expect(await exists(marker)).toBe(false);
+    });
+
+    it('does not let redirection write a file', async () => {
+      const marker = path.join(tempDir, 'redirected.txt');
+      const tool = new ExecuteBashTool({
+        workspace: tempDir,
+        requireConfirmation: false,
+      });
+
+      await tool.runAsync({
+        args: {
+          command: `${NODE} -e "process.stdout.write('DATA')" > redirected.txt`,
+        },
+        toolContext: makeContext(),
+      });
+
+      expect(await exists(marker)).toBe(false);
+    });
+
+    it('passes separators through as literal arguments', async () => {
+      const tool = new ExecuteBashTool({
+        workspace: tempDir,
+        requireConfirmation: false,
+      });
+
+      const res = (await tool.runAsync({
+        args: {
+          command:
+            `${NODE} -e "process.stdout.write(JSON.stringify(process.argv.slice(1)))" ` +
+            `';' '|' 'a b' "c;d" e\\ f`,
+        },
+        toolContext: makeContext(),
+      })) as {stdout: string};
+
+      expect(JSON.parse(res.stdout)).toEqual([';', '|', 'a b', 'c;d', 'e f']);
+    });
+
+    it('reports an unbalanced quote instead of executing', async () => {
+      const tool = new ExecuteBashTool({
+        workspace: tempDir,
+        requireConfirmation: false,
+      });
+
+      const res = (await tool.runAsync({
+        args: {command: `${NODE} -e "unterminated`},
+        toolContext: makeContext(),
+      })) as {error: string};
+
+      expect(res.error).toBe('Execution failed: No closing quotation');
     });
   });
 
@@ -198,7 +367,38 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
 
       expect(res).toEqual({error: 'This tool call is rejected.'});
     });
+  });
 
+  describe('Platform Support', () => {
+    // adk-python returns this same error rather than applying POSIX-shaped
+    // rules to `cmd.exe`, whose metacharacters differ.
+    it.runIf(IS_WINDOWS)(
+      'refuses to execute on non-POSIX platforms',
+      async () => {
+        const tool = new ExecuteBashTool({requireConfirmation: false});
+        const res = await tool.runAsync({
+          args: {command: `${NODE} --version`},
+          toolContext: makeContext(),
+        });
+
+        expect(res).toEqual({
+          error: 'ExecuteBashTool is only supported on POSIX systems.',
+        });
+      },
+    );
+
+    it.runIf(!IS_WINDOWS)('executes on POSIX platforms', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: false});
+      const res = (await tool.runAsync({
+        args: {command: `${NODE} --version`},
+        toolContext: makeContext(),
+      })) as {returncode: number};
+
+      expect(res.returncode).toBe(0);
+    });
+  });
+
+  describeOnPosix('Command Execution & Environment', () => {
     it('executes command when confirmation is approved', async () => {
       const tool = new ExecuteBashTool({requireConfirmation: true});
       const context = makeContext({
@@ -214,10 +414,20 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       expect(res.returncode).toBe(0);
       expect(res.stdout).toContain('confirmed execution');
     });
-  });
 
-  describe('Command Execution & Environment', () => {
-    it('executes a standard echo command and captures stdout', async () => {
+    it('executes without a confirmation when the gate is disabled', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: false});
+      // No `toolConfirmation` on the context: the gate is off, so it runs.
+      const res = (await tool.runAsync({
+        args: {command: `${NODE} -e "process.stdout.write('ungated')"`},
+        toolContext: makeContext(),
+      })) as {stdout: string; returncode: number};
+
+      expect(res.returncode).toBe(0);
+      expect(res.stdout).toContain('ungated');
+    });
+
+    it('executes a standard command and captures stdout', async () => {
       const tool = new ExecuteBashTool({requireConfirmation: false});
       const res = (await tool.runAsync({
         args: {
@@ -264,6 +474,18 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       expect(res.stderr).toContain('error_in_test_execution');
     });
 
+    it('reports an unknown program as an execution failure', async () => {
+      const tool = new ExecuteBashTool({requireConfirmation: false});
+      const res = (await tool.runAsync({
+        args: {command: 'adk_no_such_binary_for_tests --help'},
+        toolContext: makeContext(),
+      })) as {error: string};
+
+      expect(res.error).toContain('Execution failed:');
+    });
+  });
+
+  describeOnPosix('Timeouts', () => {
     it('handles command timeouts correctly', async () => {
       const tool = new ExecuteBashTool({
         policy: {timeoutSeconds: 1},
@@ -271,11 +493,66 @@ describe('ExecuteBashTool & BashToolPolicy', () => {
       });
 
       const res = (await tool.runAsync({
-        args: {command: `${NODE} -e "setTimeout(() => {}, 5000)"`},
+        args: {command: `${NODE} -e "setTimeout(() => {}, 30000)"`},
         toolContext: makeContext(),
       })) as {error: string};
 
       expect(res.error).toBe('Command timed out after 1 seconds.');
+    });
+
+    it('kills the whole process group, not just the direct child', async () => {
+      const marker = path.join(tempDir, 'grandchild.txt');
+      const scriptPath = path.join(tempDir, 'spawner.js');
+      // The child spawns a grandchild that writes the marker after a delay,
+      // then blocks past the timeout. Signalling only the child would leave the
+      // grandchild running to write the marker.
+      const grandchildScript =
+        `setTimeout(() => require('node:fs')` +
+        `.writeFileSync(process.argv[1], 'x'), 2000)`;
+      await fs.writeFile(
+        scriptPath,
+        `const {spawn} = require('node:child_process');\n` +
+          `spawn(process.execPath, [` +
+          `'-e', ${JSON.stringify(grandchildScript)}, ${JSON.stringify(marker)}` +
+          `], {stdio: 'ignore'});\n` +
+          `setTimeout(() => {}, 30000);\n`,
+      );
+
+      const tool = new ExecuteBashTool({
+        workspace: tempDir,
+        policy: {timeoutSeconds: 1},
+        requireConfirmation: false,
+      });
+
+      const res = (await tool.runAsync({
+        args: {command: `${NODE} ${JSON.stringify(scriptPath)}`},
+        toolContext: makeContext(),
+      })) as {error: string};
+
+      expect(res.error).toBe('Command timed out after 1 seconds.');
+
+      // Well past the grandchild's 2s delay.
+      await sleep(3500);
+      expect(await exists(marker)).toBe(false);
+    }, 20000);
+
+    it('does not report a non-timeout signal as a timeout', async () => {
+      const tool = new ExecuteBashTool({
+        policy: {timeoutSeconds: 30},
+        requireConfirmation: false,
+      });
+
+      // The command signals itself; that is not a timeout and must not be
+      // reported as one.
+      const res = (await tool.runAsync({
+        args: {
+          command: `${NODE} -e "process.kill(process.pid, 'SIGKILL')"`,
+        },
+        toolContext: makeContext(),
+      })) as {error?: string; returncode: number | null};
+
+      expect(res.error).toBeUndefined();
+      expect(res.returncode).toBeNull();
     });
   });
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
- Closes: N/A
- Related: N/A

**2. Problem:**
1. **Missing Feature Parity with Python ADK:** In Python ADK (`google.adk.tools.bash_tool`), `ExecuteBashTool` and `BashToolPolicy` are standard built-in tools. In TypeScript ADK (`adk-js`), there was previously no built-in tool that allowed agents to run terminal commands safely.
2. **Security Risks with Shell Execution:** Allowing an AI agent to execute commands through a system shell can be dangerous because shell characters (such as `;`, `|`, and `&&`) can bypass command allowlists and run unauthorized commands.
3. **Lack of Standard Controls:** TypeScript developers needed a safe and standardized way to let agents run commands with prefix allowlists, timeout controls, and human-in-the-loop approval.

**3. Solution:**
We implement `ExecuteBashTool` (also exported as `BashTool`) and `BashToolPolicy` in `@google/adk` to match the security model of Python ADK.

1. **Direct Binary Execution Without a Shell:**
   Commands are split into arguments using a parser equivalent to Python's `shlex.split`. The command is executed directly using `node:child_process.spawn` without passing through `/bin/sh`. This ensures that shell operators like `;`, `|`, and `&&` are treated as plain text arguments rather than shell commands, preventing allowlist bypasses.

2. **Policy Enforcement (`BashToolPolicy`):**
   Developers can set allowed command prefixes (for example, only allowing `['git']` commands). Dangerous operators can also be blocked as an extra layer of defense.

3. **Process Group Timeouts:**
   Commands run with configurable timeouts (defaulting to 30 seconds). When a command times out, the tool terminates the entire detached process group using `SIGKILL` so that background child processes are not left running.

4. **POSIX Platform Support and Working Directory:**
   This tool is supported on POSIX systems (Linux and macOS). Non-POSIX platforms such as Windows are refused, matching Python ADK. The tool sets the starting working directory (`cwd`) of the process to the specified workspace folder.

5. **Human-in-the-Loop Confirmation:**
   Commands require user confirmation by default before they run. The tool description automatically updates so the model knows whether human confirmation is active.

6. **Safe Packaging and Branding:**
   The tool is exported from `core/src/index.ts` so that Node child process dependencies are kept out of browser bundles. The policy class uses a brand symbol check (`isBashToolPolicy`) so it works reliably across multiple bundled packages.

---

### Testing Plan

**Unit Tests:**
- [x] I have added unit tests for this feature.
- [x] All unit tests pass locally.

**Summary of Unit Test Results:**
- Added 33 unit tests in `core/test/tools/bash_tool_test.ts`.
- Tests verify command tokenization, allowed prefix enforcement, and blocked operator handling.
- Negative security tests confirm that shell metacharacters and command chaining cannot escape the prefix allowlist.
- Tests verify that timeouts cleanly kill the full process group and do not leave background processes running.
- Tests verify human confirmation approval and rejection paths.
- Tests confirm that non-POSIX environments are properly refused.
- All 33 unit tests pass cleanly, and the full repository test suite passes with 0 errors.

---

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have added unit tests that prove the feature works and enforces security controls.
- [x] New and existing unit tests pass locally.
- [x] Linter, formatter, documentation checks, and TypeScript type checks are clean.
