### PR TITLE
fix(workflow): keep a jittered retry delay inside maxDelay

### DIFF
--- a/core/src/workflow/utils/retry_utils.ts
+++ b/core/src/workflow/utils/retry_utils.ts
@@ -103,14 +103,14 @@ export function getRetryDelaySeconds({
   const attemptForCalc = Math.max(0, attemptCount - 1);
 
   let delay = initialDelay * Math.pow(backoffFactor, attemptForCalc);
-  delay = Math.min(delay, maxDelay);
 
   if (jitter > 0.0) {
+    delay = Math.min(delay, maxDelay / (1.0 + jitter));
     // random.uniform(-jitter*delay, jitter*delay)
     const span = jitter * delay;
     const randomOffset = -span + randomFn() * (2 * span);
     delay = Math.max(0.0, delay + randomOffset);
   }
 
-  return delay;
+  return Math.min(delay, maxDelay);
 }

--- a/core/test/workflow/foundations_test.ts
+++ b/core/test/workflow/foundations_test.ts
@@ -236,4 +236,57 @@ describe('Phase 0 — getRetryDelaySeconds', () => {
     // randomFn=1 -> offset +span -> 4+4=8
     expect(delayWith(() => 1)).toBe(8);
   });
+
+  it('never exceeds maxDelay once jitter is applied', () => {
+    const cfg = prepareRetryConfig({
+      initialDelay: 1,
+      backoffFactor: 2,
+      maxDelay: 60,
+      jitter: 1,
+    });
+    for (let attemptCount = 1; attemptCount <= 12; attemptCount++) {
+      for (const draw of [0, 0.25, 0.5, 0.75, 1]) {
+        const delay = getRetryDelaySeconds({
+          retryConfig: cfg,
+          nodeState: createNodeState({attemptCount}),
+          randomFn: () => draw,
+        });
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThanOrEqual(60);
+      }
+    }
+  });
+
+  it('caps the pre-jitter delay so the widest draw lands on maxDelay', () => {
+    const cfg = prepareRetryConfig({
+      initialDelay: 1,
+      backoffFactor: 2,
+      maxDelay: 60,
+      jitter: 1,
+    });
+    const delayWith = (randomFn: () => number) =>
+      getRetryDelaySeconds({
+        retryConfig: cfg,
+        nodeState: createNodeState({attemptCount: 10}),
+        randomFn,
+      });
+    expect(delayWith(() => 0.5)).toBe(30);
+    expect(delayWith(() => 1)).toBe(60);
+    expect(delayWith(() => 0)).toBe(0);
+  });
+
+  it('still honours maxDelay when jitter is disabled', () => {
+    const cfg = prepareRetryConfig({
+      initialDelay: 1,
+      backoffFactor: 2,
+      maxDelay: 60,
+      jitter: 0,
+    });
+    expect(
+      getRetryDelaySeconds({
+        retryConfig: cfg,
+        nodeState: createNodeState({attemptCount: 20}),
+      }),
+    ).toBe(60);
+  });
 });


### PR DESCRIPTION
`getRetryDelaySeconds` capped the delay at `maxDelay` *before* adding jitter and never clamped the result, so the positive half of the jitter draw pushed it back over the bound. With the documented defaults (`maxDelay: 60`, `jitter: 1.0`) a saturated backoff slept up to **120s** — twice what the config asks for.

adk-python caps the pre-jitter delay at `max_delay / (1 + jitter)`, so even the widest positive offset lands exactly on `max_delay`, then clamps once more on the way out (`workflow/utils/_retry_utils.py:88,92`). Capping the jittered result instead would hold the bound but collapse every overshooting draw onto exactly `max_delay`, firing at one instant the retries jitter exists to spread out. This ports both steps.

### Tests
- `never exceeds maxDelay once jitter is applied` — 12 attempts × 5 draws, all within `[0, maxDelay]`. Fails on `main`.
- `caps the pre-jitter delay so the widest draw lands on maxDelay` — pins 30 / 60 / 0 at saturation. Fails on `main`.
- `still honours maxDelay when jitter is disabled` — guards the path the new pre-jitter cap skips.

Found while auditing workflow parity against adk-python. One of six independent fixes; this one touches only `retry_utils.ts`.