### PR TITLE
fix(workflow): let an agent node converse and finish a confirmed tool call

### DIFF
--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -423,7 +423,15 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
   codeExecutor?: BaseCodeExecutor;
 
   constructor(config: LlmAgentConfig) {
-    super(config);
+    // Node defaults for an agent used in a graph, matching adk-python's
+    // `build_node`: an agent re-runs on resume (its turn is what the reply is
+    // addressed to), and a task-mode agent holds the graph until it produces an
+    // output, since a turn that only asks the user a question produces none.
+    super({
+      ...config,
+      rerunOnResume: config.rerunOnResume ?? true,
+      waitForOutput: config.waitForOutput ?? config.mode === 'task',
+    });
     this.model = config.model;
     this.instruction = config.instruction ?? '';
     this.globalInstruction = config.globalInstruction ?? '';

--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -185,7 +185,7 @@ export function getCurrentTurnContents(
     }
     if (event.author === 'user' || isEventFromAnotherAgent(agentName, event)) {
       return getContents(
-        events.slice(i),
+        events.slice(turnStart(events, i)),
         agentName,
         currentBranch,
         currentIsolationScope,
@@ -194,6 +194,38 @@ export function getCurrentTurnContents(
   }
 
   return [];
+}
+
+/**
+ * Widens the turn window back over a function call the turn answers.
+ *
+ * A tool that paused for confirmation is called in one turn and answered in the
+ * next, so the response falls inside the turn while the call that earned it
+ * sits before it. Left split, the model is shown a result for a call it cannot
+ * see — it re-issues the call, and the confirmation never resolves.
+ */
+function turnStart(events: Event[], anchor: number): number {
+  const answered = new Set<string>();
+  for (const event of events.slice(anchor)) {
+    for (const part of event.content?.parts ?? []) {
+      if (part.functionResponse?.id) {
+        answered.add(part.functionResponse.id);
+      }
+    }
+  }
+  if (answered.size === 0) {
+    return anchor;
+  }
+  let start = anchor;
+  for (let i = anchor - 1; i >= 0; i--) {
+    const answersACall = (events[i].content?.parts ?? []).some((p) =>
+      p.functionCall?.id ? answered.has(p.functionCall.id) : false,
+    );
+    if (answersACall) {
+      start = i;
+    }
+  }
+  return start;
 }
 
 /**

--- a/core/src/agents/processors/request_confirmation_llm_request_processor.ts
+++ b/core/src/agents/processors/request_confirmation_llm_request_processor.ts
@@ -200,6 +200,26 @@ export class RequestConfirmationLlmRequestProcessor extends BaseLlmRequestProces
       });
 
       if (functionResponseEvent) {
+        // Put the response in the in-memory session before yielding it. The
+        // content builder runs immediately behind this processor in the same
+        // step and reads `session.events`, while a yielded event only reaches
+        // the runner — which is what durably appends it — once the step is
+        // done. Without this the model is rebuilt with neither the tool call
+        // nor its result in view, and re-issues the call every turn.
+        //
+        // In memory only, deliberately: the runner appends this same event
+        // through the session service, and `VertexAiSessionService` posts to
+        // the remote store unconditionally rather than deduping by event id,
+        // so appending here too would write it twice on Agent Engine.
+        const events = invocationContext.session.events;
+        const existing = events.findIndex(
+          (e) => e.id === functionResponseEvent.id,
+        );
+        if (existing >= 0) {
+          events[existing] = functionResponseEvent;
+        } else {
+          events.push(functionResponseEvent);
+        }
         yield functionResponseEvent;
       }
       return;

--- a/core/src/workflow/run_llm_agent_as_node.ts
+++ b/core/src/workflow/run_llm_agent_as_node.ts
@@ -47,18 +47,22 @@ export async function* runLlmAgentAsNode(
   ctx: NodeContext,
   nodeInput: unknown,
 ): AsyncGenerator<Event, void, void> {
-  if (agent.mode !== 'task' && !agent.includeContentsExplicit) {
+  const isTaskMode = agent.mode === 'task';
+
+  if (!isTaskMode && !agent.includeContentsExplicit) {
     agent.includeContents = 'none';
   }
 
-  await appendNodeInputAsUserTurn(ctx, nodeInput);
+  if (!isTaskMode) {
+    await appendNodeInputAsUserTurn(ctx, nodeInput);
+  }
 
   const agentIc = withWorkflowInstructionScope(ctx.getInvocationContext(), {
     input: nodeInput,
     outputsByNode: collectPredecessorOutputs(ctx),
   });
 
-  if (agent.mode === 'task') {
+  if (isTaskMode) {
     yield* runTaskMode(ctx, agentIc, agent);
     return;
   }
@@ -103,6 +107,10 @@ async function appendNodeInputAsUserTurn(
  * successful function response, promote the call's arguments to the node output
  * (and to `outputKey` state, if set). Mirrors adk-python's
  * `run_llm_agent_as_node` task branch.
+ *
+ * A turn that ends without `finish_task` — the agent asked the user something —
+ * is the task still in progress, so the node returns with no output and
+ * `waitForOutput` holds the graph there until the next turn.
  */
 async function* runTaskMode(
   ctx: NodeContext,
@@ -136,11 +144,6 @@ async function* runTaskMode(
 
     yield event;
   }
-
-  throw new Error(
-    `Task-mode agent '${agent.name}' ended without calling finish_task; ` +
-      'no output was produced.',
-  );
 }
 
 /**

--- a/core/test/agents/processors/request_confirmation_llm_request_processor_test.ts
+++ b/core/test/agents/processors/request_confirmation_llm_request_processor_test.ts
@@ -6,6 +6,8 @@
 
 import {
   BaseAgent,
+  BaseSessionService,
+  InMemorySessionService,
   InvocationContext,
   LlmAgent,
   PluginManager,
@@ -36,6 +38,7 @@ class MockRootAgent extends BaseAgent {
 function createMockInvocationContext(
   agent: BaseAgent,
   events: ReturnType<typeof createEvent>[] = [],
+  sessionService?: BaseSessionService,
 ): InvocationContext {
   return new InvocationContext({
     invocationId: 'test-invocation',
@@ -46,6 +49,7 @@ function createMockInvocationContext(
       appName: 'test-app',
       userId: 'test-user',
     }),
+    sessionService,
     pluginManager: new PluginManager([]),
   });
 }
@@ -241,6 +245,95 @@ describe('RequestConfirmationLlmRequestProcessor', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]).toBe(fakeResponseEvent);
+  });
+
+  it('should stage the tool response in the session without writing it', async () => {
+    // The content builder runs behind this processor in the same step and
+    // reads `session.events`, so the response has to be there. Writing it
+    // through the session service is the runner's job: it appends every event
+    // it is yielded, and a backend that does not dedupe by event id — Vertex
+    // posts to Agent Engine unconditionally — would store this one twice.
+    const {handleFunctionCallList} =
+      await import('../../../src/agents/functions.js');
+    const mockFunctionCallList = vi.mocked(handleFunctionCallList);
+
+    const fakeResponseEvent = createEvent({
+      invocationId: 'test-invocation',
+      author: 'test_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionResponse: {
+              id: 'original-fc-4',
+              name: 'my_tool',
+              response: {result: 'ok'},
+            },
+          },
+        ],
+      },
+    });
+    mockFunctionCallList.mockResolvedValueOnce(fakeResponseEvent);
+
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: 'gemini-2.5-flash',
+    });
+    vi.spyOn(agent, 'canonicalTools').mockResolvedValue([]);
+
+    const systemFunctionCallEvent = createEvent({
+      invocationId: 'test-invocation',
+      author: 'test_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'fc-confirm-4',
+              name: REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+              args: {
+                originalFunctionCall: {
+                  id: 'original-fc-4',
+                  name: 'my_tool',
+                  args: {param: 'value'},
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const userConfirmationEvent = createEvent({
+      invocationId: 'test-invocation',
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'fc-confirm-4',
+              name: REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+              response: {confirmed: true, hint: ''},
+            },
+          },
+        ],
+      },
+    });
+
+    const sessionService = new InMemorySessionService();
+    const appendEvent = vi.spyOn(sessionService, 'appendEvent');
+    const invocationContext = createMockInvocationContext(
+      agent,
+      [systemFunctionCallEvent, userConfirmationEvent],
+      sessionService,
+    );
+
+    const events = await collectEvents(invocationContext);
+
+    expect(events).toEqual([fakeResponseEvent]);
+    expect(invocationContext.session.events.at(-1)).toBe(fakeResponseEvent);
+    expect(appendEvent).not.toHaveBeenCalled();
   });
 
   it('should yield no events when handleFunctionCallList returns null', async () => {

--- a/core/test/workflow/task_mode_conversation_test.ts
+++ b/core/test/workflow/task_mode_conversation_test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A task-mode agent node converses: it may need several user turns before it
+ * can finish. A turn where it asks something and produces no output is the task
+ * still in progress, so the graph holds at that node rather than failing or
+ * running on with nothing.
+ */
+
+import {Content} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {LlmAgent} from '../../src/agents/llm_agent.js';
+import {Event} from '../../src/events/event.js';
+import {BaseLlm} from '../../src/models/base_llm.js';
+import type {BaseLlmConnection} from '../../src/models/base_llm_connection.js';
+import type {LlmRequest} from '../../src/models/llm_request.js';
+import type {LlmResponse} from '../../src/models/llm_response.js';
+import {LLMRegistry} from '../../src/models/registry.js';
+import {InMemoryRunner} from '../../src/runner/in_memory_runner.js';
+import {node} from '../../src/workflow/node.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {Workflow} from '../../src/workflow/workflow.js';
+
+/** Asks once, then finishes on the next turn. */
+class TwoTurnLlm extends BaseLlm {
+  static override readonly supportedModels = [/two-turn-.*/];
+
+  override async *generateContentAsync(
+    llmRequest: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void> {
+    const saidName = (llmRequest.contents ?? []).some((c) =>
+      (c.parts ?? []).some((p) => p.text?.includes('Ada')),
+    );
+    yield {
+      content: saidName
+        ? {
+            role: 'model',
+            parts: [{functionCall: {name: 'finish_task', args: {name: 'Ada'}}}],
+          }
+        : {role: 'model', parts: [{text: 'What is your name?'}]},
+    } as LlmResponse;
+  }
+
+  override connect(): Promise<BaseLlmConnection> {
+    throw new Error('not supported');
+  }
+}
+LLMRegistry.register(TwoTurnLlm);
+
+describe('task-mode agent node across turns', () => {
+  it('holds the graph while the agent is still asking', async () => {
+    const intake = new LlmAgent({
+      name: 'intake',
+      model: 'two-turn-1',
+      mode: 'task',
+      instruction: 'Collect the name.',
+      outputSchema: {
+        type: 'OBJECT',
+        properties: {name: {type: 'STRING'}},
+      } as never,
+    });
+    let downstreamRuns = 0;
+    const after = node(
+      (_c: NodeContext, input: {name?: string}) => {
+        downstreamRuns++;
+        return `hello ${input?.name}`;
+      },
+      {name: 'after'},
+    );
+    const wf = new Workflow({
+      name: 'intake_flow',
+      edges: [['START', intake, after]],
+    });
+
+    const runner = new InMemoryRunner({agent: wf, appName: 'app'});
+    const session = await runner.sessionService.createSession({
+      appName: 'app',
+      userId: 'u',
+    });
+    const run = async (text: string): Promise<Event[]> => {
+      const events: Event[] = [];
+      const message: Content = {role: 'user', parts: [{text}]};
+      for await (const event of runner.runAsync({
+        userId: 'u',
+        sessionId: session.id,
+        newMessage: message,
+      })) {
+        events.push(event);
+      }
+      return events;
+    };
+
+    const turn1 = await run('go');
+    expect(
+      turn1
+        .flatMap((e) => e.content?.parts ?? [])
+        .map((p) => p.text ?? '')
+        .join(' '),
+    ).toContain('What is your name?');
+    expect(downstreamRuns).toBe(0);
+
+    const turn2 = await run('Ada');
+    expect(downstreamRuns).toBe(1);
+    expect(turn2.some((e) => e.output === 'hello Ada')).toBe(true);
+  }, 30000);
+});

--- a/tests/integration/workflows/agent_in_workflow/agent_in_workflow_test.ts
+++ b/tests/integration/workflows/agent_in_workflow/agent_in_workflow_test.ts
@@ -9,9 +9,6 @@
  * identity via finish_task, a node routes on it, and a second LlmAgent uses a
  * require_confirmation tool. Scenarios mirror the Python goldens
  * `contributing/samples/workflows/agent_in_workflow/tests/*.json`.
- *
- * Only the single-turn path runs green; the multi-turn and resume paths are
- * skipped with the divergence they hit spelled out below.
  */
 
 import {getFunctionCalls} from '@google/adk';
@@ -54,17 +51,62 @@ describe('workflow sample: agent_in_workflow (task mode + confirmation)', () => 
     expect(isPaused(turn1)).toBe(true);
   }, 120000);
 
-  it.skip('lists the orders once the tool confirmation is approved', async () => {
+  it('collects the identity across several turns', async () => {
+    const perTurn = await runSample({
+      name: 'agent_in_workflow',
+      rootAgent,
+      turns: ['go', 'Jane Doe', '555-1234'],
+    });
+    const [turn1, turn2, turn3] = perTurn;
+
+    for (const turn of [turn1, turn2]) {
+      expect(authors(turn).has('intake_agent')).toBe(true);
+      expect(authors(turn).has('check_identity')).toBe(false);
+    }
+
+    expect(
+      turn3.flatMap((e) => getFunctionCalls(e)).map((c) => c.name),
+    ).toContain('finish_task');
+    expect(joinedText(turn3)).toContain(
+      'Hello Jane Doe! Let me look up your orders.',
+    );
+    expect(authors(turn3).has('generate_instruction')).toBe(true);
+  }, 180000);
+
+  it('routes back to intake when the name does not match', async () => {
+    const perTurn = await runSample({
+      name: 'agent_in_workflow',
+      rootAgent,
+      turns: ['My name is John Doe', '555-1234', 'Jane Doe, 555-1234'],
+    });
+    const events = allEvents(perTurn);
+
+    expect(events.map((e) => e.route).filter(Boolean)).toContain('retry');
+    expect(joinedText(events)).toContain(
+      'Could not find matching records for John Doe.',
+    );
+
+    expect(
+      events.filter((e) => e.author === 'check_identity').length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(joinedText(events)).toContain(
+      'Hello Jane Doe! Let me look up your orders.',
+    );
+    expect(authors(events).has('generate_instruction')).toBe(true);
+  }, 180000);
+
+  it('lists the orders once the tool confirmation is approved', async () => {
     const perTurn = await runSample({
       name: 'agent_in_workflow',
       rootAgent,
       turns: ['I am Jane Doe, my phone number is 555-1234', approve],
     });
-    const events = allEvents(perTurn);
-    expect(joinedText(events)).toContain('CBC (Complete Blood Count)');
+    expect(joinedText(allEvents(perTurn))).toContain(
+      'CBC (Complete Blood Count)',
+    );
   }, 120000);
 
-  it.skip('reports the rejection when the confirmation is declined', async () => {
+  it('reports the rejection when the confirmation is declined', async () => {
     const perTurn = await runSample({
       name: 'agent_in_workflow',
       rootAgent,
@@ -72,30 +114,4 @@ describe('workflow sample: agent_in_workflow (task mode + confirmation)', () => 
     });
     expect(joinedText(allEvents(perTurn))).toContain('rejected');
   }, 120000);
-
-  it.skip('collects the identity across several turns', async () => {
-    const perTurn = await runSample({
-      name: 'agent_in_workflow',
-      rootAgent,
-      turns: ['go', 'Jane Doe', '555-1234', approve],
-    });
-    expect(authors(allEvents(perTurn)).has('generate_instruction')).toBe(true);
-  }, 180000);
-
-  it.skip('routes back to intake when the name does not match', async () => {
-    const perTurn = await runSample({
-      name: 'agent_in_workflow',
-      rootAgent,
-      turns: [
-        'I am John Doe, my phone number is 555-1234',
-        'Jane Doe, 555-1234',
-        approve,
-      ],
-    });
-    const events = allEvents(perTurn);
-    expect(events.map((e) => e.route).filter(Boolean)).toContain('retry');
-    expect(joinedText(events)).toContain(
-      'Could not find matching records for John Doe.',
-    );
-  }, 180000);
 });

--- a/tests/integration/workflows/agent_in_workflow/model_responses.json
+++ b/tests/integration/workflows/agent_in_workflow/model_responses.json
@@ -1,7 +1,7 @@
 [
   {
-    "key": "4fa8f397250ab824",
-    "instructionAgnosticKey": "3a761bc70a4b684e",
+    "key": "cda70ddac6ecda04",
+    "instructionAgnosticKey": "72ac0e556094db7e",
     "request": {
       "contents": [
         {
@@ -11,7 +11,1110 @@
               "text": "I am Jane Doe, my phone number is 555-1234"
             }
           ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "finish_task",
+                  "args": {
+                    "name": "Jane Doe",
+                    "phone_number": "555-1234"
+                  },
+                  "id": "adk-9432115f-c234-4f73-b8a6-c5cd32016b8f"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 188,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 257,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 188
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 17
+          }
+        ],
+        "thoughtsTokenCount": 52
+      }
+    }
+  },
+  {
+    "key": "5c5365170f539e07",
+    "instructionAgnosticKey": "548db01caf18de84",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[check_identity] said: Hello Jane Doe! Let me look up your orders."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\n\nUse the find_orders tool to get the patient's orders.\nList the orders found, and then generate a concise instruction about how to prepare based on those orders.\n",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds orders for the patient.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "find_orders",
+                  "args": {},
+                  "id": "adk-15baef5c-d662-4080-bf08-83206a58ab88"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 83,
+        "candidatesTokenCount": 3,
+        "totalTokenCount": 118,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 83
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 3
+          }
+        ],
+        "thoughtsTokenCount": 32
+      }
+    }
+  },
+  {
+    "key": "744e4e9e6c00078a",
+    "instructionAgnosticKey": "5b231d4a1f166598",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "go"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Hello! I'm your medical lab intake assistant. To get started, could I please have your full name?"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 171,
+        "candidatesTokenCount": 23,
+        "totalTokenCount": 256,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 171
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 23
+          }
+        ],
+        "thoughtsTokenCount": 62
+      }
+    }
+  },
+  {
+    "key": "88648d2b30bda6ea",
+    "instructionAgnosticKey": "727aa693fca8284b",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "go"
+            }
+          ]
         },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Hello! I'm your medical lab intake assistant. To get started, could I please have your full name?"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Jane Doe"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Thank you, Jane Doe. Could I also please get your phone number?"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 196,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 228,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 196
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 15
+          }
+        ],
+        "thoughtsTokenCount": 17
+      }
+    }
+  },
+  {
+    "key": "90d84b7ec2b03cc9",
+    "instructionAgnosticKey": "4932b888add26a45",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "go"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Hello! I'm your medical lab intake assistant. To get started, could I please have your full name?"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Jane Doe"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Thank you, Jane Doe. Could I also please get your phone number?"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "555-1234"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "finish_task",
+                  "args": {
+                    "phone_number": "555-1234",
+                    "name": "Jane Doe"
+                  },
+                  "id": "adk-525f6f4f-a8dd-4558-b9b0-cd1646c515b8"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 219,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 292,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 219
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 17
+          }
+        ],
+        "thoughtsTokenCount": 56
+      }
+    }
+  },
+  {
+    "key": "5c5365170f539e07",
+    "instructionAgnosticKey": "548db01caf18de84",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[check_identity] said: Hello Jane Doe! Let me look up your orders."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\n\nUse the find_orders tool to get the patient's orders.\nList the orders found, and then generate a concise instruction about how to prepare based on those orders.\n",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds orders for the patient.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "find_orders",
+                  "args": {},
+                  "id": "adk-2ed49ab6-1c6d-43f6-8faf-b29a038f62ed"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 83,
+        "candidatesTokenCount": 3,
+        "totalTokenCount": 120,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 83
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 3
+          }
+        ],
+        "thoughtsTokenCount": 34
+      }
+    }
+  },
+  {
+    "key": "77517ef377aedaea",
+    "instructionAgnosticKey": "5e2aea58683a0364",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "My name is John Doe"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "Thanks, John Doe. What is your phone number?"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 175,
+        "candidatesTokenCount": 11,
+        "totalTokenCount": 206,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 175
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 11
+          }
+        ],
+        "thoughtsTokenCount": 20
+      }
+    }
+  },
+  {
+    "key": "1e1c036a08077c1e",
+    "instructionAgnosticKey": "a2066f03f06d597c",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "My name is John Doe"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Thanks, John Doe. What is your phone number?"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "555-1234"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "finish_task",
+                  "args": {
+                    "name": "John Doe",
+                    "phone_number": "555-1234"
+                  },
+                  "id": "adk-0a688dc8-5b25-42b6-991f-3e40e6832ec9"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 194,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 268,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 194
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 17
+          }
+        ],
+        "thoughtsTokenCount": 57
+      }
+    }
+  },
+  {
+    "key": "7c2efea7b01a5c42",
+    "instructionAgnosticKey": "dfdb03b36f51c881",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "My name is John Doe"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Thanks, John Doe. What is your phone number?"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "555-1234"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "functionCall": {
+                "name": "finish_task",
+                "args": {
+                  "name": "John Doe",
+                  "phone_number": "555-1234"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "functionResponse": {
+                "name": "finish_task",
+                "response": {
+                  "result": "Task completed."
+                }
+              }
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[check_identity] said: Could not find matching records for John Doe. Let's try again."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "It looks like \"John Doe\" didn't match our records. Could you please provide another name?"
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 243,
+        "candidatesTokenCount": 21,
+        "totalTokenCount": 300,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 243
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 21
+          }
+        ],
+        "thoughtsTokenCount": 36
+      }
+    }
+  },
+  {
+    "key": "aa3b4aa17b8b3c82",
+    "instructionAgnosticKey": "461a1e7aea806753",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "My name is John Doe"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Thanks, John Doe. What is your phone number?"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "555-1234"
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "functionCall": {
+                "name": "finish_task",
+                "args": {
+                  "name": "John Doe",
+                  "phone_number": "555-1234"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "functionResponse": {
+                "name": "finish_task",
+                "response": {
+                  "result": "Task completed."
+                }
+              }
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[check_identity] said: Could not find matching records for John Doe. Let's try again."
+            }
+          ]
+        },
+        {
+          "role": "model",
+          "parts": [
+            {
+              "text": "It looks like \"John Doe\" didn't match our records. Could you please provide another name?"
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Jane Doe, 555-1234"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "finish_task",
+                  "args": {
+                    "phone_number": "555-1234",
+                    "name": "Jane Doe"
+                  },
+                  "id": "adk-41e907e6-0ee8-469e-a377-b5672d712d7b"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 276,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 368,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 276
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 17
+          }
+        ],
+        "thoughtsTokenCount": 75
+      }
+    }
+  },
+  {
+    "key": "5c5365170f539e07",
+    "instructionAgnosticKey": "548db01caf18de84",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "For context:"
+            },
+            {
+              "text": "[check_identity] said: Hello Jane Doe! Let me look up your orders."
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\n\nUse the find_orders tool to get the patient's orders.\nList the orders found, and then generate a concise instruction about how to prepare based on those orders.\n",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds orders for the patient.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "find_orders",
+                  "args": {},
+                  "id": "adk-1a4298e3-dd85-4405-8e60-cba73ea91b53"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 83,
+        "candidatesTokenCount": 3,
+        "totalTokenCount": 127,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 83
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 3
+          }
+        ],
+        "thoughtsTokenCount": 41
+      }
+    }
+  },
+  {
+    "key": "cda70ddac6ecda04",
+    "instructionAgnosticKey": "72ac0e556094db7e",
+    "request": {
+      "contents": [
         {
           "role": "user",
           "parts": [
@@ -68,7 +1171,7 @@
                     "phone_number": "555-1234",
                     "name": "Jane Doe"
                   },
-                  "id": "adk-90346567-f3ed-4865-b210-871b9d3f2a64"
+                  "id": "adk-c165d838-4415-4106-a970-0c92226b74fd"
                 }
               }
             ]
@@ -77,14 +1180,14 @@
         }
       ],
       "usageMetadata": {
-        "promptTokenCount": 206,
+        "promptTokenCount": 188,
         "candidatesTokenCount": 17,
-        "totalTokenCount": 268,
+        "totalTokenCount": 311,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
             "modality": "TEXT",
-            "tokenCount": 206
+            "tokenCount": 188
           }
         ],
         "candidatesTokensDetails": [
@@ -93,7 +1196,7 @@
             "tokenCount": 17
           }
         ],
