### PR TITLE
fix(workflow): stop re-running a dynamic node that already settled

### DIFF
--- a/core/src/workflow/dynamic_node_scheduler.ts
+++ b/core/src/workflow/dynamic_node_scheduler.ts
@@ -61,6 +61,11 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
       // Deduplicate concurrent calls: await the in-flight task.
       return existing.task;
     }
+    if (existing?.result) {
+      // Already settled this turn without executing its body. Re-running it
+      // here would discard the recorded run and duplicate its side effects.
+      return this.handBack(ctx, existing.result, options);
+    }
 
     // Cross-turn resume: rehydrate this dynamic run from the events of the run
     // still in progress (a run that already completed must not be replayed).
@@ -122,8 +127,21 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
         parentRunId: ctx.runId,
       }),
       output: result.output,
+      result,
     });
-    if (run.options.useAsOutput) {
+    return this.handBack(ctx, result, run.options);
+  }
+
+  /**
+   * Applies a settled result to the caller's context and returns it, so a first
+   * call and a repeat call for the same path are indistinguishable.
+   */
+  private handBack(
+    ctx: NodeContext,
+    result: NodeResult,
+    options: ScheduleDynamicNodeOptions,
+  ): NodeResult {
+    if (options.useAsOutput) {
       ctx.output = result.output;
       ctx.route = result.route;
     }

--- a/core/src/workflow/schedule_dynamic_node.ts
+++ b/core/src/workflow/schedule_dynamic_node.ts
@@ -51,6 +51,12 @@ export interface DynamicNodeRun {
   output?: unknown;
   task?: Promise<NodeContext>;
   transferToAgent?: string;
+  /**
+   * The result of a run that completed without executing its body, kept so a
+   * repeat call for the same path hands back the same result. Runs that did
+   * execute are deduplicated by `task` instead.
+   */
+  result?: NodeResult;
 }
 
 /**

--- a/core/test/workflow/dynamic_resume_test.ts
+++ b/core/test/workflow/dynamic_resume_test.ts
@@ -332,4 +332,77 @@ describe('Phase 5b-cont — dynamic (ctx.runNode) resume via the Runner', () => 
     expect(turn2.some(hasRequestInputFunctionCall)).toBe(false);
     expect(turn2.some((e) => e.output === 'Approved')).toBe(true);
   });
+
+  it('hands back a fast-forwarded run when the same run id is asked for twice', async () => {
+    let stepRuns = 0;
+    const outputs: unknown[] = [];
+
+    const step = new FunctionNode('step', (_c, input) => {
+      stepRuns++;
+      return `step(${input})`;
+    });
+    const ask = new FunctionNode(
+      'ask',
+      (ctx: NodeContext) => {
+        const answer = ctx.resumeInputs['confirm'];
+        return answer === undefined
+          ? new RequestInput({interruptId: 'confirm', message: 'confirm?'})
+          : `confirmed:${answer}`;
+      },
+      {rerunOnResume: true},
+    );
+
+    const wf = new Workflow({
+      name: 'dyn_same_run_id_wf',
+      dynamicEntry: async (ctx, input) => {
+        const first = await ctx.runNode(step, input, {runId: 'once'});
+        const second = await ctx.runNode(step, input, {runId: 'once'});
+        outputs.push(first.output, second.output);
+        const a = await ctx.runNode(ask);
+        return {step: first.output, ask: a.output};
+      },
+    });
+
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'u1',
+    });
+    const runner = new Runner({appName: 'test_app', agent: wf, sessionService});
+
+    await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {role: 'user', parts: [{text: 'x'}]},
+      }),
+    );
+    // Turn 1: the in-flight task dedups the second call.
+    expect(stepRuns).toBe(1);
+
+    const turn2 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'confirm',
+                name: 'adk_request_input',
+                response: {result: 'yes'},
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Turn 2: the first call fast-forwards from the recorded run; the second
+    // must hand back that same result rather than executing the body again.
+    expect(stepRuns).toBe(1);
+    expect(outputs).toEqual(['step(x)', 'step(x)', 'step(x)', 'step(x)']);
+    expect(turn2.some((e) => e.output === 'confirmed:yes')).toBe(true);
+  });
 });


### PR DESCRIPTION
`ctx.runNode()` deduplicates by the run's in-flight `task`, but a run that settles **without executing its body** — fast-forwarded from a recorded output, or handed a resolved resume value — is booked by `completeWithoutRunning` with no task (`dynamic_node_scheduler.ts:109-131`). The guard below it then asks `runs.has(nodePath)`, which is true, so the rehydration branch is skipped and control falls through to `runFresh`.

So the second `ctx.runNode(node, input, {runId: 'once'})` of a resumed turn re-executed the body, overwrote the recorded run, and repeated whatever side effects it carries — while the *first* call for the same path had correctly returned the cached output. Within a single turn the two calls disagreed.

adk-python routes this through `check_interception`, which returns the cached output for a run already `COMPLETED` (`workflow/utils/_replay_interceptor.py:69-75`).

A settled run now keeps its `result`, and a repeat call hands back that same result. Runs that did execute are unaffected — they still dedup on the task.

### Tests

- `hands back a fast-forwarded run when the same run id is asked for twice` — drives two turns through the `Runner`, asserting the node body runs exactly once across both and that all four calls return the same output. On `main` it fails with `expected 2 to be 1`: the body ran a second time.

Found while auditing workflow parity against adk-python. One of six independent fixes.
