### PR TITLE
fix(dev): enforce caller identity on the API server's userId

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -5,4 +5,11 @@
  */
 
 export {AdkApiClient} from './server/adk_api_client.js';
-export {AdkApiServer} from './server/adk_api_server.js';
+export {
+  AdkApiServer,
+  ENFORCE_USER_IDENTITY_ENV_VAR,
+  IAP_AUTHENTICATED_USER_EMAIL_HEADER,
+  IAP_JWT_ASSERTION_HEADER,
+  iapUserIdResolver,
+} from './server/adk_api_server.js';
+export type {UserIdResolver} from './server/adk_api_server.js';

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -59,6 +59,52 @@ import {renderStructureGraphAsDot} from './structure_graph.js';
  */
 export const A2A_AUTH_TOKEN_ENV_VAR = 'ADK_A2A_AUTH_TOKEN';
 
+/**
+ * Environment variable that turns on caller identity enforcement using the
+ * built-in {@link iapUserIdResolver}, for operators who deploy behind
+ * Identity-Aware Proxy and do not construct the server themselves.
+ */
+export const ENFORCE_USER_IDENTITY_ENV_VAR = 'ADK_ENFORCE_USER_IDENTITY';
+
+/**
+ * Header Identity-Aware Proxy sets on requests it has already authenticated.
+ * The value is prefixed with the identity provider, for example
+ * `accounts.google.com:user@example.com`.
+ */
+export const IAP_AUTHENTICATED_USER_EMAIL_HEADER =
+  'x-goog-authenticated-user-email';
+
+/**
+ * Derives the caller's identity from a request whose credentials the front
+ * door has already verified. Returning `undefined` means the request carries
+ * no identity, which the server answers with `401`.
+ *
+ * A resolver must only read material the deployment's front door guarantees,
+ * such as a header the proxy sets and strips from client input. Reading an
+ * unverified request field would reintroduce the spoofing this check exists
+ * to prevent.
+ */
+export type UserIdResolver = (req: Request) => string | undefined;
+
+/**
+ * Reads the caller's email from the Identity-Aware Proxy header. IAP verifies
+ * the caller before the request reaches the container and overwrites this
+ * header on every request, so a client cannot set it.
+ */
+export function iapUserIdResolver(req: Request): string | undefined {
+  const header = req.get(IAP_AUTHENTICATED_USER_EMAIL_HEADER);
+  if (!header) {
+    return undefined;
+  }
+
+  // Strip the `accounts.google.com:` provider prefix. An email address cannot
+  // contain a colon, so the last one separates provider from identity.
+  const separator = header.lastIndexOf(':');
+  const identity = separator === -1 ? header : header.slice(separator + 1);
+
+  return identity.trim() || undefined;
+}
+
 interface ServerOptions {
   agentsDir?: string;
   host?: string;
@@ -80,6 +126,15 @@ interface ServerOptions {
    * `a2a` is enabled, the A2A surface is mounted WITHOUT authentication.
    */
   a2aAuthToken?: string;
+  /**
+   * Derives the caller's verified identity from a request. When set, the
+   * session, artifact and run endpoints refuse a request whose `userId` names
+   * anyone other than the caller. When unset, `userId` is taken from the
+   * request as before and no identity check is performed, which is only safe
+   * for a single-user local server. Defaults to {@link iapUserIdResolver} when
+   * `ADK_ENFORCE_USER_IDENTITY` is set.
+   */
+  resolveUserId?: UserIdResolver;
   reloadAgents?: boolean;
   registerProcessors?: (tracerProvider: TracerProvider) => void;
 }
@@ -127,6 +182,7 @@ export class AdkApiServer {
   private readonly logger: Logger;
   private readonly a2a: boolean;
   private readonly a2aAuthToken?: string;
+  private readonly resolveUserId?: UserIdResolver;
 
   constructor(options: ServerOptions) {
     this.host = options.host ?? 'localhost';
@@ -164,6 +220,13 @@ export class AdkApiServer {
     // to the authenticator, which rejects a token that is not usable.
     this.a2aAuthToken =
       options.a2aAuthToken || process.env[A2A_AUTH_TOKEN_ENV_VAR] || undefined;
+    // An explicit resolver wins. Otherwise the environment variable opts a
+    // deployment into the Identity-Aware Proxy header without needing code.
+    this.resolveUserId =
+      options.resolveUserId ??
+      (process.env[ENFORCE_USER_IDENTITY_ENV_VAR]
+        ? iapUserIdResolver
+        : undefined);
     this.app = express();
   }
 
@@ -212,6 +275,86 @@ export class AdkApiServer {
         allowUnauthenticated: authentication === undefined,
       });
     }
+  }
+
+  /**
+   * Checks the `userId` a request asked for against the caller's verified
+   * identity and reports the identity the request must run as.
+   *
+   * With no resolver configured this keeps the historical behaviour and hands
+   * back the requested `userId` unchanged. With a resolver configured an
+   * unidentified caller is answered `401` and a caller naming somebody else is
+   * answered `403`, in both cases without reaching the session service.
+   */
+  private authorizeUserId(
+    req: Request,
+    res: Response,
+    requestedUserId?: string,
+  ): {allowed: boolean; userId?: string} {
+    if (!this.resolveUserId) {
+      return {allowed: true, userId: requestedUserId};
+    }
+
+    const callerId = this.resolveUserId(req);
+    if (!callerId) {
+      res
+        .status(401)
+        .json({error: 'Request carries no verified caller identity'});
+      return {allowed: false};
+    }
+
+    if (requestedUserId !== undefined && requestedUserId !== callerId) {
+      this.logger.warn(
+        `Refused ${req.method} ${req.originalUrl}: the authenticated caller may not act as another user`,
+      );
+      res
+        .status(403)
+        .json({error: 'userId does not match the authenticated caller'});
+      return {allowed: false};
+    }
+
+    // A request that named nobody still runs as the caller, never as a
+    // fallback identity that a second caller could also reach.
+    return {allowed: true, userId: callerId};
+  }
+
+  /**
+   * Rejects requests that ask to act as a user other than the caller, before
+   * any handler reads `userId`.
+   *
+   * The session, artifact and event endpoints carry `userId` in the path, so
+   * the check is mounted on their shared prefix. `/run` and `/run_sse` carry
+   * it in the JSON body, so those are matched by path and read from the body
+   * that `express.json()` has already parsed. `/api/reasoning_engine` accepts
+   * an unparsed body and is checked inside its own handler instead.
+   */
+  private mountUserIdentityChecks(app: express.Application) {
+    app.use(
+      '/apps/:appName/users/:userId',
+      (req: Request, res: Response, next: express.NextFunction) => {
+        if (this.authorizeUserId(req, res, req.params['userId']).allowed) {
+          next();
+        }
+      },
+    );
+
+    app.use(
+      ['/run', '/run_sse'],
+      (req: Request, res: Response, next: express.NextFunction) => {
+        const body = req.body as {userId?: string} | undefined;
+        const {allowed, userId} = this.authorizeUserId(req, res, body?.userId);
+        if (!allowed) {
+          return;
+        }
+
+        // Pin the body to the verified identity so a handler that reads
+        // `req.body.userId` cannot see an absent or stale value.
+        if (body && userId !== undefined) {
+          body.userId = userId;
+        }
+        next();
+      },
+    );
   }
 
   private async init() {
@@ -263,6 +406,8 @@ export class AdkApiServer {
       this.logger.info(`${req.method} ${req.originalUrl}`);
       next();
     });
