### PR TITLE
fix(samples): validate the classifier's routes, and title-case Unicode

### DIFF
--- a/samples/workflows/graphs/process_pipeline/agent.ts
+++ b/samples/workflows/graphs/process_pipeline/agent.ts
@@ -18,7 +18,17 @@
  * Try "the checkout page throws a 500" or "where is my parcel?".
  */
 
-import {createEvent, LlmAgent, node, NodeContext, Workflow} from '@google/adk';
+import {
+  createEvent,
+  DEFAULT_ROUTE,
+  LlmAgent,
+  node,
+  NodeContext,
+  Workflow,
+} from '@google/adk';
+
+/** The routes this graph has edges for. */
+const ROUTES = ['BUG', 'CUSTOMER_SUPPORT', 'LOGISTICS'] as const;
 
 const processMessage = new LlmAgent({
   name: 'process_message',
@@ -32,13 +42,13 @@ const processMessage = new LlmAgent({
 // A route ARRAY fires every branch whose route key matches one of the listed
 // values (multi-route dispatch), rather than just the first match.
 const router = node(
-  (_ctx: NodeContext, nodeInput: string) =>
-    createEvent({
-      route: nodeInput
-        .split(',')
-        .map((route) => route.trim().toUpperCase())
-        .filter(Boolean),
-    }),
+  (_ctx: NodeContext, nodeInput: string) => {
+    const text = String(nodeInput).toUpperCase();
+    const matched = ROUTES.filter((route) =>
+      new RegExp(`\\b${route}\\b`).test(text),
+    );
+    return createEvent({route: matched.length > 0 ? matched : DEFAULT_ROUTE});
+  },
   {name: 'router'},
 );
 
@@ -55,6 +65,11 @@ const response2Support = node(() => message('Handling customer support...'), {
 const response3Logistics = node(() => message('Handling logistics...'), {
   name: 'response_3_logistics',
 });
+const responseUnknown = node(
+  (_ctx: NodeContext, nodeInput: string) =>
+    message(`Could not classify that (classifier said: ${nodeInput}).`),
+  {name: 'response_unknown'},
+);
 
 export const rootAgent = new Workflow({
   name: 'routing_workflow',
@@ -66,6 +81,7 @@ export const rootAgent = new Workflow({
         BUG: response1Bug,
         CUSTOMER_SUPPORT: response2Support,
         LOGISTICS: response3Logistics,
+        [DEFAULT_ROUTE]: responseUnknown,
       },
     ],
   ],

--- a/samples/workflows/routes/nested_workflow/agent.ts
+++ b/samples/workflows/routes/nested_workflow/agent.ts
@@ -36,17 +36,29 @@ const router = node(
   {name: 'router'},
 );
 
+/**
+ * Upper-cases the first letter of each word.
+ *
+ * Unicode-aware on purpose: `\b\w` is ASCII-only, so `ü` never matches — and
+ * the word boundary it creates before the *next* ASCII letter upper-cases that
+ * one instead ("strässe" -> "SträSse"). A letter whose uppercase form is more
+ * than one code point (German `ß` -> "SS") is left alone rather than mangled.
+ */
+const titleCase = (text: string) =>
+  text.replace(/(^|\P{L})(\p{L})/gu, (_match, sep: string, ch: string) => {
+    const upper = ch.toUpperCase();
+    return sep + ([...upper].length === 1 ? upper : ch);
+  });
+
 // --- Sub-workflow B: title-case each word, then frame it. ---
 const workflowB = new Workflow({
   name: 'workflow_B',
   edges: [
     [
       'START',
-      node(
-        (_ctx: NodeContext, text: string) =>
-          text.replace(/\b\w/g, (c) => c.toUpperCase()),
-        {name: 'b_title_case'},
-      ),
+      node((_ctx: NodeContext, text: string) => titleCase(text), {
+        name: 'b_title_case',
+      }),
       node((_ctx: NodeContext, text: string) => `[B] ${text}`, {
         name: 'b_frame',
       }),

--- a/tests/integration/docs_samples/docs_samples_test.ts
+++ b/tests/integration/docs_samples/docs_samples_test.ts
@@ -47,6 +47,11 @@ interface OfflineSample {
   turns: string[];
   /** Set for a sample that pauses for a human on its first turn. */
   pausesOnFirstTurn?: boolean;
+  /**
+   * The exact final output, for a sample whose transformation is the point and
+   * so is worth pinning rather than just asserting something came back.
+   */
+  expectedFinalOutput?: unknown;
 }
 
 /**
@@ -81,7 +86,10 @@ const OFFLINE: Record<string, OfflineSample> = {
   'routes/fan_out_join': {turns: ['hello world']},
   'routes/function_node': {turns: ['hello world']},
   'routes/loop_escalation': {turns: ['graph workflows']},
-  'routes/nested_workflow': {turns: ['hello world']},
+  'routes/nested_workflow': {
+    turns: ['ünïcödé strässe ß ǅungla 😀 test'],
+    expectedFinalOutput: '[B] Ünïcödé Strässe ß Ǆungla 😀 Test',
+  },
   'routes/sequence': {turns: ['hello world']},
 };
 
@@ -158,9 +166,11 @@ describe('workflow docs samples', () => {
         expect(isPaused(perTurn[perTurn.length - 1])).toBe(false);
       }
       // The last turn produces the workflow's answer.
-      expect(
-        finalOutput(allEvents([perTurn[perTurn.length - 1]])),
-      ).toBeDefined();
+      const answer = finalOutput(allEvents([perTurn[perTurn.length - 1]]));
+      expect(answer).toBeDefined();
+      if ('expectedFinalOutput' in spec) {
+        expect(answer).toEqual(spec.expectedFinalOutput);
+      }
     });
   });
 });


### PR DESCRIPTION
Two bugs in doc-quality samples, both of which teach the wrong pattern.

### #736 — `graphs/process_pipeline` drops every route and stops dead

The router split the classifier's raw reply on `,` and uppercased the pieces (`agent.ts:34-43`), with no validation against the three known route keys and no `DEFAULT_ROUTE` edge. The classifier is a model, so any message that steers its output format produces routes matching no edge — and a graph whose routes all miss just stops: no handler, no warning, exit 0.

```
[process_message]: ```json
[ "BUG", "CUSTOMER_SUPPORT", "LOGISTICS" ]
```
[user]:            <- no handler fires, no warning, exit 0
```

Worse, a chain-of-thought answer can partially match, so only the comma-piece that happens to equal a route key fires and the graph dispatches to the wrong subset.

Now scans the reply for the known keys instead of trusting its format, and adds a `DEFAULT_ROUTE` branch so an unclassifiable answer still reaches a handler. The keyword scan recovers the cases a strict split loses, rather than dumping them all to the fallback — verified:

| classifier reply | routes |
|---|---|
| `BUG, LOGISTICS` | `["BUG","LOGISTICS"]` |
| ```` ```json\n[ "BUG", "CUSTOMER_SUPPORT", "LOGISTICS" ]\n``` ```` | all three |
| `Category: BUG` | `["BUG"]` |
| `Let me think. The parcel is lost, so this is LOGISTICS.` | `["LOGISTICS"]` |
| `I cannot classify that` | `DEFAULT_ROUTE` |

The framework's silent stop is deliberate and matches adk-python, so this PR fixes the sample rather than the engine. (Its only diagnostic being a `logger.debug` the user never sees is #661; promoting that to `warn` when there is no `DEFAULT_ROUTE` edge is worth doing separately.)

### #741 — `routes/nested_workflow` mangles non-ASCII

`text.replace(/\b\w/g, (c) => c.toUpperCase())` is ASCII-only: `ü` never matches `\w`, and the word boundary that creates before the *next* ASCII letter upper-cases that one instead.

```
[b_title_case]: üNïCöDé SträSse ß ǅUngla 😀 Test
expected:       Ünïcödé Strässe ß Ǆungla 😀 Test
```

Uses Unicode property escapes. **The naive Unicode rewrite is a trap and does not work**: `ß`.toUpperCase() is `"SS"`, two code points, so `/(^|\P{L})(\p{L})/gu` + `toUpperCase` produces `SStrasse`-style mangling. The guard is `[...upper].length === 1` — iterating code points, not UTF-16 units — which leaves such a letter alone. Note `ǅ` (U+01C5, a *titlecase* character) is still expected to become `Ǆ`, so the discriminator is "does uppercasing stay one code point", not "is it a titlecase character".

Verified against the reporter's exact input and a set of edge cases (astral letters, ligatures, all-caps, leading whitespace, empty string); ASCII behaviour is unchanged.

### Tests

The docs-samples harness gains an `expectedFinalOutput`, so a sample whose transformation is the point can pin its answer instead of only asserting that something came back. `routes/nested_workflow` is now driven with the non-ASCII input.

I confirmed the assertion actually bites by reverting the sample: it fails with the reporter's exact string, `'[B] üNïCöDé SträSse ß ǅUngla 😀 Test'`.

`process_pipeline` is model-backed, so it stays construct-only — the added `DEFAULT_ROUTE` edge is validated at construction.

Full `integration` suite green (235 passed, 8 skipped), `tsc --noEmit` and `ts:check:samples` clean.

Fixes #736
Fixes #741