### PR TITLE
fix: guard reads in the dev server against DNS rebinding

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -92,6 +92,23 @@ function getBoolean(option?: string | boolean): boolean {
   return false;
 }
 
+/**
+ * Splits the comma-separated --allowed_hosts value into a list, dropping
+ * empty/whitespace-only entries. An unset or empty option yields undefined
+ * rather than [], so it composes with ServerOptions.allowedHosts?: string[]
+ * without callers needing to special-case "no value provided".
+ */
+function getAllowedHosts(option?: string): string[] | undefined {
+  if (!option) {
+    return undefined;
+  }
+  const hosts = option
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean);
+  return hosts.length > 0 ? hosts : undefined;
+}
+
 const AGENT_DIR_ARGUMENT = new Argument(
   '[agents_dir]',
   'Agent file or directory of agents to serve. For directory the internal structure should be agents_dir/{agentName}.js or agents_dir/{agentName}/agent.js. Agent file should has export of the rootAgent as instance of BaseAgent (e.g LlmAgent) or a Workflow',
@@ -107,6 +124,13 @@ const PORT_OPTION = new Option(
 const ORIGINS_OPTION = new Option(
   '--allow_origins <string>',
   'Optional. The allow origins of the server',
+).default('');
+const ALLOWED_HOSTS_OPTION = new Option(
+  '--allowed_hosts <string>',
+  'Optional. Comma-separated list of additional Host header values the ' +
+    'DNS-rebinding guard accepts, independent of --allow_origins. Use ' +
+    'this to widen the guard for a reverse proxy in front of a ' +
+    'loopback-bound server without opening --allow_origins to "*".',
 ).default('');
 const VERBOSE_OPTION = new Option(
   '-v, --verbose [boolean]',
@@ -214,6 +238,7 @@ export function createProgram(): Command {
     .addOption(HOST_OPTION)
     .addOption(PORT_OPTION)
     .addOption(ORIGINS_OPTION)
+    .addOption(ALLOWED_HOSTS_OPTION)
     .addOption(VERBOSE_OPTION)
     .addOption(LOG_LEVEL_OPTION)
     .addOption(SESSION_SERVICE_URI_OPTION)
@@ -237,6 +262,7 @@ export function createProgram(): Command {
           port: parseInt(options['port'], 10),
           serveDebugUI: true,
           allowOrigins: options['allow_origins'],
+          allowedHosts: getAllowedHosts(options['allowed_hosts']),
           sessionService: getSessionServiceFromOptions(options),
           artifactService: getArtifactServiceFromOptions(options),
           otelToCloud: options['otel_to_cloud'] ? true : false,
@@ -260,6 +286,7 @@ export function createProgram(): Command {
     .addOption(HOST_OPTION)
     .addOption(PORT_OPTION)
     .addOption(ORIGINS_OPTION)
+    .addOption(ALLOWED_HOSTS_OPTION)
     .addOption(VERBOSE_OPTION)
     .addOption(LOG_LEVEL_OPTION)
     .addOption(SESSION_SERVICE_URI_OPTION)
@@ -283,6 +310,7 @@ export function createProgram(): Command {
           port: parseInt(options['port'], 10),
           serveDebugUI: false,
           allowOrigins: options['allow_origins'],
+          allowedHosts: getAllowedHosts(options['allowed_hosts']),
           sessionService: getSessionServiceFromOptions(options),
           artifactService: getArtifactServiceFromOptions(options),
           otelToCloud: options['otel_to_cloud'] ? true : false,

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -50,6 +50,10 @@ import {
   serializeAgent,
   serializeAppInfo,
 } from './app_info.js';
+import {
+  getAllowedRequestHosts,
+  isDnsRebindingRequest,
+} from './dns_rebinding_guard.js';
 import {renderStructureGraphAsDot} from './structure_graph.js';
 
 /**
@@ -217,6 +221,31 @@ export class AdkApiServer {
   private async init() {
     const app = this.app;
     await this.setupTelemetry();
+
+    // Registered before any route (including /health, /, /version) so the
+    // DNS-rebinding guard applies to every endpoint, not just the ones
+    // registered after this point. Origin cannot be relied on here: a
+    // DNS-rebound page's requests look same-origin to the browser, which
+    // omits Origin for them, so safe methods (GET/HEAD/OPTIONS) get the
+    // same check as everything else.
+    const allowedRequestHosts = getAllowedRequestHosts(this.allowOrigins);
+    app.use((req: Request, res: Response, next: express.NextFunction) => {
+      if (
+        isDnsRebindingRequest(req.headers.host, this.host, allowedRequestHosts)
+      ) {
+        this.logger.warn(
+          `Rejected request with Host "${req.headers.host}": the server is bound to ` +
+            `${this.host} and only loopback hosts are accepted. Set --allow_origins ` +
+            `to the origin you are reaching this server through.`,
+        );
+        res
+          .status(403)
+          .type('text/plain')
+          .send('Forbidden: possible DNS-rebinding request');
+        return;
+      }
+      next();
+    });
 
     if (this.serveDebugUI) {
       app.get('/', (req: Request, res: Response) => {

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -74,6 +74,15 @@ interface ServerOptions {
   agentFileLoadOptions?: AgentFileOptions;
   serveDebugUI?: boolean;
   allowOrigins?: string;
+  /**
+   * Additional Host header values the DNS-rebinding guard accepts besides
+   * loopback and any host derivable from `allowOrigins`. Independent of
+   * CORS: this widens what the guard accepts without opening
+   * `allowOrigins` to `'*'`, which is the only way to do so otherwise. Set
+   * this to the host an operator's reverse proxy presents to this server
+   * when the server itself binds to loopback behind that proxy.
+   */
+  allowedHosts?: string[];
   otelToCloud?: boolean;
   logger?: Logger;
   logLevel?: LogLevel;
@@ -118,6 +127,7 @@ export class AdkApiServer {
   private readonly artifactService: BaseArtifactService;
   private readonly serveDebugUI: boolean;
   private readonly allowOrigins?: string;
+  private readonly allowedHosts?: string[];
   private readonly otelToCloud: boolean;
   private readonly registerProcessors?: (
     tracerProvider: TracerProvider,
@@ -149,6 +159,7 @@ export class AdkApiServer {
       );
     this.serveDebugUI = options.serveDebugUI ?? false;
     this.allowOrigins = options.allowOrigins;
+    this.allowedHosts = options.allowedHosts;
     this.otelToCloud = options.otelToCloud ?? false;
     this.registerProcessors = options.registerProcessors;
     this.memoryExporter = new InMemoryExporter(this.sessionTraceDict);
@@ -228,15 +239,19 @@ export class AdkApiServer {
     // DNS-rebound page's requests look same-origin to the browser, which
     // omits Origin for them, so safe methods (GET/HEAD/OPTIONS) get the
     // same check as everything else.
-    const allowedRequestHosts = getAllowedRequestHosts(this.allowOrigins);
+    const allowedRequestHosts = getAllowedRequestHosts(
+      this.allowOrigins,
+      this.allowedHosts,
+    );
     app.use((req: Request, res: Response, next: express.NextFunction) => {
       if (
         isDnsRebindingRequest(req.headers.host, this.host, allowedRequestHosts)
       ) {
         this.logger.warn(
-          `Rejected request with Host "${req.headers.host}": the server is bound to ` +
-            `${this.host} and only loopback hosts are accepted. Set --allow_origins ` +
-            `to the origin you are reaching this server through.`,
+          `Rejected request with Host ${JSON.stringify(String(req.headers.host).slice(0, 128))}: the server is bound to ` +
+            `${this.host} and only loopback hosts are accepted. Set the ` +
+            `allowedHosts server option (or --allowed_hosts on the CLI) to ` +
+            `the host you are reaching this server through.`,
         );
         res
           .status(403)

--- a/dev/src/server/dns_rebinding_guard.ts
+++ b/dev/src/server/dns_rebinding_guard.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * DNS-rebinding guard for the dev server (adk web / api_server).
+ *
+ * A page reached by rebinding an attacker-controlled hostname to 127.0.0.1
+ * is same-origin as far as the browser is concerned, so it omits Origin --
+ * meaning read endpoints (GET /list-apps, /version, etc.) are reachable from
+ * any external page a developer running the dev server happens to visit,
+ * with no explicit configuration required to be vulnerable. Origin cannot
+ * be relied on to catch this; the guard keys off Host instead, on every
+ * method including GET, applied as the very first middleware before any
+ * route.
+ */
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost']);
+
+/** Returns *host* without its port, or unchanged if it has no valid one. */
+function stripPort(host: string): string {
+  // A malformed authority must come back whole, so callers never read
+  // "127.0.0.1:8000.evil.com" as loopback.
+  if (host.startsWith('[')) {
+    // [addr] or [addr]:port
+    const closeBracket = host.indexOf(']');
+    if (closeBracket === -1) {
+      return host;
+    }
+    const bare = host.slice(1, closeBracket);
+    const suffix = host.slice(closeBracket + 1);
+    if (suffix && !/^:\d+$/.test(suffix)) {
+      return host;
+    }
+    return bare;
+  }
+  const colonCount = (host.match(/:/g) ?? []).length;
+  if (colonCount === 1) {
+    // host:port; bracketless IPv6 has more colons.
+    const colonIndex = host.indexOf(':');
+    if (!/^\d+$/.test(host.slice(colonIndex + 1))) {
+      return host;
+    }
+    return host.slice(0, colonIndex);
+  }
+  return host;
+}
+
+/**
+ * Returns true if *host* (with or without a port) refers to a loopback
+ * address: 127.0.0.0/8, ::1, or "localhost".
+ */
+export function isLoopbackAddress(host: string): boolean {
+  // Host names are case-insensitive and may carry a root dot ("localhost.").
+  const bare = stripPort(host).toLowerCase().replace(/\.$/, '');
+  if (LOOPBACK_HOSTNAMES.has(bare)) {
+    return true;
+  }
+  if (bare === '::1') {
+    return true;
+  }
+  const ipv4Match = bare.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match && ipv4Match.slice(1).every((octet) => Number(octet) <= 255)) {
+    return ipv4Match[1] === '127';
+  }
+  return false;
+}
+
+/**
+ * Returns the hosts the DNS-rebinding guard accepts besides loopback, or
+ * `null` if every host should be accepted (guard disabled).
+ *
+ * A loopback bind behind a same-machine proxy sees the proxy's hostname in
+ * Host, so an operator naming an origin in --allow_origins vouches for that
+ * origin's host. Only "*" opts out of the guard entirely.
+ */
+export function getAllowedRequestHosts(
+  allowOrigins: string | undefined,
+): Set<string> | null {
+  const origin = (allowOrigins ?? '').trim();
+  if (!origin || origin === '*') {
+    return origin === '*' ? null : new Set<string>();
+  }
+  try {
+    const host = new URL(origin).hostname;
+    return host ? new Set([host.toLowerCase()]) : new Set<string>();
+  } catch {
+    return new Set<string>(); // A malformed origin vouches for no host.
+  }
+}
+
+/**
+ * Returns true if *req* must be rejected as a possible DNS-rebinding
+ * attempt: the server is bound to loopback, and the request's Host header
+ * names neither loopback nor an operator-configured origin's host.
+ *
+ * Origin cannot catch this: browsers omit it on requests they consider
+ * same-origin, as a DNS-rebound page's requests are, so this must be
+ * applied to every request, safe methods (GET/HEAD/OPTIONS) included.
+ */
+export function isDnsRebindingRequest(
+  hostHeaderValue: string | undefined,
+  bindHost: string | undefined,
+  allowedRequestHosts: Set<string> | null,
+): boolean {
+  if (allowedRequestHosts === null || bindHost === undefined) {
+    return false;
+  }
+  if (!isLoopbackAddress(bindHost)) {
+    return false;
+  }
+  if (hostHeaderValue === undefined) {
+    // Browsers always send Host, so its absence is not a rebinding vector.
+    return false;
+  }
+  if (hostHeaderValue.includes(',')) {
+    // Node joins duplicate headers with a comma; Host is a singleton
+    // header, so more than one value is smuggling, not a client.
+    return true;
+  }
+  if (isLoopbackAddress(hostHeaderValue)) {
+    return false;
+  }
+  const bareHost = stripPort(hostHeaderValue).toLowerCase().replace(/\.$/, '');
+  return !allowedRequestHosts.has(bareHost);
+}

--- a/dev/src/server/dns_rebinding_guard.ts
+++ b/dev/src/server/dns_rebinding_guard.ts
@@ -74,21 +74,38 @@ export function isLoopbackAddress(host: string): boolean {
  *
  * A loopback bind behind a same-machine proxy sees the proxy's hostname in
  * Host, so an operator naming an origin in --allow_origins vouches for that
- * origin's host. Only "*" opts out of the guard entirely.
+ * origin's host, and *extraAllowedHosts* (ServerOptions.allowedHosts /
+ * --allowed_hosts) vouches for any host explicitly listed there -- the
+ * latter exists so an embedder behind a proxy can widen the guard without
+ * having to open CORS to every origin on the internet just to get a Host
+ * header through. Only "*" in allowOrigins opts out of the guard entirely.
  */
 export function getAllowedRequestHosts(
   allowOrigins: string | undefined,
+  extraAllowedHosts?: readonly string[],
 ): Set<string> | null {
   const origin = (allowOrigins ?? '').trim();
-  if (!origin || origin === '*') {
-    return origin === '*' ? null : new Set<string>();
+  if (origin === '*') {
+    return null;
   }
-  try {
-    const host = new URL(origin).hostname;
-    return host ? new Set([host.toLowerCase()]) : new Set<string>();
-  } catch {
-    return new Set<string>(); // A malformed origin vouches for no host.
+  const hosts = new Set<string>();
+  if (origin) {
+    try {
+      const host = new URL(origin).hostname;
+      if (host) {
+        hosts.add(host.toLowerCase());
+      }
+    } catch {
+      // A malformed origin vouches for no host.
+    }
   }
+  for (const rawHost of extraAllowedHosts ?? []) {
+    const host = rawHost.trim().toLowerCase();
+    if (host) {
+      hosts.add(host);
+    }
+  }
+  return hosts;
 }
 
 /**

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -24,6 +24,7 @@ import {
   Workflow,
 } from '@google/adk';
 import {ReadableSpan} from '@opentelemetry/sdk-trace-base';
+import * as http from 'node:http';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 
@@ -262,6 +263,84 @@ describe('AdkWebServer', () => {
       expect(response.status).toBe(200);
       expect(response.data?.version).toBe(version);
       expect(response.data?.version).toMatch(/^\d+\.\d+\.\d+/);
+    });
+  });
+
+  /**
+   * Sends a GET with an explicit Host header, bypassing whatever Host `url`'s
+   * hostname would otherwise imply. `fetch()` cannot do this: undici rewrites
+   * Host to match the actual connection target for any request it dispatches,
+   * which is exactly why the DNS-rebinding guard below has to be tested with
+   * a lower-level client that reproduces what a rebound page's browser
+   * actually sends on the wire.
+   */
+  function getWithHost(url: string, hostHeader: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const target = new URL(url);
+      const req = http.request(
+        {
+          host: target.hostname,
+          port: target.port,
+          path: target.pathname,
+          method: 'GET',
+          headers: {Host: hostHeader},
+        },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  describe('DNS-rebinding guard', () => {
+    // Regression tests for a missing DNS-rebinding guard: the server bound
+    // to loopback with no --allow_origins configured accepted requests
+    // naming an arbitrary Host, which a page reached via a rebound hostname
+    // would send. Origin cannot catch this -- browsers omit it on requests
+    // they consider same-origin, as a rebound page's are -- so the guard
+    // must key off Host instead, on every method including GET.
+    let guardServer: AdkApiServer;
+
+    beforeEach(async () => {
+      guardServer = new AdkApiServer({
+        agentLoader: {
+          listAgents: () => Promise.resolve(['testApp']),
+        } as unknown as AgentLoader,
+      });
+      await guardServer.start();
+    });
+
+    afterEach(async () => {
+      await guardServer.stop();
+    });
+
+    it('accepts a request whose Host names the loopback bind', async () => {
+      const status = await getWithHost(
+        `${guardServer.url}/version`,
+        'localhost',
+      );
+      expect(status).toBe(200);
+    });
+
+    it('rejects a GET whose Host does not name loopback', async () => {
+      const status = await getWithHost(
+        `${guardServer.url}/version`,
+        'evil.attacker.example',
+      );
+      expect(status).toBe(403);
+    });
+
+    it('rejects a read endpoint with no Origin header at all', async () => {
+      // The exact shape of a DNS-rebound page's request: same-origin as far
+      // as the browser is concerned, so no Origin header is sent.
+      const status = await getWithHost(
+        `${guardServer.url}/list-apps`,
+        'evil.attacker.example',
+      );
+      expect(status).toBe(403);
     });
   });
 

--- a/dev/test/server/dns_rebinding_guard_test.ts
+++ b/dev/test/server/dns_rebinding_guard_test.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+
+import {
+  getAllowedRequestHosts,
+  isDnsRebindingRequest,
+  isLoopbackAddress,
+} from '../../src/server/dns_rebinding_guard.js';
+
+describe('isLoopbackAddress', () => {
+  it('accepts localhost, with and without a port', () => {
+    expect(isLoopbackAddress('localhost')).toBe(true);
+    expect(isLoopbackAddress('localhost:8000')).toBe(true);
+    expect(isLoopbackAddress('LOCALHOST:8000')).toBe(true);
+    expect(isLoopbackAddress('localhost.:8000')).toBe(true);
+  });
+
+  it('accepts the 127.0.0.0/8 range, with and without a port', () => {
+    expect(isLoopbackAddress('127.0.0.1')).toBe(true);
+    expect(isLoopbackAddress('127.0.0.1:8000')).toBe(true);
+    expect(isLoopbackAddress('127.0.0.2:8000')).toBe(true);
+    expect(isLoopbackAddress('127.000.000.001:8000')).toBe(true);
+  });
+
+  it('accepts ::1, bracketed, with and without a port', () => {
+    expect(isLoopbackAddress('::1')).toBe(true);
+    expect(isLoopbackAddress('[::1]')).toBe(true);
+    expect(isLoopbackAddress('[::1]:8000')).toBe(true);
+  });
+
+  it('rejects a dotted-quad payload disguised with a fake port suffix', () => {
+    // The exact bug this guard exists to close: a malformed authority must
+    // come back whole from stripPort, not read as loopback.
+    expect(isLoopbackAddress('127.0.0.1:8000.evil.com')).toBe(false);
+    expect(isLoopbackAddress('127.0.0.1:evil.com')).toBe(false);
+  });
+
+  it('rejects a bracketed host with a non-port suffix', () => {
+    expect(isLoopbackAddress('[::1]x:8000')).toBe(false);
+    expect(isLoopbackAddress('[evil.attacker.example]')).toBe(false);
+  });
+
+  it('rejects a bracketed host with no closing bracket', () => {
+    expect(isLoopbackAddress('[::1')).toBe(false);
+  });
+
+  it('rejects a non-loopback host', () => {
+    expect(isLoopbackAddress('evil.attacker.example')).toBe(false);
+    expect(isLoopbackAddress('0.0.0.0')).toBe(false);
+    expect(isLoopbackAddress('127.0.0.256')).toBe(false); // out of range octet
+  });
+});
+
+describe('getAllowedRequestHosts', () => {
+  it('vouches for the hostname of a real configured origin', () => {
+    const hosts = getAllowedRequestHosts('http://proxy.example');
+    expect(hosts).toEqual(new Set(['proxy.example']));
+  });
+
+  it('disables the guard entirely for a wildcard origin', () => {
+    expect(getAllowedRequestHosts('*')).toBeNull();
+  });
+
+  it('vouches for no host on a malformed origin', () => {
+    expect(getAllowedRequestHosts('not a valid url')).toEqual(new Set());
+  });
+
+  it('vouches for no host when allowOrigins is unset', () => {
+    expect(getAllowedRequestHosts(undefined)).toEqual(new Set());
+  });
+
+  it('merges extraAllowedHosts with the origin-derived host', () => {
+    const hosts = getAllowedRequestHosts('http://proxy.example', [
+      'Other.Example',
+      '  padded.example  ',
+    ]);
+    expect(hosts).toEqual(
+      new Set(['proxy.example', 'other.example', 'padded.example']),
+    );
+  });
+
+  it('accepts extraAllowedHosts with no allowOrigins set at all', () => {
+    const hosts = getAllowedRequestHosts(undefined, ['proxy.example']);
+    expect(hosts).toEqual(new Set(['proxy.example']));
+  });
+
+  it('ignores empty/whitespace-only entries in extraAllowedHosts', () => {
+    const hosts = getAllowedRequestHosts(undefined, ['', '   ']);
+    expect(hosts).toEqual(new Set());
+  });
+
+  it('still disables the guard for "*" even with extraAllowedHosts set', () => {
+    expect(getAllowedRequestHosts('*', ['proxy.example'])).toBeNull();
+  });
+});
+
+describe('isDnsRebindingRequest', () => {
+  const LOOPBACK_BIND = 'localhost';
+  const NON_LOOPBACK_BIND = '0.0.0.0';
+
+  it('never rejects when the guard is disabled (null allowedRequestHosts)', () => {
+    expect(
+      isDnsRebindingRequest('evil.attacker.example', LOOPBACK_BIND, null),
+    ).toBe(false);
+  });
+
+  it('never rejects when the server is not bound to loopback', () => {
+    // The guard's entire premise is a loopback bind being reachable from
+    // an attacker-controlled hostname; a non-loopback bind is already
+    // reachable by design, so there is nothing for the guard to protect.
+    expect(
+      isDnsRebindingRequest(
+        'evil.attacker.example',
+        NON_LOOPBACK_BIND,
+        new Set(),
+      ),
+    ).toBe(false);
+  });
+
+  it('never rejects an absent Host header', () => {
+    // Browsers always send Host; its absence is not a rebinding vector,
+    // and rejecting it would just break non-browser callers for nothing.
+    expect(isDnsRebindingRequest(undefined, LOOPBACK_BIND, new Set())).toBe(
+      false,
+    );
+  });
+
+  it('rejects a Host header containing a comma', () => {
+    // Host is a singleton header; more than one value reaching this point
+    // is a smuggling attempt, not something a normal client produces.
+    expect(
+      isDnsRebindingRequest(
+        'evil.attacker.example,localhost',
+        LOOPBACK_BIND,
+        new Set(),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts a Host that resolves to loopback', () => {
+    expect(
+      isDnsRebindingRequest('127.0.0.1:8000', LOOPBACK_BIND, new Set()),
+    ).toBe(false);
+    expect(isDnsRebindingRequest('[::1]:8000', LOOPBACK_BIND, new Set())).toBe(
+      false,
+    );
+  });
+
+  it('accepts a Host explicitly present in allowedRequestHosts', () => {
+    expect(
+      isDnsRebindingRequest(
+        'proxy.example',
+        LOOPBACK_BIND,
+        new Set(['proxy.example']),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a Host that is neither loopback nor allow-listed', () => {
+    expect(
+      isDnsRebindingRequest('evil.attacker.example', LOOPBACK_BIND, new Set()),
+    ).toBe(true);
+  });
+
+  it('rejects the disguised-loopback attack this guard exists for', () => {
+    expect(
+      isDnsRebindingRequest(
+        '127.0.0.1:8000.evil.com',
+        LOOPBACK_BIND,
+        new Set(),
+      ),
+    ).toBe(true);
+    expect(
+      isDnsRebindingRequest('127.0.0.1:evil.com', LOOPBACK_BIND, new Set()),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
The dev server (`adk web` / `api_server`) applied CORS only when an operator explicitly configured `--allow_origins`, and had no Host-header validation anywhere. A page reached by rebinding an attacker-controlled hostname to `127.0.0.1` is same-origin as far as the browser is concerned, so it omits `Origin` -- meaning every read endpoint (`GET /list-apps`, `/version`, and others) was reachable from any external page a developer running the dev server happened to visit, with no explicit configuration required to be vulnerable.

This matches the fix adk-python shipped the same day (`2cf4fd1`) for the identical bug in the identical framework.

Adds `isDnsRebindingRequest`, checking the `Host` header against the server's actual bind host (not a client-suppliable header) and any operator-configured `--allow_origins` host. Applied as the very first middleware, before any route including `/health` and `/version`, and on every method (not just state-changing ones) since `Origin` cannot be relied on for a same-origin-looking rebound request.

Dynamically confirmed with `node:http`'s raw client -- `fetch()` silently rewrites `Host` to match the real connection target for any request it dispatches, so it can't be used to reproduce what a rebound page's browser actually sends on the wire. Added three regression tests: accepts a request whose Host names the loopback bind, rejects a GET whose Host does not, and rejects a read endpoint with no Origin header at all (the exact shape of a DNS-rebound request). Full `adk_api_server_test.ts` suite (70 tests) passes.