### PR TITLE
fix(workflow): stop duplicating a delegated output, and parse a structured reply

### DIFF
--- a/core/src/workflow/dynamic_node_scheduler.ts
+++ b/core/src/workflow/dynamic_node_scheduler.ts
@@ -68,8 +68,12 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
       const prior = reconstructNodeStatesByPath(
         eventsForCurrentRun(ctx.session?.events ?? [], ctx.invocationId),
       ).get(nodePath);
-      if (prior && !node.rerunOnResume && isFastForwardable(prior)) {
+      if (prior && isFastForwardable(prior)) {
         // Completed in a prior turn -> return cached output, do not re-execute.
+        // `rerunOnResume` is deliberately not consulted, as in the static twin
+        // (`Workflow.scheduleNode`): it says what to do with an interrupt the
+        // node is still waiting on, and `isFastForwardable` has already ruled
+        // a waiting node out. Consulted here it would replay the whole run.
         return this.completeWithoutRunning(
           ctx,
           {nodePath, runId, options},

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -75,6 +75,15 @@ export class NodeContext {
    * resumed run can tell that an ancestor already has a result.
    */
   outputForAncestors: readonly string[] = [];
+
+  /**
+   * Whether this node handed its output to a child run with `useAsOutput`.
+   *
+   * The child already emitted that value as its own result, so an event from
+   * this node repeating it would put the same text in the stream twice. The
+   * node still reports the output — only the duplicate event is suppressed.
+   */
+  outputDelegated = false;
   readonly actions: EventActions;
   resumeInputs: Record<string, unknown>;
   isolationScope?: string;

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -294,6 +294,7 @@ async function runChildNode({
     if (options.useAsOutput) {
       parent.output = child.output;
       parent.route = child.route;
+      parent.outputDelegated = true;
     }
 
     return child;
@@ -423,6 +424,14 @@ async function runOnce({
     enrichEvent({event, child, nodeName, branch, isolationScope});
     if (event.output !== undefined) {
       child.output = event.output;
+      if (child.outputDelegated) {
+        const stateDelta = event.actions?.stateDelta;
+        if (!stateDelta || Object.keys(stateDelta).length === 0) {
+          return;
+        }
+        event.output = undefined;
+        event.content = undefined;
+      }
     }
     if (event.route !== undefined) {
       child.route = event.route;

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -440,7 +440,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/** Unwraps a `{result: value}` FunctionResponse envelope to the bare value. */
+/**
+ * Unwraps a `{result: value}` FunctionResponse envelope to the bare value.
+ *
+ * Every string value is JSON-parsed when it parses, because the envelope does
+ * not say whether the text is structured: a client answering a `RequestInput`
+ * that declared a `responseSchema` sends the object as text (the web frontend
+ * wraps whatever the user submitted as `{result: text}`), and the node expects
+ * the object back. Text that is not JSON — "approve", "shorter" — is returned
+ * as-is, and so a plain answer that happens to be valid JSON is converted too:
+ * "42" comes back as a number, "true" as a boolean. That is deliberate parity
+ * with Python's `_unwrap_response`, and harmless downstream —
+ * {@link interruptResponseMismatch} exempts scalars from the schema check.
+ */
 export function unwrapResponse(response: unknown): unknown {
   if (
     response &&
@@ -449,7 +461,16 @@ export function unwrapResponse(response: unknown): unknown {
     Object.keys(response).length === 1 &&
     RESULT_KEY in response
   ) {
-    return (response as Record<string, unknown>)[RESULT_KEY];
+    const value = (response as Record<string, unknown>)[RESULT_KEY];
+    return typeof value === 'string' ? parseJsonIfPossible(value) : value;
   }
   return response;
+}
+
+function parseJsonIfPossible(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
 }

--- a/core/src/workflow/workflow.ts
+++ b/core/src/workflow/workflow.ts
@@ -438,9 +438,12 @@ export class Workflow extends BaseNode {
     loop.activated.add(nodeName);
 
     // Resume: fast-forward a node that already completed in a prior run
-    // (cached output, all interrupts resolved), unless it must rerun on resume.
+    // (cached output, all interrupts resolved). `rerunOnResume` governs an
+    // interrupt the node is still waiting on, not a run that already produced
+    // its result, and `isFastForwardable` excludes a waiting node — so the flag
+    // is not consulted here. Python reaches its cached-result case first too.
     const prior = loop.rehydrated.get(nodeName)?.shift();
-    if (prior && !node.rerunOnResume && isFastForwardable(prior)) {
+    if (prior && isFastForwardable(prior)) {
       loop.pending.set(
         nodeName,
         Promise.resolve({

--- a/core/test/workflow/dynamic_resume_test.ts
+++ b/core/test/workflow/dynamic_resume_test.ts
@@ -112,6 +112,85 @@ describe('Phase 5b-cont — dynamic (ctx.runNode) resume via the Runner', () => 
     expect(turn2.some((e) => e.output === 'confirmed:yes')).toBe(true);
   });
 
+  it('replays a completed rerun-on-resume child instead of running it again', async () => {
+    // `rerunOnResume` says what to do with an interrupt the child is still
+    // waiting on, not that a run which already produced its output should
+    // happen again. The static graph replays such a node (`resume_loopback_
+    // test.ts`); a child reached through `ctx.runNode()` must agree.
+    let stepRuns = 0;
+    let askRuns = 0;
+
+    const step = new FunctionNode(
+      'step',
+      (_c, input) => {
+        stepRuns++;
+        return `step(${input})`;
+      },
+      {rerunOnResume: true},
+    );
+    const ask = new FunctionNode(
+      'ask',
+      (ctx: NodeContext) => {
+        askRuns++;
+        const answer = ctx.resumeInputs['confirm'];
+        return answer === undefined
+          ? new RequestInput({interruptId: 'confirm', message: 'confirm?'})
+          : `confirmed:${answer}`;
+      },
+      {rerunOnResume: true},
+    );
+
+    const wf = new Workflow({
+      name: 'dyn_replay_wf',
+      dynamicEntry: async (ctx, input) => {
+        const s = await ctx.runNode(step, input);
+        const a = await ctx.runNode(ask);
+        return {step: s.output, ask: a.output};
+      },
+    });
+
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'u1',
+    });
+    const runner = new Runner({appName: 'test_app', agent: wf, sessionService});
+
+    await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {role: 'user', parts: [{text: 'x'}]},
+      }),
+    );
+    expect(stepRuns).toBe(1);
+
+    const turn2 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'confirm',
+                name: 'adk_request_input',
+                response: {result: 'yes'},
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Completed last turn, so it is replayed from its cached output even
+    // though it asked to rerun on resume.
+    expect(stepRuns).toBe(1);
+    expect(askRuns).toBe(2);
+    expect(turn2.some((e) => e.output === 'confirmed:yes')).toBe(true);
+  });
+
   it('hands the resume value to a rerunOnResume=false child without re-running it', async () => {
     let askRuns = 0;
 

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -265,9 +265,41 @@ describe('interruptResponseMismatch', () => {
     expect(
       interruptResponseMismatch(
         'i1',
-        unwrapResponse({result: '21'}),
+        // Not '21': that would unwrap to a number and pass as a scalar rather
+        // than as the string this asserts about.
+        unwrapResponse({result: 'twenty-one'}),
         stringSchema,
       ),
     ).toBeUndefined();
+  });
+});
+
+describe('unwrapResponse', () => {
+  it('parses a structured reply the frontend sent as text', () => {
+    expect(unwrapResponse({result: '{"userResponse":"yes"}'})).toEqual({
+      userResponse: 'yes',
+    });
+  });
+
+  it('leaves text that is not JSON alone', () => {
+    expect(unwrapResponse({result: 'approve'})).toBe('approve');
+  });
+
+  it('parses any string that is JSON, scalars included', () => {
+    // The envelope does not say whether the text is structured, so a plain
+    // answer that happens to be valid JSON is converted too. Python's
+    // `_unwrap_response` does the same, and the schema check exempts scalars.
+    expect(unwrapResponse({result: '42'})).toBe(42);
+    expect(unwrapResponse({result: 'true'})).toBe(true);
+  });
+
+  it('passes a value that is not a {result: x} envelope through', () => {
+    expect(unwrapResponse({userResponse: 'yes'})).toEqual({
+      userResponse: 'yes',
+    });
+    expect(unwrapResponse({result: 'a', hint: 'b'})).toEqual({
+      result: 'a',
+      hint: 'b',
+    });
   });
 });

--- a/core/test/workflow/node_state_events_test.ts
+++ b/core/test/workflow/node_state_events_test.ts
@@ -10,11 +10,14 @@
  * reads through `ctx.state`.
  */
 
+import {Content} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {createEvent, Event} from '../../src/events/event.js';
+import {InMemoryRunner} from '../../src/runner/in_memory_runner.js';
 import {AsyncQueue} from '../../src/utils/async_queue.js';
 import {node} from '../../src/workflow/node.js';
 import {NodeContext} from '../../src/workflow/node_context.js';
+import {RequestInput} from '../../src/workflow/request_input.js';
 import {Workflow} from '../../src/workflow/workflow.js';
 import {createIc} from './test_helpers.js';
 
@@ -81,5 +84,96 @@ describe('node state writes and the event stream', () => {
 
     expect(deltas(events)).toEqual([{seen: 'X'}]);
     expect(output).toBe('read:X');
+  });
+});
+
+describe('resume value unwrapping', () => {
+  it('parses a structured reply sent as text', async () => {
+    const ask = node(
+      (ctx: NodeContext) => {
+        const answer = ctx.resumeInputs['ask'];
+        return answer ?? new RequestInput({interruptId: 'ask', message: '?'});
+      },
+      {name: 'ask', rerunOnResume: true},
+    );
+    const wf = new Workflow({name: 'wf', edges: [['START', ask]]});
+    const runner = new InMemoryRunner({agent: wf, appName: 'app'});
+    const session = await runner.sessionService.createSession({
+      appName: 'app',
+      userId: 'u',
+    });
+    const drain = async (message: Content): Promise<Event[]> => {
+      const events: Event[] = [];
+      for await (const event of runner.runAsync({
+        userId: 'u',
+        sessionId: session.id,
+        newMessage: message,
+      })) {
+        events.push(event);
+      }
+      return events;
+    };
+
+    await drain({role: 'user', parts: [{text: 'go'}]});
+    const turn2 = await drain({
+      role: 'user',
+      parts: [
+        {
+          functionResponse: {
+            id: 'ask',
+            name: 'adk_request_input',
+            response: {result: '{"approved": true, "days": 2}'},
+          },
+        },
+      ],
+    });
+
+    expect(turn2.find((e) => e.output !== undefined)?.output).toEqual({
+      approved: true,
+      days: 2,
+    });
+  });
+
+  it('leaves a plain-text reply alone', async () => {
+    const ask = node(
+      (ctx: NodeContext) => {
+        const answer = ctx.resumeInputs['ask'];
+        return answer ?? new RequestInput({interruptId: 'ask', message: '?'});
+      },
+      {name: 'ask', rerunOnResume: true},
+    );
+    const wf = new Workflow({name: 'wf2', edges: [['START', ask]]});
+    const runner = new InMemoryRunner({agent: wf, appName: 'app2'});
+    const session = await runner.sessionService.createSession({
+      appName: 'app2',
+      userId: 'u',
+    });
+    const drain = async (message: Content): Promise<Event[]> => {
+      const events: Event[] = [];
+      for await (const event of runner.runAsync({
+        userId: 'u',
+        sessionId: session.id,
+        newMessage: message,
+      })) {
+        events.push(event);
+      }
+      return events;
+    };
+
+    await drain({role: 'user', parts: [{text: 'go'}]});
+    const turn2 = await drain({
+      role: 'user',
+      parts: [
+        {
+          functionResponse: {
+            id: 'ask',
+            name: 'adk_request_input',
+            response: {result: 'approve'},
+          },
+        },
+      ],
+    });
+
+    expect(turn2.find((e) => e.output !== undefined)?.output).toBe('approve');
   });
 });

--- a/core/test/workflow/resume_loopback_test.ts
+++ b/core/test/workflow/resume_loopback_test.ts
@@ -163,6 +163,37 @@ describe('workflow resume — routing back through an already-run node', () => {
     expect(turn3.some((e) => e.output === 'sent')).toBe(true);
   });
 
+  it('replays a completed rerun-on-resume node instead of running it again', async () => {
+    let ran = 0;
+    const once = node(
+      () => {
+        ran++;
+        return `ran ${ran}`;
+      },
+      {name: 'once', rerunOnResume: true},
+    );
+    const gate = node(
+      (ctx: NodeContext, value: string) => {
+        const answer = ctx.resumeInputs['gate'];
+        return answer
+          ? `${value}/${answer}`
+          : new RequestInput({interruptId: 'gate', message: 'ok?'});
+      },
+      {name: 'gate', rerunOnResume: true},
+    );
+    const wf = new Workflow({
+      name: 'replay',
+      edges: [['START', once, gate]],
+    });
+    const run = await driver(wf);
+
+    await run.run(text('go'));
+    const turn2 = await run.run(reply('gate', 'yes'));
+
+    expect(ran).toBe(1);
+    expect(turn2.some((e) => e.output === 'ran 1/yes')).toBe(true);
+  });
+
   it('replays a routing node from its recorded route instead of re-running it', async () => {
     let routed = 0;
     const gate = node(

--- a/tests/integration/workflows/agent_in_workflow/model_responses.json
+++ b/tests/integration/workflows/agent_in_workflow/model_responses.json
@@ -68,7 +68,7 @@
                     "phone_number": "555-1234",
                     "name": "Jane Doe"
                   },
-                  "id": "adk-12954685-17c9-4aeb-b1ee-077ec784040d"
+                  "id": "adk-90346567-f3ed-4865-b210-871b9d3f2a64"
                 }
               }
             ]
@@ -79,7 +79,7 @@
       "usageMetadata": {
         "promptTokenCount": 206,
         "candidatesTokenCount": 17,
-        "totalTokenCount": 309,
+        "totalTokenCount": 268,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -93,7 +93,7 @@
             "tokenCount": 17
           }
         ],
-        "thoughtsTokenCount": 86
+        "thoughtsTokenCount": 45
       }
     }
   },
@@ -145,7 +145,7 @@
                 "functionCall": {
                   "name": "find_orders",
                   "args": {},
-                  "id": "adk-a616820b-74f2-45aa-821e-1a2af5b30eb9"
+                  "id": "adk-6324f509-f68b-4129-8ecc-e0986fe6f234"
                 }
               }
             ]
@@ -156,7 +156,7 @@
       "usageMetadata": {
         "promptTokenCount": 83,
         "candidatesTokenCount": 3,
-        "totalTokenCount": 129,
+        "totalTokenCount": 120,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -170,7 +170,84 @@
             "tokenCount": 3
           }
         ],
