### PR TITLE
fix(workflow): let an item that asks the user pause the whole worker

### DIFF
--- a/core/src/workflow/nodes/parallel_worker.ts
+++ b/core/src/workflow/nodes/parallel_worker.ts
@@ -50,6 +50,11 @@ export interface ParallelWorkerConfig {
  * - **All-or-nothing.** If any item throws, the first error is rethrown and the
  *   already-computed sibling outputs are discarded. Make individual items
  *   failure-tolerant if partial results matter.
+ * - **An item that interrupts pauses the whole worker.** It has no output to
+ *   contribute, so the worker stops claiming items, emits no list, and raises
+ *   the child's interrupt ids as its own. Once they are answered the worker
+ *   re-runs from the top (`rerunOnResume`), and items that already completed
+ *   are fast-forwarded by their run id rather than executed again.
  * - **Cancellation stops scheduling only.** On abort/timeout the loop stops
  *   claiming new items, but items already in flight run to completion —
  *   `ctx.runNode` has no way to forward a signal into a child run.
@@ -93,6 +98,10 @@ export class ParallelWorker extends BaseNode {
     // silent hole in `results` and resolving successfully.
     let failed = false;
     let firstError: unknown;
+    // An item that stops to ask the user has no result to contribute, so the
+    // fan-out stops claiming work the same way a failure does.
+    let interrupted = false;
+    const interruptIds: string[] = [];
 
     // Populated only when the ParallelWorker itself declares a timeout; on a
     // plain invocation abort the invocation-level signal is the one that fires.
@@ -103,7 +112,7 @@ export class ParallelWorker extends BaseNode {
     // Keep claiming the next item until the list is exhausted, an item fails,
     // or the invocation is aborted.
     const worker = async (): Promise<void> => {
-      while (!failed && !isAborted()) {
+      while (!failed && !interrupted && !isAborted()) {
         const i = nextIndex++;
         if (i >= items.length) {
           break;
@@ -119,6 +128,15 @@ export class ParallelWorker extends BaseNode {
             runId: String(i),
             overrideNodePath: `${ctx.nodePath}.${this.inner.name}@${i}`,
           });
+          if (child.interruptIds.length > 0) {
+            interrupted = true;
+            for (const id of child.interruptIds) {
+              if (!interruptIds.includes(id)) {
+                interruptIds.push(id);
+              }
+            }
+            break;
+          }
           results[i] = child.output;
         } catch (err) {
           if (!failed) {
@@ -134,6 +152,14 @@ export class ParallelWorker extends BaseNode {
 
     if (failed) {
       throw firstError;
+    }
+    if (interrupted) {
+      for (const id of interruptIds) {
+        if (!ctx.interruptIds.includes(id)) {
+          ctx.interruptIds.push(id);
+        }
+      }
+      return;
     }
     if (isAborted()) {
       // Aborted mid-flight: `results` may have holes for unscheduled items, so

--- a/core/test/workflow/parallel_worker_test.ts
+++ b/core/test/workflow/parallel_worker_test.ts
@@ -5,10 +5,17 @@
  */
 
 import {describe, expect, it} from 'vitest';
+import {Event} from '../../src/events/event.js';
+import {Runner} from '../../src/runner/runner.js';
+import {InMemorySessionService} from '../../src/sessions/in_memory_session_service.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
 import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
 import {JoinNode} from '../../src/workflow/nodes/join_node.js';
 import {ParallelWorker} from '../../src/workflow/nodes/parallel_worker.js';
+import {RequestInput} from '../../src/workflow/request_input.js';
+import {hasRequestInputFunctionCall} from '../../src/workflow/utils/hitl_utils.js';
 import {buildNode} from '../../src/workflow/utils/workflow_graph_utils.js';
+import {Workflow} from '../../src/workflow/workflow.js';
 import {createIc, driveNode, replyAgent} from './test_helpers.js';
 
 describe('ParallelWorker', () => {
@@ -104,6 +111,35 @@ describe('ParallelWorker', () => {
     expect(rejected).toBe(true);
   });
 
+  it('emits no list when an item stops to ask the user', async () => {
+    const inner = new FunctionNode('maybeAsk', (_c, n: number) => {
+      if (n === 2) {
+        return new RequestInput({interruptId: `ask-${n}`, message: 'confirm?'});
+      }
+      return n * 10;
+    });
+    const {output} = await driveNode(new ParallelWorker(inner), [1, 2, 3]);
+    // Not [10, undefined, 30]: a hole would be indistinguishable from an item
+    // that legitimately returned nothing, and the worker would report success.
+    expect(output).toBeUndefined();
+  });
+
+  it('stops claiming items once one interrupts', async () => {
+    const started: number[] = [];
+    const inner = new FunctionNode('maybeAsk', (_c, n: number) => {
+      started.push(n);
+      if (n === 1) {
+        return new RequestInput({interruptId: 'ask-1', message: 'confirm?'});
+      }
+      return n;
+    });
+    await driveNode(
+      new ParallelWorker(inner, {maxParallelWorkers: 1}),
+      [1, 2, 3],
+    );
+    expect(started).toEqual([1]);
+  });
+
   it('stops scheduling items once the invocation is aborted', async () => {
     let calls = 0;
     const inner = new FunctionNode('count', (_c, n: number) => {
@@ -184,5 +220,90 @@ describe('JoinNode', () => {
     const {output} = await driveNode(join, aggregated);
     expect(output).toEqual(aggregated);
     expect(join.requiresAllPredecessors).toBe(true);
+  });
+});
+
+describe('ParallelWorker human-in-the-loop', () => {
+  async function collect(gen: AsyncGenerator<Event>): Promise<Event[]> {
+    const out: Event[] = [];
+    for await (const e of gen) {
+      out.push(e);
+    }
+    return out;
+  }
+
+  it('pauses the fan-out, then completes it with the answer on resume', async () => {
+    const runs: number[] = [];
+    const inner = new FunctionNode(
+      'review',
+      (ctx: NodeContext, n: number) => {
+        runs.push(n);
+        if (n === 2) {
+          const answer = ctx.resumeInputs['ask-2'];
+          return answer === undefined
+            ? new RequestInput({interruptId: 'ask-2', message: 'confirm 2?'})
+            : `2:${answer}`;
+        }
+        return `${n}:auto`;
+      },
+      {rerunOnResume: true},
+    );
+
+    const wf = new Workflow({
+      name: 'pw_hitl_wf',
+      dynamicEntry: async (ctx) => {
+        const worker = new ParallelWorker(inner, {maxParallelWorkers: 1});
+        const result = await ctx.runNode(worker, [1, 2, 3]);
+        return result.output;
+      },
+    });
+
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'u1',
+    });
+    const runner = new Runner({appName: 'test_app', agent: wf, sessionService});
+
+    const turn1 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {role: 'user', parts: [{text: 'go'}]},
+      }),
+    );
+
+    expect(turn1.some(hasRequestInputFunctionCall)).toBe(true);
+    expect(runs).toEqual([1, 2]);
+    // No list yet: emitting one here records a hole for item 2 that the resumed
+    // turn would then fast-forward, discarding the answer before it is given.
+    expect(turn1.some((e) => Array.isArray(e.output))).toBe(false);
+
+    const turn2 = await collect(
+      runner.runAsync({
+        userId: 'u1',
+        sessionId: session.id,
+        newMessage: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'ask-2',
+                name: 'adk_request_input',
+                response: {result: 'ok'},
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Item 1 is fast-forwarded by run id, item 2 resumes, item 3 runs fresh.
+    expect(runs).toEqual([1, 2, 2, 3]);
+    expect(turn2.find((e) => Array.isArray(e.output))?.output).toEqual([
+      '1:auto',
+      '2:ok',
+      '3:auto',
+    ]);
   });
 });


### PR DESCRIPTION
`ParallelWorker` read `child.output` for every item and never looked at `child.interruptIds` (`parallel_worker.ts:122`), so an item that stopped to ask the user contributed `undefined` and the worker emitted an ordinary list around the gap — `['1:auto', undefined, '3:auto']` — reported as success.

The turn does still pause, because the interrupt reaches the loop through the scheduler. That is what makes this lossy rather than merely wrong: **the worker has by then recorded that list as its output, so the resumed turn fast-forwards it, re-emits the same list, and never runs the item the question was for.** The user is asked, answers, and the answer is discarded. The gap is permanent.

Observed on `main`, driving two turns through the `Runner`:

```
turn 1  paused: true   items run: [1,2,3]   output: ['1:auto', null, '3:auto']
turn 2  items run: []                       output: ['1:auto', null, '3:auto']
```

With this change:

```
turn 1  paused: true   items run: [1,2]     output: (none)
turn 2  items run: [2,3]                    output: ['1:auto', '2:ok', '3:auto']
```

An interrupted item now stops the fan-out the way a failed one does: no list is emitted, and the child's interrupt ids are raised as the worker's own. Because the worker already carries `rerunOnResume`, the next turn re-enters it, items that finished are fast-forwarded by their run id, and the answered item resumes.

adk-python raises `NodeInterruptedError` from the equivalent path and aborts the fan-out (`workflow/_parallel_worker.py`); this is the same stop, expressed with the interrupt plumbing the TS engine already has.

### Tests

- `emits no list when an item stops to ask the user` — fails on `main` with `expected [10, undefined, 30] to be undefined`.
- `stops claiming items once one interrupts` — fails on `main` with `expected [1,2,3] to deeply equal [1]`.
- `pauses the fan-out, then completes it with the answer on resume` — the two-turn `Runner` case above. Fails on `main`.

Found while auditing workflow parity against adk-python. One of six fixes; note that #708 stacks on this branch.
