### PR TITLE
fix(deps): bump grpc to 1.82.1 in the cross-language Go test backend

### DIFF
--- a/tests/cross_language/a2a/ts_go/go_backend/go.mod
+++ b/tests/cross_language/a2a/ts_go/go_backend/go.mod
@@ -25,18 +25,18 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel v1.41.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/log v0.16.0 // indirect
-	go.opentelemetry.io/otel/metric v1.41.0 // indirect
-	go.opentelemetry.io/otel/trace v1.41.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
-	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	rsc.io/omap v1.2.0 // indirect
 	rsc.io/ordered v1.1.1 // indirect


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change

1. Link to an existing issue (if applicable):
   N/A — Dependabot security alert, no public issue.

2. Or, if no issue exists, describe the change:

**Problem**: `tests/cross_language/a2a/ts_go/go_backend` pins `google.golang.org/grpc` v1.79.3. That version is inside the vulnerable range of [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) (HIGH, vulnerable `< 1.82.1`, first patched `1.82.1`). Its sibling fixture module `tests/cross_language/a2a/go_ts/go_client` moved to 1.82.1 in #530. The two Go modules in the cross-language suite have resolved different dependency graphs since then.

**Solution**: Every version here is copied from `go_client/go.mod`, not chosen independently, so both modules resolve one graph again. The otel and genproto moves are transitive consequences of the grpc requirement — `go mod tidy` produces the six lines together. All six stay `// indirect`; the module never imports grpc directly. This is test fixture code: no package source, no public API, no `go.sum`, and no npm manifest is touched.

| Module                                      | Before                               | After                                |
| ------------------------------------------- | ------------------------------------ | ------------------------------------ |
| `google.golang.org/grpc`                    | `v1.79.3`                            | `v1.82.1`                            |
| `google.golang.org/genproto/googleapis/api` | `v0.0.0-20260128011058-8636f8732409` | `v0.0.0-20260414002931-afd174a4e478` |
| `google.golang.org/genproto/googleapis/rpc` | `v0.0.0-20260128011058-8636f8732409` | `v0.0.0-20260414002931-afd174a4e478` |
| `go.opentelemetry.io/otel`                  | `v1.41.0`                            | `v1.43.0`                            |
| `go.opentelemetry.io/otel/metric`           | `v1.41.0`                            | `v1.43.0`                            |
| `go.opentelemetry.io/otel/trace`            | `v1.41.0`                            | `v1.43.0`                            |

The `go 1.25.0` directive is unchanged and no `toolchain` line was added. No other open pull request on this repository changes this file.

### Testing Plan

Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.

Unit Tests:
[ ] I have added or updated unit tests for my change. N/A — the change adds no executable line. A test that asserts the contents of `go.mod` is a change-detector test.
[x] All unit tests pass locally.

```
$ npx vitest run --project cross-language
 ✓ |cross-language| tests/cross_language/a2a/ts_go/ts_a2a_go_test.ts (2 tests) 1451ms
 ✓ |cross-language| tests/cross_language/a2a/go_ts/go_a2a_ts_test.ts (2 tests) 5600ms
 Test Files  2 passed (2)
      Tests  4 passed (4)
```

**Proof the change is load-bearing.** A dependency bump has no test line to mutate, so I mutated the manifest and re-resolved the build graph. `.github/workflows/cross-language-integration.yml` runs `go mod tidy` in both module directories, which is the compile gate here.

```
$ cd tests/cross_language/a2a/ts_go/go_backend
$ go list -m google.golang.org/grpc              # this branch
google.golang.org/grpc v1.82.1
$ git show main:./go.mod > go.mod                # mutation: restore the pinned set on main
$ go list -m google.golang.org/grpc
google.golang.org/grpc v1.79.3
```

Manual End-to-End (E2E) Tests:

```
cd tests/cross_language/a2a/ts_go/go_backend
go mod tidy && git diff --exit-code go.mod   # clean: the pinned set is what tidy resolves
go build ./... && go vet ./...               # both exit 0
go list -m google.golang.org/grpc            # v1.82.1
```

Run with Go 1.26.5 on linux/amd64.

### Checklist

[x] I have read the CONTRIBUTING.md document.
[x] I have performed a self-review of my own code.
[x] I have commented my code, particularly in hard-to-understand areas.
[ ] I have added tests that prove my fix is effective or that my feature works. N/A — no new code; the existing cross-language suite exercises the bumped module.
[x] New and existing unit tests pass locally with my changes.