-        "thoughtsTokenCount": 43
+        "thoughtsTokenCount": 34
+      }
+    }
+  },
+  {
+    "key": "5c5365170f539e07",
+    "instructionAgnosticKey": "548db01caf18de84",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[check_identity] said: Hello Jane Doe! Let me look up your orders."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\n\nUse the find_orders tool to get the patient's orders.\nList the orders found, and then generate a concise instruction about how to prepare based on those orders.\n",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds orders for the patient.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "find_orders",
+                  "args": {},
+                  "id": "adk-281d2bf5-fc1e-422a-b80e-84ed27aeab92"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 83,
+        "candidatesTokenCount": 3,
+        "totalTokenCount": 120,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 83
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 3
+          }
+        ],
+        "thoughtsTokenCount": 34
       }
     }
   }

--- a/tests/integration/workflows/request_input_advanced/model_responses.json
+++ b/tests/integration/workflows/request_input_advanced/model_responses.json
@@ -47,7 +47,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\n  \"days\": 1,\n  \"reason\": \"sick\"\n}"
+                "text": "{\"days\": 1, \"reason\": \"sick day\"}"
               }
             ]
           },
@@ -56,8 +56,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 42,
-        "candidatesTokenCount": 19,
-        "totalTokenCount": 103,
+        "candidatesTokenCount": 13,
+        "totalTokenCount": 96,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -68,10 +68,10 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 19
+            "tokenCount": 13
           }
         ],
