### PR TITLE
fix(workflow): let a resumed graph route back through a node it already ran

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -385,6 +385,16 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
   disallowTransferToParent: boolean;
   disallowTransferToPeers: boolean;
   includeContents: 'default' | 'none';
+
+  /**
+   * Whether {@link includeContents} was set by the caller rather than defaulted.
+   *
+   * A workflow node runs its agent for a single turn on the input the graph
+   * handed it, so the agent must not also read the surrounding conversation —
+   * unless the author asked for it. Mirrors Python checking
+   * `'include_contents' in agent.model_fields_set`.
+   */
+  readonly includeContentsExplicit: boolean;
   mode?: 'single_turn' | 'task';
   inputSchema?: Schema;
   outputSchema?: Schema;
@@ -422,6 +432,7 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
     this.disallowTransferToParent = config.disallowTransferToParent ?? false;
     this.disallowTransferToPeers = config.disallowTransferToPeers ?? false;
     this.includeContents = config.includeContents ?? 'default';
+    this.includeContentsExplicit = config.includeContents !== undefined;
     this.inputSchemaSource = config.inputSchema;
     this.outputSchemaSource = config.outputSchema;
     this.inputSchema = isZodObject(config.inputSchema)

--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -22,6 +22,7 @@ import {
   AF_FUNCTION_CALL_ID_PREFIX,
   REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
   REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+  REQUEST_INPUT_FUNCTION_CALL_NAME,
 } from '../functions.js';
 
 /**
@@ -66,31 +67,9 @@ export function getContents(
       continue;
     }
 
-    // Skip events without content, or generated neither by user nor by model.
-    // E.g. events purely for mutating session states.
-    if (!event.content?.role || event.content.parts?.[0]?.text === '') {
-      continue;
-    }
-
-    // Skip events not in the current branch.
-    // simplicity: direct segment prefix check avoids per-invocation Trie allocations; upgrade to Trie index if unique branches > 100
     if (
-      currentBranch &&
-      event.branch &&
-      !isSegmentPrefix(currentBranch, event.branch)
+      !shouldIncludeEventInContext(event, currentBranch, currentIsolationScope)
     ) {
-      continue;
-    }
-
-    if (isOutsideIsolationScope(event, currentIsolationScope)) {
-      continue;
-    }
-
-    if (isAuthEvent(event)) {
-      continue;
-    }
-
-    if (isToolConfirmationEvent(event)) {
       continue;
     }
 
@@ -111,6 +90,65 @@ export function getContents(
     contents.push(content);
   }
   return contents;
+}
+
+/**
+ * Whether an event may appear in an LLM request at all: it carries content,
+ * belongs to the current branch and isolation scope, and is not an internal
+ * auth/confirmation event.
+ *
+ * Shared by {@link getContents} and {@link getCurrentTurnContents} so the scan
+ * for where a turn starts cannot settle on an event the build then drops —
+ * which yields empty contents. Mirrors Python's
+ * `_should_include_event_in_context`, which its equivalent scan also applies.
+ */
+function shouldIncludeEventInContext(
+  event: Event,
+  currentBranch?: string,
+  currentIsolationScope?: string,
+): boolean {
+  if (!event.content?.role || event.content.parts?.[0]?.text === '') {
+    return false;
+  }
+  if (
+    currentBranch &&
+    event.branch &&
+    !isSegmentPrefix(currentBranch, event.branch)
+  ) {
+    return false;
+  }
+  if (isOutsideIsolationScope(event, currentIsolationScope)) {
+    return false;
+  }
+  return (
+    !isAuthEvent(event) &&
+    !isToolConfirmationEvent(event) &&
+    !isRequestInputEvent(event)
+  );
+}
+
+/**
+ * Whether the event is a workflow human-input interrupt or its reply.
+ *
+ * Like the auth and tool-confirmation interrupts alongside it, this exchange is
+ * between the framework and the client, not something the model asked for. An
+ * agent that never issued the call must not be shown its reply: the reply would
+ * arrive as a function response with no matching call in view, which the
+ * rearrange step rejects outright.
+ */
+function isRequestInputEvent(event: Event): boolean {
+  if (!event.content?.parts) {
+    return false;
+  }
+  for (const part of event.content.parts) {
+    if (
+      part.functionCall?.name === REQUEST_INPUT_FUNCTION_CALL_NAME ||
+      part.functionResponse?.name === REQUEST_INPUT_FUNCTION_CALL_NAME
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -140,7 +178,9 @@ export function getCurrentTurnContents(
   // Find the latest event that starts the current turn and process from there.
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i];
-    if (isOutsideIsolationScope(event, currentIsolationScope)) {
+    if (
+      !shouldIncludeEventInContext(event, currentBranch, currentIsolationScope)
+    ) {
       continue;
     }
     if (event.author === 'user' || isEventFromAnotherAgent(agentName, event)) {

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -69,6 +69,13 @@ export interface ExecuteChildNodeParams {
    */
   abortSignal?: AbortSignal;
   nodeState?: NodeState;
+  /**
+   * Resume responses this run may consume, overriding the parent's. The
+   * workflow loop passes an empty map for a run that is not the one recovered
+   * from the previous turn, so a node re-triggered later in a resumed turn
+   * starts clean instead of re-reading a response it already answered.
+   */
+  resumeInputs?: Record<string, unknown>;
 }
 
 /**
@@ -130,6 +137,7 @@ async function runChildNode({
     options = {},
     abortSignal,
     nodeState: callerNodeState,
+    resumeInputs,
   },
   nodeName,
   nodePath,
@@ -174,7 +182,7 @@ async function runChildNode({
     channel: parent.channel,
     nodePath,
     runId,
-    resumeInputs: parent.resumeInputs,
+    resumeInputs: resumeInputs ?? parent.resumeInputs,
     isolationScope,
   });
   // Propagate the dynamic scheduler down; a nested Workflow overrides it.

--- a/core/src/workflow/nodes/function_node.ts
+++ b/core/src/workflow/nodes/function_node.ts
@@ -121,6 +121,8 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
       // Plain value or Promise of a value.
       yield await (result as Promise<FunctionNodeResult<TOutput>>);
     }
+
+    yield undefined;
   }
 
   /**
@@ -182,6 +184,27 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
     return Object.keys(delta).length > 0 ? delta : undefined;
   }
 
+  /**
+   * Writes an emitted event's state delta into the node's own state view, and
+   * records it as already attached so {@link pendingStateDelta} does not emit a
+   * second event carrying the same keys.
+   */
+  private applyEmittedState(
+    ctx: NodeContext,
+    delta: Record<string, unknown> | undefined,
+  ): void {
+    if (!delta || Object.keys(delta).length === 0) {
+      return;
+    }
+    ctx.state.update(delta);
+    const shadow = this.attachedStateByCtx.get(ctx);
+    if (shadow) {
+      for (const [key, value] of Object.entries(delta)) {
+        shadow.set(key, value);
+      }
+    }
+  }
+
   protected override toEvent(ctx: NodeContext, data: unknown): Event | null {
     const stateDelta = this.pendingStateDelta(ctx);
 
@@ -206,6 +229,7 @@ export class FunctionNode<TInput = unknown, TOutput = unknown> extends BaseNode<
         // node's accumulated context state.
         event.actions.stateDelta = {...stateDelta, ...event.actions.stateDelta};
       }
+      this.applyEmittedState(ctx, event.actions.stateDelta);
       return event;
     }
 

--- a/core/src/workflow/run_llm_agent_as_node.ts
+++ b/core/src/workflow/run_llm_agent_as_node.ts
@@ -47,6 +47,10 @@ export async function* runLlmAgentAsNode(
   ctx: NodeContext,
   nodeInput: unknown,
 ): AsyncGenerator<Event, void, void> {
+  if (agent.mode !== 'task' && !agent.includeContentsExplicit) {
+    agent.includeContents = 'none';
+  }
+
   await appendNodeInputAsUserTurn(ctx, nodeInput);
 
   const agentIc = withWorkflowInstructionScope(ctx.getInvocationContext(), {

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -219,22 +219,102 @@ export function resolvedInterruptResponses(
   return resolved;
 }
 
+/**
+ * Reconstructs each node's prior runs in order, rather than merging them into
+ * one record per node.
+ *
+ * A node the graph routes back to runs more than once, and a pause can fall
+ * between two of its runs — the revise loop in the request-input samples pauses
+ * on `request_human_review@1`, resumes, and pauses again on `@2`. Merged into a
+ * single record those two runs are indistinguishable, and the resumed turn
+ * replays the first run's answer forever. `google/adk-python` avoids this by
+ * keying its recovered executions on `name@run_id`; TypeScript node paths carry
+ * no run id for static graph nodes, so the runs are recovered positionally
+ * instead: the Nth activation in the resumed turn matches the Nth prior run.
+ *
+ * A run is closed once it has produced an output, a route, or an interrupt, so
+ * the next event for that node opens the next run. Events a run emits before
+ * that (messages, state deltas) accumulate into the run in progress.
+ */
+export function reconstructNodeRuns(
+  events: Event[],
+  parentPath?: string,
+): Map<string, RehydratedNode[]> {
+  return reconstructRuns(events, keyFn(parentPath));
+}
+
+function keyFn(parentPath?: string): (event: Event) => string | undefined {
+  if (parentPath) {
+    return (event) =>
+      event.nodeInfo?.path
+        ? directChildName(event.nodeInfo.path, parentPath)
+        : undefined;
+  }
+  return (event) =>
+    event.nodeInfo?.path ? nodeNameFromPath(event.nodeInfo.path) : event.author;
+}
+
+/** Whether a run has reached a terminal result, so the next event is a new run. */
+function isRunClosed(node: RehydratedNode): boolean {
+  return (
+    node.output !== undefined ||
+    node.route !== undefined ||
+    node.interruptIds.size > 0
+  );
+}
+
 /** Shared scan that groups node events by the key returned by `keyFor`. */
 function reconstruct(
   events: Event[],
   keyFor: (event: Event) => string | undefined,
 ): Map<string, RehydratedNode> {
-  const nodes = new Map<string, RehydratedNode>();
-  const interruptOwner = new Map<string, string>();
+  const merged = new Map<string, RehydratedNode>();
+  for (const [key, runs] of reconstructRuns(events, keyFor)) {
+    const node: RehydratedNode = {
+      interruptIds: new Set(),
+      resolvedResponses: new Map(),
+    };
+    for (const run of runs) {
+      if (run.output !== undefined) {
+        node.output = run.output;
+        node.branch = run.branch;
+      }
+      if (run.route !== undefined) node.route = run.route;
+      if (run.input !== undefined) node.input = run.input;
+      for (const id of run.interruptIds) node.interruptIds.add(id);
+      for (const [id, value] of run.resolvedResponses) {
+        node.resolvedResponses.set(id, value);
+      }
+    }
+    merged.set(key, node);
+  }
+  return merged;
+}
+
+function reconstructRuns(
+  events: Event[],
+  keyFor: (event: Event) => string | undefined,
+): Map<string, RehydratedNode[]> {
+  const nodes = new Map<string, RehydratedNode[]>();
+  const interruptOwner = new Map<string, RehydratedNode>();
   const resolved = resolvedInterruptResponses(events);
 
-  const getNode = (name: string): RehydratedNode => {
-    let node = nodes.get(name);
-    if (!node) {
-      node = {interruptIds: new Set(), resolvedResponses: new Map()};
-      nodes.set(name, node);
+  const currentRun = (name: string): RehydratedNode => {
+    let runs = nodes.get(name);
+    if (!runs) {
+      runs = [];
+      nodes.set(name, runs);
     }
-    return node;
+    const open = runs[runs.length - 1];
+    if (open && !isRunClosed(open)) {
+      return open;
+    }
+    const run: RehydratedNode = {
+      interruptIds: new Set(),
+      resolvedResponses: new Map(),
+    };
+    runs.push(run);
+    return run;
   };
 
   for (const event of events) {
@@ -245,8 +325,9 @@ function reconstruct(
       for (const part of event.content.parts) {
         const fr = part.functionResponse;
         if (fr?.id && interruptOwner.has(fr.id) && resolved.has(fr.id)) {
-          const owner = interruptOwner.get(fr.id)!;
-          getNode(owner).resolvedResponses.set(fr.id, resolved.get(fr.id));
+          interruptOwner
+            .get(fr.id)!
+            .resolvedResponses.set(fr.id, resolved.get(fr.id));
         }
       }
       continue;
@@ -257,7 +338,7 @@ function reconstruct(
     if (!key) {
       continue;
     }
-    const node = getNode(key);
+    const node = currentRun(key);
     if (event.output !== undefined) {
       node.output = event.output;
       node.branch = event.branch;
@@ -267,7 +348,7 @@ function reconstruct(
     }
     for (const id of event.longRunningToolIds ?? []) {
       node.interruptIds.add(id);
-      interruptOwner.set(id, key);
+      interruptOwner.set(id, node);
     }
     // Capture the node's original input, stashed on the interrupt event, so a
     // resumed waiting node re-runs with it (not the resume message). Guard the
@@ -296,11 +377,12 @@ function lastUserEvent(events: Event[]): Event | undefined {
 }
 
 /**
- * Whether a rehydrated node can be fast-forwarded on resume: it produced an
- * output and all of its raised interrupts have been resolved.
+ * Whether a rehydrated node can be fast-forwarded on resume: it produced a
+ * result — an output or a route — and all of its raised interrupts have been
+ * resolved.
  */
 export function isFastForwardable(node: RehydratedNode): boolean {
-  if (node.output === undefined) {
+  if (node.output === undefined && node.route === undefined) {
     return false;
   }
   for (const id of node.interruptIds) {

--- a/core/src/workflow/workflow.ts
+++ b/core/src/workflow/workflow.ts
@@ -32,7 +32,7 @@ import {
   eventsForCurrentRun,
   isFastForwardable,
   makeFastForwardResult,
-  reconstructNodeStates,
+  reconstructNodeRuns,
   RehydratedNode,
   resolvedInterruptResponses,
 } from './utils/rehydration_utils.js';
@@ -101,7 +101,10 @@ class LoopState {
   readonly pending = new Map<string, Promise<CompletedTask>>();
   readonly interruptIds = new Set<string>();
   /** Per-node state reconstructed from prior session events (resume). */
-  rehydrated: Map<string, RehydratedNode> = new Map();
+  rehydrated: Map<string, RehydratedNode[]> = new Map();
+
+  /** Nodes already activated in this turn, so a repeat activation is visible. */
+  activated: Set<string> = new Set();
   errorShutDown = false;
   /**
    * Workflow-scoped abort signal handed to each scheduled node so a failure can
@@ -226,7 +229,7 @@ export class Workflow extends BaseNode {
       ctx.session?.events ?? [],
       ctx.invocationId,
     );
-    const rehydrated = reconstructNodeStates(
+    const rehydrated = reconstructNodeRuns(
       runEvents,
       ctx.nodePath || undefined,
     );
@@ -431,10 +434,12 @@ export class Workflow extends BaseNode {
   ): void {
     const node = this.getStaticNode(nodeName);
     const nodeState = loop.nodes.get(nodeName)!;
+    const repeatActivation = loop.activated.has(nodeName);
+    loop.activated.add(nodeName);
 
     // Resume: fast-forward a node that already completed in a prior run
     // (cached output, all interrupts resolved), unless it must rerun on resume.
-    const prior = loop.rehydrated.get(nodeName);
+    const prior = loop.rehydrated.get(nodeName)?.shift();
     if (prior && !node.rerunOnResume && isFastForwardable(prior)) {
       loop.pending.set(
         nodeName,
@@ -498,6 +503,7 @@ export class Workflow extends BaseNode {
       input: nodeInput,
       abortSignal: loop.abortSignal,
       nodeState,
+      resumeInputs: repeatActivation ? {} : undefined,
       options: {
         runId,
         useSubBranch: trigger.useSubBranch,

--- a/core/test/workflow/agent_node_contents_test.ts
+++ b/core/test/workflow/agent_node_contents_test.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * What an `LlmAgent` sees when it runs as a workflow node: the input the graph
+ * handed it, and nothing else. The node input is appended as the agent's user
+ * turn and predecessor outputs reach it through the instruction scope, so
+ * leaving the surrounding conversation in duplicates the one and leaks the
+ * other.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {LlmAgent} from '../../src/agents/llm_agent.js';
+import {createEvent, Event} from '../../src/events/event.js';
+import {BaseLlm} from '../../src/models/base_llm.js';
+import type {BaseLlmConnection} from '../../src/models/base_llm_connection.js';
+import type {LlmRequest} from '../../src/models/llm_request.js';
+import type {LlmResponse} from '../../src/models/llm_response.js';
+import {LLMRegistry} from '../../src/models/registry.js';
+import {AsyncQueue} from '../../src/utils/async_queue.js';
+import {node} from '../../src/workflow/node.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {Workflow} from '../../src/workflow/workflow.js';
+import {createIc} from './test_helpers.js';
+
+const requests: LlmRequest[] = [];
+
+/** Captures each request and answers with a fixed reply. */
+class CaptureLlm extends BaseLlm {
+  static override readonly supportedModels = [/capture-.*/];
+
+  override async *generateContentAsync(
+    llmRequest: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void> {
+    requests.push(
+      structuredClone({contents: llmRequest.contents}) as LlmRequest,
+    );
+    yield {content: {role: 'model', parts: [{text: 'ok'}]}} as LlmResponse;
+  }
+
+  override connect(): Promise<BaseLlmConnection> {
+    throw new Error('not supported');
+  }
+}
+LLMRegistry.register(CaptureLlm);
+
+async function drive(wf: Workflow, input: unknown): Promise<void> {
+  const channel = new AsyncQueue<Event>();
+  const root = new NodeContext({
+    invocationContext: createIc(),
+    channel,
+    nodePath: '',
+    runId: 'root',
+  });
+  const run = root.runNode(wf, input, {useAsOutput: true}).then(
+    () => channel.close(),
+    (err) => channel.fail(err),
+  );
+  for await (const _event of channel) {
+    // drain
+  }
+  await run;
+}
+
+const texts = (request: LlmRequest): string[] =>
+  (request.contents ?? []).flatMap((c) =>
+    (c.parts ?? []).map((p) => p.text ?? ''),
+  );
+
+describe('LlmAgent as a workflow node — request contents', () => {
+  it('sees its node input once, not the user turn as well', async () => {
+    requests.length = 0;
+    const agent = new LlmAgent({
+      name: 'agent',
+      model: 'capture-1',
+      instruction: 'answer',
+    });
+    const wf = new Workflow({name: 'wf', edges: [['START', agent]]});
+
+    await drive(wf, 'hello');
+
+    expect(requests).toHaveLength(1);
+    expect(texts(requests[0])).toEqual(['hello']);
+  });
+
+  it('does not inherit a predecessor node output that emitted no content', async () => {
+    requests.length = 0;
+    const produce = node(
+      (_c: NodeContext, value: string) =>
+        createEvent({output: `wrapped:${value}`}),
+      {name: 'produce'},
+    );
+    const agent = new LlmAgent({
+      name: 'agent',
+      model: 'capture-1',
+      instruction: 'answer',
+    });
+    const wf = new Workflow({name: 'wf', edges: [['START', produce, agent]]});
+
+    await drive(wf, 'hello');
+
+    expect(requests).toHaveLength(1);
+    expect(texts(requests[0])).toEqual(['wrapped:hello']);
+  });
+
+  it('honours an explicit includeContents', async () => {
+    requests.length = 0;
+    const agent = new LlmAgent({
+      name: 'agent',
+      model: 'capture-1',
+      instruction: 'answer',
+      includeContents: 'default',
+    });
+    const wf = new Workflow({name: 'wf', edges: [['START', agent]]});
+
+    await drive(wf, 'hello');
+
+    expect(agent.includeContents).toBe('default');
+    expect(texts(requests[0])).toContain('hello');
+  });
+});

--- a/core/test/workflow/node_state_events_test.ts
+++ b/core/test/workflow/node_state_events_test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * How a node's state writes reach the event stream and the nodes after it.
+ * Both directions matter: the session is rebuilt from events, and a later node
+ * reads through `ctx.state`.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {createEvent, Event} from '../../src/events/event.js';
+import {AsyncQueue} from '../../src/utils/async_queue.js';
+import {node} from '../../src/workflow/node.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {Workflow} from '../../src/workflow/workflow.js';
+import {createIc} from './test_helpers.js';
+
+async function drive(
+  wf: Workflow,
+  input?: unknown,
+): Promise<{output: unknown; events: Event[]}> {
+  const channel = new AsyncQueue<Event>();
+  const root = new NodeContext({
+    invocationContext: createIc(),
+    channel,
+    nodePath: '',
+    runId: 'root',
+  });
+  const events: Event[] = [];
+  const run = root.runNode(wf, input, {useAsOutput: true}).then(
+    () => channel.close(),
+    (err) => channel.fail(err),
+  );
+  for await (const event of channel) {
+    events.push(event);
+  }
+  await run;
+  return {output: root.output, events};
+}
+
+const deltas = (events: Event[]): Array<Record<string, unknown>> =>
+  events
+    .map((e) => e.actions?.stateDelta ?? {})
+    .filter((d) => Object.keys(d).length > 0);
+
+describe('node state writes and the event stream', () => {
+  it('reports state written by a generator node that yields nothing', async () => {
+    const write = node(
+      // eslint-disable-next-line require-yield
+      async function* (ctx: NodeContext, input: string) {
+        ctx.state.set('seen', input);
+      },
+      {name: 'write'},
+    );
+    const read = node((ctx: NodeContext) => `read:${ctx.state.get('seen')}`, {
+      name: 'read',
+    });
+    const wf = new Workflow({name: 'wf', edges: [['START', write, read]]});
+
+    const {output, events} = await drive(wf, 'x');
+
+    expect(deltas(events)).toEqual([{seen: 'x'}]);
+    expect(output).toBe('read:x');
+  });
+
+  it('makes state carried on an emitted event readable by the next node', async () => {
+    const write = node(
+      (_c: NodeContext, input: string) =>
+        createEvent({actions: {stateDelta: {seen: input.toUpperCase()}}}),
+      {name: 'write'},
+    );
+    const read = node((ctx: NodeContext) => `read:${ctx.state.get('seen')}`, {
+      name: 'read',
+    });
+    const wf = new Workflow({name: 'wf', edges: [['START', write, read]]});
+
+    const {output, events} = await drive(wf, 'x');
+
+    expect(deltas(events)).toEqual([{seen: 'X'}]);
+    expect(output).toBe('read:X');
+  });
+});

--- a/core/test/workflow/resume_loopback_test.ts
+++ b/core/test/workflow/resume_loopback_test.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resuming a graph that routes back through a node it already ran.
+ *
+ * Both human-in-the-loop shapes in `contributing/samples/workflows` do this:
+ * the reviewer asks for a revision, the graph loops back to the drafting node,
+ * and the review node asks again. The recovered state of a prior run has to
+ * apply to exactly one activation, or the loop replays that run's answer
+ * forever.
+ */
+
+import {Content} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {createEvent, Event} from '../../src/events/event.js';
+import {InMemoryRunner} from '../../src/runner/in_memory_runner.js';
+import {node} from '../../src/workflow/node.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {RequestInput} from '../../src/workflow/request_input.js';
+import {Workflow} from '../../src/workflow/workflow.js';
+
+/** Caps a turn so a routing regression fails the test instead of hanging it. */
+const MAX_EVENTS_PER_TURN = 40;
+
+interface Driver {
+  run(message: Content): Promise<Event[]>;
+}
+
+async function driver(agent: Workflow): Promise<Driver> {
+  const runner = new InMemoryRunner({agent, appName: 'app'});
+  const session = await runner.sessionService.createSession({
+    appName: 'app',
+    userId: 'u',
+  });
+  return {
+    async run(message: Content): Promise<Event[]> {
+      const events: Event[] = [];
+      for await (const event of runner.runAsync({
+        userId: 'u',
+        sessionId: session.id,
+        newMessage: message,
+      })) {
+        events.push(event);
+        if (events.length > MAX_EVENTS_PER_TURN) {
+          throw new Error(
+            `Runaway turn: over ${MAX_EVENTS_PER_TURN} events, the graph is ` +
+              'looping on a resumed node.',
+          );
+        }
+      }
+      return events;
+    },
+  };
+}
+
+const text = (value: string): Content => ({
+  role: 'user',
+  parts: [{text: value}],
+});
+
+const reply = (id: string, value: string): Content => ({
+  role: 'user',
+  parts: [
+    {
+      functionResponse: {
+        id,
+        name: 'adk_request_input',
+        response: {result: value},
+      },
+    },
+  ],
+});
+
+function pendingInterruptId(events: Event[]): string {
+  const id = events
+    .flatMap((e) => e.content?.parts ?? [])
+    .find((p) => p.functionCall)?.functionCall?.id;
+  expect(id, 'the turn should have paused on an interrupt').toBeDefined();
+  return id!;
+}
+
+const routes = (events: Event[]): unknown[] =>
+  events.map((e) => e.route).filter((r) => r !== undefined);
+
+describe('workflow resume — routing back through an already-run node', () => {
+  it('re-runs the drafting node when the reviewer asks for a revision', async () => {
+    let drafts = 0;
+    const draft = node(() => `draft #${++drafts}`, {name: 'draft'});
+    const askReview = node(
+      (_c: NodeContext, value: string) =>
+        new RequestInput({message: `review: ${value}`}),
+      {name: 'ask_review'},
+    );
+    const handleReview = node(
+      (_c: NodeContext, answer: string) =>
+        createEvent({route: answer === 'approve' ? 'approved' : 'revise'}),
+      {name: 'handle_review'},
+    );
+    const send = node(() => 'sent', {name: 'send'});
+
+    const wf = new Workflow({
+      name: 'two_node',
+      edges: [
+        ['START', draft, askReview, handleReview],
+        [handleReview, {revise: draft, approved: send}],
+      ],
+    });
+    const run = await driver(wf);
+
+    const turn1 = await run.run(text('go'));
+    const turn2 = await run.run(reply(pendingInterruptId(turn1), 'shorter'));
+
+    expect(routes(turn2)).toEqual(['revise']);
+    expect(drafts).toBe(2);
+
+    const turn3 = await run.run(reply(pendingInterruptId(turn2), 'approve'));
+    expect(routes(turn3)).toEqual(['approved']);
+    expect(turn3.some((e) => e.output === 'sent')).toBe(true);
+    expect(drafts).toBe(2);
+  });
+
+  it('does not hand a rerun-on-resume node the reply it already consumed', async () => {
+    let drafts = 0;
+    const draft = node(() => `draft #${++drafts}`, {name: 'draft'});
+    const review = node(
+      (ctx: NodeContext, value: string) => {
+        const answer = ctx.resumeInputs['review'];
+        if (!answer) {
+          return new RequestInput({
+            interruptId: 'review',
+            message: `review: ${value}`,
+          });
+        }
+        return createEvent({
+          route: answer === 'approve' ? 'approved' : 'revise',
+        });
+      },
+      {name: 'review', rerunOnResume: true},
+    );
+    const send = node(() => 'sent', {name: 'send'});
+
+    const wf = new Workflow({
+      name: 'rerun',
+      edges: [
+        ['START', draft, review],
+        [review, {revise: draft, approved: send}],
+      ],
+    });
+    const run = await driver(wf);
+
+    await run.run(text('go'));
+    const turn2 = await run.run(reply('review', 'shorter'));
+
+    expect(routes(turn2)).toEqual(['revise']);
+    expect(drafts).toBe(2);
+
+    const turn3 = await run.run(reply('review', 'approve'));
+    expect(routes(turn3)).toEqual(['approved']);
+    expect(turn3.some((e) => e.output === 'sent')).toBe(true);
+  });
+
+  it('replays a routing node from its recorded route instead of re-running it', async () => {
+    let routed = 0;
+    const gate = node(
+      (_c: NodeContext, value: string) => {
+        routed++;
+        return new RequestInput({interruptId: 'gate', message: value});
+      },
+      {name: 'gate'},
+    );
+    const decide = node(
+      (_c: NodeContext, answer: string) => {
+        return createEvent({route: answer === 'stop' ? 'stop' : 'go'});
+      },
+      {name: 'decide'},
+    );
+    const finish = node(() => 'done', {name: 'finish'});
+    const halt = node(() => 'halted', {name: 'halt'});
+
+    const wf = new Workflow({
+      name: 'routing',
+      edges: [
+        ['START', gate, decide],
+        [decide, {go: finish, stop: halt}],
+      ],
+    });
+    const run = await driver(wf);
+
+    const turn1 = await run.run(text('go'));
+    const turn2 = await run.run(reply(pendingInterruptId(turn1), 'go'));
+
+    expect(routed).toBe(1);
+    expect(routes(turn2)).toEqual(['go']);
+    expect(turn2.some((e) => e.output === 'done')).toBe(true);
+  });
+});

--- a/tests/integration/workflows/agent_in_workflow/model_responses.json
+++ b/tests/integration/workflows/agent_in_workflow/model_responses.json
@@ -68,7 +68,7 @@
                     "phone_number": "555-1234",
                     "name": "Jane Doe"
                   },
-                  "id": "adk-18e2b23f-d850-491f-b7ac-349573590968"
+                  "id": "adk-12954685-17c9-4aeb-b1ee-077ec784040d"
                 }
               }
             ]
@@ -79,7 +79,7 @@
       "usageMetadata": {
         "promptTokenCount": 206,
         "candidatesTokenCount": 17,
-        "totalTokenCount": 272,
+        "totalTokenCount": 309,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -93,53 +93,15 @@
             "tokenCount": 17
           }
         ],
-        "thoughtsTokenCount": 49
+        "thoughtsTokenCount": 86
       }
     }
   },
   {
-    "key": "1a51e880b664a1a9",
-    "instructionAgnosticKey": "e041756c62222956",
+    "key": "5c5365170f539e07",
+    "instructionAgnosticKey": "548db01caf18de84",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "I am Jane Doe, my phone number is 555-1234"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "I am Jane Doe, my phone number is 555-1234"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[intake_agent] called tool `finish_task` with parameters: {\"phone_number\":\"555-1234\",\"name\":\"Jane Doe\"}"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[intake_agent] tool `finish_task` returned result: {\"result\":\"Task completed.\"}"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -183,7 +145,7 @@
                 "functionCall": {
                   "name": "find_orders",
                   "args": {},
-                  "id": "adk-979e2633-064e-4077-91df-8433807d7dcc"
+                  "id": "adk-a616820b-74f2-45aa-821e-1a2af5b30eb9"
                 }
               }
             ]
@@ -192,14 +154,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 182,
+        "promptTokenCount": 83,
         "candidatesTokenCount": 3,
-        "totalTokenCount": 251,
+        "totalTokenCount": 129,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 182
+            "tokenCount": 83
           }
         ],
         "candidatesTokensDetails": [
@@ -208,7 +170,7 @@
             "tokenCount": 3
           }
         ],
-        "thoughtsTokenCount": 66
+        "thoughtsTokenCount": 43
       }
     }
   }

--- a/tests/integration/workflows/auth_oauth/agent.ts
+++ b/tests/integration/workflows/auth_oauth/agent.ts
@@ -24,7 +24,7 @@
  * TypeScript note: Python reads the credential via `ctx.get_auth_response(cfg)`.
  * `NodeContext` has no such helper; the framework stores the exchanged
  * credential at `temp:<credentialKey>` in state (see `AuthHandler`), which the
- * node reads instead. Same as `auth_api_key`; see the gap report.
+ * node reads instead. Same as `auth_api_key`.
  *
  * Sample queries:
  *   - "start"

--- a/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
+++ b/tests/integration/workflows/dynamic_fan_out_fan_in/model_responses.json
@@ -1,25 +1,9 @@
 [
   {
-    "key": "f9bb8dcf0415f757",
-    "instructionAgnosticKey": "c5961d15bc449f56",
+    "key": "b386c4192eb9fd20",
+    "instructionAgnosticKey": "7b8db6467af3e028",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "AI, Cloud Computing, Quantum Computing"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "AI"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -46,7 +30,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "AI, Cloud, Quantum: The Ultimate Tech Trifecta."
+                "text": "Triple Threat: Handling 3 Topics, One Swift Stroke."
               }
             ]
           },
@@ -54,14 +38,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 54,
+        "promptTokenCount": 46,
         "candidatesTokenCount": 12,
-        "totalTokenCount": 430,
+        "totalTokenCount": 90,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 54
+            "tokenCount": 46
           }
         ],
         "candidatesTokensDetails": [
@@ -70,31 +54,15 @@
             "tokenCount": 12
           }
         ],
-        "thoughtsTokenCount": 364
+        "thoughtsTokenCount": 32
       }
     }
   },
   {
-    "key": "7faf7d4e0cbe2a36",
-    "instructionAgnosticKey": "4a31d3b714eb27f2",
+    "key": "b386c4192eb9fd20",
+    "instructionAgnosticKey": "7b8db6467af3e028",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "AI, Cloud Computing, Quantum Computing"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Cloud Computing"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -121,7 +89,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "AI, Cloud, Quantum: The Tech Trinity Forging Our Future."
+                "text": "Triple Threat: Parallel Processing Engaged."
               }
             ]
           },
