### PR TITLE
fix(telemetry): make a workflow's spans retrievable so its traces render

### DIFF
--- a/core/src/telemetry/tracing.ts
+++ b/core/src/telemetry/tracing.ts
@@ -100,17 +100,20 @@ export function traceAgentInvocation({
 export interface TraceWorkflowInvocationParams {
   workflowName: string;
   nodePath: string;
+  sessionId: string;
 }
 
 export function traceWorkflowInvocation({
   workflowName,
   nodePath,
+  sessionId,
 }: TraceWorkflowInvocationParams): void {
   const span = trace.getActiveSpan();
   if (!span) return;
 
   span.setAttributes({
     [GEN_AI_OPERATION_NAME]: 'invoke_workflow',
+    [GEN_AI_CONVERSATION_ID]: sessionId,
     [ADK_WORKFLOW_NAME]: workflowName,
     [ADK_NODE_PATH]: nodePath,
   });
@@ -277,6 +280,9 @@ export function traceCallLlm({
   span.setAttributes({
     'gen_ai.system': 'gcp.vertex.agent',
     'gen_ai.request.model': llmRequest.model,
+    ...(invocationContext.agent?.name
+      ? {[GEN_AI_AGENT_NAME]: invocationContext.agent.name}
+      : {}),
     'gcp.vertex.agent.invocation_id': invocationContext.invocationId,
     'gcp.vertex.agent.session_id': invocationContext.session.id,
     'gcp.vertex.agent.event_id': eventId,

--- a/core/src/workflow/workflow.ts
+++ b/core/src/workflow/workflow.ts
@@ -200,6 +200,7 @@ export class Workflow extends BaseNode {
         traceWorkflowInvocation({
           workflowName: this.name,
           nodePath: ctx.nodePath,
+          sessionId: ctx.invocationContext.session.id,
         });
         return this.orchestrate(ctx, nodeInput, dynamicState, abort.controller);
       });

--- a/core/test/telemetry/tracing_test.ts
+++ b/core/test/telemetry/tracing_test.ts
@@ -248,6 +248,7 @@ describe('Telemetry Tracing Functions', () => {
       expect(mockSpan.setAttributes).toHaveBeenCalledWith({
         'gen_ai.system': 'gcp.vertex.agent',
         'gen_ai.request.model': 'test-model',
+        'gen_ai.agent.name': 'test-agent',
         'gcp.vertex.agent.invocation_id': 'test-invocation-id',
         'gcp.vertex.agent.session_id': 'test-session-id',
         'gcp.vertex.agent.event_id': 'test-event-id',

--- a/core/test/workflow/telemetry_test.ts
+++ b/core/test/workflow/telemetry_test.ts
@@ -77,6 +77,7 @@ describe('workflow telemetry — span tree', () => {
 
     expect(wfSpan.attributes).toMatchObject({
       'gen_ai.operation.name': 'invoke_workflow',
+      'gen_ai.conversation.id': 's1',
       'adk.workflow.name': 'seq',
       'adk.node.path': 'seq',
     });

--- a/dev/src/utils/telemetry_utils.ts
+++ b/dev/src/utils/telemetry_utils.ts
@@ -86,15 +86,14 @@ export class InMemoryExporter implements SpanExporter {
   ): void {
     for (const span of spans) {
       const traceId = span.spanContext().traceId;
-      if (span.name === 'call_llm') {
-        const attributes = {...span.attributes};
-        const sessionId = attributes['gcp.vertex.agent.session_id'] as string;
-        if (sessionId) {
-          if (!this.traceDict[sessionId]) {
-            this.traceDict[sessionId] = [traceId];
-          } else {
-            this.traceDict[sessionId].push(traceId);
-          }
+      const attributes = span.attributes;
+      const sessionId = (attributes['gcp.vertex.agent.session_id'] ??
+        attributes['gen_ai.conversation.id']) as string | undefined;
+      if (sessionId) {
+        if (!this.traceDict[sessionId]) {
+          this.traceDict[sessionId] = [traceId];
+        } else {
+          this.traceDict[sessionId].push(traceId);
         }
       }
     }

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -932,6 +932,45 @@ describe('AdkWebServer', () => {
       expect(session.status).toBe(200);
       expect(session.data![0].name).toBe('call_llm');
     });
+
+    it('serves traces for a workflow with no LLM span', async () => {
+      const workflowSpan = {
+        name: 'invoke_workflow wf',
+        spanContext: () => ({traceId: 'trace3', spanId: 'span3'}),
+        startTime: [1, 0],
+        endTime: [2, 0],
+        attributes: {'gen_ai.conversation.id': 'session3'},
+        parentSpanContext: undefined,
+      } as unknown as ReadableSpan;
+      const nodeSpan = {
+        name: 'execute_node wf.one',
+        spanContext: () => ({traceId: 'trace3', spanId: 'span4'}),
+        startTime: [1, 0],
+        endTime: [2, 0],
+        attributes: {'adk.node.path': 'wf.one'},
+        parentSpanContext: {spanId: 'span3'},
+      } as unknown as ReadableSpan;
+      (
+        server as unknown as {
+          memoryExporter: {
+            export: (
+              spans: ReadableSpan[],
+              resultCallback: (result: {code: number}) => void,
+            ) => void;
+          };
+        }
+      ).memoryExporter.export([workflowSpan, nodeSpan], () => {});
+
+      const response = await client.get<{name: string}[]>(
+        '/debug/trace/session/session3',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data!.map((s) => s.name)).toEqual([
+        'invoke_workflow wf',
+        'execute_node wf.one',
+      ]);
+    });
   });
 
   describe('Graph', () => {


### PR DESCRIPTION
`GET /debug/trace/session/:id` returned `[]` for any workflow without an LLM node, so the Dev UI Traces pane was permanently empty for exactly the function-only graphs the `routes` samples teach — despite the spans being created and exported:

```bash
npx adk api_server ../samples/workflows/routes --port 8957 &
curl -s -X POST localhost:8957/run -d '{"appName":"sequence",...}'   # 3 node events land fine
curl -s localhost:8957/debug/trace/session/s1                        # []
```

### Two gaps, both required

1. **`InMemoryExporter.export()` indexed a trace only from a span named `call_llm`** (`dev/src/utils/telemetry_utils.ts:89`). adk-python has no such name filter — it indexes any span carrying a session id.
2. **No workflow span named its session,** so removing the filter alone would not have helped. `traceWorkflowInvocation` (`core/src/telemetry/tracing.ts:112-116`) set only `gen_ai.operation.name`, `adk.workflow.name` and `adk.node.path`; adk-python's `invoke_workflow` span sets `gen_ai.conversation.id`. Only `traceCallLlm` and `traceAgentInvocation` stamped a session, and a workflow of plain function nodes has neither.

`getFinishedSpans` already returns every span sharing an indexed trace id, so opening the trace is the whole fix: `invoke_workflow` and `execute_node` come back with it.

**Checked against the prebuilt UI before choosing the shape.** `getTrace()` validates the response with a zod schema, and the array is all-or-nothing — one bad element blanks the pane. The extra required attributes apply only when `gen_ai.operation.name` is `invoke_agent` or `generate_content`; `invoke_workflow` and `execute_node` hit the permissive branch, so exposing them needs no new attributes and cannot break the UI.

### Also: `gen_ai.agent.name` on the `call_llm` span (#735)

`traceCallLlm` set `gen_ai.system`, the model, invocation/session/event ids and token counts — but no agent name. That attribute existed only on `invoke_agent`, so a consumer reading LLM spans could not tell which agent issued a request. This is why the Dev UI's "System instructions were modified between consecutive turns" alert fires on every multi-agent workflow: it diffs consecutive LLM requests in a session with no grouping key, and two different agents having different system instructions is the normal shape of a workflow, not a misconfiguration.

adk-web already parses `attrAgentName` from `gen_ai.agent.name`; it was simply always `undefined` on the records the check iterates. With the name present, adk-web can bucket per agent instead of tree-walking `parent_span_id`. That half is filed upstream — this PR just puts the value on the wire.

### Out of scope

`GET /debug/trace/:eventId` still 404s for node events: no node span carries `gcp.vertex.agent.event_id`, and a node can emit many events. adk-python's exporter has the identical gate, so this is parity rather than a regression. The forward path is `gcp.vertex.agent.associated_event_ids`, which the prebuilt UI already parses — worth its own issue.

### Blast radius

Additive. Sessions that returned `[]` start returning spans; no response shape changes. `InMemoryExporter.spans` now grows for non-LLM runs too (it already had no eviction beyond `clear()`). One new attribute reaches any user OTel backend.

### Tests

- `core/test/workflow/telemetry_test.ts` — the `invoke_workflow` attribute bag now pins `gen_ai.conversation.id`.
- `core/test/telemetry/tracing_test.ts` — the `call_llm` bag now pins `gen_ai.agent.name`.
- `dev/test/server/adk_api_server_test.ts` — a workflow span plus a child node span, neither named `call_llm`, are both served from `/debug/trace/session/:id`.

`unit:core` + `unit:dev` green (3399), `tsc --noEmit` clean.

Fixes #742
Part of #735 (the adk-web half is filed separately)

---
🤖 Generated with CloudCode — session `ses_ffe43504bffe6Ri37Ev6HdRG3f`
