### PR TITLE
feat(workflow): enforce a node's declared stateSchema

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -246,7 +246,7 @@ export type {
 export {InMemorySessionService} from './sessions/in_memory_session_service.js';
 export {createSession} from './sessions/session.js';
 export type {CompositeSessionKey, Session} from './sessions/session.js';
-export {State} from './sessions/state.js';
+export {State, StateSchemaError, isStateSchemaError} from './sessions/state.js';
 export {AgentTool, isAgentTool} from './tools/agent_tool.js';
 export type {AgentToolConfig} from './tools/agent_tool.js';
 export {BaseTool, isBaseTool} from './tools/base_tool.js';

--- a/core/src/sessions/state.ts
+++ b/core/src/sessions/state.ts
@@ -4,7 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {objectSchemaFields, SchemaLike} from '../utils/schema.js';
 import {recordStateWrite} from './state_write_order.js';
+
+/** Raised when a state mutation violates the declared state schema. */
+export class StateSchemaError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StateSchemaError';
+    Object.setPrototypeOf(this, StateSchemaError.prototype);
+  }
+}
+
+/** Type guard for {@link StateSchemaError}. */
+export function isStateSchemaError(e: unknown): e is StateSchemaError {
+  return e instanceof Error && e.name === 'StateSchemaError';
+}
 
 /**
  * A state mapping that maintains the current value and the pending-commit
@@ -20,7 +35,59 @@ export class State {
     private value: Record<string, unknown> = {},
     /** The delta change to the current value that hasn't been committed. */
     private delta: Record<string, unknown> = {},
+    /**
+     * Declares the keys this state may hold and their types. When set, every
+     * mutation is checked against it; prefixed keys are exempt.
+     */
+    readonly schema?: SchemaLike,
   ) {}