-        "thoughtsTokenCount": 45
+        "thoughtsTokenCount": 106
       }
     }
   },
@@ -145,7 +1248,7 @@
                 "functionCall": {
                   "name": "find_orders",
                   "args": {},
-                  "id": "adk-6324f509-f68b-4129-8ecc-e0986fe6f234"
+                  "id": "adk-2409e37d-09f0-48a9-adc6-675904a1d337"
                 }
               }
             ]
@@ -156,7 +1259,7 @@
       "usageMetadata": {
         "promptTokenCount": 83,
         "candidatesTokenCount": 3,
-        "totalTokenCount": 120,
+        "totalTokenCount": 127,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -170,7 +1273,186 @@
             "tokenCount": 3
           }
         ],
-        "thoughtsTokenCount": 34
+        "thoughtsTokenCount": 41
+      }
+    }
+  },
+  {
+    "key": "363bbcfe5fead81b",
+    "instructionAgnosticKey": "0c6282ade1f44048",
+    "request": {
+      "contents": [
+        {
+          "role": "model",
+          "parts": [
+            {
+              "functionCall": {
+                "name": "find_orders",
+                "args": {}
+              }
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "functionResponse": {
+                "name": "find_orders",
+                "response": {
+                  "results": [
+                    "CBC (Complete Blood Count)",
+                    "Lipid Panel"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\n\nUse the find_orders tool to get the patient's orders.\nList the orders found, and then generate a concise instruction about how to prepare based on those orders.\n",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds orders for the patient.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "The patient has the following orders:\n* CBC (Complete Blood Count)\n* Lipid Panel\n\nPlease instruct the patient to fast for 8-12 hours prior to their appointment for accurate test results. They may drink water."
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 78,
+        "candidatesTokenCount": 47,
+        "totalTokenCount": 203,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 78
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 47
+          }
+        ],
+        "thoughtsTokenCount": 78
+      }
+    }
+  },
+  {
+    "key": "cda70ddac6ecda04",
+    "instructionAgnosticKey": "72ac0e556094db7e",
+    "request": {
+      "contents": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "text": "I am Jane Doe, my phone number is 555-1234"
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are a medical lab intake assistant. Your job is to chat with\nthe user to get their full name and phone number. Do not make up\ninformation. Once you have both, finish your task.\nIf identity check failed, ask for another name.\n\nDo NOT call `finish_task` prematurely. Use your available tools to fully complete every aspect of the task first. If the task is unclear, ask the user for clarification before proceeding. Once the task is fully complete, call `finish_task` by itself with no accompanying text output.",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "finish_task",
+                "description": "Signal that this agent has completed its delegated task. Call this when you have finished your delegated task. Pass the required output data in the parameters.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {
+                    "name": {
+                      "type": "STRING",
+                      "description": "The patient's full name."
+                    },
+                    "phone_number": {
+                      "type": "STRING",
+                      "description": "The patient's phone number."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "phone_number"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "intake_agent"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "functionCall": {
+                  "name": "finish_task",
+                  "args": {
+                    "name": "Jane Doe",
+                    "phone_number": "555-1234"
+                  },
+                  "id": "adk-54b39661-1db8-4d67-a844-5e4fe0ac50fe"
+                }
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 188,
+        "candidatesTokenCount": 17,
+        "totalTokenCount": 263,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 188
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 17
+          }
+        ],
+        "thoughtsTokenCount": 58
       }
     }
   },
@@ -222,7 +1504,7 @@
                 "functionCall": {
                   "name": "find_orders",
                   "args": {},
-                  "id": "adk-281d2bf5-fc1e-422a-b80e-84ed27aeab92"
+                  "id": "adk-136f6412-fb3c-40de-9fbe-a0364b556791"
                 }
               }
             ]