@@ -129,47 +97,31 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 55,
-        "candidatesTokenCount": 14,
-        "totalTokenCount": 985,
+        "promptTokenCount": 46,
+        "candidatesTokenCount": 8,
+        "totalTokenCount": 811,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 55
+            "tokenCount": 46
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 14
+            "tokenCount": 8
           }
         ],
-        "thoughtsTokenCount": 916
+        "thoughtsTokenCount": 757
       }
     }
   },
   {
-    "key": "2105595e08af2b48",
-    "instructionAgnosticKey": "3be2874c299f0acb",
+    "key": "b386c4192eb9fd20",
+    "instructionAgnosticKey": "7b8db6467af3e028",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "AI, Cloud Computing, Quantum Computing"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Quantum Computing"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -196,7 +148,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "AI, Cloud, Quantum: Forging the Future of Computing."
+                "text": "**3-Way Flow: Parallel Processing Unleashed!**"
               }
             ]
           },
@@ -204,23 +156,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 55,
-        "candidatesTokenCount": 13,
-        "totalTokenCount": 1296,
+        "promptTokenCount": 46,
+        "candidatesTokenCount": 12,
+        "totalTokenCount": 893,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 55
+            "tokenCount": 46
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 13
+            "tokenCount": 12
           }
         ],
-        "thoughtsTokenCount": 1228
+        "thoughtsTokenCount": 835
       }
     }
   }