-        "thoughtsTokenCount": 42
+        "thoughtsTokenCount": 41
       }
     }
   },
@@ -123,7 +123,7 @@
             "role": "model",
             "parts": [
               {
-                "text": "{\n  \"days\": 2,\n  \"reason\": \"sick\"\n}"
+                "text": "{\"days\": 2, \"reason\": \"sick\"}"
               }
             ]
           },
@@ -132,8 +132,8 @@
       ],
       "usageMetadata": {
         "promptTokenCount": 42,
-        "candidatesTokenCount": 19,
-        "totalTokenCount": 109,
+        "candidatesTokenCount": 12,
+        "totalTokenCount": 94,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -144,10 +144,86 @@
         "candidatesTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 19
+            "tokenCount": 12
           }
         ],
-        "thoughtsTokenCount": 48
+        "thoughtsTokenCount": 40
+      }
+    }
+  },
+  {
+    "key": "b51e345498e7b9f5",
+    "instructionAgnosticKey": "96eabf2989d95490",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "2 sick days"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "responseSchema": {
+          "type": "OBJECT",
+          "properties": {
+            "days": {
+              "type": "INTEGER",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991,
+              "description": "Number of days requested."
+            },
+            "reason": {
+              "type": "STRING",
+              "description": "Reason for the time off."
+            }
+          },
+          "required": [
+            "days",
+            "reason"
+          ]
+        },
+        "responseMimeType": "application/json",
+        "systemInstruction": "Extract the number of days and the reason from the user's natural language time off request.",
+        "labels": {
+          "adk_agent_name": "process_request"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "{\"days\": 2, \"reason\": \"sick\"}"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 42,
+        "candidatesTokenCount": 12,
+        "totalTokenCount": 118,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 42
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 12
+          }
+        ],
+        "thoughtsTokenCount": 64
       }
     }
   }