@@ -233,7 +1515,7 @@
       "usageMetadata": {
         "promptTokenCount": 83,
         "candidatesTokenCount": 3,
-        "totalTokenCount": 120,
+        "totalTokenCount": 127,
         "trafficType": "ON_DEMAND",
         "promptTokensDetails": [
           {
@@ -247,7 +1529,93 @@
             "tokenCount": 3
           }
         ],
-        "thoughtsTokenCount": 34
+        "thoughtsTokenCount": 41
+      }
+    }
+  },
+  {
+    "key": "aa20c20a93b6509b",
+    "instructionAgnosticKey": "d760e5c79bb67ec2",
+    "request": {
+      "contents": [
+        {
+          "role": "model",
+          "parts": [
+            {
+              "functionCall": {
+                "name": "find_orders",
+                "args": {}
+              }
+            }
+          ]
+        },
+        {
+          "role": "user",
+          "parts": [
+            {
+              "functionResponse": {
+                "name": "find_orders",
+                "response": {
+                  "error": "This tool call is rejected."
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "config": {
+        "systemInstruction": "You are an agent. Your internal name is \"generate_instruction\".\n\n\nUse the find_orders tool to get the patient's orders.\nList the orders found, and then generate a concise instruction about how to prepare based on those orders.\n",
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "name": "find_orders",
+                "description": "Finds orders for the patient.",
+                "parameters": {
+                  "type": "OBJECT",
+                  "properties": {}
+                }
+              }
+            ]
+          }
+        ],
+        "labels": {
+          "adk_agent_name": "generate_instruction"
+        }
+      }
+    },
+    "response": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "I am sorry, I cannot find the orders at this time. The tool call was rejected."
+              }
+            ]
+          },
+          "finishReason": "STOP"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 75,
+        "candidatesTokenCount": 19,
+        "totalTokenCount": 136,
+        "trafficType": "ON_DEMAND",
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 75
+          }
+        ],
+        "candidatesTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 19
+          }
+        ],
+        "thoughtsTokenCount": 42
       }
     }
   }