--- a/tests/integration/workflows/dynamic_nodes/model_responses.json
+++ b/tests/integration/workflows/dynamic_nodes/model_responses.json
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Blooming Beauty: The Timeless Allure of Flowers"
+                "text": "\"Blooms Aweigh: Celebrating the Beauty of Flowers\""
               }
             ]
           },
@@ -36,8 +36,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 46,
-        "candidatesTokenCount": 10,
-        "totalTokenCount": 87,
+        "candidatesTokenCount": 13,
+        "totalTokenCount": 79,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -48,42 +48,23 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 10
+            "tokenCount": 13
           }
         ],
-        "thoughtsTokenCount": 31
+        "thoughtsTokenCount": 20
       }
     }
   },
   {
-    "key": "dca2d3a7772916d9",
-    "instructionAgnosticKey": "81cb6cad2d7fab34",
+    "key": "4e5aaa538c42d52c",
+    "instructionAgnosticKey": "5fc1b0c8979abc16",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: Blooming Beauty: The Timeless Allure of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Timeless Allure of Flowers"
+              "text": "\"Blooms Aweigh: Celebrating the Beauty of Flowers\""
             }
           ]
         }
@@ -124,7 +105,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}"
+                "text": "{\n  \"grade\": \"unrelated\",\n  \"feedback\": \"To make this headline more tech-focused, consider incorporating elements like 'AI in horticulture,' 'digital flower identification,' 'robotics for plant care,' or 'software for botanical analysis.' For example: 'AI's Role in Blooms Aweigh: Revolutionizing Flower Cultivation' or 'Digital Blooms: Software Innovations for Floral Design.'\"\n}"
               }
             ]
           },
