### PR TITLE
fix(agents): stop warning about transfer config the author never set

### DIFF
--- a/core/src/agents/instructions.ts
+++ b/core/src/agents/instructions.ts
@@ -18,21 +18,22 @@ const SOURCE_NODE_PLACEHOLDER =
   /<\s*[A-Za-z_]\w*\.([A-Za-z_]\w*)\s+from\s+([A-Za-z_]\w*)\s*>/g;
 
 /**
- * Resolves `<Class.field from source_node>` placeholders against a workflow
- * scope (predecessor outputs by node name). Synchronous; unresolved placeholders
- * are left untouched. Mirrors Python's source-node-qualified data selection.
+ * Resolves one `<Class.field from source_node>` placeholder against a workflow
+ * scope (predecessor outputs by node name). Synchronous; an unresolved
+ * placeholder is returned untouched. Mirrors Python's source-node-qualified
+ * data selection.
  */
-function resolveSourceNodePlaceholders(
-  template: string,
+function resolveSourceNode(
+  raw: string,
+  field: string,
+  nodeName: string,
   scope: WorkflowInstructionScope,
 ): string {
-  return template.replace(SOURCE_NODE_PLACEHOLDER, (raw, field, nodeName) => {
-    const out = scope.outputsByNode?.[nodeName];
-    if (out && typeof out === 'object' && field in (out as object)) {
-      return formatValue((out as Record<string, unknown>)[field], false);
-    }
-    return raw;
-  });
+  const out = scope.outputsByNode?.[nodeName];
+  if (out && typeof out === 'object' && field in (out as object)) {
+    return formatValue((out as Record<string, unknown>)[field], false);
+  }
+  return raw;
 }
 
 /**
@@ -152,18 +153,22 @@ export async function injectSessionState(
   template: string,
   readonlyContext: ReadonlyContext,
 ): Promise<string> {
-  // Workflow: first resolve `<Class.field from source_node>` placeholders, and
-  // enable `{Class.field}` resolution below. Both are no-ops (placeholders left
+  // Workflow: `<Class.field from source_node>` placeholders, plus
+  // `{Class.field}` resolution below. Both are no-ops (placeholders left
   // untouched) for ordinary agents, which have no workflow scope.
   const scope = readonlyContext.invocationContext.workflowInstructionScope;
-  if (scope) {
-    template = resolveSourceNodePlaceholders(template, scope);
-  }
+  const sourceMatches = scope
+    ? Array.from(template.matchAll(SOURCE_NODE_PLACEHOLDER)).map((match) => ({
+        raw: match[0],
+        index: match.index!,
+        resolved: resolveSourceNode(match[0], match[1], match[2], scope),
+      }))
+    : [];
 
   const pattern = /\{+[^{}]*}+/g;
   const matches = Array.from(template.matchAll(pattern));
 
-  if (matches.length === 0) {
+  if (matches.length === 0 && sourceMatches.length === 0) {
     return template;
   }
 
@@ -225,11 +230,16 @@ export async function injectSessionState(
   await Promise.all(resolutions.values());
 
   // Reconstruct template using pre-parsed matches
+  const allMatches = [...parsedMatches, ...sourceMatches].sort(
+    (a, b) => a.index - b.index,
+  );
   const result: string[] = [];
   let lastEnd = 0;
-  for (const pm of parsedMatches) {
+  for (const pm of allMatches) {
     result.push(template.slice(lastEnd, pm.index));
-    if (pm.isValid) {
+    if ('resolved' in pm) {
+      result.push(pm.resolved);
+    } else if (pm.isValid) {
       const replacement = await resolutions.get(pm.key)!;
       result.push(replacement);
     } else {

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -526,15 +526,19 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
 
     // Validate output schema related configurations.
     if (this.outputSchema) {
-      if (!this.disallowTransferToParent || !this.disallowTransferToPeers) {
+      const transferRequested =
+        config.disallowTransferToParent === false ||
+        config.disallowTransferToPeers === false ||
+        !!this.subAgents?.length;
+      if (transferRequested) {
         logger.warn(
           `Invalid config for agent ${
             this.name
           }: outputSchema cannot co-exist with agent transfer configurations. Setting disallowTransferToParent=true, disallowTransferToPeers=true`,
         );
-        this.disallowTransferToParent = true;
-        this.disallowTransferToPeers = true;
       }
+      this.disallowTransferToParent = true;
+      this.disallowTransferToPeers = true;
     }
   }
 

--- a/core/test/agents/instructions_test.ts
+++ b/core/test/agents/instructions_test.ts
@@ -364,5 +364,40 @@ describe('injectSessionState', () => {
         '{CityTime.missing}',
       );
     });
+
+    it('does not rescan an injected source-node value for {placeholders}', async () => {
+      const ctx = makeContext({}, undefined, {
+        outputsByNode: {city_generator: {city: '{my_city}'}},
+      });
+      expect(
+        await injectSessionState(
+          'The city is <City.city from city_generator>.',
+          ctx,
+        ),
+      ).toBe('The city is {my_city}.');
+    });
+
+    it('does not rescan an injected {Class.field} value for {placeholders}', async () => {
+      const ctx = makeContext({}, undefined, {input: {city: '{my_city}'}});
+      expect(await injectSessionState('The city is {City.city}.', ctx)).toBe(
+        'The city is {my_city}.',
+      );
+    });
+
+    it('does not rescan an injected state value for {placeholders}', async () => {
+      const ctx = makeContext({city: '{my_city}'});
+      expect(await injectSessionState('The city is {city}.', ctx)).toBe(
+        'The city is {my_city}.',
+      );
+    });
+
+    it('resolves source-node and state placeholders in one pass', async () => {
+      const ctx = makeContext({tone: 'formal'}, undefined, {
+        outputsByNode: {lookup: {city: 'Rome'}},
+      });
+      expect(
+        await injectSessionState('{tone}: <City.city from lookup> now', ctx),
+      ).toBe('formal: Rome now');
+    });
   });
 });

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -34,6 +34,7 @@ import {Content, Schema, Type} from '@google/genai';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
+import {logger} from '../../src/utils/logger.js';
 
 class MockLlmConnection implements BaseLlmConnection {
   sendHistory(_history: Content[]): Promise<void> {
@@ -441,6 +442,37 @@ describe('LlmAgent Schema Initialization', () => {
     });
     expect(agent.disallowTransferToParent).toBe(true);
     expect(agent.disallowTransferToPeers).toBe(true);
+  });
+
+  it('warns about transfer only when transfer was asked for explicitly', () => {
+    const outputSchema: Schema = {type: Type.OBJECT};
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const quiet = new LlmAgent({name: 'quiet', outputSchema});
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(quiet.disallowTransferToParent).toBe(true);
+    expect(quiet.disallowTransferToPeers).toBe(true);
+
+    new LlmAgent({
+      name: 'loud',
+      outputSchema,
+      disallowTransferToPeers: false,
+    });
+    expect(warnSpy).toHaveBeenCalledOnce();
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns about transfer when outputSchema co-exists with subAgents', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const agent = new LlmAgent({
+      name: 'parent',
+      outputSchema: {type: Type.OBJECT},
+      subAgents: [new LlmAgent({name: 'child'})],
+    });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(agent.disallowTransferToPeers).toBe(true);
+    warnSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Two independent papercuts in how an agent's instruction and config are resolved, both of which mislead the developer about correct code.

### #725 — spurious `outputSchema cannot co-exist with agent transfer` warning

The guard at `core/src/agents/llm_agent.ts:528` read the resolved `disallowTransferToParent` / `disallowTransferToPeers` fields, which the constructor has already defaulted to `false` at :440-441. It therefore could not distinguish "the author asked for transfer" from "the author never mentioned transfer", and fired on **every** agent that sets an `outputSchema` — telling it its config was invalid. It is the first line the canonical `data_handling/schemas` sample prints, on both backends and in `adk web`.

Now consults the config the way `includeContentsExplicit` (:397, :443) already does for the same class of problem. The flags are still forced to `true` unconditionally, so resolved behaviour is unchanged — only the log line goes away.

Note for review: upstream `adk-python`'s `__check_output_schema` has the same unconditional shape, so this is a deliberate divergence rather than a port error.

### #726 — injected data re-scanned for `{placeholders}`

`injectSessionState` substituted `<Class.field from source_node>` into the template and *then* ran the `{...}` state scan over the result, so injected data was treated as template source. A predecessor output containing `{my_city}` aborted the run with ``Context variable not found: `my_city` ``:

```
[city_generator_agent]: {my_city}
[lookup_time_function]: {"timeInfo":"10:10 AM","city":"{my_city}"}
[city_report_agent] error: UNKNOWN_ERROR: Context variable not found: `my_city`.
```

Not a contrived prompt-injection case — any workflow that pipes model- or user-supplied text into a downstream instruction inherits it: a filename, a code snippet, a translated string.

Source-node values are now resolved to `(index, raw, value)` triples and spliced in during the same reconstruction pass the `{...}` matches use. That pass is exactly why the `{...}` path was already immune: it slices the *original* template between recorded match indices and never writes a resolved value back. `{...}` and `<...>` use disjoint delimiters, so merging the two match lists by index is unambiguous.

### Tests

- `core/test/agents/llm_agent_test.ts`: silent by default, warns when a transfer flag is explicitly `false`, warns when `subAgents` is non-empty. The existing "should enforce transfer restrictions" case is unchanged and still passes (it sets both flags explicitly).
- `core/test/agents/instructions_test.ts`: an injected source-node value, an injected `{Class.field}` value and an injected state value all stay literal; source-node and state placeholders resolve in one pass.
- Full `unit:core` green (3105 tests), `tsc --noEmit` clean.

Fixes #725
Fixes #726

---
🤖 Generated with CloudCode — session `ses_ffe43504bffe6Ri37Ev6HdRG3f`