### PR TITLE
fix(workflow): report an aborted node as aborted, not timed out

### DIFF
--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -487,7 +487,8 @@ async function runOnce({
   // timeout (and any external abort). On the deadline (or abort) the engine
   // stops consuming events, closes the generator so its `finally` runs, and
   // aborts `child.abortSignal` so a cooperative body can cancel its in-flight
-  // work; the run rejects with NodeTimeoutError. Mirrors Python's
+  // work; the run rejects with NodeTimeoutError for a fired deadline and
+  // InvocationAbortedError for any other abort. Mirrors Python's
   // `asyncio.wait_for`.
   const timeoutSeconds = node.timeout;
   const controller = new AbortController();
@@ -497,8 +498,12 @@ async function runOnce({
   } else {
     parentSignal?.addEventListener('abort', onParentAbort, {once: true});
   }
+  let deadlineFired = false;
   const timer = setTimeout(
-    () => controller.abort(),
+    () => {
+      deadlineFired = true;
+      controller.abort();
+    },
     (timeoutSeconds ?? 0) * 1000,
   );
   child.abortSignal = controller.signal;
@@ -507,7 +512,13 @@ async function runOnce({
   // reused across iterations so we don't leak a listener per step.
   const aborted = new Promise<never>((_, reject) => {
     const fail = () =>
-      reject(new NodeTimeoutError({nodeName, timeout: timeoutSeconds ?? 0}));
+      reject(
+        deadlineFired
+          ? new NodeTimeoutError({nodeName, timeout: timeoutSeconds ?? 0})
+          : new InvocationAbortedError(
+              `Invocation aborted while running node '${nodeName}'.`,
+            ),
+      );
     if (controller.signal.aborted) {
       fail();
     } else {

--- a/core/test/workflow/node_execution_test.ts
+++ b/core/test/workflow/node_execution_test.ts
@@ -258,6 +258,80 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
     expect(seen).not.toContain('late'); // produced after the deadline -> dropped
     expect(captured?.aborted).toBe(true); // signal fired for cooperative cancel
   });
+
+  it('reports an external abort on a timeout-bearing node as an abort', async () => {
+    const controller = new AbortController();
+    const node = new FnNode(
+      'slow',
+      () => new Promise((resolve) => setTimeout(() => resolve('late'), 500)),
+      {timeout: 10},
+    );
+    setTimeout(() => controller.abort(), 10);
+
+    const err = await driveNode(
+      node,
+      'x',
+      createIc({}, controller.signal),
+    ).then(
+      () => undefined,
+      (e) => e,
+    );
+
+    expect(isInvocationAbortedError(err)).toBe(true);
+    expect(isNodeTimeoutError(err)).toBe(false);
+  });
+
+  it('does not spend a retry attempt on an external abort', async () => {
+    const controller = new AbortController();
+    let attempts = 0;
+    const node = new FnNode(
+      'slow',
+      () => {
+        attempts++;
+        return new Promise((resolve) => setTimeout(() => resolve('late'), 500));
+      },
+      {
+        timeout: 10,
+        retryConfig: {maxAttempts: 3, initialDelay: 0, jitter: 0},
+      },
+    );
+    setTimeout(() => controller.abort(), 10);
+
+    const err = await driveNode(
+      node,
+      'x',
+      createIc({}, controller.signal),
+    ).then(
+      () => undefined,
+      (e) => e,
+    );
+
+    expect(isInvocationAbortedError(err)).toBe(true);
+    // Attributed to the run, not laundered through the retry backoff's own
+    // abort, which would mean the attempt was booked before anyone noticed.
+    expect((err as Error).message).toContain("node 'slow'");
+    expect(attempts).toBe(1);
+  });
+
+  it('still reports a fired deadline as a timeout when a signal is present', async () => {
+    const controller = new AbortController();
+    const node = new FnNode(
+      'slow',
+      () => new Promise((resolve) => setTimeout(() => resolve('late'), 500)),
+      {timeout: 0.02},
+    );
+
+    const err = await driveNode(
+      node,
+      'x',
+      createIc({}, controller.signal),
+    ).then(
+      () => undefined,
+      (e) => e,
+    );
+
+    expect(isNodeTimeoutError(err)).toBe(true);
+  });
 });
 
 describe('output schema validation (Zod v3 / Zod v4 / genai Schema)', () => {


### PR DESCRIPTION
A node carrying a `timeout` races each step against a single abort controller fed by **both** the deadline and the external signal, but the rejection was hardcoded to `NodeTimeoutError` (`node_runner.ts:508-516`). So cancelling an invocation — or a sibling failing, which aborts the workflow-scoped signal — surfaced on every timeout-bearing node as a timeout it never hit.

That is not just a mislabel. `runNode` treats `InvocationAbortedError` as terminal and everything else as retryable (`node_runner.ts:256`), so a cancelled node fell into the retry path, booked another attempt, and sat out the backoff before the delay's own abort check finally stopped it. **The node body ran twice for one cancellation.**

The deadline path now records which of the two fired and raises accordingly. The doc comment above it already claimed this was the behaviour; it now is.

### Tests
- `reports an external abort on a timeout-bearing node as an abort` — fails on `main`.
- `does not spend a retry attempt on an external abort` — asserts the error is attributed to the run (`node 'slow'`), not laundered through the retry backoff's own abort, which produces the same error type. Fails on `main`.
- `still reports a fired deadline as a timeout when a signal is present` — guards the genuine-timeout path.

Found while auditing workflow parity against adk-python. One of six independent fixes; this one touches only `node_runner.ts`.