@@ -132,55 +113,31 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 92,
-        "candidatesTokenCount": 70,
-        "totalTokenCount": 324,
+        "promptTokenCount": 74,
+        "candidatesTokenCount": 86,
+        "totalTokenCount": 334,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 92
+            "tokenCount": 74
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 70
+            "tokenCount": 86
           }
         ],
-        "thoughtsTokenCount": 162
+        "thoughtsTokenCount": 174
       }
     }
   },
   {
-    "key": "6c72bb0fcdd7042b",
-    "instructionAgnosticKey": "a133bf8d41cdf97c",
+    "key": "f4b13bbc112bbd74",
+    "instructionAgnosticKey": "9bbb5dd7bf7d06c8",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "model",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Timeless Allure of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Timeless Allure of Flowers"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -188,13 +145,13 @@
               "text": "For context:"
             },
             {
-              "text": "[evaluate_headline] said: {\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}"
+              "text": "[evaluate_headline] said: {\n  \"grade\": \"unrelated\",\n  \"feedback\": \"To make this headline more tech-focused, consider incorporating elements like 'AI in horticulture,' 'digital flower identification,' 'robotics for plant care,' or 'software for botanical analysis.' For example: 'AI's Role in Blooms Aweigh: Revolutionizing Flower Cultivation' or 'Digital Blooms: Software Innovations for Floral Design.'\"\n}"
             }
           ]
         }
       ],
       "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}\n    ",
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"To make this headline more tech-focused, consider incorporating elements like 'AI in horticulture,' 'digital flower identification,' 'robotics for plant care,' or 'software for botanical analysis.' For example: 'AI's Role in Blooms Aweigh: Revolutionizing Flower Cultivation' or 'Digital Blooms: Software Innovations for Floral Design.'\"}\n    ",
         "labels": {
           "adk_agent_name": "generate_headline"
         }
@@ -207,7 +164,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "AI's Floral Revolution: Designing Digital Blooms"
+                "text": "AI in Full Bloom: Revolutionizing the Future of Flowers"
               }
             ]
           },
@@ -215,82 +172,36 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 212,
-        "candidatesTokenCount": 9,
-        "totalTokenCount": 936,
+        "promptTokenCount": 217,
+        "candidatesTokenCount": 11,
+        "totalTokenCount": 771,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 212
+            "tokenCount": 217
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 9
+            "tokenCount": 11
           }
         ],
-        "thoughtsTokenCount": 715
+        "thoughtsTokenCount": 543
       }
     }
   },
   {
-    "key": "23c78a6f3b150214",
-    "instructionAgnosticKey": "20036aed37d9d4a2",
+    "key": "9d8a34689a5b7d90",
+    "instructionAgnosticKey": "bc88945041fce61e",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: Blooming Beauty: The Timeless Allure of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Timeless Allure of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "model",
-          "parts": [
-            {
-              "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider topics like 'AI in Floral Design: Crafting Digital Bouquets,' 'Robotic Gardens: Automating Flower Cultivation,' 'Bioinformatics Unlocks the Secrets of Blooming,' or 'VR Flower Arranging: A New Dimension of Beauty.'\"}"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: AI's Floral Revolution: Designing Digital Blooms"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "AI's Floral Revolution: Designing Digital Blooms"
+              "text": "AI in Full Bloom: Revolutionizing the Future of Flowers"
             }
           ]
         }
@@ -331,7 +242,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\"grade\": \"tech-related\", \"feedback\": \"This headline is highly tech-related, specifically mentioning 'AI' and 'Digital Blooms,' which are key concepts in artificial intelligence and digital design/software.\"}"
+                "text": "{\n  \"grade\": \"tech-related\",\n  \"feedback\": \"\"\n}"
               }
             ]
           },
@@ -339,23 +250,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 190,
-        "candidatesTokenCount": 44,
-        "totalTokenCount": 416,
+        "promptTokenCount": 72,
+        "candidatesTokenCount": 19,
+        "totalTokenCount": 363,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 190
+            "tokenCount": 72
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 44
+            "tokenCount": 19
           }
         ],
-        "thoughtsTokenCount": 182
+        "thoughtsTokenCount": 272
       }
     }
   }

--- a/tests/integration/workflows/loop/model_responses.json
+++ b/tests/integration/workflows/loop/model_responses.json
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "The Computer Revolution: Shaping Our Digital Future"
+                "text": "\"The Evolution of Computing: From Room-Sized Machines to Pocket Powerhouses\""
               }
             ]
           },
@@ -36,8 +36,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 46,
-        "candidatesTokenCount": 8,
-        "totalTokenCount": 594,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 80,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -48,402 +48,23 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 8
+            "tokenCount": 17
           }
         ],
-        "thoughtsTokenCount": 540
+        "thoughtsTokenCount": 17
       }
     }
   },
   {
-    "key": "09142a2f4182a0ef",
-    "instructionAgnosticKey": "5601a53640996e24",
+    "key": "8a4787b4f016f1df",
+    "instructionAgnosticKey": "9dacb053ca9ddcce",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "computer"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: The Computer Revolution: Shaping Our Digital Future"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "The Computer Revolution: Shaping Our Digital Future"
-            }
-          ]
-        }
-      ],
-      "config": {
-        "responseSchema": {
-          "type": "OBJECT",
-          "properties": {
-            "grade": {
-              "type": "STRING",
-              "enum": [
-                "tech-related",
-                "unrelated"
-              ],
-              "description": "Decide if the headline is related to technology or software engineering."
-            },
-            "feedback": {
-              "type": "STRING",
-              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
-            }
-          },
-          "required": [
-            "grade",
-            "feedback"
-          ]
-        },
-        "responseMimeType": "application/json",
-        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
-        "labels": {
-          "adk_agent_name": "evaluate_headline"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "{\n  \"grade\": \"tech-related\",\n  \"feedback\": \"\"\n}"
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 88,
-        "candidatesTokenCount": 19,
-        "totalTokenCount": 328,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 88
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 19
-          }
-        ],
-        "thoughtsTokenCount": 221
-      }
-    }
-  },
-  {
-    "key": "ba32ce85868d31a6",
-    "instructionAgnosticKey": "d5b3da4b095b2f9e",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "flower"
-            }
-          ]
-        }
-      ],
-      "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
-        "labels": {
-          "adk_agent_name": "generate_headline"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "Blooming Beauty: The Enduring Charm of Flowers"
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 46,
-        "candidatesTokenCount": 9,
-        "totalTokenCount": 74,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 46
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 9
-          }
-        ],
-        "thoughtsTokenCount": 19
-      }
-    }
-  },
-  {
-    "key": "d1adcca1e879897f",
-    "instructionAgnosticKey": "cfe2236122cc6b85",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: Blooming Beauty: The Enduring Charm of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Enduring Charm of Flowers"
-            }
-          ]
-        }
-      ],
-      "config": {
-        "responseSchema": {
-          "type": "OBJECT",
-          "properties": {
-            "grade": {
-              "type": "STRING",
-              "enum": [
-                "tech-related",
-                "unrelated"
-              ],
-              "description": "Decide if the headline is related to technology or software engineering."
-            },
-            "feedback": {
-              "type": "STRING",
-              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
-            }
-          },
-          "required": [
-            "grade",
-            "feedback"
-          ]
-        },
-        "responseMimeType": "application/json",
-        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
-        "labels": {
-          "adk_agent_name": "evaluate_headline"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}"
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 90,
-        "candidatesTokenCount": 90,
-        "totalTokenCount": 371,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 90
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 90
-          }
-        ],
-        "thoughtsTokenCount": 191
-      }
-    }
-  },
-  {
-    "key": "3ba3628b133649b7",
-    "instructionAgnosticKey": "6b5d3e51a69f808a",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "model",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Enduring Charm of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Enduring Charm of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[evaluate_headline] said: {\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}"
-            }
-          ]
-        }
-      ],
-      "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}\n    ",
-        "labels": {
-          "adk_agent_name": "generate_headline"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "AI-Powered Petals: How Technology is Redefining Flower Cultivation"
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 250,
-        "candidatesTokenCount": 15,
-        "totalTokenCount": 696,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 250
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 15
-          }
-        ],
-        "thoughtsTokenCount": 431
-      }
-    }
-  },
-  {
-    "key": "1158f54ecb2f7e2f",
-    "instructionAgnosticKey": "4996630b58425479",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: Blooming Beauty: The Enduring Charm of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Blooming Beauty: The Enduring Charm of Flowers"
-            }
-          ]
-        },
-        {
-          "role": "model",
-          "parts": [
-            {
-              "text": "{\"grade\": \"unrelated\", \"feedback\": \"To make this headline more tech-focused, consider integrating technology themes. For example, you could discuss using AI for plant care, robotics in horticulture, data science for flower breeding, or virtual reality for botanical experiences. Original: 'Blooming Beauty: The Enduring Charm of Flowers'. Tech-focused example: 'AI in Bloom: Using Deep Learning to Cultivate the Next Generation of Flowers'.\"}"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_headline] said: AI-Powered Petals: How Technology is Redefining Flower Cultivation"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "AI-Powered Petals: How Technology is Redefining Flower Cultivation"
+              "text": "\"The Evolution of Computing: From Room-Sized Machines to Pocket Powerhouses\""
             }
           ]
         }
@@ -492,14 +113,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 220,
+        "promptTokenCount": 78,
         "candidatesTokenCount": 12,
-        "totalTokenCount": 340,
+        "totalTokenCount": 194,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 220
+            "tokenCount": 78
           }
         ],
         "candidatesTokensDetails": [
@@ -508,7 +129,278 @@
             "tokenCount": 12
           }
         ],
