### PR TITLE
fix(api-server): return the events a failed invocation produced from /run

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -905,8 +905,8 @@ export class AdkApiServer {
         }
       });
 
+      const events: Event[] = [];
       try {
-        const events: Event[] = [];
         for await (const e of this.executeAgentRun({
           appName,
           userId,
@@ -923,7 +923,7 @@ export class AdkApiServer {
       } catch (e: unknown) {
         const error = `Failed to run agent: ${e}`;
 
-        res.status(500).json({error});
+        res.status(500).json({error, events});
         this.logger.error(error);
       }
     });
@@ -946,6 +946,7 @@ export class AdkApiServer {
           res.status(400).json({error: 'appName is required in input'});
           return;
         }
+        const events: Event[] = [];
         try {
           await this.sessionService.getOrCreateSession({
             appName,
@@ -953,7 +954,6 @@ export class AdkApiServer {
             sessionId,
             state: {},
           });
-          const events: Event[] = [];
           const abortController = new AbortController();
           req.on('close', () => {
             abortController.abort();
@@ -971,7 +971,7 @@ export class AdkApiServer {
           res.json({output: events});
         } catch (e: unknown) {
           const error = `Failed to run agent via Reasoning Engine API: ${e}`;
-          res.status(500).json({error});
+          res.status(500).json({error, output: events});
           this.logger.error(error);
         }
       };

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -122,7 +122,7 @@ class HttpClient {
 
     if (response.status > 399) {
       throw {
-        response: {status: response.status},
+        response: {status: response.status, data, text},
         message: (data as {error?: string})?.error || response.statusText,
       };
     }
@@ -636,6 +636,66 @@ describe('AdkWebServer', () => {
       } finally {
         agentLoader.getAgentFile = originalGetAgentFile;
       }
+    });
+
+    it('should return the events a failed invocation produced', async () => {
+      const originalGetAgentFile = agentLoader.getAgentFile;
+      agentLoader.getAgentFile = (() =>
+        Promise.resolve({
+          load: () =>
+            Promise.resolve(
+              new Workflow({
+                name: 'wf',
+                edges: [
+                  [
+                    'START',
+                    node(async () => 'ok', {name: 'first'}),
+                    node(
+                      async () => {
+                        throw new Error('boom');
+                      },
+                      {name: 'second'},
+                    ),
+                  ],
+                ],
+              }),
+            ),
+          async [Symbol.asyncDispose](): Promise<void> {
+            return;
+          },
+        })) as unknown as AgentLoader['getAgentFile'];
+
+      await sessionService.createSession({
+        appName: 'testApp',
+        userId: 'testUser',
+        sessionId: 'failSession',
+      });
+
+      let status: number | undefined;
+      let body: {error: string; events: Event[]} | undefined;
+      try {
+        await client.post('/run', {
+          appName: 'testApp',
+          userId: 'testUser',
+          sessionId: 'failSession',
+          newMessage: {parts: [{text: 'Hello'}], role: 'user'},
+        });
+      } catch (e: unknown) {
+        const response = (e as {response: {status: number; data: typeof body}})
+          .response;
+        status = response.status;
+        body = response.data;
+      } finally {
+        agentLoader.getAgentFile = originalGetAgentFile;
+      }
+
+      expect(status).toBe(500);
+      expect(body?.error).toContain('Failed to run agent');
+      expect(body?.events.some((e) => e.author === 'first')).toBe(true);
+      const nodeError = body?.events.find(
+        (e) => (e as Event & {isNodeError?: boolean}).isNodeError,
+      );
+      expect(nodeError?.nodeInfo?.path).toBe('wf.second');
     });
 
     it('should pass abortSignal to Runner.runAsync in /run', async () => {


### PR DESCRIPTION
`/run_sse` writes each event to the wire as it arrives, so a caller sees the structured node-error event — carrying `nodeInfo.path`, `errorType`, `errorCode` and `attemptCount` — when a node throws. `/run` returned HTTP 500 and a one-line string for the same invocation, and the caller had no way to tell which node failed:

```
/run      HTTP 500  {"error":"Failed to run agent: TypeError: e.toUpperCase is not a function"}
/run_sse  data: {"author":"my_function_node","nodeInfo":{"path":"function_node_pipeline.my_function_node"},
                 "isNodeError":true,"errorType":"TypeError","errorMessage":"...","attemptCount":1}
```

### Root cause

`const events: Event[] = []` was declared **inside** the `try` (`dev/src/server/adk_api_server.ts:909`), so it was not even in scope in the `catch` at `:923`. Hoisting it is the fix.

The events are always there to report, and that is guaranteed rather than incidental: `Workflow.orchestrate` emits the node-error event via `ctx.emit` (`workflow.ts:338`) and only then rethrows (`:341`), and `runNodeAsInvocation` drains the channel to completion in its `for await` before `await settle` surfaces the rejection. So the consumer always receives the error event first.

### Why 500 and not 200

`/run_sse` ends with 200 because it has already flushed headers, so status parity with it is not really available. Keeping the 500:

- adk-python also fails the request (`worker()` collects the events, any non-`SessionNotFoundError` exception propagates to FastAPI's handler and the events are lost), so 200 would be a deliberate divergence.
- The Dev UI never calls `/run` — only `/run_sse` (`dev/src/server/adk_api_client.ts:140`, and confirmed in the prebuilt bundle). `/run`'s clients are scripts and the `adk api_server` API, for which a failed invocation silently returning 200 is worse than a 500 that carries the payload.
- It does not break anyone branching on the status code.

The 200 success shape is unchanged (a bare `Event[]`); only the 500 body gains an `events` key, so a client already parsing `{error}` still works. `/api/reasoning_engine` (`:956-975`) had the identical bug and gets the same treatment.

### Tests

`dev/test/server/adk_api_server_test.ts` — a workflow whose first node succeeds and whose second throws; asserts 500, the first node's event, and `nodeInfo.path === 'wf.second'` on the node-error event.

The `HttpClient` test helper discarded the response body on non-2xx, so no test could assert on an error body at all; it now carries `data`/`text` through. The three existing 500 assertions only read `status` and are unaffected (they also fail before any event is produced, so they stay green either way).

Full `unit:dev` green (300), `tsc --noEmit` clean.

Fixes #743