+
+    this.mountUserIdentityChecks(app);
 
     app.get('/list-apps', async (req: Request, res: Response) => {
       try {
@@ -937,7 +1082,15 @@ export class AdkApiServer {
       const executeQuery = async (body: any) => {
         const input = body.input || {};
         const appName = input.appName || body.appName;
-        const userId = input.userId || body.userId || 'default-user';
+        const authorized = this.authorizeUserId(
+          req,
+          res,
+          input.userId || body.userId || undefined,
+        );
+        if (!authorized.allowed) {
+          return;
+        }
+        const userId = authorized.userId || 'default-user';
         const sessionId =
           input.sessionId || body.sessionId || 'default-session';
         const newMessage = input.newMessage || body.newMessage;
@@ -1077,8 +1230,29 @@ export class AdkApiServer {
     });
   }
 
+  /**
+   * Warns when the server is reachable beyond this machine and still trusts
+   * the `userId` the client sends. `adk deploy` binds to `0.0.0.0`, so this
+   * fires exactly on the deployments where a second user can reach the API.
+   */
+  private warnIfUserIdIsUnverified() {
+    const loopbackHosts = ['localhost', '127.0.0.1', '::1'];
+    if (this.resolveUserId || loopbackHosts.includes(this.host)) {
+      return;
+    }
+
+    this.logger.warn(
+      `Serving on ${this.host} without caller identity enforcement. Sessions ` +
+        `are separated only by the userId each request sends, so any caller ` +
+        `that reaches this server can read, run as, or delete another user's ` +
+        `sessions. Set ${ENFORCE_USER_IDENTITY_ENV_VAR} when deploying behind ` +
+        `Identity-Aware Proxy, or pass a resolveUserId resolver.`,
+    );
+  }
+
   async start(): Promise<void> {
     await this.init();
+    this.warnIfUserIdIsUnverified();
 
     return new Promise((resolve, reject) => {
       this.server = this.app.listen(this.port, this.host, async () => {

--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -63,6 +63,15 @@ export const A2A_AUTH_TOKEN_ENV_VAR = 'ADK_A2A_AUTH_TOKEN';
  * Environment variable that turns on caller identity enforcement using the
  * built-in {@link iapUserIdResolver}, for operators who deploy behind
  * Identity-Aware Proxy and do not construct the server themselves.
+ *
+ * Setting this asserts that Identity-Aware Proxy terminates authentication in
+ * front of this server. It does not establish that, and it cannot check it:
+ * the resolver reads a request header, which is trustworthy only because IAP
+ * overwrites it. On a deployment IAP does not front, setting this provides no
+ * protection at all -- a client simply sends the header itself -- while the
+ * server stops warning and starts answering `401` and `403`, so every signal
+ * an operator would read says "protected". Deployments that terminate identity
+ * some other way should pass their own {@link UserIdResolver} instead.
  */
 export const ENFORCE_USER_IDENTITY_ENV_VAR = 'ADK_ENFORCE_USER_IDENTITY';
 
@@ -73,6 +82,13 @@ export const ENFORCE_USER_IDENTITY_ENV_VAR = 'ADK_ENFORCE_USER_IDENTITY';
  */
 export const IAP_AUTHENTICATED_USER_EMAIL_HEADER =
   'x-goog-authenticated-user-email';
+
+/**
+ * Header carrying the signed assertion Identity-Aware Proxy attaches to every
+ * request it forwards. {@link iapUserIdResolver} checks only that it is
+ * present, never its signature.
+ */
+export const IAP_JWT_ASSERTION_HEADER = 'x-goog-iap-jwt-assertion';
 
 /**
  * Derives the caller's identity from a request whose credentials the front
@@ -90,10 +106,39 @@ export type UserIdResolver = (req: Request) => string | undefined;
  * Reads the caller's email from the Identity-Aware Proxy header. IAP verifies
  * the caller before the request reaches the container and overwrites this
  * header on every request, so a client cannot set it.
+ *
+ * This is only sound where IAP genuinely fronts the server. The two shape
+ * checks below narrow what an unfronted deployment gives away, but nothing
+ * here verifies a signature, so they do not make the resolver safe to use
+ * without IAP.
+ *
+ * Identity is compared exactly, letter case included, so a caller IAP reports
+ * as `Alice@example.com` may not act as `alice@example.com`. That is the
+ * fail-closed direction and deliberate: a resolver may return an opaque
+ * subject id where case is meaningful, so the comparison cannot assume email
+ * semantics.
  */
 export function iapUserIdResolver(req: Request): string | undefined {
   const header = req.get(IAP_AUTHENTICATED_USER_EMAIL_HEADER);
   if (!header) {
+    return undefined;
+  }
+
+  // IAP sets exactly one value and overwrites whatever the client sent. Node
+  // joins duplicate headers with `, ` before this reads them, so more than one
+  // value means something in front appended instead of replacing, and there is
+  // no way to tell which value it vouched for. An address cannot contain a
+  // comma unquoted, so this rejects nothing IAP would have produced.
+  if (header.includes(',')) {
+    return undefined;
+  }
+
+  // IAP attaches a signed assertion to every request it forwards. Requiring it
+  // to be present costs nothing and catches a client that reached the server
+  // directly and set only the email header. It is not verification: a caller
+  // who knows to send this header too still gets past it, which is why the
+  // header is trustworthy only when IAP actually fronts the deployment.
+  if (!req.get(IAP_JWT_ASSERTION_HEADER)) {
     return undefined;
   }
 
@@ -183,6 +228,7 @@ export class AdkApiServer {
   private readonly a2a: boolean;
   private readonly a2aAuthToken?: string;
   private readonly resolveUserId?: UserIdResolver;
+  private readonly identityEnforcedFromEnv: boolean;
 
   constructor(options: ServerOptions) {
     this.host = options.host ?? 'localhost';
@@ -222,11 +268,11 @@ export class AdkApiServer {
       options.a2aAuthToken || process.env[A2A_AUTH_TOKEN_ENV_VAR] || undefined;
     // An explicit resolver wins. Otherwise the environment variable opts a
     // deployment into the Identity-Aware Proxy header without needing code.
+    this.identityEnforcedFromEnv =
+      !options.resolveUserId && !!process.env[ENFORCE_USER_IDENTITY_ENV_VAR];
     this.resolveUserId =
       options.resolveUserId ??
-      (process.env[ENFORCE_USER_IDENTITY_ENV_VAR]
-        ? iapUserIdResolver
-        : undefined);
+      (this.identityEnforcedFromEnv ? iapUserIdResolver : undefined);
     this.app = express();
   }
 
@@ -304,12 +350,18 @@ export class AdkApiServer {
     }
 
     if (requestedUserId !== undefined && requestedUserId !== callerId) {
+      // Naming the compared values would put an identity the caller does not
+      // own into a log an operator may share, so the log says which caller was
+      // refused and leaves the requested id to the access log.
       this.logger.warn(
-        `Refused ${req.method} ${req.originalUrl}: the authenticated caller may not act as another user`,
+        `Refused ${req.method} ${req.originalUrl}: the authenticated caller ` +
+          `may not act as another user. Identities are compared exactly, so a ` +
+          `userId differing only in letter case is refused here too.`,
       );
-      res
-        .status(403)
-        .json({error: 'userId does not match the authenticated caller'});
+      res.status(403).json({
+        error:
+          'userId does not match the authenticated caller (compared exactly, including letter case)',
+      });
       return {allowed: false};
     }
 
@@ -355,6 +407,115 @@ export class AdkApiServer {
         next();
       },
     );
+  }
+
+  /**
+   * Finds the session a recorded trace belongs to.
+   *
+   * `call_llm` spans register their trace id against the session they ran in,
+   * and every other span of the same invocation shares that trace id, so a
+   * tool span reached by event id resolves through the same map. A trace with
+   * no `call_llm` span has no session recorded and resolves to `undefined`,
+   * which the caller treats as unattributable rather than as public.
+   */
+  private findSessionIdForTrace(traceId?: string): string | undefined {
+    if (!traceId) {
+      return undefined;
+    }
+
+    for (const [sessionId, traceIds] of Object.entries(this.sessionTraceDict)) {
+      if (traceIds.includes(traceId)) {
+        return sessionId;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Resolves the caller for a request to the trace stores, answering `401`
+   * when enforcement is on and the request carries no identity.
+   *
+   * This runs before the store is read so that an unidentified caller cannot
+   * tell an event id that exists from one that does not, and so the trace
+   * routes answer the same `401` as every other enforced route. A `callerId`
+   * of `undefined` on an allowed result means no resolver is configured and
+   * the historical behaviour applies.
+   */
+  private resolveTraceCaller(
+    req: Request,
+    res: Response,
+  ): {allowed: boolean; callerId?: string} {
+    if (!this.resolveUserId) {
+      return {allowed: true};
+    }
+
+    const callerId = this.resolveUserId(req);
+    if (!callerId) {
+      res
+        .status(401)
+        .json({error: 'Request carries no verified caller identity'});
+      return {allowed: false};
+    }
+
+    return {allowed: true, callerId};
+  }
+
+  /**
+   * Reports whether a session belongs to the caller.
+   *
+   * The trace stores hold every user's spans in one process and are keyed by
+   * session and event id alone, so there is no `userId` in the path to compare
+   * against. Ownership is established by reading the session back as the
+   * caller: a session the caller does not own is not returned to them, so a
+   * miss is a refusal. When the route carries no app name the loaded apps are
+   * tried in turn, since these routes are mounted both with and without an app
+   * prefix.
+   */
+  private async callerOwnsSession(
+    req: Request,
+    callerId: string,
+    sessionId: string | undefined,
+  ): Promise<boolean> {
+    if (!sessionId) {
+      return false;
+    }
+
+    const appName = req.params['appName'];
+    const appNames = appName ? [appName] : await this.agentLoader.listAgents();
+
+    for (const candidate of appNames) {
+      // A session service that rejects an unknown app should not decide the
+      // whole lookup, so a throw is treated as "not this app" and the
+      // remaining candidates still get their turn.
+      const session = await this.sessionService
+        .getSession({appName: candidate, userId: callerId, sessionId})
+        .catch(() => undefined);
+      if (session) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Refuses a trace the caller cannot be shown to own.
+   *
+   * A trace whose session cannot be resolved is refused rather than served,
+   * which costs the owner their traces once the session is deleted. That is
+   * the right way round for a store that answers with the prompts, model
+   * responses and tool arguments of a conversation.
+   */
+  private refuseTrace(req: Request, res: Response) {
+    this.logger.warn(
+      `Refused ${req.method} ${req.originalUrl}: traces are served only to ` +
+        `the owner of the session they belong to`,
+    );
+
+    return res
+      .status(403)
+      .json({error: 'Traces are served only to the session owner'});
   }
 
   private async init() {
@@ -429,13 +590,29 @@ export class AdkApiServer {
     // UI's path is not needed to answer.
     app.get(
       ['/debug/trace/:eventId', '/dev/apps/:appName/debug/trace/:eventId'],
-      (req: Request, res: Response) => {
+      async (req: Request, res: Response) => {
         try {
+          const {allowed, callerId} = this.resolveTraceCaller(req, res);
+          if (!allowed) {
+            return;
+          }
+
           const eventId = req.params['eventId'];
           const eventDict = this.traceDict[eventId];
 
           if (!eventDict) {
             return res.status(404).json({error: 'Trace not found'});
+          }
+
+          if (callerId) {
+            // The stored attributes carry the trace id, which is what ties
+            // this event back to a session and so to an owner.
+            const sessionId = this.findSessionIdForTrace(
+              eventDict['trace_id'] as string | undefined,
+            );
+            if (!(await this.callerOwnsSession(req, callerId, sessionId))) {
+              return this.refuseTrace(req, res);
+            }
           }
 
           return res.json(eventDict);
@@ -455,9 +632,21 @@ export class AdkApiServer {
         '/debug/trace/session/:sessionId',
         '/dev/apps/:appName/debug/trace/session/:sessionId',
       ],
-      (req: Request, res: Response) => {
+      async (req: Request, res: Response) => {
         try {
+          const {allowed, callerId} = this.resolveTraceCaller(req, res);
+          if (!allowed) {
+            return;
+          }
+
           const sessionId = req.params['sessionId'];
+          if (
+            callerId &&
+            !(await this.callerOwnsSession(req, callerId, sessionId))
+          ) {
+            return this.refuseTrace(req, res);
+          }
+
           const spans = this.memoryExporter.getFinishedSpans(sessionId);
           if (spans.length === 0) {
             return res.json([]);
@@ -968,6 +1157,11 @@ export class AdkApiServer {
     app.post(
       '/apps/:appName/eval_sets/:evalSetId/add_session',
       (req: Request, res: Response) => {
+        // When this lands it will take a `userId` and `sessionId` in its body,
+        // and it sits outside every prefix `mountUserIdentityChecks` covers, so
+        // it must run its own `authorizeUserId` on the body's `userId` before
+        // reading the named session. The eval routes under this prefix are the
+        // only place left where a `userId` arrives unchecked.
         return res.status(501).json({error: 'Not implemented'});
       },
     );
@@ -1250,9 +1444,34 @@ export class AdkApiServer {
     );
   }
 
+  /**
+   * Reports that enforcement rests on a header, on the path that can be turned
+   * on without writing any code.
+   *
+   * An embedder passing an explicit resolver has already decided where
+   * identity comes from. The environment variable has no such step, so the
+   * assumption it makes is stated once at startup rather than left to whoever
+   * later reads a `401` and concludes the server is protected.
+   */
+  private warnIfIdentityIsAssumedFromEnv() {
+    if (!this.identityEnforcedFromEnv) {
+      return;
+    }
+
+    this.logger.warn(
+      `${ENFORCE_USER_IDENTITY_ENV_VAR} is set, so callers are identified ` +
+        `from the ${IAP_AUTHENTICATED_USER_EMAIL_HEADER} header. That header ` +
+        `is only trustworthy where Identity-Aware Proxy fronts this server ` +
+        `and overwrites it; reached directly, any client can send it and be ` +
+        `any user. Pass a resolveUserId resolver if identity is terminated ` +
+        `some other way.`,
+    );
+  }
+
   async start(): Promise<void> {
     await this.init();
     this.warnIfUserIdIsUnverified();
+    this.warnIfIdentityIsAssumedFromEnv();
 
     return new Promise((resolve, reject) => {
       this.server = this.app.listen(this.port, this.host, async () => {

--- a/dev/test/index_test.ts
+++ b/dev/test/index_test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+
+import * as devPackage from '../src/index.js';
+import {
+  ENFORCE_USER_IDENTITY_ENV_VAR,
+  IAP_AUTHENTICATED_USER_EMAIL_HEADER,
+  IAP_JWT_ASSERTION_HEADER,
+  iapUserIdResolver,
+} from '../src/server/adk_api_server.js';
+
+describe('package surface', () => {
+  // The identity enforcement hook is only usable by an embedder if it reaches
+  // the package entry point. Exporting it from the module alone leaves
+  // `resolveUserId` reachable only through a deep import of an internal path.
+  it('exposes the caller identity extension point', () => {
+    expect(devPackage.iapUserIdResolver).toBe(iapUserIdResolver);
+    expect(devPackage.ENFORCE_USER_IDENTITY_ENV_VAR).toBe(
+      ENFORCE_USER_IDENTITY_ENV_VAR,
+    );
+    expect(devPackage.IAP_AUTHENTICATED_USER_EMAIL_HEADER).toBe(
+      IAP_AUTHENTICATED_USER_EMAIL_HEADER,
+    );
+    expect(devPackage.IAP_JWT_ASSERTION_HEADER).toBe(IAP_JWT_ASSERTION_HEADER);
+  });
+
+  it('exposes the server and client it has always exported', () => {
+    expect(devPackage.AdkApiServer).toBeTypeOf('function');
+    expect(devPackage.AdkApiClient).toBeTypeOf('function');
+  });
+});

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -31,6 +31,8 @@ import {
   A2A_AUTH_TOKEN_ENV_VAR,
   AdkApiServer,
   ENFORCE_USER_IDENTITY_ENV_VAR,
+  IAP_AUTHENTICATED_USER_EMAIL_HEADER,
+  IAP_JWT_ASSERTION_HEADER,
   iapUserIdResolver,
 } from '../../src/server/adk_api_server.js';
 import {AgentLoader} from '../../src/utils/agent_loader.js';
@@ -1610,6 +1612,7 @@ describe('AdkWebServer', () => {
     const CALLER = 'caller@example.com';
     const VICTIM = 'victim@example.com';
     const IAP_HEADER = 'X-Goog-Authenticated-User-Email';
+    const IAP_ASSERTION = 'X-Goog-Iap-Jwt-Assertion';
 
     let identityServer: AdkApiServer | undefined;
 
@@ -1637,13 +1640,27 @@ describe('AdkWebServer', () => {
         method = 'GET',
         caller,
         body,
-      }: {method?: string; caller?: string; body?: unknown} = {},
+        headers = {},
+      }: {
+        method?: string;
+        caller?: string;
+        body?: unknown;
+        headers?: Record<string, string>;
+      } = {},
     ) => {
       const response = await fetch(`${baseUrl}${path}`, {
         method,
         headers: {
           ...(body ? {'Content-Type': 'application/json'} : {}),
-          ...(caller ? {[IAP_HEADER]: `accounts.google.com:${caller}`} : {}),
+          // IAP attaches the signed assertion to everything it forwards, so a
+          // caller these cases treat as authenticated carries both headers.
+          ...(caller
+            ? {
+                [IAP_HEADER]: `accounts.google.com:${caller}`,
+                [IAP_ASSERTION]: 'signed.assertion.stub',
+              }
+            : {}),
+          ...headers,
         },
         body: body ? JSON.stringify(body) : undefined,
       });
@@ -1662,12 +1679,17 @@ describe('AdkWebServer', () => {
     });
 
     describe('iapUserIdResolver', () => {
-      const resolverFor = (header?: string) =>
+      const resolverFor = (header?: string, withAssertion = true) =>
         iapUserIdResolver({
-          get: (name: string) =>
-            name.toLowerCase() === IAP_HEADER.toLowerCase()
-              ? header
-              : undefined,
+          get: (name: string) => {
+            const wanted = name.toLowerCase();
+            if (wanted === IAP_AUTHENTICATED_USER_EMAIL_HEADER) {
+              return header;
+            }
+            return wanted === IAP_JWT_ASSERTION_HEADER && withAssertion
+              ? 'signed.assertion.stub'
+              : undefined;
+          },
         } as unknown as Parameters<typeof iapUserIdResolver>[0]);
 
       it('reads the email out of the provider-prefixed header', () => {
@@ -1682,6 +1704,54 @@ describe('AdkWebServer', () => {
         expect(resolverFor(undefined)).toBeUndefined();
         expect(resolverFor('accounts.google.com:')).toBeUndefined();
       });
+
+      it('reports no identity when the header carries more than one value', () => {
+        // Node joins duplicate headers with `, `. IAP overwrites rather than
+        // appends, so two values mean something else in front appended and
+        // there is no way to tell which one it vouched for. Taking the last
+        // would hand the request to whoever appended.
+        expect(
+          resolverFor(
+            `accounts.google.com:${VICTIM}, accounts.google.com:${CALLER}`,
+          ),
+        ).toBeUndefined();
+      });
+
+      it('reports no identity when the IAP assertion is missing', () => {
+        expect(
+          resolverFor(`accounts.google.com:${CALLER}`, false),
+        ).toBeUndefined();
+      });
+    });
+
+    it('refuses a caller whose IAP header carries a second appended value', async () => {
+      const baseUrl = await startIdentityServer();
+
+      const response = await request(
+        baseUrl,
+        `/apps/testApp/users/${CALLER}/sessions`,
+        {
+          caller: VICTIM,
+          headers: {
+            [IAP_HEADER]: `accounts.google.com:${VICTIM}, accounts.google.com:${CALLER}`,
+          },
+        },
+      );
+
+      // The appended value does not win: the request is refused outright
+      // rather than served as the caller named last.
+      expect(response.status).toBe(401);
+    });
+
+    it('refuses a caller that sends the email header without the IAP assertion', async () => {
+      const baseUrl = await startIdentityServer();
+
+      const response = await fetch(
+        `${baseUrl}/apps/testApp/users/${CALLER}/sessions`,
+        {headers: {[IAP_HEADER]: `accounts.google.com:${CALLER}`}},
+      );
+
+      expect(response.status).toBe(401);
     });
 
     it('leaves userId unchecked when no resolver is configured', async () => {
@@ -1838,6 +1908,183 @@ describe('AdkWebServer', () => {
       });
 
       expect(response.status).toBe(403);
+    });
+
+    describe('Trace endpoints', () => {
+      // The trace stores carry `llm_request`, `llm_response`, `tool_call_args`
+      // and `tool_response` for every session in the process and are keyed by
+      // session and event id alone, so they need the same ownership check as
+      // the routes that name a user in the path.
+      const OWNED_SESSION = 'ownedTraceSession';
+      const VICTIM_SESSION = 'victimTraceSession';
+      const TRACE_ID = 'trace-of-the-victims-session';
+      const EVENT_ID = 'event-in-the-victims-session';
+
+      /**
+       * Writes into the exporters' stores directly. Traces are recorded from
+       * span export, which needs a model call the test agent does not make, so
+       * the stores are seeded to exercise the lookup these routes perform.
+       */
+      const seedTrace = (
+        target: AdkApiServer,
+        {sessionId, traceId}: {sessionId: string; traceId: string},
+      ) => {
+        const stores = target as unknown as {
+          traceDict: Record<string, Record<string, unknown>>;
+          sessionTraceDict: Record<string, string[]>;
+        };
+        stores.traceDict[EVENT_ID] = {
+          trace_id: traceId,
+          'gcp.vertex.agent.llm_request': '{"contents":"the victim prompt"}',
+          'gcp.vertex.agent.tool_response': '{"result":"the victim secret"}',
+        };
+        stores.sessionTraceDict[sessionId] = [traceId];
+      };
+
+      beforeEach(async () => {
+        await sessionService.createSession({
+          appName: 'testApp',
+          userId: CALLER,
+          sessionId: OWNED_SESSION,
+        });
+        await sessionService.createSession({
+          appName: 'testApp',
+          userId: VICTIM,
+          sessionId: VICTIM_SESSION,
+        });
+      });
+
+      it('serves session traces unchecked when no resolver is configured', async () => {
+        const response = await client.get(
+          `/debug/trace/session/${VICTIM_SESSION}`,
+        );
+
+        expect(response.status).toBe(200);
+      });
+
+      it('refuses session traces to a request with no caller identity', async () => {
+        const baseUrl = await startIdentityServer();
+
+        const response = await request(
+          baseUrl,
+          `/debug/trace/session/${VICTIM_SESSION}`,
+        );
+
+        expect(response.status).toBe(401);
+      });
+
+      it("refuses another user's session traces", async () => {
+        const baseUrl = await startIdentityServer();
+
+        const response = await request(
+          baseUrl,
+          `/debug/trace/session/${VICTIM_SESSION}`,
+          {caller: CALLER},
+        );
+
+        expect(response.status).toBe(403);
+      });
+
+      it("refuses another user's session traces under the app-prefixed route", async () => {
+        // The dev UI asks under `/dev/apps/<app>/`, which is a separate mount
+        // of the same store and so needs the same refusal.
+        const baseUrl = await startIdentityServer();
+
+        const response = await request(
+          baseUrl,
+          `/dev/apps/testApp/debug/trace/session/${VICTIM_SESSION}`,
+          {caller: CALLER},
+        );
+
+        expect(response.status).toBe(403);
+      });
+
+      it('serves a caller the traces of their own session', async () => {
+        const baseUrl = await startIdentityServer();
+
+        const response = await request(
+          baseUrl,
+          `/debug/trace/session/${OWNED_SESSION}`,
+          {caller: CALLER},
+        );
+
+        expect(response.status).toBe(200);
+      });
+
+      it('refuses an event trace to a request with no caller identity', async () => {
+        const baseUrl = await startIdentityServer();
+        seedTrace(identityServer!, {
+          sessionId: VICTIM_SESSION,
+          traceId: TRACE_ID,
+        });
+
+        const response = await request(baseUrl, `/debug/trace/${EVENT_ID}`);
+
+        // 401 rather than the handler's 404, so an unidentified caller cannot
+        // tell an event id that exists from one that does not.
+        expect(response.status).toBe(401);
+      });
+
+      it("refuses an event trace belonging to another user's session", async () => {
+        const baseUrl = await startIdentityServer();
+        seedTrace(identityServer!, {
+          sessionId: VICTIM_SESSION,
+          traceId: TRACE_ID,
+        });
+
+        const response = await request(baseUrl, `/debug/trace/${EVENT_ID}`, {
+          caller: CALLER,
+        });
+
+        expect(response.status).toBe(403);
+        expect(JSON.stringify(response.body)).not.toContain('victim secret');
+      });
+
+      it('refuses an event trace that cannot be tied back to a session', async () => {
+        const baseUrl = await startIdentityServer();
+        // A trace whose session was never recorded has no owner to check
+        // against, so it is refused rather than served.
+        seedTrace(identityServer!, {
+          sessionId: VICTIM_SESSION,
+          traceId: TRACE_ID,
+        });
+        (
+          identityServer as unknown as {
+            sessionTraceDict: Record<string, string[]>;
+          }
+        ).sessionTraceDict[VICTIM_SESSION] = [];
+
+        const response = await request(baseUrl, `/debug/trace/${EVENT_ID}`, {
+          caller: CALLER,
+        });
+
+        expect(response.status).toBe(403);
+      });
+
+      it('serves a caller an event trace from their own session', async () => {
+        const baseUrl = await startIdentityServer();
+        seedTrace(identityServer!, {
+          sessionId: OWNED_SESSION,
+          traceId: TRACE_ID,
+        });
+
+        const response = await request(baseUrl, `/debug/trace/${EVENT_ID}`, {
+          caller: CALLER,
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.body?.['trace_id']).toBe(TRACE_ID);
+      });
+
+      it('still reports an unknown event as not found to an identified caller', async () => {
+        const baseUrl = await startIdentityServer();
+
+        const response = await request(baseUrl, '/debug/trace/no-such-event', {
+          caller: CALLER,
+        });
+
+        expect(response.status).toBe(404);
+      });
     });
   });
 });

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -30,6 +30,8 @@ import {z} from 'zod';
 import {
   A2A_AUTH_TOKEN_ENV_VAR,
   AdkApiServer,
+  ENFORCE_USER_IDENTITY_ENV_VAR,
+  iapUserIdResolver,
 } from '../../src/server/adk_api_server.js';
 import {AgentLoader} from '../../src/utils/agent_loader.js';
 import {version} from '../../src/version.js';
@@ -1601,6 +1603,241 @@ describe('AdkWebServer', () => {
         const response = await fetch(`${server.url}/debug/trace/${eventId}`);
         expect(response.status).toBe(404);
       }
+    });
+  });
+
+  describe('Caller identity enforcement', () => {
+    const CALLER = 'caller@example.com';
+    const VICTIM = 'victim@example.com';
+    const IAP_HEADER = 'X-Goog-Authenticated-User-Email';
+
+    let identityServer: AdkApiServer | undefined;
+
+    /**
+     * Starts a second server that derives the caller from the IAP header, so
+     * these cases exercise the enforced configuration without disturbing the
+     * unauthenticated server the rest of the suite uses.
+     */
+    const startIdentityServer = async () => {
+      identityServer = new AdkApiServer({
+        agentLoader,
+        sessionService,
+        memoryService,
+        artifactService,
+        resolveUserId: iapUserIdResolver,
+      });
+      await identityServer.start();
+      return identityServer.url;
+    };
+
+    const request = async (
+      baseUrl: string,
+      path: string,
+      {
+        method = 'GET',
+        caller,
+        body,
+      }: {method?: string; caller?: string; body?: unknown} = {},
+    ) => {
+      const response = await fetch(`${baseUrl}${path}`, {
+        method,
+        headers: {
+          ...(body ? {'Content-Type': 'application/json'} : {}),
+          ...(caller ? {[IAP_HEADER]: `accounts.google.com:${caller}`} : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      return {
+        status: response.status,
+        body: (await response.json().catch(() => undefined)) as
+          | Record<string, unknown>
+          | undefined,
+      };
+    };
+
+    afterEach(async () => {
+      await identityServer?.stop();
+      identityServer = undefined;
+      vi.unstubAllEnvs();
+    });
+
+    describe('iapUserIdResolver', () => {
+      const resolverFor = (header?: string) =>
+        iapUserIdResolver({
+          get: (name: string) =>
+            name.toLowerCase() === IAP_HEADER.toLowerCase()
+              ? header
+              : undefined,
+        } as unknown as Parameters<typeof iapUserIdResolver>[0]);
+
+      it('reads the email out of the provider-prefixed header', () => {
+        expect(resolverFor(`accounts.google.com:${CALLER}`)).toBe(CALLER);
+      });
+
+      it('accepts a header carrying a bare email', () => {
+        expect(resolverFor(CALLER)).toBe(CALLER);
+      });
+
+      it('reports no identity when the header is absent or empty', () => {
+        expect(resolverFor(undefined)).toBeUndefined();
+        expect(resolverFor('accounts.google.com:')).toBeUndefined();
+      });
+    });
+
+    it('leaves userId unchecked when no resolver is configured', async () => {
+      // The default server is the historical behaviour, kept so a single-user
+      // local run does not need an identity provider.
+      const response = await client.get<{sessions: Session[]}>(
+        `/apps/testApp/users/${VICTIM}/sessions`,
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('turns on the IAP resolver from the environment', async () => {
+      vi.stubEnv(ENFORCE_USER_IDENTITY_ENV_VAR, '1');
+      const envServer = new AdkApiServer({
+        agentLoader,
+        sessionService,
+        memoryService,
+        artifactService,
+      });
+      await envServer.start();
+
+      try {
+        const response = await request(
+          envServer.url,
+          `/apps/testApp/users/${VICTIM}/sessions`,
+        );
+        expect(response.status).toBe(401);
+      } finally {
+        await envServer.stop();
+      }
+    });
+
+    it('rejects a request that carries no caller identity', async () => {
+      const baseUrl = await startIdentityServer();
+
+      const response = await request(
+        baseUrl,
+        `/apps/testApp/users/${CALLER}/sessions`,
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('serves a caller asking for their own sessions', async () => {
+      const baseUrl = await startIdentityServer();
+
+      const response = await request(
+        baseUrl,
+        `/apps/testApp/users/${CALLER}/sessions`,
+        {caller: CALLER},
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it("refuses to read another user's sessions", async () => {
+      const baseUrl = await startIdentityServer();
+
+      const response = await request(
+        baseUrl,
+        `/apps/testApp/users/${VICTIM}/sessions`,
+        {caller: CALLER},
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("refuses to delete another user's session and leaves it in place", async () => {
+      const baseUrl = await startIdentityServer();
+      await sessionService.createSession({
+        appName: 'testApp',
+        userId: VICTIM,
+        sessionId: 'victimSession',
+      });
+
+      const response = await request(
+        baseUrl,
+        `/apps/testApp/users/${VICTIM}/sessions/victimSession`,
+        {method: 'DELETE', caller: CALLER},
+      );
+
+      expect(response.status).toBe(403);
+      // The session the caller tried to remove is still there, so the refusal
+      // happened before the delete rather than alongside it.
+      await expect(
+        sessionService.getSession({
+          appName: 'testApp',
+          userId: VICTIM,
+          sessionId: 'victimSession',
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('refuses a /run body naming another user', async () => {
+      const baseUrl = await startIdentityServer();
+      await sessionService.createSession({
+        appName: 'testApp',
+        userId: VICTIM,
+        sessionId: 'victimRunSession',
+      });
+
+      const response = await request(baseUrl, '/run', {
+        method: 'POST',
+        caller: CALLER,
+        body: {
+          appName: 'testApp',
+          userId: VICTIM,
+          sessionId: 'victimRunSession',
+          newMessage: {role: 'user', parts: [{text: 'dump the history'}]},
+        },
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    it('runs a /run body that omits userId as the caller', async () => {
+      const baseUrl = await startIdentityServer();
+      await sessionService.createSession({
+        appName: 'testApp',
+        userId: CALLER,
+        sessionId: 'callerRunSession',
+      });
+
+      const response = await request(baseUrl, '/run', {
+        method: 'POST',
+        caller: CALLER,
+        body: {
+          appName: 'testApp',
+          sessionId: 'callerRunSession',
+          newMessage: {role: 'user', parts: [{text: 'hello'}]},
+        },
+      });
+
+      // A body with no userId is pinned to the caller, so the run finds the
+      // caller's session instead of falling back to a shared identity.
+      expect(response.status).toBe(200);
+    });
+
+    it('refuses a reasoning_engine query naming another user', async () => {
+      const baseUrl = await startIdentityServer();
+
+      const response = await request(baseUrl, '/api/reasoning_engine', {
+        method: 'POST',
+        caller: CALLER,
+        body: {
+          input: {
+            appName: 'testApp',
+            userId: VICTIM,
+            sessionId: 'victimEngineSession',
+            newMessage: {role: 'user', parts: [{text: 'dump the history'}]},
+          },
+        },
+      });
+
+      expect(response.status).toBe(403);
     });
   });
 });


### PR DESCRIPTION
### Link to Issue or Description of Change

**Description of change:**

Reported to Google as issue **523194529** (OSS VRP). That report covered two bugs. The `deleteSession` half was fixed in #492. This change is the other half.

**Problem:**

The API server takes `userId` straight from the request and hands it to the session service, with nothing tying it to the caller.

- `/run` and `/run_sse` read it from the body: `const {appName, userId, sessionId, newMessage, stateDelta} = req.body;`
- Every session, artifact and event endpoint reads it from the path: `req.params['userId']`
- `/api/reasoning_engine` reads `input.userId || body.userId || 'default-user'`

On a deployment serving more than one user, any caller who can reach the server can name somebody else and read their session history, run an agent against it, or delete it.

The ownership check in `getSession` does not help here. It compares the stored `userId` against the `userId` the same caller supplied, so a caller who controls both sides of that comparison always passes it. The same is true of the check #492 added to `deleteSession`. Listing is not a barrier either: `GET /apps/:appName/users/:userId/sessions` returns every session for whatever `userId` is asked for, so session ids are enumerated rather than guessed.

This is not limited to local use. `cli_deploy_cloud_run.ts` and `cli_deploy_agent_engine.ts` both call `createDockerFile`, and `deploy_utils.ts` sets the container command to `adk web` or `adk api_server`, which start this server.

**Solution:**

Add an optional `resolveUserId` resolver that derives the caller from material the front door has already verified, and enforce that the request's `userId` matches it.

- `UserIdResolver` is the extension point, with `iapUserIdResolver` built in for the `X-Goog-Authenticated-User-Email` header that Identity-Aware Proxy sets and overwrites on every request.
- `ADK_ENFORCE_USER_IDENTITY` selects the built-in resolver, so a deployment can turn this on through the environment without changing the generated Dockerfile or constructing the server itself.
- With a resolver configured, a request carrying no caller identity is answered `401` and a request naming another user is answered `403`, both before the session service is reached.
- A `/run` body that omits `userId` runs as the caller instead of falling back to an identity a second caller could also reach.
- The check is mounted on the shared `/apps/:appName/users/:userId` prefix, on `/run` and `/run_sse`, and inside `/api/reasoning_engine`, which parses its own body and so cannot be covered by middleware.
- The `/debug/trace` routes are covered too. They take no `userId`, so ownership is established by reading the session back as the caller: a session the caller does not own is not returned to them, so a miss is a refusal. An event id resolves to its session through the trace id the exporter already records, which covers tool spans as well as `call_llm` spans. Identity is resolved before the store is read, so an unidentified caller gets `401` rather than a `404` that distinguishes an event id that exists from one that does not.
- `UserIdResolver`, `iapUserIdResolver`, `ENFORCE_USER_IDENTITY_ENV_VAR`, `IAP_AUTHENTICATED_USER_EMAIL_HEADER` and `IAP_JWT_ASSERTION_HEADER` are exported from `dev/src/index.ts`, so passing your own resolver does not need a deep import of an internal path.

`iapUserIdResolver` fails closed on two request shapes IAP does not produce. A header carrying more than one value is refused rather than resolved to the last one, because Node joins duplicates with `", "` and IAP overwrites instead of appending, so a second value means something else in front appended and the vouched-for value cannot be identified. The `x-goog-iap-jwt-assertion` header must also be present; that is not verification and is not treated as any, but IAP attaches it to everything it forwards and a client reaching the server directly usually sets only the email header.

Identity is compared exactly, letter case included. A resolver may return an opaque subject id where case is meaningful, so the comparison cannot assume email semantics. The `403` and its log line say that letter case counts, so a mismatch reads as a mismatch rather than as an attack.

Deliberately kept out of scope: no JWT signature verification. A resolver should only read what the front door guarantees, and shipping a half-verified token decoder in the framework would invite exactly the trust the bug is about. Deployments that terminate identity differently can pass their own resolver.

**Relationship to adk-python:**

This is a deliberate divergence, not a port. `adk-python` has no equivalent feature: `api_server.py` reads `user_id` off the path with no `Depends(...)` auth on any route, and its docstring documents the exposure away as the operator's job. `UserIdResolver` and `ADK_ENFORCE_USER_IDENTITY` are being invented here, so if Python later grows an equivalent these are the shapes that have to be reconciled.

To answer the question directly: the `adk-python` instance is not unreported. It was reported to Google's OSS VRP separately from 523194529, and I am happy to supply the reference to whoever wants to pick it up on the Python side. I have no view on which runtime's answer should win — that is the product decision this PR is asking the maintainers to make deliberately rather than by merging a fix into one runtime.

**Compatibility:**

With no resolver configured the behaviour is unchanged, so a single-user local `adk web` session keeps working with arbitrary user ids and no identity provider. That includes the `/debug/trace` routes, which stay open on a server that has not turned enforcement on. A server bound to a non-loopback address without a resolver now logs a warning at startup, which is the case `adk deploy` produces, since the generated Dockerfile passes `--host=0.0.0.0`.

`ADK_ENFORCE_USER_IDENTITY` asserts that Identity-Aware Proxy terminates authentication in front of this server, and cannot check that. Set without IAP it grants no protection at all -- a client simply sends the header itself -- while the server stops warning and starts answering `401` and `403`, so every signal an operator would read says protected. That is now stated in the variable's documentation and logged once at startup when the environment variable, rather than an explicit resolver, selected enforcement.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added a `Caller identity enforcement` block to `dev/test/server/adk_api_server_test.ts`:

1. `iapUserIdResolver` parses the provider-prefixed header, accepts a bare email, and reports no identity when the header is absent or empty.
2. With no resolver, a request naming another user is still served, covering the unchanged local path.
3. `ADK_ENFORCE_USER_IDENTITY` turns the built-in resolver on.
4. A request with no caller identity gets `401`.
5. A caller asking for their own sessions gets `200`.
6. A caller asking for another user's sessions gets `403`.
7. A caller deleting another user's session gets `403`, and the test then asserts the session is still retrievable, so the refusal is shown to happen before the delete rather than alongside it.
8. A `/run` body naming another user gets `403`.
9. A `/run` body omitting `userId` runs as the caller and finds the caller's own session.
10. An `/api/reasoning_engine` query naming another user gets `403`.

Added for the review follow-ups:

11. The resolver reports no identity when the header carries more than one value, and end to end a doubled header aimed at the appended user is answered `401` rather than served as that user.
12. The resolver reports no identity when the IAP assertion header is absent, and end to end a caller sending only the email header is answered `401`.
13. `/debug/trace/session/:sessionId` is `200` with no resolver, `401` with no caller identity, `403` for another user's session on both the bare and the `/dev/apps/:appName/` mount, and `200` for the owner.
14. `/debug/trace/:eventId` is `401` with no caller identity, `403` for an event belonging to another user's session, `403` for an event whose session cannot be resolved, `200` for the owner, and still `404` for an event id that does not exist.
15. `dev/test/index_test.ts` pins the package surface, so the extension point cannot silently stop being exported again.

Verified locally, matching what `validation.yaml` runs: `npm run build`, `ts:check`, `ts:check:samples`, `test:unit` at 236 files / 3430 tests all passing, `lint`, `format:check`, `docs:check` and `secretlint` clean, plus `scripts/check_license.sh`.

**Negative controls.** Each new guard was removed in turn to confirm the tests are bound to it rather than passing on their own:

| Guard removed | Result |
| --- | --- |
| `resolveUserId` forced `undefined` in the constructor (original commit) | the 7 enforcement cases fail, the rest of the file passes |
| trace ownership check | 6 fail |
| multi-valued header refusal | 2 fail |
| IAP assertion requirement | 2 fail |
| barrel exports reverted | `index_test.ts` fails |

**End-to-end.** Probed against a server built from `dev/dist`, importing `iapUserIdResolver` from the package entry point rather than an internal path, with a trace seeded into the exporters for `alice`'s session:

```
enforced server -- session traces
  no identity  -> /debug/trace/session/alice-session                       401
  bob          -> /debug/trace/session/alice-session                       403
  bob          -> /dev/apps/app1/debug/trace/session/alice-session         403
  alice OWNER  -> /debug/trace/session/alice-session                       200

enforced server -- event traces
  no identity  -> /debug/trace/<eventId>                                   401
  bob          -> /debug/trace/<eventId>                                   403   no span content
  alice OWNER  -> /debug/trace/<eventId>                                   200   span content returned
  alice        -> /debug/trace/no-such-event                               404

enforced server -- header shape
  email header, no IAP assertion                                           401
  doubled email header alice,bob -> bob's path                             401

enforced server -- surface the first commit already covered
  alice -> own sessions                                                    200
  bob   -> alice's sessions                                                403

no resolver -- historical behaviour
  no identity -> /debug/trace/session/alice-session                        200
  no identity -> /debug/trace/<eventId>                                    200   span content returned
  no identity -> alice's sessions                                          200
```

15/15. The owner-side rows are the positive control: the refusals are not the whole store having gone dark. `alice` still reads back `gcp.vertex.agent.llm_request` and `tool_response` for her own session, and the refused responses carry only `{"error": ...}`.

