### PR TITLE
feat(live): support partial content turns that do not complete the turn

### DIFF
--- a/core/src/agents/live_request_queue.ts
+++ b/core/src/agents/live_request_queue.ts
@@ -10,8 +10,19 @@ import {ActivityEnd, ActivityStart, Blob, Content} from '@google/genai';
  * Request sent to live agents.
  */
 export interface LiveRequest {
-  /** If set, send the content to the model in turn-by-turn mode. */
+  /**
+   * If set, send the content to the model in turn-by-turn mode.
+   *
+   * When multiple fields are set, they are processed by priority (highest
+   * first): activityStart > activityEnd > blob > content.
+   */
   content?: Content;
+  /**
+   * If set, the content is a partial turn update that does not complete the
+   * current model turn, so the model folds it into the conversation without
+   * responding yet.
+   */
+  partial?: boolean;
   /** If set, send the blob to the model in realtime mode. */
   blob?: Blob;
   /** If set, signal the start of user activity to the model. */
@@ -118,10 +129,15 @@ export class LiveRequestQueue {
 
   /**
    * Sends a content object to the queue.
+   *
    * @param content The content to send.
+   * @param partial Whether the content is a partial turn update that does not
+   *     complete the model turn. Use it to add content to the conversation
+   *     without prompting a response, e.g. a line already spoken on the model's
+   *     behalf (`role: 'model'`) so it neither repeats nor answers it.
    */
-  sendContent(content: Content) {
-    this.send({content});
+  sendContent(content: Content, partial = false) {
+    this.send({content, partial});
   }
 
   /**

--- a/core/src/agents/live_request_queue.ts
+++ b/core/src/agents/live_request_queue.ts
@@ -8,19 +8,20 @@ import {ActivityEnd, ActivityStart, Blob, Content} from '@google/genai';
 
 /**
  * Request sent to live agents.
+ *
+ * When multiple fields are set, they are dispatched by priority (highest
+ * first): close > activityStart > activityEnd > blob > content.
  */
 export interface LiveRequest {
-  /**
-   * If set, send the content to the model in turn-by-turn mode.
-   *
-   * When multiple fields are set, they are processed by priority (highest
-   * first): activityStart > activityEnd > blob > content.
-   */
+  /** If set, send the content to the model in turn-by-turn mode. */
   content?: Content;
   /**
    * If set, the content is a partial turn update that does not complete the
    * current model turn, so the model folds it into the conversation without
    * responding yet.
+   *
+   * Only meaningful together with `content`; ignored for `blob`,
+   * `activityStart`, `activityEnd` and `close`.
    */
   partial?: boolean;
   /** If set, send the blob to the model in realtime mode. */
@@ -129,7 +130,6 @@ export class LiveRequestQueue {
 
   /**
    * Sends a content object to the queue.
-   *
    * @param content The content to send.
    * @param partial Whether the content is a partial turn update that does not
    *     complete the model turn. Use it to add content to the conversation

--- a/core/src/agents/llm_agent.ts
+++ b/core/src/agents/llm_agent.ts
@@ -1212,7 +1212,7 @@ export class LlmAgent extends BaseAgent<LlmAgentConfig> {
       return;
     }
     if (liveRequest.content) {
-      await connection.sendContent(liveRequest.content);
+      await connection.sendContent(liveRequest.content, liveRequest.partial);
     }
   }
 

--- a/core/src/models/base_llm_connection.ts
+++ b/core/src/models/base_llm_connection.ts
@@ -26,14 +26,16 @@ export interface BaseLlmConnection {
   /**
    * Sends the content to the model.
    *
-   * The model will respond immediately upon receiving the content.
+   * Unless `partial` is set, the model will respond immediately upon receiving
+   * the content.
    * If you send function responses, all parts in the content should be function
    * responses.
    *
    * @param content The content to send to the model.
    * @param partial Whether the content is a partial turn update that does not
    *     complete the model turn. Implementations that do not support partial
-   *     updates may ignore it and complete the turn as usual.
+   *     updates may ignore it and complete the turn as usual. Ignored when the
+   *     content carries function responses.
    */
   sendContent(content: Content, partial?: boolean): Promise<void>;
 

--- a/core/src/models/base_llm_connection.ts
+++ b/core/src/models/base_llm_connection.ts
@@ -31,8 +31,11 @@ export interface BaseLlmConnection {
    * responses.
    *
    * @param content The content to send to the model.
+   * @param partial Whether the content is a partial turn update that does not
+   *     complete the model turn. Implementations that do not support partial
+   *     updates may ignore it and complete the turn as usual.
    */
-  sendContent(content: Content): Promise<void>;
+  sendContent(content: Content, partial?: boolean): Promise<void>;
 
   /**
    * Sends a chunk of audio or a frame of video to the model in realtime.

--- a/core/src/models/gemini_llm_connection.ts
+++ b/core/src/models/gemini_llm_connection.ts
@@ -63,8 +63,12 @@ export class GeminiLlmConnection implements BaseLlmConnection {
    * responses.
    *
    * @param content The content to send to the model.
+   * @param partial Whether the content is a partial turn update that does not
+   *     complete the model turn. The model folds it into the conversation and
+   *     keeps waiting instead of responding. Sent via sendClientContent --
+   *     realtimeInput has no no-response variant.
    */
-  async sendContent(content: Content): Promise<void> {
+  async sendContent(content: Content, partial = false): Promise<void> {
     if (!content.parts) {
       throw new Error('Content must have parts.');
     }
@@ -80,13 +84,18 @@ export class GeminiLlmConnection implements BaseLlmConnection {
     } else {
       logger.debug('Sending LLM new content', content);
       const isGemini3x = isGemini3xFlashLive(this.modelVersion);
-      if (isGemini3x && content.parts.length === 1 && content.parts[0].text) {
+      if (
+        !partial &&
+        isGemini3x &&
+        content.parts.length === 1 &&
+        content.parts[0].text
+      ) {
         logger.debug('Using sendRealtimeInput for Gemini 3.x text input');
         this.geminiSession.sendRealtimeInput({text: content.parts[0].text});
       } else {
         this.geminiSession.sendClientContent({
           turns: [content],
-          turnComplete: true,
+          turnComplete: !partial,
         });
       }
     }

--- a/core/src/models/gemini_llm_connection.ts
+++ b/core/src/models/gemini_llm_connection.ts
@@ -58,15 +58,16 @@ export class GeminiLlmConnection implements BaseLlmConnection {
   /**
    * Sends a user content to the gemini model.
    *
-   * The model will respond immediately upon receiving the content.
+   * Unless `partial` is set, the model will respond immediately upon receiving
+   * the content.
    * If you send function responses, all parts in the content should be function
    * responses.
    *
    * @param content The content to send to the model.
    * @param partial Whether the content is a partial turn update that does not
    *     complete the model turn. The model folds it into the conversation and
-   *     keeps waiting instead of responding. Sent via sendClientContent --
-   *     realtimeInput has no no-response variant.
+   *     keeps waiting instead of responding. Ignored when the content carries
+   *     function responses, which never complete a turn on their own.
    */
   async sendContent(content: Content, partial = false): Promise<void> {
     if (!content.parts) {
@@ -84,6 +85,12 @@ export class GeminiLlmConnection implements BaseLlmConnection {
     } else {
       logger.debug('Sending LLM new content', content);
       const isGemini3x = isGemini3xFlashLive(this.modelVersion);
+      // realtimeInput has no no-response variant, so a partial update has to go
+      // through sendClientContent. On Gemini 3.x this splits the transport:
+      // partials go over sendClientContent (added to the context in order)
+      // while plain text turns go over sendRealtimeInput (optimized for
+      // responsiveness, no ordering guarantee). A partial immediately followed
+      // by a normal turn may therefore reach the model out of order.
       if (
         !partial &&
         isGemini3x &&

--- a/core/test/agents/live_request_queue_test.ts
+++ b/core/test/agents/live_request_queue_test.ts
@@ -13,7 +13,14 @@ describe('LiveRequestQueue', () => {
     const queue = new LiveRequestQueue();
     const content = createUserContent('content test');
     queue.sendContent(content);
-    expect(await queue.get()).toEqual({content});
+    expect(await queue.get()).toEqual({content, partial: false});
+  });
+
+  it('should set partial on sendContent', async () => {
+    const queue = new LiveRequestQueue();
+    const content = createUserContent('content test');
+    queue.sendContent(content, true);
+    expect(await queue.get()).toEqual({content, partial: true});
   });
 
   it('should handle sendRealtime', async () => {

--- a/core/test/models/gemini_llm_connection_test.ts
+++ b/core/test/models/gemini_llm_connection_test.ts
@@ -164,8 +164,6 @@ describe('GeminiLlmConnection', () => {
         parts: [{text: 'progress'}],
       };
 
-      // realtimeInput has no no-response variant, so a partial update has to go
-      // through sendClientContent even on Gemini 3.x.
       await connection.sendContent(content, true);
 
       expect(mockSession.sendRealtimeInput).not.toHaveBeenCalled();
@@ -173,6 +171,28 @@ describe('GeminiLlmConnection', () => {
         turns: [content],
         turnComplete: false,
       });
+    });
+
+    it('should complete the turn on the first non-partial content after a partial', async () => {
+      const connection = new GeminiLlmConnection(
+        mockSession,
+        'gemini-2.5-flash',
+      );
+
+      await connection.sendContent(
+        {role: 'model', parts: [{text: 'already spoken'}]},
+        true,
+      );
+      await connection.sendContent({role: 'user', parts: [{text: 'and now?'}]});
+
+      expect(mockSession.sendClientContent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({turnComplete: false}),
+      );
+      expect(mockSession.sendClientContent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({turnComplete: true}),
+      );
     });
 
     it('should send tool response regardless of partial', async () => {

--- a/core/test/models/gemini_llm_connection_test.ts
+++ b/core/test/models/gemini_llm_connection_test.ts
@@ -137,6 +137,69 @@ describe('GeminiLlmConnection', () => {
       });
     });
 
+    it('should keep the turn open when partial is set', async () => {
+      const connection = new GeminiLlmConnection(
+        mockSession,
+        'gemini-2.5-flash',
+      );
+      const content: Content = {
+        role: 'model',
+        parts: [{text: 'already spoken'}],
+      };
+
+      await connection.sendContent(content, true);
+
+      expect(mockSession.sendClientContent).toHaveBeenCalledWith({
+        turns: [content],
+        turnComplete: false,
+      });
+    });
+
+    it('should not use sendRealtimeInput for Gemini 3.x when partial is set', async () => {
+      const connection = new GeminiLlmConnection(
+        mockSession,
+        'gemini-3.1-flash-live',
+      );
+      const content: Content = {
+        parts: [{text: 'progress'}],
+      };
+
+      // realtimeInput has no no-response variant, so a partial update has to go
+      // through sendClientContent even on Gemini 3.x.
+      await connection.sendContent(content, true);
+
+      expect(mockSession.sendRealtimeInput).not.toHaveBeenCalled();
+      expect(mockSession.sendClientContent).toHaveBeenCalledWith({
+        turns: [content],
+        turnComplete: false,
+      });
+    });
+
+    it('should send tool response regardless of partial', async () => {
+      const connection = new GeminiLlmConnection(
+        mockSession,
+        'gemini-2.5-flash',
+      );
+      const content: Content = {
+        parts: [
+          {
+            functionResponse: {
+              name: 'tool_a',
+              response: {result: 'ok'},
+              id: '1',
+            },
+          },
+        ],
+      };
+
+      await connection.sendContent(content, true);
+
+      expect(mockSession.sendToolResponse).toHaveBeenCalledWith({
+        functionResponses: [content.parts![0].functionResponse],
+      });
+      expect(mockSession.sendClientContent).not.toHaveBeenCalled();
+    });
+
     it('should throw error if content has no parts', async () => {
       const connection = new GeminiLlmConnection(
         mockSession,

--- a/core/test/runner/run_live_test.ts
+++ b/core/test/runner/run_live_test.ts
@@ -697,7 +697,16 @@ describe('Runner.runLive', () => {
 
     const queue = new LiveRequestQueue();
     const content: Content = {role: 'user', parts: [{text: 'hi there'}]};
+    const partialContent: Content = {
+      role: 'model',
+      parts: [{text: 'progress'}],
+    };
+    const rawContent: Content = {role: 'user', parts: [{text: 'raw'}]};
     queue.sendContent(content);
+    queue.sendContent(partialContent, true);
+    // Raw send() leaves partial unset, so it reaches the connection as
+    // undefined and the connection default applies.
+    queue.send({content: rawContent});
     queue.close();
     for await (const _ of runner.runLive({
       userId: TEST_USER_ID,
@@ -707,34 +716,12 @@ describe('Runner.runLive', () => {
       // drain
     }
 
-    expect(llm.connection!.contentCalls).toEqual([content]);
-    expect(llm.connection!.partialFlags).toEqual([false]);
-  });
-
-  it('forwards the partial flag from the queue to the connection', async () => {
-    const llm = new FakeLiveLlm([{turnComplete: true}]);
-    const agent = new LlmAgent({name: 'agent', model: llm});
-    const runner = new Runner({
-      appName: TEST_APP_ID,
-      agent,
-      sessionService,
-      artifactService,
-    });
-
-    const queue = new LiveRequestQueue();
-    const content: Content = {role: 'model', parts: [{text: 'already spoken'}]};
-    queue.sendContent(content, true);
-    queue.close();
-    for await (const _ of runner.runLive({
-      userId: TEST_USER_ID,
-      sessionId: TEST_SESSION_ID,
-      liveRequestQueue: queue,
-    })) {
-      // drain
-    }
-
-    expect(llm.connection!.contentCalls).toEqual([content]);
-    expect(llm.connection!.partialFlags).toEqual([true]);
+    expect(llm.connection!.contentCalls).toEqual([
+      content,
+      partialContent,
+      rawContent,
+    ]);
+    expect(llm.connection!.partialFlags).toEqual([false, true, undefined]);
   });
 
   it('stops early when the abort signal is already aborted', async () => {

--- a/core/test/runner/run_live_test.ts
+++ b/core/test/runner/run_live_test.ts
@@ -29,6 +29,7 @@ const TEST_SESSION_ID = 'test_session_id';
 class RecordingConnection implements BaseLlmConnection {
   readonly historyCalls: Content[][] = [];
   readonly contentCalls: Content[] = [];
+  readonly partialFlags: Array<boolean | undefined> = [];
   readonly realtimeCalls: Blob[] = [];
   activityStartCalls = 0;
   activityEndCalls = 0;
@@ -49,7 +50,7 @@ class RecordingConnection implements BaseLlmConnection {
   async sendHistory(history: Content[]): Promise<void> {
     this.historyCalls.push(history);
   }
-  async sendContent(content: Content): Promise<void> {
+  async sendContent(content: Content, partial?: boolean): Promise<void> {
     if (this.sendDelayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, this.sendDelayMs));
     }
@@ -61,6 +62,7 @@ class RecordingConnection implements BaseLlmConnection {
       throw this.sendContentError;
     }
     this.contentCalls.push(content);
+    this.partialFlags.push(partial);
   }
   async sendRealtime(blob: Blob): Promise<void> {
     if (this.sendDelayMs > 0) {
@@ -706,6 +708,33 @@ describe('Runner.runLive', () => {
     }
 
     expect(llm.connection!.contentCalls).toEqual([content]);
+    expect(llm.connection!.partialFlags).toEqual([false]);
+  });
+
+  it('forwards the partial flag from the queue to the connection', async () => {
+    const llm = new FakeLiveLlm([{turnComplete: true}]);
+    const agent = new LlmAgent({name: 'agent', model: llm});
+    const runner = new Runner({
+      appName: TEST_APP_ID,
+      agent,
+      sessionService,
+      artifactService,
+    });
+
+    const queue = new LiveRequestQueue();
+    const content: Content = {role: 'model', parts: [{text: 'already spoken'}]};
+    queue.sendContent(content, true);
+    queue.close();
+    for await (const _ of runner.runLive({
+      userId: TEST_USER_ID,
+      sessionId: TEST_SESSION_ID,
+      liveRequestQueue: queue,
+    })) {
+      // drain
+    }
+
+    expect(llm.connection!.contentCalls).toEqual([content]);
+    expect(llm.connection!.partialFlags).toEqual([true]);
   });
 
   it('stops early when the abort signal is already aborted', async () => {


### PR DESCRIPTION
Ports the adk-python design for adding content to a live conversation without prompting a response (adk-python 07aa1e09, "fix(live): keep streaming tool yields from completing turns", PR #6009 / issue #5947).

### Link to Issue or Description of Change

- Closes: #756

**Problem:**
There is currently no way to append content to a live turn without asking the model to answer it. Every `sendContent` path completes the turn, so a caller that wants the model to simply *know* something, a line already spoken on its behalf by client-side TTS, an out-of-band note, a streaming tool's intermediate yield, has to either provoke a spurious model reply or skip the context entirely.

**Solution:**
Python threads a `partial` flag through the existing content path rather than adding a parallel API. This mirrors that shape in TypeScript:

- `LiveRequest.partial` carries the flag through the queue.
- `LiveRequestQueue.sendContent(content, partial = false)` sets it.
- `BaseLlmConnection.sendContent(content, partial?)` takes it. An optional parameter is the TypeScript equivalent of Python's protected `_send_content` overload: implementations that do not support partial updates may ignore it, and existing implementers keep compiling.
- `GeminiLlmConnection.sendContent` sends `turnComplete: !partial`, and skips the Gemini 3.x `sendRealtimeInput` text shortcut when partial is set, matching the `not partial` guard in Python. realtimeInput has no no-response variant, so a partial update must go through sendClientContent.

### Testing Plan

Adds coverage mirroring the Python tests (test_live_request_queue.py, test_gemini_llm_connection.py): the queue sets partial, the connection keeps the turn open, the Gemini 3.x shortcut is bypassed, tool responses are unaffected, and the flag reaches the connection through the live send loop.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed npm test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
