### PR TITLE
fix(workflow): stamp the invocation id on an event a node built itself

### DIFF
--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -577,6 +577,9 @@ function enrichEvent({
   if (!event.author) {
     event.author = nodeName;
   }
+  if (!event.invocationId) {
+    event.invocationId = child.invocationId;
+  }
   // Engine-owned: always stamp the true node path (see doc above).
   event.nodeInfo = {...(event.nodeInfo ?? {}), path: child.nodePath};
   if (event.output !== undefined) {

--- a/core/test/workflow/node_execution_test.ts
+++ b/core/test/workflow/node_execution_test.ts
@@ -46,6 +46,16 @@ describe('Phase 1 — node execution & the push/pull bridge', () => {
     // Engine stamps provenance without clobbering.
     expect(events[0].nodeInfo?.path).toBe('router');
     expect(events[0].author).toBe('router');
+    expect(events[0].invocationId).toBe('inv-1');
+  });
+
+  it('does not clobber an invocation id the node set itself', async () => {
+    const node = new FnNode('router', () =>
+      createEvent({invocationId: 'mine', output: 'q'}),
+    );
+    const {events} = await driveNode(node, 'in');
+
+    expect(events[0].invocationId).toBe('mine');
   });
 
   it('supports nested ctx.runNode() with correct node paths (the bridge)', async () => {


### PR DESCRIPTION
`enrichEvent` (`core/src/workflow/node_runner.ts:570`) stamps `author`, `nodeInfo.path`, `branch` and `isolationScope` — and never `invocationId`. An `Event` a node hands back from `createEvent()` is passed through untouched (`nodes/function_node.ts:222`, `base_node.ts:221`), while every *constructing* branch does set it. `createEvent` defaults the field to `''` rather than leaving it undefined (`events/event.ts:176`), so the event is persisted with a blank invocation id while every sibling event of the same invocation carries the real one:

```
task_A_node   invocationId = 'e-7fcd4d33-80fc-40bc-9e64-46fe899aac38'
router        invocationId = ''          <-- returns createEvent({route, output})
task_B_agent  invocationId = 'e-7fcd4d33-80fc-40bc-9e64-46fe899aac38'
```

The damage is to persisted data and to anything that groups by invocation. The Dev UI graph, for one, never highlights the edge into such a node: `getWorkflowHighlights` (`dev/src/server/agent_graph.ts:489`) breaks its backward walk on the first `invocationId` mismatch.

Reproduced on `routes/branches`, `routes/function_node`, `data_handling/node_output`, `data_handling/routing_output`, `data_handling/structured_output` and `graphs/get_started`. It is live in the repo's own fixtures too — `tests/integration/workflows/route/agent.ts:44` and `:62` both return a bare `createEvent`.

### Notes for review

- Tests the **falsy** value, not `undefined`, because `createEvent` writes `''`.
- Follows `enrichEvent`'s own documented rule — only fill in what the node left unset — so a node can still set its own id.
- The carry-forward workaround in `rehydration_utils.ts:78-90` **stays**: sessions written before this change still hold `''`, and engine-minted interrupt events still exist. Its comment ("Not every node event carries an invocation id…") is this bug documented as a feature, and can be revisited separately.
- Fixture-neutral: `invocationId` is in `IGNORE_FIELDS` (`tests/integration/test_case_utils.ts:160-171`) and is already regex-asserted at :239.

### Tests

`core/test/workflow/node_execution_test.ts` — extends the existing "passes through an explicitly emitted Event" case, plus a new one asserting an id the node set itself is not clobbered. Full `unit:core` (3100) and workflow + docs integration (125) green.

Fixes #715