### PR DESCRIPTION
Stacked on #702 → #700 → #698. Clears the last four skipped sample scenarios; **no skipped workflow tests remain.**

## A task-mode agent node could not take a second turn

Asked only for a name, `intake_agent` replies with a question and no output, and the wrapper threw `ended without calling finish_task`. But that is the sample's stated job — *chat with the user to get their full name and phone number* — and three Python goldens collect the identity over three turns.

A turn that ends in a question is the task still in progress, so the node now returns without an output and the graph holds there. `waitForOutput` already existed on `BaseNode` and the workflow loop already honoured it; nothing ever set it. Python's `build_node` sets it for `task`/`chat` nodes.

The node input is also no longer injected as a user turn for those agents: they read the conversation from the session, and re-stating the opening request after every reply is how the model lost the thread. Python's `prepare_llm_agent_input` returns early for the same reason.

## Approving a tool confirmation did nothing

Two causes, one behind the other.

**The agent node did not re-run on resume**, so it completed with the confirmation reply as its *output* and the tool call was stranded. Python's `build_node` defaults `rerun_on_resume=True` for an `LlmAgent` — which is exactly what the port had been compensating for with a `node(agent, {rerunOnResume: true})` wrapper the Python sample does not have.

**With that fixed the confirmation resolved — and the agent called the tool again, every turn.** A request processor's yielded events are appended by the runner only once the step completes, so the response the confirmation processor had just produced was absent from `session.events` when the content builder ran immediately behind it. The model was rebuilt with neither the call nor its result in view.

Two changes close it: the processor stages the response in the in-memory session before yielding, and the turn window widens back over the call that a response in the window answers. Without the second, the model is shown a result for a call it cannot see — which is the same reason it kept re-issuing it.

## Result

All five `agent_in_workflow` scenarios run: single-turn intake, multi-turn intake, the retry route (Python's `wrong_name.json` turns), approve, and decline.

**3547 passing, 8 skipped** across `unit:core`, `unit:dev` and `integration`. The 8 are pre-existing platform gates (Windows PowerShell/CMD, `build_setup`) — every skip introduced by this stack is gone.

New unit test `core/test/workflow/task_mode_conversation_test.ts` covers the hold-and-continue behaviour without a live model.

### Review follow-up

The staging is in memory only, deliberately. The runner is the single durable writer: it appends every event it is yielded, and `VertexAiSessionService.appendEvent` posts to Agent Engine unconditionally rather than deduping by event id, so a session-service append here too would store the tool response twice on Vertex. `request_confirmation_llm_request_processor_test.ts` now asserts the response reaches `session.events` and that `appendEvent` is not called.