-        "thoughtsTokenCount": 108
+        "thoughtsTokenCount": 104
+      }
+    }
+  },
+  {
+    "key": "ba32ce85868d31a6",
+    "instructionAgnosticKey": "d5b3da4b095b2f9e",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "flower"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: \n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "**Flowers: Nature's Colorful Masterpieces**"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 46,
+        "candidatesTokenCount": 10,
+        "totalTokenCount": 210,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 46
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 10
+          }
+        ],
+        "thoughtsTokenCount": 154
+      }
+    }
+  },
+  {
+    "key": "4d004673075e31fa",
+    "instructionAgnosticKey": "1f7e333c52e75042",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "**Flowers: Nature's Colorful Masterpieces**"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ],
+              "description": "Decide if the headline is related to technology or software engineering."
+            },
+            "feedback": {
+              "type": "STRING",
+              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "{\n  \"grade\": \"unrelated\",\n  \"feedback\": \"To make this headline more tech-focused, consider adding elements like 'AI in floral design,' 'bio-engineering for new flower varieties,' or 'innovative software for garden planning.'\"\n}"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 71,
+        "candidatesTokenCount": 55,
+        "totalTokenCount": 226,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 71
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 55
+          }
+        ],
+        "thoughtsTokenCount": 100
+      }
+    }
+  },
+  {
+    "key": "f088dd4b7be65fa8",
+    "instructionAgnosticKey": "4c726c234d778726",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[evaluate_headline] said: {\n  \"grade\": \"unrelated\",\n  \"feedback\": \"To make this headline more tech-focused, consider adding elements like 'AI in floral design,' 'bio-engineering for new flower varieties,' or 'innovative software for garden planning.'\"\n}"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_headline\".\n\n\n    Write a headline about the topic \"flower\".\n    If feedback is provided, take it into account.\n    The feedback: {\"grade\":\"unrelated\",\"feedback\":\"To make this headline more tech-focused, consider adding elements like 'AI in floral design,' 'bio-engineering for new flower varieties,' or 'innovative software for garden planning.'\"}\n    ",
+        "labels": {
+          "adk_agent_name": "generate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "AI Blooms: How Technology is Redefining Flower Cultivation and Floral Design"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 155,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 425,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 155
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 15
+          }
+        ],
+        "thoughtsTokenCount": 255
+      }
+    }
+  },
+  {
+    "key": "d274ae9c443cd86d",
+    "instructionAgnosticKey": "8b79a7d324a206f2",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "AI Blooms: How Technology is Redefining Flower Cultivation and Floral Design"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "grade": {
+              "type": "STRING",
+              "enum": [
+                "tech-related",
+                "unrelated"
+              ],
+              "description": "Decide if the headline is related to technology or software engineering."
+            },
+            "feedback": {
+              "type": "STRING",
+              "description": "If the headline is unrelated to technology, provide feedback on how to make it more tech-focused."
+            }
+          },
+          "required": [
+            "grade",
+            "feedback"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "\n    Grade whether the headline is related to technology or software engineering.\n    ",
+        "labels": {
+          "adk_agent_name": "evaluate_headline"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "{\n  \"grade\": \"tech-related\",\n  \"feedback\": \"\"\n}"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 76,
+        "candidatesTokenCount": 19,
+        "totalTokenCount": 311,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 76
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 19
+          }
+        ],
+        "thoughtsTokenCount": 216
       }
     }
   }

--- a/tests/integration/workflows/loop_self/agent.ts
+++ b/tests/integration/workflows/loop_self/agent.ts
@@ -42,7 +42,6 @@ const validateInput = node(
       throw new Error('Invalid input.');
     } else {
       ctx.state.set('target_number', parsedNumber);
-      yield createEvent({});
     }
   },
   {name: 'validate_input'},

--- a/tests/integration/workflows/nested_workflow/agent.ts
+++ b/tests/integration/workflows/nested_workflow/agent.ts
@@ -35,7 +35,6 @@ const processInput = node(
       throw new Error('Invalid year format.');
     }
     ctx.state.set('year', match[0]);
-    yield createEvent({});
   },
   {name: 'process_input'},
 );

--- a/tests/integration/workflows/nested_workflow/model_responses.json
+++ b/tests/integration/workflows/nested_workflow/model_responses.json
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Mark Zuckerberg"
+                "text": "Robert Pattinson"
               }
             ]
           },
@@ -36,8 +36,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 52,
-        "candidatesTokenCount": 2,
-        "totalTokenCount": 167,
+        "candidatesTokenCount": 3,
+        "totalTokenCount": 96,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -48,10 +48,66 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 2
+            "tokenCount": 3
           }
         ],
-        "thoughtsTokenCount": 113
+        "thoughtsTokenCount": 41
+      }
+    }
+  },
+  {
+    "key": "c18e393877853a11",
+    "instructionAgnosticKey": "fb99c860252431b8",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Robert Pattinson"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_bio\".\n\n\n    Write a short, engaging 3-sentence biography for the specified person.\n    ",
+        "labels": {
+          "adk_agent_name": "generate_bio"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Robert Pattinson shot to global stardom as the brooding vampire Edward Cullen in the *Twilight* saga, captivating millions worldwide. He then masterfully transitioned to critically acclaimed independent films, earning praise for his intense performances in movies like *Good Time* and *The Lighthouse*. Most recently, he donned the cape and cowl as the Caped Crusader in *The Batman*, solidifying his status as one of Hollywood's most versatile and compelling leading men."
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 36,
+        "candidatesTokenCount": 90,
+        "totalTokenCount": 308,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 36
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 90
+          }
+        ],
+        "thoughtsTokenCount": 182
       }
     }
   },
@@ -83,7 +139,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "In December 1984, the Bhopal disaster occurred in India, where a leak of methyl isocyanate gas from a Union Carbide plant killed thousands immediately and caused long-term health issues for hundreds of thousands more. This industrial catastrophe remains one of the world's worst, raising critical questions about corporate responsibility, industrial safety, and environmental justice."
+                "text": "In December 1984, the Bhopal disaster occurred in India when a Union Carbide pesticide plant leaked toxic gas, killing thousands instantly and causing long-term health issues for hundreds of thousands more. This catastrophe remains one of the world's worst industrial accidents, leading to significant legal battles, environmental activism, and reforms in corporate safety regulations globally."
               }
             ]
           },
@@ -93,7 +149,7 @@
       "usageMetadata": {
         "promptTokenCount": 52,
         "candidatesTokenCount": 70,
-        "totalTokenCount": 302,
+        "totalTokenCount": 701,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -107,82 +163,7 @@
             "tokenCount": 70
           }
         ],
-        "thoughtsTokenCount": 180
-      }
-    }
-  },
-  {
-    "key": "010aa2005042745b",
-    "instructionAgnosticKey": "cb42c8dbd3a6eff9",
-    "request": {
-      "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "1984"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[find_name] said: Mark Zuckerberg"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Mark Zuckerberg"
-            }
-          ]
-        }
-      ],
-      "config": {
-        "systemInstruction": "You are an agent. Your internal name is \"generate_bio\".\n\n\n    Write a short, engaging 3-sentence biography for the specified person.\n    ",
-        "labels": {
-          "adk_agent_name": "generate_bio"
-        }
-      }
-    },
-    "response": {
-      "candidates": [
-        {
-          "content": {
-            "role": "model",
-            "parts": [
-              {
-                "text": "Mark Zuckerberg is the visionary co-founder and CEO of Meta Platforms, the company behind Facebook. He launched the groundbreaking social media platform from his Harvard dorm room, forever changing how billions connect and interact globally. Today, he continues to drive Meta's ambitious push into the metaverse, aiming to shape the next generation of digital experience."
-              }
-            ]
-          },
-          "finishReason": "STOP"
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 51,
-        "candidatesTokenCount": 66,
-        "totalTokenCount": 245,
-        "trafficType": "ON_DEMAND",
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 51
-          }
-        ],
-        "candidatesTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 66
-          }
-        ],
-        "thoughtsTokenCount": 128
+        "thoughtsTokenCount": 579
       }
     }
   }

--- a/tests/integration/workflows/node_as_tool/model_responses.json
+++ b/tests/integration/workflows/node_as_tool/model_responses.json
@@ -70,7 +70,7 @@
                   "args": {
                     "user_id": "c123"
                   },
-                  "id": "adk-e49b8903-4128-4665-bf17-af8f9b73509e"
+                  "id": "adk-2333f4a6-613b-4285-983b-64b2ca0323ee"
                 }
               }
             ]
@@ -81,7 +81,7 @@
       "usageMetadata": {
         "promptTokenCount": 162,
         "candidatesTokenCount": 12,
-        "totalTokenCount": 263,
+        "totalTokenCount": 274,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -95,7 +95,7 @@
             "tokenCount": 12
           }
         ],
-        "thoughtsTokenCount": 89
+        "thoughtsTokenCount": 100
       }
     }
   },
@@ -197,7 +197,7 @@
                   "args": {
                     "tier": "Verified VIP Member"
                   },
-                  "id": "adk-f6ee1e8a-2716-4b6f-9a4e-0dc93a9450fb"
+                  "id": "adk-165d46f5-4f95-4095-8396-10cebd7089b8"
                 }
               }
             ]
@@ -208,7 +208,7 @@
       "usageMetadata": {
         "promptTokenCount": 190,
         "candidatesTokenCount": 7,
-        "totalTokenCount": 269,
+        "totalTokenCount": 256,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -222,7 +222,7 @@
             "tokenCount": 7
           }
         ],
-        "thoughtsTokenCount": 72
+        "thoughtsTokenCount": 59
       }
     }
   },
@@ -356,7 +356,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Your discount for user c123, who is a Verified VIP Member, is 20% off."
+                "text": "Your membership tier is Verified VIP Member, and you receive a 20% discount."
               }
             ]
           },
@@ -365,8 +365,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 233,
-        "candidatesTokenCount": 23,
-        "totalTokenCount": 371,
+        "candidatesTokenCount": 18,
+        "totalTokenCount": 396,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -377,10 +377,10 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 23
+            "tokenCount": 18
           }
         ],
-        "thoughtsTokenCount": 115
+        "thoughtsTokenCount": 145
       }
     }
   }

--- a/tests/integration/workflows/node_output/model_responses.json
+++ b/tests/integration/workflows/node_output/model_responses.json
@@ -1,28 +1,9 @@
 [
   {
-    "key": "e2e6a68125810d7f",
-    "instructionAgnosticKey": "c59e48dcc910513c",
+    "key": "ccda84296ec48f98",
+    "instructionAgnosticKey": "cf6f22ff16664446",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "go"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_string_output] said: Processed input: go"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -69,7 +50,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\n  \"title\": \"Just Go: Embracing the Journey of Action and Discovery\",\n  \"description\": \"A deep dive into the philosophy of taking the first step, overcoming inertia, and finding liberation in the act of beginning, whether it's a new project, a personal goal, or an adventure.\",\n  \"category\": \"Personal Growth\"\n}"
+                "text": "{\n  \"title\": \"The Impetus of Motion: Exploring the Forces That Drive Us Forward\",\n  \"description\": \"This topic delves into the various internal and external catalysts that initiate action, progress, and change in individuals, societies, and nature. From the first spark of an idea to the momentum of a movement, we investigate what truly makes things 'go'.\",\n  \"category\": \"Philosophy & Psychology\"\n}"
               }
             ]
           },
@@ -77,23 +58,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 68,
-        "candidatesTokenCount": 76,
-        "totalTokenCount": 676,
+        "promptTokenCount": 50,
+        "candidatesTokenCount": 89,
+        "totalTokenCount": 349,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 68
+            "tokenCount": 50
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 76
+            "tokenCount": 89
           }
         ],