+
+  /**
+   * Checks a whole delta against {@link schema}, for writes that reach the
+   * session without passing through this object — a node emitting an event
+   * that carries its own `stateDelta`.
+   */
+  validateDelta(delta: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(delta)) {
+      this.validate(key, value);
+    }
+  }
+
+  /**
+   * Checks one key/value pair against {@link schema}, throwing
+   * {@link StateSchemaError} when the key is undeclared or its value does not
+   * match the declared type.
+   *
+   * Prefixed keys (`app:`, `user:`, `temp:`, or any other namespace) belong to
+   * a scope wider than this state and are never validated — the same carve-out
+   * adk-python makes.
+   */
+  private validate(key: string, value: unknown): void {
+    if (this.schema === undefined || key.includes(':')) {
+      return;
+    }
+    const fields = objectSchemaFields(this.schema);
+    if (!fields) {
+      return;
+    }
+    if (!fields.has(key)) {
+      throw new StateSchemaError(
+        `Key '${key}' is not declared in the state schema. Declared fields: ` +
+          JSON.stringify([...fields.keys()].sort()),
+      );
+    }
+    const field = fields.get(key);
+    if (!field) {
+      return;
+    }
+    const parsed = field.safeParse(value);
+    if (!parsed.success) {
+      throw new StateSchemaError(
+        `Value for '${key}' does not match the type declared in the state ` +
+          `schema: ${parsed.error.message}`,
+      );
+    }
+  }
 
   /**
    * Returns the value of the state dict for the given key.
@@ -49,6 +116,7 @@ export class State {
    * @param value The value to set.
    */
   set(key: string, value: unknown) {
+    this.validate(key, value);
     this.value[key] = value;
     this.delta[key] = value;
     // Stamp the write so that committing this delta later cannot roll the key
@@ -76,6 +144,7 @@ export class State {
    * @param delta The delta to update the state with.
    */
   update(delta: Record<string, unknown>) {
+    this.validateDelta(delta);
     // This should be revised while working on the parallel tool execution.
     Object.assign(this.delta, delta);
     Object.assign(this.value, delta);

--- a/core/src/utils/schema.ts
+++ b/core/src/utils/schema.ts
@@ -146,3 +146,141 @@ export function compileJsonSchema(jsonSchema: unknown): z4.ZodType | undefined {
     return undefined;
   }
 }
+
+/**
+ * Per-field validators for object schemas, keyed by the schema itself. Built
+ * once per schema for the same reason {@link genaiValidators} exists: a schema
+ * outlives the values checked against it.
+ */
+const objectFieldValidators = new WeakMap<
+  object,
+  Map<string, z4.ZodType | undefined> | null
+>();
+
+/**
+ * Decomposes an object {@link SchemaLike} into its declared fields, each mapped
+ * to a validator for that field alone.
+ *
+ * This is what lets a *partial* object be checked key by key. A state schema
+ * declares the keys a workflow may write, but the state holds only the ones
+ * written so far, so validating the whole object against the schema would
+ * reject it for missing fields that simply have not been set yet.
+ *
+ * Returns `undefined` when the schema is not an object schema or cannot be
+ * decomposed, and maps a field to `undefined` when that field's own schema has
+ * no Zod equivalent. Both mean "unvalidatable" rather than invalid, consistent
+ * with {@link parseWithSchema}.
+ */
+export function objectSchemaFields(
+  schema: SchemaLike,
+): Map<string, z4.ZodType | undefined> | undefined {
+  const cached = objectFieldValidators.get(schema as object);
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+  let fields: Map<string, z4.ZodType | undefined> | null = null;
+  try {
+    const document = toJsonSchema(schema);
+    const properties = document['properties'];
+    if (properties && typeof properties === 'object') {
+      fields = new Map(
+        Object.entries(properties as Record<string, unknown>).map(
+          ([name, fieldSchema]) => [name, compileField(fieldSchema, document)],
+        ),
+      );
+    }
+  } catch {
+    fields = null;
+  }
+  objectFieldValidators.set(schema as object, fields);
+  return fields ?? undefined;
+}
+
+/** Sentinel for a `$ref` that cannot be inlined; caught per field. */
+const UNRESOLVABLE_REF = Symbol('unresolvable-ref');
+
+/**
+ * Compiles one field of a schema document into a validator, resolving any
+ * `$ref` it carries against that document first.
+ *
+ * A field whose refs cannot be inlined degrades to `undefined` — unvalidated —
+ * on its own, rather than costing the other fields their validators.
+ */
+function compileField(
+  fieldSchema: unknown,
+  document: unknown,
+): z4.ZodType | undefined {
+  try {
+    return compileJsonSchema(inlineRefs(fieldSchema, document));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves a local JSON Pointer (`#/properties/foo`) against `document`.
+ */
+function resolvePointer(document: unknown, ref: string): unknown {
+  if (!ref.startsWith('#')) {
+    throw UNRESOLVABLE_REF;
+  }
+  let node: unknown = document;
+  for (const rawSegment of ref.slice(1).split('/').filter(Boolean)) {
+    const segment = decodeURIComponent(rawSegment)
+      .replaceAll('~1', '/')
+      .replaceAll('~0', '~');
+    if (node === null || typeof node !== 'object') {
+      throw UNRESOLVABLE_REF;
+    }
+    node = (node as Record<string, unknown>)[segment];
+  }
+  if (node === undefined) {
+    throw UNRESOLVABLE_REF;
+  }
+  return node;
+}
+
+/**
+ * Replaces every local `$ref` in `node` with the schema it points at.
+ *
+ * A field is compiled on its own, detached from the document that defines it,
+ * so a `$ref` in it would dangle. Zod v4 inlines repeated sub-schemas and never
+ * emits one, but `zod-to-json-schema` (Zod v3) points the second use of a
+ * shared sub-schema back at the first — `{"$ref": "#/properties/nested"}` — and
+ * an uninlined field silently loses its type check.
+ *
+ * A ref that cannot be resolved, and a cycle (`z.lazy` recursion, which has no
+ * finite inlining), throw {@link UNRESOLVABLE_REF}; the caller degrades that
+ * field to unvalidated.
+ */
+function inlineRefs(
+  node: unknown,
+  document: unknown,
+  seen: ReadonlySet<string> = new Set(),
+): unknown {
+  if (Array.isArray(node)) {
+    return node.map((item) => inlineRefs(item, document, seen));
+  }
+  if (node === null || typeof node !== 'object') {
+    return node;
+  }
+  const entries = Object.entries(node as Record<string, unknown>);
+  const ref = (node as Record<string, unknown>)['$ref'];
+  if (typeof ref === 'string') {
+    if (seen.has(ref)) {
+      throw UNRESOLVABLE_REF;
+    }
+    const target = inlineRefs(
+      resolvePointer(document, ref),
+      document,
+      new Set([...seen, ref]),
+    );
+    const siblings = Object.fromEntries(
+      entries.filter(([key]) => key !== '$ref'),
+    );
+    return {...(target as Record<string, unknown>), ...siblings};
+  }
+  return Object.fromEntries(
+    entries.map(([key, value]) => [key, inlineRefs(value, document, seen)]),
+  );
+}

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -9,6 +9,7 @@ import {Event} from '../events/event.js';
 import {createEventActions, EventActions} from '../events/event_actions.js';
 import {State} from '../sessions/state.js';
 import {AsyncQueue} from '../utils/async_queue.js';
+import type {SchemaLike} from '../utils/schema.js';
 import type {RouteValue, RunnableNode} from './graph.js';
 import {executeChildNode, RunNodeOptions} from './node_runner.js';
 import type {ScheduleDynamicNode} from './schedule_dynamic_node.js';
@@ -52,6 +53,11 @@ export interface NodeContextOptions {
   isolationScope?: string;
   /** Accumulator for event actions (state delta, etc). */
   actions?: EventActions;
+  /**
+   * Declares the keys this node may write to `ctx.state` and their types.
+   * Resolved by the runner: the node's own schema, or the parent's.
+   */
+  stateSchema?: SchemaLike;
 }
 
 /**
@@ -121,6 +127,12 @@ export class NodeContext {
   /** The current attempt number (1-based) for the running node (see retry). */
   attemptCount = 1;
 
+  /**
+   * The state schema in force for this node, inherited by its children unless
+   * they declare their own.
+   */
+  readonly stateSchema?: SchemaLike;
+
   private readonly _state: State;
   private readonly dynamicRunCounters = new Map<string, number>();
   /** Run ids this context handed out automatically, per node name. */
@@ -140,9 +152,11 @@ export class NodeContext {
     // Python's `ctx.state` -> `ctx.actions.state_delta` behaviour, and land in
     // `session.state` at once so a reader outside the workflow — an agent
     // resolving a `{key}` instruction, a callback, a tool — sees them.
+    this.stateSchema = opts.stateSchema;
     this._state = new State(
       opts.invocationContext.session.state,
       this.actions.stateDelta,
+      opts.stateSchema,
     );
   }
 

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -184,6 +184,8 @@ async function runChildNode({
     runId,
     resumeInputs: resumeInputs ?? parent.resumeInputs,
     isolationScope,
+    // A node's own schema wins; otherwise it answers to its parent's.
+    stateSchema: node.stateSchema ?? parent.stateSchema,
   });
   // Propagate the dynamic scheduler down; a nested Workflow overrides it.
   child.scheduler = parent.scheduler;
@@ -422,6 +424,12 @@ async function runOnce({
 }: RunOnceParams): Promise<void> {
   const consume = (event: Event): void => {
     enrichEvent({event, child, nodeName, branch, isolationScope});
+    // An event can carry a state delta that never went through `ctx.state`,
+    // so the schema is enforced here too rather than only on the setter.
+    const emittedDelta = event.actions?.stateDelta;
+    if (emittedDelta && emittedDelta !== child.actions.stateDelta) {
+      child.state.validateDelta(emittedDelta);
+    }
     if (event.output !== undefined) {
       child.output = event.output;
       if (child.outputDelegated) {

--- a/core/test/utils/schema_test.ts
+++ b/core/test/utils/schema_test.ts
@@ -8,7 +8,11 @@ import {Schema, Type} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
-import {parseWithSchema, toJsonSchema} from '../../src/utils/schema.js';
+import {
+  objectSchemaFields,
+  parseWithSchema,
+  toJsonSchema,
+} from '../../src/utils/schema.js';
 import {zodObjectToSchema} from '../../src/utils/simple_zod_to_json.js';
 
 describe('parseWithSchema', () => {
@@ -152,5 +156,80 @@ describe('toJsonSchema', () => {
       },
       required: ['count'],
     });
+  });
+});
+
+describe('objectSchemaFields', () => {
+  const fieldsOf = (schema: Parameters<typeof objectSchemaFields>[0]) =>
+    objectSchemaFields(schema);
+
+  it('decomposes a Zod v4 object into per-field validators', () => {
+    const fields = fieldsOf(z4.object({count: z4.number(), name: z4.string()}));
+    expect([...fields!.keys()]).toEqual(['count', 'name']);
+    expect(fields!.get('count')!.safeParse(1).success).toBe(true);
+    expect(fields!.get('count')!.safeParse('1').success).toBe(false);
+  });
+
+  it('decomposes a Zod v3 object into per-field validators', () => {
+    const fields = fieldsOf(z3.object({count: z3.number(), name: z3.string()}));
+    expect([...fields!.keys()]).toEqual(['count', 'name']);
+    expect(fields!.get('count')!.safeParse(1).success).toBe(true);
+    expect(fields!.get('count')!.safeParse('1').success).toBe(false);
+  });
+
+  it('decomposes a genai Schema into per-field validators', () => {
+    const fields = fieldsOf({
+      type: Type.OBJECT,
+      properties: {count: {type: Type.NUMBER}, name: {type: Type.STRING}},
+    } as Schema);
+    expect([...fields!.keys()]).toEqual(['count', 'name']);
+    expect(fields!.get('count')!.safeParse(1).success).toBe(true);
+    expect(fields!.get('count')!.safeParse('1').success).toBe(false);
+  });
+
+  it('resolves a $ref to a reused sub-schema (Zod v3)', () => {
+    // zod-to-json-schema points the second use of a shared sub-schema back at
+    // the first as `{$ref: '#/properties/first'}`. Compiled detached from the
+    // document, that field would silently lose its type check.
+    const inner = z3.object({a: z3.string()});
+    const fields = fieldsOf(z3.object({first: inner, second: inner}));
+    const second = fields!.get('second');
+    expect(second).toBeDefined();
+    expect(second!.safeParse({a: 'ok'}).success).toBe(true);
+    expect(second!.safeParse({a: 1}).success).toBe(false);
+  });
+
+  it('agrees across Zod v3 and Zod v4 for the same shape', () => {
+    const v3 = fieldsOf(z3.object({n: z3.number(), s: z3.string().nullable()}));
+    const v4 = fieldsOf(z4.object({n: z4.number(), s: z4.string().nullable()}));
+    expect([...v3!.keys()]).toEqual([...v4!.keys()]);
+    for (const key of v3!.keys()) {
+      for (const value of [1, 'x', null, {}]) {
+        expect(v3!.get(key)!.safeParse(value).success).toBe(
+          v4!.get(key)!.safeParse(value).success,
+        );
+      }
+    }
+  });
+
+  it('degrades only the recursive field of a cyclic schema', () => {
+    interface Tree {
+      name: string;
+      child?: Tree;
+    }
+    const tree: z3.ZodType<Tree> = z3.lazy(() =>
+      z3.object({name: z3.string(), child: tree.optional()}),
+    );
+    const fields = fieldsOf(z3.object({root: tree, plain: z3.string()}));
+    // A cycle has no finite inlining, so that field goes unvalidated — but its
+    // siblings keep their validators.
+    expect(fields!.has('root')).toBe(true);
+    expect(fields!.get('root')).toBeUndefined();
+    expect(fields!.get('plain')!.safeParse('s').success).toBe(true);
+  });
+
+  it('returns undefined for a schema that is not an object', () => {
+    expect(fieldsOf(z4.string())).toBeUndefined();
+    expect(fieldsOf(z3.string())).toBeUndefined();
   });
 });

--- a/core/test/workflow/state_schema_test.ts
+++ b/core/test/workflow/state_schema_test.ts
@@ -1,0 +1,355 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Schema, Type} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {z as z3} from 'zod/v3';
+import {z as z4} from 'zod/v4';
+import {createEvent} from '../../src/events/event.js';
+import {isStateSchemaError, State} from '../../src/sessions/state.js';
+import {NodeContext} from '../../src/workflow/node_context.js';
+import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
+import {Workflow} from '../../src/workflow/workflow.js';
+import {driveWorkflow, replyAgent} from './test_helpers.js';
+
+/** The same shape in every dialect ADK accepts, so each is held to it. */
+const dialects = {
+  'Zod v4': z4.object({
+    counter: z4.number(),
+    label: z4.string(),
+    note: z4.string().nullable(),
+  }),
+  'Zod v3': z3.object({
+    counter: z3.number(),
+    label: z3.string(),
+    note: z3.string().nullable(),
+  }),
+  'genai Schema': {
+    type: Type.OBJECT,
+    properties: {
+      counter: {type: Type.NUMBER},
+      label: {type: Type.STRING},
+      note: {type: Type.STRING, nullable: true},
+    },
+  } as Schema,
+} as const;
+
+/** The dialect the plumbing tests use; enforcement is covered for all three. */
+const schema = dialects['Zod v4'];
+
+describe.each(Object.entries(dialects))(
+  'State schema — %s',
+  (_name, schema) => {
+    const stateWithSchema = () => new State({}, {}, schema);
+
+    it('rejects an undeclared key', () => {
+      const state = stateWithSchema();
+      expect(() => state.set('nope', 1)).toThrow(
+        /not declared in the state schema/,
+      );
+      try {
+        state.set('nope', 1);
+      } catch (err) {
+        expect(isStateSchemaError(err)).toBe(true);
+        // The message names what is allowed, so the fix is obvious.
+        expect((err as Error).message).toContain('counter');
+      }
+    });
+
+    it('accepts a declared key', () => {
+      const state = stateWithSchema();
+      state.set('counter', 7);
+      expect(state.get('counter')).toBe(7);
+    });
+
+    it('rejects a value of the wrong type', () => {
+      const state = stateWithSchema();
+      expect(() => state.set('counter', 'seven')).toThrow(
+        /does not match the type declared/,
+      );
+    });
+
+    it('accepts null for a nullable field', () => {
+      const state = stateWithSchema();
+      state.set('note', null);
+      expect(state.get('note')).toBeNull();
+    });
+
+    it('never validates prefixed keys', () => {
+      const state = stateWithSchema();
+      for (const key of ['app:x', 'user:y', 'temp:z', 'other:w']) {
+        state.set(key, {anything: true});
+        expect(state.get(key)).toEqual({anything: true});
+      }
+    });
+
+    it('validates every key of an update()', () => {
+      const state = stateWithSchema();
+      expect(() => state.update({counter: 1, nope: 2})).toThrow(
+        /not declared in the state schema/,
+      );
+      state.update({counter: 1, label: 'ok'});
+      expect(state.get('label')).toBe('ok');
+    });
+  },
+);
+
+describe('State schema — dialect-independent behaviour', () => {
+  it('allows anything when no schema is declared', () => {
+    const state = new State({}, {});
+    state.set('whatever', {deeply: {nested: true}});
+    expect(state.get('whatever')).toEqual({deeply: {nested: true}});
+  });
+
+  it('leaves a non-object schema unenforced rather than rejecting writes', () => {
+    for (const nonObject of [z4.string(), z3.string()]) {
+      const state = new State({}, {}, nonObject);
+      state.set('anything', 1);
+      expect(state.get('anything')).toBe(1);
+    }
+  });
+});
+
+describe('Workflow-level state schema', () => {
+  it('defaults to undefined', () => {
+    const wf = new Workflow({
+      name: 'no_schema',
+      edges: [['START', new FunctionNode('n', () => 'x')]],
+    });
+    expect(wf.stateSchema).toBeUndefined();
+  });
+
+  it('accepts writes that match', async () => {
+    const write = new FunctionNode('write', (ctx: NodeContext) => {
+      ctx.state.set('counter', 1);
+      ctx.state.set('label', 'hello');
+      return 'done';
+    });
+    const wf = new Workflow({
+      name: 'valid',
+      stateSchema: schema,
+      edges: [['START', write]],
+    });
+    const {output} = await driveWorkflow(wf, 'x');
+    expect(output).toBe('done');
+  });
+
+  it('rejects an undeclared key written through ctx.state', async () => {
+    const write = new FunctionNode('write', (ctx: NodeContext) => {
+      ctx.state.set('undeclared', 1);
+      return 'done';
+    });
+    const wf = new Workflow({
+      name: 'bad_key',
+      stateSchema: schema,
+      edges: [['START', write]],
+    });
+    await expect(driveWorkflow(wf, 'x')).rejects.toThrow(
+      /not declared in the state schema/,
+    );
+  });
+
+  it('rejects an undeclared key carried on an emitted event', async () => {
+    const write = new FunctionNode('write', function* () {
+      yield createEvent({output: 'done', actions: {stateDelta: {nope: 1}}});
+    });
+    const wf = new Workflow({
+      name: 'bad_event_key',
+      stateSchema: schema,
+      edges: [['START', write]],
+    });
+    await expect(driveWorkflow(wf, 'x')).rejects.toThrow(
+      /not declared in the state schema/,
+    );
+  });
+
+  it('accepts a declared key carried on an emitted event', async () => {
+    const write = new FunctionNode('write', function* () {
+      yield createEvent({output: 'done', actions: {stateDelta: {counter: 3}}});
+    });
+    const wf = new Workflow({
+      name: 'good_event_key',
+      stateSchema: schema,
+      edges: [['START', write]],
+    });
+    const {output} = await driveWorkflow(wf, 'x');
+    expect(output).toBe('done');
+  });
+
+  it('allows prefixed keys at runtime', async () => {
+    const write = new FunctionNode('write', (ctx: NodeContext) => {
+      ctx.state.set('app:anything', {free: 'form'});
+      ctx.state.set('temp:scratch', 42);
+      return 'done';
+    });
+    const wf = new Workflow({
+      name: 'prefixed',
+      stateSchema: schema,
+      edges: [['START', write]],
+    });
+    expect((await driveWorkflow(wf, 'x')).output).toBe('done');
+  });
+
+  it('allows anything when the workflow declares no schema', async () => {
+    const write = new FunctionNode('write', (ctx: NodeContext) => {
+      ctx.state.set('anything', 'goes');
+      return 'done';
+    });
+    const wf = new Workflow({
+      name: 'unschemad',
+      edges: [['START', write]],
+    });
+    expect((await driveWorkflow(wf, 'x')).output).toBe('done');
+  });
+
+  it('enforces a Zod v3 schema end to end', async () => {
+    const write = new FunctionNode('write', (ctx: NodeContext) => {
+      ctx.state.set('undeclared', 1);
+      return 'done';
+    });
+    const wf = new Workflow({
+      name: 'v3_workflow',
+      stateSchema: dialects['Zod v3'],
+      edges: [['START', write]],
+    });
+    await expect(driveWorkflow(wf, 'x')).rejects.toThrow(
+      /not declared in the state schema/,
+    );
+  });
+
+  it('enforces a genai Schema end to end', async () => {
+    const write = new FunctionNode('write', (ctx: NodeContext) => {
+      ctx.state.set('counter', 'not a number');
+      return 'done';
+    });
+    const wf = new Workflow({
+      name: 'genai_workflow',
+      stateSchema: dialects['genai Schema'],
+      edges: [['START', write]],
+    });
+    await expect(driveWorkflow(wf, 'x')).rejects.toThrow(
+      /does not match the type declared/,
+    );
+  });
+});
+
+describe('Node-level state schema and inheritance', () => {
+  const nodeSchema = z4.object({nodeKey: z4.string()});
+
+  it('validates writes against a schema declared on the node', async () => {
+    const write = new FunctionNode(
+      'write',
+      (ctx: NodeContext) => {
+        ctx.state.set('counter', 1);
+        return 'done';
+      },
+      {stateSchema: nodeSchema},
+    );
+    const wf = new Workflow({name: 'node_schema', edges: [['START', write]]});
+    await expect(driveWorkflow(wf, 'x')).rejects.toThrow(
+      /not declared in the state schema/,
+    );
+  });
+
+  it('accepts writes that match the node schema', async () => {
+    const write = new FunctionNode(
+      'write',
+      (ctx: NodeContext) => {
+        ctx.state.set('nodeKey', 'ok');
+        return 'done';
+      },
+      {stateSchema: nodeSchema},
+    );
+    const wf = new Workflow({name: 'node_ok', edges: [['START', write]]});
+    expect((await driveWorkflow(wf, 'x')).output).toBe('done');
+  });
+
+  it('lets a node schema override the workflow schema', async () => {
+    // `nodeKey` is not in the workflow schema, and `counter` is not in the
+    // node's — the node answers only to its own.
+    const write = new FunctionNode(
+      'write',
+      (ctx: NodeContext) => {
+        ctx.state.set('nodeKey', 'ok');
+        return 'done';
+      },
+      {stateSchema: nodeSchema},
+    );
+    const wf = new Workflow({
+      name: 'override',
+      stateSchema: schema,
+      edges: [['START', write]],
+    });
+    expect((await driveWorkflow(wf, 'x')).output).toBe('done');
+  });
+
+  it('inherits the workflow schema when the node declares none', async () => {
+    const good = new FunctionNode('good', (ctx: NodeContext) => {
+      ctx.state.set('counter', 1);
+      return 'ok';
+    });
+    const bad = new FunctionNode('bad', (ctx: NodeContext) => {
+      ctx.state.set('nodeKey', 'x');
+      return 'ok';
+    });
+    const okWf = new Workflow({
+      name: 'inherit_ok',
+      stateSchema: schema,
+      edges: [['START', good]],
+    });
+    expect((await driveWorkflow(okWf, 'x')).output).toBe('ok');
+
+    const badWf = new Workflow({
+      name: 'inherit_bad',
+      stateSchema: schema,
+      edges: [['START', bad]],
+    });
+    await expect(driveWorkflow(badWf, 'x')).rejects.toThrow(
+      /not declared in the state schema/,
+    );
+  });
+
+  it('rejects an undeclared outputKey written by an agent node', async () => {
+    const agent = replyAgent('writer', 'hi', {outputKey: 'undeclaredKey'});
+    const wf = new Workflow({
+      name: 'agent_output_key',
+      stateSchema: schema,
+      edges: [['START', agent]],
+    });
+    await expect(driveWorkflow(wf, 'x')).rejects.toThrow(
+      /not declared in the state schema/,
+    );
+  });
+
+  it('accepts a declared outputKey written by an agent node', async () => {
+    const agent = replyAgent('writer', 'hi', {outputKey: 'label'});
+    const wf = new Workflow({
+      name: 'agent_output_key_ok',
+      stateSchema: schema,
+      edges: [['START', agent]],
+    });
+    expect((await driveWorkflow(wf, 'x')).output).toBe('hi');
+  });
+
+  it('inherits through a nested workflow', async () => {
+    const inner = new FunctionNode('inner', (ctx: NodeContext) => {
+      ctx.state.set('undeclared', 1);
+      return 'ok';
+    });
+    const innerWf = new Workflow({
+      name: 'inner_wf',
+      edges: [['START', inner]],
+    });
+    const outer = new Workflow({
+      name: 'outer_wf',
+      stateSchema: schema,
+      edges: [['START', innerWf]],
+    });
+    await expect(driveWorkflow(outer, 'x')).rejects.toThrow(
+      /not declared in the state schema/,
+    );
+  });
+});


### PR DESCRIPTION
`stateSchema` has been accepted on every node config since the workflow engine landed — declared on `BaseNodeConfig` (`base_node.ts:68`), stored on `BaseNode` (`:104,126`), listed in the builder's allowlist (`workflow_graph_utils.ts:171`) — and **read by nothing**. A workflow ported from adk-python kept its schema and silently lost every guarantee that came with it: no error at construction, no error at runtime, no enforcement. adk-python threads the same field from `_workflow.py:188-210` through `agents/context.py:175-185` into `sessions/state.py`, which raises on any violating mutation, and covers it with 23 tests.

Declaring a schema now means what it says.

## What it does

`State` takes an optional schema and checks each mutation against it. An undeclared key and a value of the wrong type both raise `StateSchemaError`, and the message names the declared fields so the fix is obvious:

```
Key 'undeclared' is not declared in the state schema.
Declared fields: ["counter","label","note"]
```

Prefixed keys (`app:`, `user:`, `temp:`, or any other namespace) are exempt, as in adk-python — they belong to a scope wider than the workflow.

Resolution follows adk-python: **a node's own schema wins, otherwise it answers to its parent's.** One schema on a `Workflow` covers the graph beneath it, a node can still narrow it, and nested workflows inherit.

## All three schema dialects

Zod v3, Zod v4 and a genai `Schema` are enforced identically, and the tests hold all three to the same shape rather than assuming a shared code path makes them equivalent.

That took more than routing through `toJsonSchema`. The two Zod versions emit different JSON Schema dialects, and one difference bites:

```js
// Zod v4 inlines the repeated sub-schema
"second": {"type": "object", "properties": {"a": {"type": "string"}}}

// zod-to-json-schema (v3) points back at the first use
"second": {"$ref": "#/properties/first"}
```

Because a field is compiled *detached* from the document that defines it, that `$ref` dangled — so with a v3 schema, any field reusing a sub-schema silently lost its type check while still being accepted as a declared key. Refs are now resolved against the document before compiling.

Cycles are handled too: `z.lazy` recursion has no finite inlining, so that one field degrades to unvalidated while its siblings stay enforced — verified for both v3 and v4, which both emit a self-`$ref` there.

## Two other differences from the Python port

Both forced by the platform, not preference:

**Schema decomposition.** Python reads `model_fields` off a Pydantic model. A `SchemaLike` here is one of three formats, so a new `objectSchemaFields` decomposes any of them into per-field validators. Per-field matters: validating the *whole* object would reject a state for keys simply not written yet, and state is partial by nature. A schema that can't be decomposed is left unenforced rather than treated as rejecting everything — the same degradation `parseWithSchema` already makes.

**Event-carried deltas.** Writes also arrive on an emitted event's `stateDelta` without passing through `ctx.state` — an agent node's `outputKey` is the common case — so the node runner validates those too. Tested on the real agent path, not just synthetically.

## Deliberately not ported

Python additionally rejects, at construction, a `FunctionNode` whose parameters aren't declared in the schema (`_workflow.py:188-210`, 4 of its 23 tests). That check exists to support **parameter binding**, which adk-js doesn't have — a TS node body takes `(ctx, input)` and reads state explicitly, so there are no parameters to match. Porting it would mean inventing a check for a feature that doesn't exist here.

## Tests

**`core/test/workflow/state_schema_test.ts`** — 36 cases. The six enforcement behaviours run against all three dialects (undeclared key, declared-key acceptance, wrong type, nullable field, prefixed-key exemption, `update()` validating every key), plus workflow-level writes, event-carried deltas both ways, agent `outputKey` both ways, node-level schema, node-overrides-workflow, node-inherits-workflow, inheritance through a nested workflow, and end-to-end workflow cases on v3 and on genai.

**`core/test/utils/schema_test.ts`** — 8 cases for `objectSchemaFields`: decomposition in each dialect, the v3 `$ref` regression, a v3-vs-v4 agreement check over the same shape, cyclic degradation, and non-object schemas.

Failing on `main`: the 8 rejection cases in the workflow suite, and the v3 `$ref` case (`expected undefined to be defined`). The rest are positive guards that must keep passing.

Full suite green: 3368 unit, 225 integration (8 pre-existing skips), typedoc clean.

## Note on scope

`StateSchemaError` and `isStateSchemaError` are exported at the package root alongside `State`. Enforcement lives in `State`, so it applies wherever a schema is supplied — today only the workflow path supplies one, and every other `State` construction is unchanged and unaffected.