--- a/tests/integration/workflows/request_input_advanced/request_input_advanced_test.ts
+++ b/tests/integration/workflows/request_input_advanced/request_input_advanced_test.ts
@@ -65,7 +65,7 @@ describe('workflow sample: request_input_advanced (structured HITL)', () => {
     );
   }, 120000);
 
-  it.skip('renders the decision from a structured resume', async () => {
+  it('renders the decision from a structured resume', async () => {
     const perTurn = await runSample({
       name: 'request_input_advanced',
       rootAgent,

--- a/tests/integration/workflows/use_as_output/use_as_output_test.ts
+++ b/tests/integration/workflows/use_as_output/use_as_output_test.ts
@@ -37,18 +37,14 @@ describe('workflow sample: use_as_output', () => {
       .map((p) => p.text ?? '')
       .join('');
 
-    const orchestrate = events.find((e) => e.author === 'orchestrate');
-    expect(orchestrate?.output).toBe(summaryText);
-
     expect(finalOutput(events)).toBe(`final: ${summaryText}`);
 
-    expect(summary?.nodeInfo?.outputFor).toEqual([
-      summary?.nodeInfo?.path,
-      orchestrate?.nodeInfo?.path,
-    ]);
+    const outputFor = summary?.nodeInfo?.outputFor ?? [];
+    expect(outputFor[0]).toBe(summary?.nodeInfo?.path);
+    expect(outputFor[1]).toContain('orchestrate');
 
     expect(
       events.filter((e) => e.output === summaryText).map((e) => e.author),
-    ).toEqual(['summarizer', 'orchestrate']);
+    ).toEqual(['summarizer']);
   }, 60000);
 });


### PR DESCRIPTION
Stacked on #700, which is stacked on #698. Three more of the divergences the ported samples caught.

## A delegated output was published twice

A node that hands its output to a child with `useAsOutput` emitted that value again as its own event, so the same text appeared twice where Python's `use_as_output` golden has it once. The child already published it; the parent now reports the output without repeating the event. An event that also carries a state delta still gets out, minus the duplicated output.

## A structured human reply never bound

A client answering a `RequestInput` that declared a `responseSchema` submits the object as text — the frontend wraps whatever was typed as `{result: "<json>"}` — and `unwrapResponse` handed the raw string straight on. `request_input_advanced` therefore **denied a request that had been approved**. It now JSON-parses a string result when it parses, exactly as Python's `_unwrap_response` does; text that is not JSON (`approve`, `shorter`) is untouched. The parse is not limited to `responseSchema` replies — the envelope does not say whether its text is structured — so a plain answer that is valid JSON converts too (`42` → a number). `interruptResponseMismatch` exempts scalars from the schema check, and `hitl_test.ts` pins each case.

`request_input_advanced`'s structured-resume scenario is un-skipped and green.

## A finished run is replayed whatever the rerun setting

`rerunOnResume` says what to do with an interrupt the node is still waiting on, not that a finished run should happen again. Python reaches its cached-result case before consulting the flag; TypeScript consulted the flag first, so a completed `rerunOnResume` node re-ran on every later turn. Both schedulers had the gate — the static graph in `workflow.ts` and the `ctx.runNode()` path in `dynamic_node_scheduler.ts` — and only fixing the first left a completed dynamic child re-running while the static graph replayed its twin, so both are fixed. `isFastForwardable` has already ruled a waiting node out by that point, which is why the flag has no business there.

## Tests

`resume_loopback_test.ts`, `dynamic_resume_test.ts` and `node_state_events_test.ts` gain cases for the replay ordering on both schedulers and for both resume-unwrapping paths; `hitl_test.ts` pins `unwrapResponse` itself. 3541 passing, 12 skipped across `unit:core`, `unit:dev` and `integration`.

## Two I did not land

I got partway into the tool-confirmation resume and backed it out rather than ship half of it.

**Root cause found:** Python's `build_node` defaults `rerun_on_resume=True` for an `LlmAgent` used as a node (`_workflow_graph_utils.py:93-95`); TypeScript defaults it false. That is why the `agent_in_workflow` port needed an explicit `node(agent, {rerunOnResume: true})` wrapper that Python does not have. Adding the default does make the confirmation resolve and `find_orders` return — but the resumed agent is then rebuilt with only its node input in view, never sees the call it already made, and re-issues it, so the user is asked to confirm on every turn. Ending one ask short is bad; asking forever is worse, so both that default and the turn-window widening I tried alongside it are out of this PR.

Finishing it means deciding how an agent node resumes a mid-flight tool call across turns — the pending call has to be back in the agent's view without dragging the whole conversation with it. Worth its own change.

**Task-mode multi-turn** (an agent that needs a second user turn throws `ended without calling finish_task`) is a missing feature rather than a bug: Python sets `wait_for_output = True` for `task`/`chat` mode nodes and TypeScript has no equivalent. Also its own change.

Both stay documented in the skipped `agent_in_workflow` scenarios.

---