-        "thoughtsTokenCount": 532
+        "thoughtsTokenCount": 210
       }
     }
   }

--- a/tests/integration/workflows/parallel_worker/model_responses.json
+++ b/tests/integration/workflows/parallel_worker/model_responses.json
@@ -34,7 +34,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "[\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
+                "text": "[\n  \"gardening\",\n  \"botany\",\n  \"bees\"\n]"
               }
             ]
           },
@@ -43,8 +43,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 19,
-        "candidatesTokenCount": 21,
-        "totalTokenCount": 133,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 66,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -55,37 +55,18 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 21
+            "tokenCount": 20
           }
         ],
-        "thoughtsTokenCount": 93
+        "thoughtsTokenCount": 27
       }
     }
   },
   {
-    "key": "57f651819556f230",
-    "instructionAgnosticKey": "5851154691d9ee9f",
+    "key": "bfa5021ba9e9267f",
+    "instructionAgnosticKey": "5cbdb7a52d07aab7",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[find_related_topics] said: [\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -125,7 +106,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\n  \"topic\": \"BOTANY\",\n  \"explanation\": \"Botany is the scientific study of plants, and flowers are the reproductive structures of many plant species. Therefore, the study of flowers, their structure, function, classification, and evolution, is a core component of botany.\"\n}"
+                "text": "{\n  \"topic\": \"BOTANY\",\n  \"explanation\": \"Botany is the scientific study of plants, and flowers are a central subject within this field. Botanists study the morphology, anatomy, physiology, genetics, ecology, and evolution of flowers, as they are crucial for plant reproduction, classification, and understanding plant diversity.\"\n}"
               }
             ]
           },
@@ -133,50 +114,31 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 57,
-        "candidatesTokenCount": 62,
-        "totalTokenCount": 153,
+        "promptTokenCount": 23,
+        "candidatesTokenCount": 71,
+        "totalTokenCount": 136,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 57
+            "tokenCount": 23
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 62
+            "tokenCount": 71
           }
         ],
-        "thoughtsTokenCount": 34
+        "thoughtsTokenCount": 42
       }
     }
   },
   {
-    "key": "74227dc97594ce04",
-    "instructionAgnosticKey": "77607772828009d0",
+    "key": "b5a5f000bf9e532e",
+    "instructionAgnosticKey": "1570ada1892676ed",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[find_related_topics] said: [\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -216,7 +178,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\n  \"topic\": \"GARDENING\",\n  \"explanation\": \"Gardening is the practice of cultivating and caring for plants, including flowers. Flowers are a primary focus in many gardens, grown for their aesthetic beauty, fragrance, or for purposes like cutting or attracting pollinators. Therefore, gardening is the activity directly involving the planting, growing, and maintenance of flowers.\"\n}"
+                "text": "{\n  \"topic\": \"GARDENING\",\n  \"explanation\": \"Gardening is the practice of cultivating and growing plants as part of horticulture. This often directly involves the planting, tending, and harvesting of flowers for aesthetic enjoyment, scent, or decorative purposes. Flowers are a primary component and desired outcome for many gardeners.\"\n}"
               }
             ]
           },
@@ -224,55 +186,36 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 58,
-        "candidatesTokenCount": 78,
-        "totalTokenCount": 172,
+        "promptTokenCount": 24,
+        "candidatesTokenCount": 69,
+        "totalTokenCount": 126,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 58
+            "tokenCount": 24
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 78
+            "tokenCount": 69
           }
         ],
-        "thoughtsTokenCount": 36
+        "thoughtsTokenCount": 33
       }
     }
   },
   {
-    "key": "077708ea225d7754",
-    "instructionAgnosticKey": "98824ea692e191ff",
+    "key": "fd5a4677430bab7a",
+    "instructionAgnosticKey": "42a0418822d5a65a",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "flower"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[find_related_topics] said: [\n  \"Botany\",\n  \"Gardening\",\n  \"Pollination\"\n]"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "POLLINATION"
+              "text": "BEES"
             }
           ]
         }
@@ -307,7 +250,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\n  \"topic\": \"POLLINATION\",\n  \"explanation\": \"Pollination is a vital process directly involving flowers. It is the transfer of pollen, typically from the anther to the stigma of a flower, which enables fertilization and the production of seeds and fruits. Flowers are the reproductive organs of many plants, specifically evolved to attract pollinators (like insects or birds) or to facilitate wind pollination, making them central to the entire pollination mechanism.\"\n}"
+                "text": "{\n  \"topic\": \"BEES\",\n  \"explanation\": \"Bees have a crucial symbiotic relationship with flowers. Flowers provide bees with nectar (a sugary liquid for energy) and pollen (a protein source for bee larvae) as food. In return, as bees move from flower to flower collecting these resources, they inadvertently transfer pollen grains, facilitating the pollination process. This pollination is essential for the reproduction of many flowering plants, leading to fruit and seed production.\"\n}"
               }
             ]
           },
@@ -315,23 +258,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 58,
-        "candidatesTokenCount": 94,
-        "totalTokenCount": 191,
+        "promptTokenCount": 23,
+        "candidatesTokenCount": 97,
+        "totalTokenCount": 168,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 58
+            "tokenCount": 23
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 94
+            "tokenCount": 97
           }
         ],
-        "thoughtsTokenCount": 39
+        "thoughtsTokenCount": 48
       }
     }
   }

--- a/tests/integration/workflows/request_input/model_responses.json
+++ b/tests/integration/workflows/request_input/model_responses.json
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Subject: Re: Your recent inquiry regarding your phone\n\nDear Valued Customer,\n\nThank you for reaching out to us. I'm very sorry to hear that your phone has broken. I understand how frustrating and inconvenient this can be, and we're here to help.\n\nTo assist you best, could you please provide a few more details about what happened? Specifically, it would be helpful if you could tell us:\n\n*   **What is the model of your phone?** (e.g., iPhone 12, Samsung Galaxy S23, etc.)\n*   **What exactly happened to it?** (e.g., screen cracked, stopped turning on, dropped in water, etc.)\n*   **When did this occur?**\n*   **Have you tried any troubleshooting steps already?**\n\nOnce we have a better understanding of the situation, we can guide you through the next steps, which may include troubleshooting, repair options, warranty information, or potential replacement options.\n\nPlease reply to this email with the details, or if you prefer to speak with someone directly, you can call our support team at [Your Support Phone Number] during business hours.\n\nWe look forward to helping you resolve this as quickly as possible.\n\nSincerely,\n\n[Your Name/Support Team Name]\n[Your Company Name]\n[Your Company Website (Optional)]"
+                "text": "Subject: We're Sorry to Hear About Your Phone - How Can We Help?\n\nDear Valued Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone broke, and we understand how frustrating that can be.\n\nTo help us assist you best, could you please provide a few more details about what happened? Specifically, it would be helpful if you could tell us:\n\n*   **What is the model of your phone?** (e.g., [Your Company Phone Model X, or specific manufacturer/model])\n*   **When did the incident occur?**\n*   **Could you describe how the phone broke?** (e.g., fell, stopped working suddenly, screen cracked, etc.)\n*   **Is the phone still under warranty?**\n\nOnce we have a better understanding of the situation, we can guide you through the next steps, whether it's troubleshooting, repair options, or warranty claims.\n\nPlease reply to this email with the requested information, or if you prefer to speak with someone directly, you can contact our support team at [Your Support Phone Number] during our business hours, or visit our support page at [Link to Your Company's Support Page/Returns/Warranty Info].\n\nWe look forward to helping you resolve this issue as quickly as possible.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
               }
             ]
           },
@@ -36,8 +36,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 58,
-        "candidatesTokenCount": 282,
-        "totalTokenCount": 580,
+        "candidatesTokenCount": 288,
+        "totalTokenCount": 578,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -48,10 +48,10 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 282
+            "tokenCount": 288
           }
         ],
-        "thoughtsTokenCount": 240
+        "thoughtsTokenCount": 232
       }
     }
   },
@@ -83,7 +83,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Subject: Regarding Your Phone Issue - We're Here to Help!\n\nDear [Customer Name],\n\nThank you for reaching out to us. We're very sorry to hear that your phone has broken, and we understand how frustrating this can be.\n\nTo help us best assist you, could you please provide a few more details?\n\n*   **What is the make and model of your phone?** (e.g., iPhone 15, Samsung Galaxy S23)\n*   **When did the phone break, and what happened?** (e.g., dropped it, screen stopped working, won't turn on, water damage)\n*   **When and where did you purchase the phone?** (This helps us check warranty status.)\n\nOnce we have this information, we can better advise you on the next steps, whether it's troubleshooting, warranty service, repair options, or a replacement.\n\nPlease reply to this email with the details, or feel free to call us directly at [Your Company Phone Number] if you'd prefer to discuss it over the phone. Our support team is available [Hours of Operation, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to helping you resolve this as quickly as possible.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+                "text": "Subject: Regarding Your Recent Issue: \"Phone Broke\"\n\nDear Customer,\n\nThank you for reaching out to us. We're sorry to hear that your phone has broken. We understand how frustrating it can be when your device isn't working as it should.\n\nTo help us understand the situation better and assist you most effectively, could you please provide us with a few more details?\n\n*   **What is the model of your phone?** (e.g., iPhone 13, Samsung Galaxy S22, Google Pixel 7)\n*   **What exactly happened?** (e.g., dropped it, stopped turning on, screen cracked, water damage, stopped charging)\n*   **When did this occur?**\n*   **Is your phone still under warranty or did you purchase any extended protection plans?**\n\nOnce we have a little more information, we can guide you through the best next steps, which might include troubleshooting tips, repair options, or warranty information.\n\nPlease reply to this email with the details, or if you prefer, you can call our support team directly at [Your Support Phone Number] during our business hours [Your Business Hours].\n\nWe look forward to helping you resolve this as quickly as possible.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
               }
             ]
           },
@@ -92,8 +92,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 58,
-        "candidatesTokenCount": 279,
-        "totalTokenCount": 546,
+        "candidatesTokenCount": 270,
+        "totalTokenCount": 417,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -104,10 +104,130 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 279
+            "tokenCount": 270
           }
         ],
