### PR TITLE
fix(workflow): match a retryable exception by its class name

### DIFF
--- a/core/src/workflow/utils/retry_utils.ts
+++ b/core/src/workflow/utils/retry_utils.ts
@@ -20,19 +20,35 @@ const DEFAULT_BACKOFF_FACTOR = 2.0;
 const DEFAULT_JITTER = 1.0;
 
 /**
- * Resolves the runtime name of a thrown value for exception-name matching.
- * Mirrors Python's `type(exception).__name__`.
+ * Resolves every runtime name a thrown value can be matched by: its class name,
+ * as Python's `type(exception).__name__` gives, and any `name` assigned on top
+ * of it. A subclass that never sets `this.name` inherits `'Error'`, so the two
+ * disagree exactly when matching on one alone would miss.
  */
-export function errorName(error: unknown): string {
+export function errorNames(error: unknown): string[] {
   if (error instanceof Error) {
-    // `name` is set by well-behaved Error subclasses; fall back to the
-    // constructor name for plain `throw new Error()` cases.
-    return error.name || error.constructor.name;
+    const names = [error.constructor?.name, error.name].filter(
+      (name): name is string => !!name,
+    );
+    return [...new Set(names)];
   }
   if (typeof error === 'object' && error !== null) {
-    return error.constructor.name;
+    return [error.constructor.name];
   }
-  return typeof error;
+  return [typeof error];
+}
+
+/**
+ * Resolves the most specific runtime name of a thrown value, for reporting.
+ * Mirrors Python's `type(exception).__name__`, preferring an assigned `name`
+ * only when the class name carries nothing more than `Error`.
+ */
+export function errorName(error: unknown): string {
+  const [className, assigned] = errorNames(error);
+  if (className === 'Error' && assigned) {
+    return assigned;
+  }
+  return className;
 }
 
 /** Parameters for {@link shouldRetryNode}. */
@@ -63,7 +79,10 @@ export function shouldRetryNode({
   }
 
   const exceptions = retryConfig.exceptions;
-  if (exceptions !== undefined && !exceptions.includes(errorName(error))) {
+  if (
+    exceptions !== undefined &&
+    !errorNames(error).some((name) => exceptions.includes(name))
+  ) {
     return false;
   }
 

--- a/core/test/workflow/foundations_test.ts
+++ b/core/test/workflow/foundations_test.ts
@@ -24,6 +24,7 @@ import {
   prepareRetryConfig,
 } from '../../src/workflow/retry_config.js';
 import {
+  errorName,
   getRetryDelaySeconds,
   shouldRetryNode,
 } from '../../src/workflow/utils/retry_utils.js';
@@ -176,6 +177,65 @@ describe('Phase 0 — shouldRetryNode', () => {
         nodeState: state(1),
       }),
     ).toBe(false);
+  });
+
+  it('matches a subclass that never assigns this.name', () => {
+    class RateLimitedError extends Error {}
+    const cfg = prepareRetryConfig({exceptions: [RateLimitedError]});
+    expect(
+      shouldRetryNode({
+        error: new RateLimitedError('x'),
+        retryConfig: cfg,
+        nodeState: state(1),
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryNode({
+        error: new Error('x'),
+        retryConfig: cfg,
+        nodeState: state(1),
+      }),
+    ).toBe(false);
+  });
+
+  it('matches a subclass by class name or by an assigned name', () => {
+    class RetryableError extends Error {
+      constructor(message?: string) {
+        super(message);
+        this.name = 'Retryable';
+      }
+    }
+    for (const cfg of [
+      prepareRetryConfig({exceptions: ['Retryable']}),
+      prepareRetryConfig({exceptions: [RetryableError]}),
+    ]) {
+      expect(
+        shouldRetryNode({
+          error: new RetryableError('x'),
+          retryConfig: cfg,
+          nodeState: state(1),
+        }),
+      ).toBe(true);
+    }
+  });
+});
+
+describe('Phase 0 — errorName', () => {
+  it('reports the class name of a subclass that never assigns this.name', () => {
+    class RateLimitedError extends Error {}
+    expect(errorName(new RateLimitedError('x'))).toBe('RateLimitedError');
+  });
+
+  it('keeps an assigned name when the class name adds nothing', () => {
+    const err = new Error('x');
+    err.name = 'Custom';
+    expect(errorName(err)).toBe('Custom');
+    expect(errorName(new Error('x'))).toBe('Error');
+  });
+
+  it('reports non-Error throws by type', () => {
+    expect(errorName('boom')).toBe('string');
+    expect(errorName(7)).toBe('number');
   });
 });
 


### PR DESCRIPTION
`retryConfig.exceptions` accepts error classes and normalizes each to its static `.name` (`normalizeRetryExceptions`, `retry_config.ts:76`). Matching then read the **instance** `.name` — which a subclass only carries if it assigns one. `class RateLimitedError extends Error {}` inherits `'Error'` from the prototype, and because that inherited value is truthy the `|| error.constructor.name` fallback never ran.

So `exceptions: [RateLimitedError]` matched nothing and the node failed without a single retry, silently. adk-python reads `type(exception).__name__` and has no such hole.

Matching now considers both names a thrown value carries:
- the **class name**, which is what Python compares and what `normalizeRetryExceptions` wrote into the config;
- any **assigned `name`**, which is idiomatic enough in JS that dropping it would trade one silent miss for another.

`errorName` still returns a single name for `NodeErrorEvent.errorType`, now preferring the class name and falling back to an assigned one only when the class contributes nothing but `Error`.

### Tests
- `matches a subclass that never assigns this.name` — the reported bug. Fails on `main`.
- `matches a subclass by class name or by an assigned name` — both config spellings. Fails on `main`.
- Three `errorName` cases covering subclass, assigned-name, and non-`Error` throws.

Found while auditing workflow parity against adk-python. One of six independent fixes; this one touches only `retry_utils.ts`.