### PR TITLE
fix(models): consult GOOGLE_API_KEY on the Gemini API path

### DIFF
--- a/core/src/models/apigee_llm.ts
+++ b/core/src/models/apigee_llm.ts
@@ -40,10 +40,10 @@ export interface ApigeeLlmParams extends GeminiParams {
    */
   proxyUrl?: string;
   /**
-   * API key to use. If not provided, it will look for
-   * the GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable. If gemini
-   * provider is selected and no key is provided, the fake key "-" will be
-   * used for the "x-goog-api-key" header.
+   * API key to use. If not provided, it will look for the GOOGLE_GENAI_API_KEY,
+   * GOOGLE_API_KEY or GEMINI_API_KEY environment variable, in that order. If
+   * gemini provider is selected and no key is provided, the fake key "-" will
+   * be used for the "x-goog-api-key" header.
    */
   apiKey?: string;
 }

--- a/core/src/models/google_llm.ts
+++ b/core/src/models/google_llm.ts
@@ -36,7 +36,8 @@ export interface GeminiParams {
   model?: string;
   /**
    * The API key to use for the Gemini API. If not provided, it will look for
-   * the GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.
+   * the GOOGLE_GENAI_API_KEY, GOOGLE_API_KEY or GEMINI_API_KEY environment
+   * variable, in that order.
    */
   apiKey?: string;
   /**
@@ -117,7 +118,7 @@ export class Gemini extends BaseLlm {
     });
     if (!params.vertexai && !params.apiKey) {
       throw new Error(
-        'API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.',
+        'API key must be provided via constructor or the GOOGLE_GENAI_API_KEY, GOOGLE_API_KEY or GEMINI_API_KEY environment variable.',
       );
     }
     this.project = params.project;
@@ -395,8 +396,19 @@ export function geminiInitParams({
     }
   } else {
     if (!params.apiKey && !isBrowser()) {
+      // `GOOGLE_API_KEY` before `GEMINI_API_KEY`, matching @google/genai's own
+      // `getApiKeyFromEnv()` and adk-python, which leaves the choice to the SDK
+      // entirely. Resolving the key here shadows the SDK, so an order that
+      // disagrees with it makes its "Both GOOGLE_API_KEY and GEMINI_API_KEY are
+      // set. Using GOOGLE_API_KEY." warning describe a key adk-js did not use.
+      //
+      // `GOOGLE_GENAI_API_KEY` stays first: no SDK understands that name, and
+      // `adk create` writes it into every scaffolded .env, so it is the
+      // adk-js-specific override.
       params.apiKey =
-        process.env['GOOGLE_GENAI_API_KEY'] || process.env['GEMINI_API_KEY'];
+        process.env['GOOGLE_GENAI_API_KEY'] ||
+        process.env['GOOGLE_API_KEY'] ||
+        process.env['GEMINI_API_KEY'];
     }
   }
   return params;

--- a/core/test/models/google_llm_test.ts
+++ b/core/test/models/google_llm_test.ts
@@ -62,6 +62,7 @@ describe('GoogleLlm', () => {
     delete process.env['GOOGLE_CLOUD_PROJECT'];
     delete process.env['GOOGLE_CLOUD_LOCATION'];
     delete process.env['GOOGLE_GENAI_API_KEY'];
+    delete process.env['GOOGLE_API_KEY'];
     delete process.env['GEMINI_API_KEY'];
     delete process.env['GOOGLE_GENAI_USE_VERTEXAI'];
     delete process.env['GOOGLE_GENAI_USE_ENTERPRISE'];
@@ -75,6 +76,13 @@ describe('GoogleLlm', () => {
     expect(() => new TestGemini({model: 'gemini-1.5-flash'})).toThrow(
       /API key must be provided/,
     );
+  });
+
+  it('should construct with only GOOGLE_API_KEY set', () => {
+    // GOOGLE_API_KEY used to be absent from the Gemini-path order entirely, so
+    // setting only it failed at construction rather than picking the key up.
+    process.env['GOOGLE_API_KEY'] = 'google-api-key';
+    expect(() => new TestGemini({model: 'gemini-1.5-flash'})).not.toThrow();
   });
 
   it('should set tracking headers correctly when GOOGLE_CLOUD_AGENT_ENGINE_ID is not set', () => {
@@ -289,6 +297,28 @@ describe('GoogleLlm', () => {
       };
       const params = geminiInitParams(input);
       expect(params.apiKey).toBe('env-api-key');
+    });
+
+    it('should use GOOGLE_API_KEY env var if apiKey is missing', () => {
+      process.env['GOOGLE_API_KEY'] = 'google-api-key';
+      const params = geminiInitParams({model: 'gemini-1.5-flash'});
+      expect(params.apiKey).toBe('google-api-key');
+    });
+
+    it('should prefer GOOGLE_API_KEY over GEMINI_API_KEY', () => {
+      // Matches @google/genai and adk-python. The SDK warns "Both ... are set.
+      // Using GOOGLE_API_KEY."; adk-js must not then use the other one.
+      process.env['GOOGLE_API_KEY'] = 'google-api-key';
+      process.env['GEMINI_API_KEY'] = 'gemini-api-key';
+      const params = geminiInitParams({model: 'gemini-1.5-flash'});
+      expect(params.apiKey).toBe('google-api-key');
+    });
+
+    it('should prefer GOOGLE_GENAI_API_KEY over GOOGLE_API_KEY', () => {
+      process.env['GOOGLE_GENAI_API_KEY'] = 'genai-api-key';
+      process.env['GOOGLE_API_KEY'] = 'google-api-key';
+      const params = geminiInitParams({model: 'gemini-1.5-flash'});
+      expect(params.apiKey).toBe('genai-api-key');
     });
 
     it('should return undefined apiKey if missing', () => {

--- a/dev/src/cli/cli_create.ts
+++ b/dev/src/cli/cli_create.ts
@@ -164,9 +164,9 @@ function generateEnvFile(options: AgentCreationOptions): string {
   const lines = [];
   if (options.apiKey) {
     // The Gemini API path — the one `GOOGLE_GENAI_USE_VERTEXAI=0` selects —
-    // reads GOOGLE_GENAI_API_KEY / GEMINI_API_KEY (see `geminiInitParams` in
-    // core). GOOGLE_API_KEY is only consulted for Vertex AI Express Mode, so
-    // writing it here left every scaffolded project unable to authenticate.
+    // reads GOOGLE_GENAI_API_KEY, then GOOGLE_API_KEY, then GEMINI_API_KEY (see
+    // `geminiInitParams` in core). GOOGLE_GENAI_API_KEY is the adk-js-specific
+    // name and wins outright, so it is the unambiguous one to scaffold.
     lines.push(`GOOGLE_GENAI_API_KEY=${options.apiKey}`);
     lines.push(`GOOGLE_GENAI_USE_VERTEXAI=0`);
   }


### PR DESCRIPTION
`geminiInitParams` resolved `GOOGLE_GENAI_API_KEY || GEMINI_API_KEY` (`core/src/models/google_llm.ts:397-399`).

**`GOOGLE_API_KEY` was not in that order at all.** It is read only by `getExpressModeApiKey()` (`core/src/utils/vertex_ai_utils.ts:40`), and only when enterprise mode is on — which is exactly the branch this code is *not* in. So the report's "inverted precedence" understates it. Two consequences:

1. **A `GOOGLE_API_KEY`-only user cannot run at all.** `google_llm.ts:118` throws `API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.` before the SDK is ever consulted. That is the variable both adk-python and `@google/genai` document as the primary one.

2. **With both set, the warning describes a key we did not use.** adk-js used `GEMINI_API_KEY` while the SDK printed *"Both GOOGLE_API_KEY and GEMINI_API_KEY are set. Using GOOGLE_API_KEY."* The `GoogleGenAI` constructor calls `getApiKeyFromEnv()` unconditionally *before* it reads `options.apiKey`, so passing an explicit key does not suppress the warning — it just makes it wrong.

adk-python never resolves the key itself; it builds its client with no `api_key` and lets python-genai decide, which documents "prioritizing GOOGLE_API_KEY". Since adk-js *does* resolve it here, and thereby shadows the SDK, the order has to agree with the SDK.

### Why not just delete the resolution and let the SDK decide

That drops the fail-fast at `:118`, and it removes `GOOGLE_GENAI_API_KEY` — a name no SDK understands and which `adk create` writes into every scaffolded `.env` (`dev/src/cli/cli_create.ts:170`). Every scaffolded project would break. So `GOOGLE_GENAI_API_KEY` stays first as the adk-js-specific override, with `GOOGLE_API_KEY` then `GEMINI_API_KEY` behind it.

### Blast radius

A behaviour change, not an API change. The only regression is a user who sets *both* `GOOGLE_API_KEY` and `GEMINI_API_KEY` and relies on `GEMINI_API_KEY` winning — precisely the case where the SDK already tells them the opposite. Everyone with only `GOOGLE_API_KEY` goes from a hard throw to working. Worth a release note.

Also updates the strings that enumerate the variables (`google_llm.ts:39,120`, `apigee_llm.ts:44`) and the now-inaccurate comment at `cli_create.ts:166-171`.

### Tests

`core/test/models/google_llm_test.ts` — `GOOGLE_API_KEY` alone is picked up, wins over `GEMINI_API_KEY`, loses to `GOOGLE_GENAI_API_KEY`, and the constructor no longer throws with only it set.

⚠️ `clearEnv()` did not delete `GOOGLE_API_KEY`; now that it is in the order, an ambient key on a dev machine would leak into every test in that file. Fixed in the same commit.

`unit:core` + `unit:dev` green (3402), `tsc --noEmit` clean.

Fixes #712