-        "thoughtsTokenCount": 209
+        "thoughtsTokenCount": 89
+      }
+    }
+  },
+  {
+    "key": "2bb5ba2af14c8a1f",
+    "instructionAgnosticKey": "7d399be2c6c4129c",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "phone broke"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"phone broke\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Subject: Re: Your recent inquiry regarding your phone\n\nDear Valued Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone is broken, and we understand how frustrating that can be.\n\nTo help us understand the situation better and assist you as quickly as possible, could you please provide a few more details about what happened?\n\nFor example, it would be helpful to know:\n*   **What specific model of phone do you have?** (e.g., iPhone 13, Samsung Galaxy S22, etc.)\n*   **When did this happen?**\n*   **What exactly happened to your phone?** (e.g., dropped it, water damage, stopped turning on, screen cracked, etc.)\n*   **Is your phone still under warranty?** (If you know)\n\nOnce we have a little more information, we'll be able to guide you through the best next steps, whether it's troubleshooting, repair options, or warranty claims.\n\nPlease reply to this email with the details, or feel free to call our customer support line directly at [Your Company Phone Number] if you'd prefer to speak with someone. Our team is available [Operating Hours, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to hearing from you and helping to resolve this issue.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 302,
+        "totalTokenCount": 523,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 58
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 302
+          }
+        ],
+        "thoughtsTokenCount": 163
+      }
+    }
+  },
+  {
+    "key": "99358c323abda287",
+    "instructionAgnosticKey": "d6946d766b636b24",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "phone broke"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Subject: Re: Your recent inquiry regarding your phone\n\nDear Valued Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone is broken, and we understand how frustrating that can be.\n\nTo help us understand the situation better and assist you as quickly as possible, could you please provide a few more details about what happened?\n\nFor example, it would be helpful to know:\n*   **What specific model of phone do you have?** (e.g., iPhone 13, Samsung Galaxy S22, etc.)\n*   **When did this happen?**\n*   **What exactly happened to your phone?** (e.g., dropped it, water damage, stopped turning on, screen cracked, etc.)\n*   **Is your phone still under warranty?** (If you know)\n\nOnce we have a little more information, we'll be able to guide you through the best next steps, whether it's troubleshooting, repair options, or warranty claims.\n\nPlease reply to this email with the details, or feel free to call our customer support line directly at [Your Company Phone Number] if you'd prefer to speak with someone. Our team is available [Operating Hours, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to hearing from you and helping to resolve this issue.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"{\"role\":\"user\",\"parts\":[{\"functionResponse\":{\"id\":\"d64324ed-d979-487b-827b-a4dae8222932\",\"name\":\"adk_request_input\",\"response\":{\"result\":\"shorter\"}}}]}\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"shorter\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Okay, I will revise the previous email to make it shorter, as requested by the manager's feedback.\n\nHere's the revised, shorter draft:\n\nSubject: Re: Your phone issue\n\nDear Valued Customer,\n\nThank you for contacting us. We're sorry to hear your phone is broken.\n\nTo help us assist you, please provide more details:\n*   **What is your phone model?**\n*   **What happened to it?** (e.g., dropped, not turning on, cracked screen)\n*   **Is it under warranty?**\n\nOnce we have this information, we can guide you on the best next steps.\n\nPlease reply to this email or call us at [Your Company Phone Number].\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 444,
+        "candidatesTokenCount": 166,
+        "totalTokenCount": 757,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 444
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 166
+          }
+        ],
+        "thoughtsTokenCount": 147
       }
     }
   }

--- a/tests/integration/workflows/request_input/request_input_test.ts
+++ b/tests/integration/workflows/request_input/request_input_test.ts
@@ -49,7 +49,7 @@ describe('workflow sample: request_input (HITL)', () => {
     expect(isPaused(turn2)).toBe(false);
   }, 120000);
 
-  it.skip('revises on feedback, then sends on approval', async () => {
+  it('revises on feedback, then sends on approval', async () => {
     const perTurn = await runSample({
       name: 'request_input',
       rootAgent,

--- a/tests/integration/workflows/request_input_advanced/model_responses.json
+++ b/tests/integration/workflows/request_input_advanced/model_responses.json
@@ -1,17 +1,9 @@
 [
   {
-    "key": "075ada6d0639573f",
-    "instructionAgnosticKey": "fe44a59739a4f475",
+    "key": "d178e94a7f7fb768",
+    "instructionAgnosticKey": "05741fd6f32cccb3",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "1 sick day"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -55,7 +47,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\"days\": 1, \"reason\": \"sick\"}"
+                "text": "{\n  \"days\": 1,\n  \"reason\": \"sick\"\n}"
               }
             ]
           },
@@ -63,39 +55,31 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 45,
-        "candidatesTokenCount": 12,
-        "totalTokenCount": 108,
+        "promptTokenCount": 42,
+        "candidatesTokenCount": 19,
+        "totalTokenCount": 103,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 45
+            "tokenCount": 42
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 12
+            "tokenCount": 19
           }
         ],
-        "thoughtsTokenCount": 51
+        "thoughtsTokenCount": 42
       }
     }
   },
   {
-    "key": "e05c319f8df062fe",
-    "instructionAgnosticKey": "ec90e37d89e9eb1d",
+    "key": "b51e345498e7b9f5",
+    "instructionAgnosticKey": "96eabf2989d95490",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "2 sick days"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -139,7 +123,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\"days\": 2, \"reason\": \"sick days\"}"
+                "text": "{\n  \"days\": 2,\n  \"reason\": \"sick\"\n}"
               }
             ]
           },
@@ -147,23 +131,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 45,
-        "candidatesTokenCount": 13,
+        "promptTokenCount": 42,
+        "candidatesTokenCount": 19,
         "totalTokenCount": 109,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 45
+            "tokenCount": 42
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 13
+            "tokenCount": 19
           }
         ],
-        "thoughtsTokenCount": 51
+        "thoughtsTokenCount": 48
       }
     }
   }

--- a/tests/integration/workflows/request_input_rerun/model_responses.json
+++ b/tests/integration/workflows/request_input_rerun/model_responses.json
@@ -27,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Subject: Regarding Your Recent Report - Phone Issue\n\nDear [Customer Name],\n\nThank you for reaching out to us. We're very sorry to hear that your phone is broken, and we understand how frustrating that can be.\n\nTo help us understand the situation better and assist you as quickly as possible, could you please provide us with a few more details? Specifically, it would be very helpful if you could tell us:\n\n1.  **What model of phone is it?** (e.g., iPhone 13, Samsung Galaxy S22, etc.)\n2.  **When did you purchase the phone?** (An approximate date is fine if you don't have the exact one)\n3.  **Can you describe what happened when it broke?** (e.g., dropped it, stopped working suddenly, screen cracked, won't turn on, water damage, etc.)\n4.  **Do you have any warranty or protection plans associated with the device?**\n\nOnce we have this information, we'll be able to guide you through the next steps, which may include troubleshooting, repair options, or potential replacement under warranty.\n\nPlease reply to this email with the details requested. Alternatively, if you prefer to speak with someone, you can call our support team at [Your Phone Number] during our business hours of [Business Hours, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to helping you resolve this issue promptly.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+                "text": "Subject: We're sorry to hear about your phone! How can we help?\n\nDear Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone is broken, and we understand how frustrating that can be.\n\nTo help us understand the issue and assist you best, could you please provide a few more details?\n\n*   **What specific model of phone do you have?** (e.g., iPhone 13, Samsung Galaxy S22)\n*   **What exactly happened to it?** (e.g., screen cracked, stopped turning on, water damage, not charging)\n*   **When did this occur?**\n*   **Is your phone still under warranty or did you purchase any extended protection plans?**\n\nOnce we have a better understanding of the situation, we can guide you through the next steps, which may include troubleshooting, repair options, or warranty claims.\n\nPlease reply to this email with the requested information, or feel free to call our support team directly at [Your Support Phone Number] if you prefer to speak with someone.\n\nWe look forward to helping you resolve this as quickly as possible.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
               }
             ]
           },
@@ -36,8 +36,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 58,
-        "candidatesTokenCount": 323,
-        "totalTokenCount": 796,
+        "candidatesTokenCount": 255,
+        "totalTokenCount": 423,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -48,10 +48,10 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 323
+            "tokenCount": 255
           }
         ],
-        "thoughtsTokenCount": 415
+        "thoughtsTokenCount": 110
       }
     }
   },
@@ -83,7 +83,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Subject: Regarding Your Recent Phone Issue - How Can We Help?\n\nDear Valued Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone has broken, and we understand how frustrating and disruptive this can be. Please accept our sincerest apologies for the inconvenience this has caused.\n\nTo help us assist you best and find the quickest resolution, could you please provide us with a few more details? Specifically, it would be very helpful if you could tell us:\n\n*   What is the **model of your phone**?\n*   When did you **purchase it**? (This helps us check warranty status)\n*   Could you please describe **what happened** and **what exactly is broken or not working**? (e.g., screen cracked, not turning on, water damage, etc.)\n\nOnce we have this information, we can better advise you on the next steps, which may include troubleshooting, repair options, or exploring warranty coverage.\n\nIn the meantime, you can also visit our support page for common issues and warranty information here: [Link to Your Company's Support/Warranty Page]\n\nWe are committed to helping you get this resolved as quickly as possible. Please reply to this email with the details requested, or if you prefer to speak with someone directly, you can contact our support team at [Your Phone Number] or start a live chat on our website at [Link to Live Chat].\n\nThank you for your patience as we work to assist you.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+                "text": "Subject: Regarding your recent message about your phone\n\nDear Customer,\n\nThank you for reaching out to us. I'm very sorry to hear that your phone has broken. I understand how frustrating and inconvenient this can be, as we rely on our phones so much every day.\n\nTo help us understand the situation better and assist you as quickly as possible, could you please provide a few more details?\n\n*   What is the **make and model** of your phone?\n*   When did the issue occur, and can you describe what happened or what \"broke\" specifically (e.g., screen cracked, not turning on, water damage)?\n*   Do you know if your phone is still under **warranty** or if you have any **insurance** coverage for it?\n\nOnce we have this information, we can explore the best options for repair or replacement and guide you through the next steps.\n\nPlease reply to this email with the details, or if you prefer, you can call our support team directly at [Your Support Phone Number] or visit our support page at [Your Support Website Link] for more immediate assistance.\n\nWe're here to help get this resolved for you.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
               }
             ]
           },
@@ -92,8 +92,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 58,
-        "candidatesTokenCount": 322,
-        "totalTokenCount": 1284,
+        "candidatesTokenCount": 255,
+        "totalTokenCount": 842,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -104,10 +104,130 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 322
+            "tokenCount": 255
           }
         ],
-        "thoughtsTokenCount": 904
+        "thoughtsTokenCount": 529
+      }
+    }
+  },
+  {
+    "key": "2bb5ba2af14c8a1f",
+    "instructionAgnosticKey": "7d399be2c6c4129c",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "phone broke"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"phone broke\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Subject: We're sorry to hear about your phone – How can we help?\n\nDear Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone broke. We understand how frustrating and inconvenient this can be.\n\nTo help us understand the situation better and assist you as quickly as possible, could you please provide a few more details?\n\n*   **What is the make and model of your phone?** (e.g., iPhone 15, Samsung Galaxy S24, Google Pixel 8)\n*   **When did you purchase the phone?** (approximately)\n*   **Could you describe what happened?** (e.g., dropped it, stopped working suddenly, screen cracked, won't turn on)\n\nOnce we have a better understanding of the issue, we can guide you through the next steps, which might include troubleshooting, warranty assessment, or repair options.\n\nPlease reply to this email with the requested information, or feel free to call our support team directly at [Your Support Phone Number] if you'd prefer to speak with someone. Our hours are [Your Operating Hours, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to helping you resolve this as soon as possible.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 58,
+        "candidatesTokenCount": 280,
+        "totalTokenCount": 433,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 58
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 280
+          }
+        ],
+        "thoughtsTokenCount": 95
+      }
+    }
+  },
+  {
+    "key": "ff25ae3445e679de",
+    "instructionAgnosticKey": "7b26a7f660b5819e",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "phone broke"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Subject: We're sorry to hear about your phone – How can we help?\n\nDear Customer,\n\nThank you for reaching out to us. We're very sorry to hear that your phone broke. We understand how frustrating and inconvenient this can be.\n\nTo help us understand the situation better and assist you as quickly as possible, could you please provide a few more details?\n\n*   **What is the make and model of your phone?** (e.g., iPhone 15, Samsung Galaxy S24, Google Pixel 8)\n*   **When did you purchase the phone?** (approximately)\n*   **Could you describe what happened?** (e.g., dropped it, stopped working suddenly, screen cracked, won't turn on)\n\nOnce we have a better understanding of the issue, we can guide you through the next steps, which might include troubleshooting, warranty assessment, or repair options.\n\nPlease reply to this email with the requested information, or feel free to call our support team directly at [Your Support Phone Number] if you'd prefer to speak with someone. Our hours are [Your Operating Hours, e.g., Monday-Friday, 9 AM - 5 PM EST].\n\nWe look forward to helping you resolve this as soon as possible.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"draft_email\".\n\n\n    Please write a polite, helpful response email to the following customer complaint: \"{\"role\":\"user\",\"parts\":[{\"functionResponse\":{\"id\":\"human_review\",\"name\":\"adk_request_input\",\"response\":{\"result\":\"shorter\"}}}]}\"\n\n    If there is any feedback from the manager to revise the draft, please incorporate it: \"shorter\"\n    ",
+        "labels": {
+          "adk_agent_name": "draft_email"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Subject: Regarding Your Phone Issue – How Can We Help?\n\nDear Customer,\n\nWe're sorry to hear your phone broke and understand the inconvenience.\n\nTo assist you efficiently, please tell us:\n\n*   **Phone make and model?**\n*   **Approximate purchase date?**\n*   **What happened?** (e.g., dropped, stopped working, screen cracked)\n\nWith these details, we can better advise on troubleshooting, warranty, or repair options.\n\nPlease reply to this email or call us at [Your Support Phone Number] ([Your Operating Hours]).\n\nWe look forward to helping you.\n\nSincerely,\n\nThe [Your Company Name] Support Team"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 391,
+        "candidatesTokenCount": 141,
+        "totalTokenCount": 1574,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 391
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 141
+          }
+        ],
+        "thoughtsTokenCount": 1042
       }
     }
   }

--- a/tests/integration/workflows/request_input_rerun/request_input_rerun_test.ts
+++ b/tests/integration/workflows/request_input_rerun/request_input_rerun_test.ts
@@ -49,7 +49,7 @@ describe('workflow sample: request_input_rerun (HITL)', () => {
     expect(joinedText(turn2)).toContain('Draft rejected.');
   }, 120000);
 
-  it.skip('re-runs the review node to revise, then approves', async () => {
+  it('re-runs the review node to revise, then approves', async () => {
     const perTurn = await runSample({
       name: 'request_input_rerun',
       rootAgent,

--- a/tests/integration/workflows/route/model_responses.json
+++ b/tests/integration/workflows/route/model_responses.json
@@ -54,7 +54,7 @@
       "usageMetadata": {
         "promptTokenCount": 25,
         "candidatesTokenCount": 6,
-        "totalTokenCount": 63,
+        "totalTokenCount": 60,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -68,23 +68,15 @@
             "tokenCount": 6
           }
         ],
-        "thoughtsTokenCount": 32
+        "thoughtsTokenCount": 29
       }
     }
   },
   {
-    "key": "f2b4cd3df00d7860",
-    "instructionAgnosticKey": "91bb24ccd3a5ed98",
+    "key": "100505b197e7cc8d",
+    "instructionAgnosticKey": "1c7399c7e32aa748",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "who are you"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -119,14 +111,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 41,
+        "promptTokenCount": 38,
         "candidatesTokenCount": 11,
-        "totalTokenCount": 85,
+        "totalTokenCount": 83,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 41
+            "tokenCount": 38
           }
         ],
         "candidatesTokensDetails": [
@@ -135,7 +127,7 @@
             "tokenCount": 11
           }
         ],
-        "thoughtsTokenCount": 33
+        "thoughtsTokenCount": 34
       }
     }
   }

--- a/tests/integration/workflows/sequence/model_responses.json
+++ b/tests/integration/workflows/sequence/model_responses.json
@@ -1,17 +1,9 @@
 [
   {
-    "key": "9a4363ea0fe135a2",
-    "instructionAgnosticKey": "b2a784f7e90793f2",
+    "key": "344ca7d27432abea",
+    "instructionAgnosticKey": "b7d8b17b7ea4d757",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "go"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -35,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Grape"
+                "text": "Apple"
               }
             ]
           },
@@ -43,63 +35,36 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 37,
-        "candidatesTokenCount": 2,
-        "totalTokenCount": 63,
+        "promptTokenCount": 36,
+        "candidatesTokenCount": 1,
+        "totalTokenCount": 59,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 37
+            "tokenCount": 36
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 2
+            "tokenCount": 1
           }
         ],
-        "thoughtsTokenCount": 24
+        "thoughtsTokenCount": 22
       }
     }
   },
   {
-    "key": "774281fdd2b8ca86",
-    "instructionAgnosticKey": "8312b27786d22e92",
+    "key": "b87634a049ca625e",
+    "instructionAgnosticKey": "76f05d0d271c04a2",
     "request": {
       "contents": [
         {
           "role": "user",
           "parts": [
             {
-              "text": "go"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "go"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "For context:"
-            },
-            {
-              "text": "[generate_fruit_agent] said: Grape"
-            }
-          ]
-        },
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Grape"
+              "text": "Apple"
             }
           ]
         }
@@ -118,7 +83,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "Grapes are rich in antioxidants, particularly resveratrol, which can help protect your heart and blood vessels."
+                "text": "Eating an apple can help promote good digestion due to its high fiber content."
               }
             ]
           },
@@ -126,23 +91,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 44,
-        "candidatesTokenCount": 20,
-        "totalTokenCount": 90,
+        "promptTokenCount": 28,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 64,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 44
+            "tokenCount": 28
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 20
+            "tokenCount": 15
           }
         ],
-        "thoughtsTokenCount": 26
+        "thoughtsTokenCount": 21
       }
     }
   }

--- a/tests/integration/workflows/state/agent.ts
+++ b/tests/integration/workflows/state/agent.ts
@@ -10,12 +10,11 @@
  * TypeScript note: Python's `read_state_via_param` reads a state value by
  * automatic parameter-name injection. `FunctionNode` in TypeScript has a fixed
  * `(ctx, input)` signature, so the value is read explicitly via `ctx.state`.
- * See the gap report.
  *
  * Run (offline):  npm run sample -- tests/integration/workflows/state/agent.ts
  */
 
-import {node, NodeContext, Workflow} from '@google/adk';
+import {createEvent, Event, node, NodeContext, Workflow} from '@google/adk';
 
 function processInitialInput(ctx: NodeContext, nodeInput: string): string {
   // Set initial input in state via direct dictionary modification.
@@ -23,8 +22,10 @@ function processInitialInput(ctx: NodeContext, nodeInput: string): string {
   return nodeInput;
 }
 
-function updateStateViaEvent(ctx: NodeContext, nodeInput: string): void {
-  ctx.state.set('uppercased_text', nodeInput.toUpperCase());
+function updateStateViaEvent(_ctx: NodeContext, nodeInput: string): Event {
+  return createEvent({
+    actions: {stateDelta: {uppercased_text: nodeInput.toUpperCase()}},
+  });
 }
 
 function readStateViaCtx(ctx: NodeContext): string {

--- a/tests/integration/workflows/use_as_output/model_responses.json
+++ b/tests/integration/workflows/use_as_output/model_responses.json
@@ -1,17 +1,9 @@
 [
   {
-    "key": "4d165d7296a857c7",
-    "instructionAgnosticKey": "6dd9a37e6d1e4f74",
+    "key": "0e7b07a014bc9a1e",
+    "instructionAgnosticKey": "4da46c316b797362",
     "request": {
       "contents": [
-        {
-          "role": "user",
-          "parts": [
-            {
-              "text": "go"
-            }
-          ]
-        },
         {
           "role": "user",
           "parts": [
@@ -35,7 +27,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "The provided text is too short and does not contain enough information to summarize."
+                "text": "The text is the word \"go,\" which typically functions as an imperative to start or proceed."
               }
             ]
           },
@@ -43,23 +35,23 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 25,
-        "candidatesTokenCount": 15,
-        "totalTokenCount": 68,
+        "promptTokenCount": 24,
+        "candidatesTokenCount": 19,
+        "totalTokenCount": 448,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 25
+            "tokenCount": 24
           }
         ],
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 15
+            "tokenCount": 19
           }
         ],
-        "thoughtsTokenCount": 28
+        "thoughtsTokenCount": 405
       }
     }
   }


### PR DESCRIPTION
Stacked on #698 (base `workflow-samples-parity`) — it is the branch that made these reachable.

Both human-in-the-loop samples pause, take a revision, loop back to the drafting node and ask again. Neither could: **the turn never ended.** On resume the review node emitted `route: 'revise'`, and instead of routing to its target the engine re-invoked that same node with the same reply, forever — ~87k iterations in 40 seconds, reproducible with no model calls. Python walks this path in `request_input/tests/phone_broke.json` and reaches `draft_email@2`.

## Root cause

Recovered state was keyed by node name and never consumed, so *every* activation of a node in a resumed turn matched the single run recorded for it. Python keys its recovered executions on `name@run_id`; TypeScript node paths carry no run id for static graph nodes, so this recovers positionally instead — each node's prior runs are reconstructed in order and the Nth activation claims the Nth run. A run closes once it has an output, a route or an interrupt, so the next event for that node opens the next one.

Two more things had to hold for the loop to terminate:

- **A repeat activation gets no resume responses.** The first run of the turn is the one the reply was addressed to; a `rerunOnResume` node handed it again answers itself and loops.
- **A node that recorded only a route is replayed from it.** Requiring an output to fast-forward meant routing nodes re-ran and re-emitted their route on every later turn, so an approval arrived alongside a stale `revise`.

## Also fixed

Found next to it, while getting the samples to run:

- **Workflow `LlmAgent` nodes ran with the whole conversation in the prompt.** Python forces `include_contents='none'` for single-turn nodes (`_llm_agent_wrapper.py:386-389`); nothing here did. The node input — already the last user turn when the node follows START — arrived twice, and sibling nodes' turns leaked in. The `use_as_output` summarizer read `go` twice and answered *"the single word \"gogo\""*. An explicit `includeContents` is still honoured.
- **The turn-start scan could settle on an event the content build then drops** (a node output carrying no content), producing an empty prompt. It now applies the same inclusion test, as Python's scan does.
- **`adk_request_input` and its reply are no longer shown to agents.** Like the auth and confirmation interrupts beside it, that exchange is between the framework and the client; an agent that never issued the call was handed the reply as a dangling function response, which the rearrange step rejects outright.
- **State written by a generator node that yields nothing is flushed as an event.** It reached the session but left no delta in the log, so a session rebuilt from its events lost the key.
- **State carried on an emitted event** (`yield Event(state=...)`) is written through, so the next node reads it instead of `undefined` until the runner catches up.

## Tests

- `core/test/workflow/resume_loopback_test.ts` — both HITL shapes plus the routing-node replay. Each turn is capped at 40 events, so a routing regression fails the test instead of hanging it.
- `core/test/workflow/agent_node_contents_test.ts` — what an agent node's request actually contains.
- `core/test/workflow/node_state_events_test.ts` — both state-to-event directions.
- The four sample scenarios that had to be skipped in #698 are now un-skipped and green; every fixture was re-recorded against a live model.

3519 passing, 13 skipped across `unit:core`, `unit:dev` and `integration`.

## Not addressed

Left deliberately, each still documented in the skipped sample tests:

- Tool confirmation inside an agent node does not resume without `rerunOnResume`, which Python does not need.
- A task-mode agent that needs a second user turn throws.
- `inputSchema` validates but does not coerce a JSON string, so Python's structured HITL resume cannot bind.
- Python emits an error event per retried attempt; TypeScript records the failure once. That one is a deliberate TS choice — `core/test/workflow/node_error_event_test.ts` pins it — so it is a divergence to decide on, not a defect to fix.

