### PR TITLE
fix(workflow): let a child's pending interrupt hold its caller

### DIFF
--- a/core/src/workflow/dynamic_node_scheduler.ts
+++ b/core/src/workflow/dynamic_node_scheduler.ts
@@ -44,7 +44,37 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
     private readonly abortSignal?: AbortSignal,
   ) {}
 
+  /**
+   * Runs a `ctx.runNode()` call and reports any interrupt it is still waiting
+   * on to the caller's own context.
+   *
+   * A child's interrupt is the caller's problem: the caller cannot produce a
+   * trustworthy result until the human answers, and until the engine knows the
+   * caller is waiting it marks it COMPLETED and schedules its successor —
+   * which then runs on the `undefined` the caller returned when it bailed out.
+   * `ParallelWorker` has always copied its items' interrupt ids onto its own
+   * context for exactly this reason; doing it here extends that to every
+   * caller instead of only the one that remembered.
+   *
+   * Only unresolved interrupts arrive here. A child fast-forwarded from a
+   * checkpoint, or handed a resolved reply as its output, reports none.
+   */
   async schedule(
+    ctx: NodeContext,
+    node: BaseNode,
+    input: unknown,
+    options: ScheduleDynamicNodeOptions,
+  ): Promise<NodeContext | NodeResult> {
+    const result = await this.scheduleRun(ctx, node, input, options);
+    for (const id of result.interruptIds) {
+      if (!ctx.interruptIds.includes(id)) {
+        ctx.interruptIds.push(id);
+      }
+    }
+    return result;
+  }
+
+  private async scheduleRun(
     ctx: NodeContext,
     node: BaseNode,
     input: unknown,

--- a/core/test/workflow/hitl_flow_test.ts
+++ b/core/test/workflow/hitl_flow_test.ts
@@ -102,6 +102,76 @@ describe('Phase 5 — HITL (pause / resume)', () => {
     expect(resumed.output).toBe('c:a:x|gate:ok');
   });
 
+  describe('an interrupt raised by a ctx.runNode child', () => {
+    /**
+     * `supervisor -> summarize`, where the supervisor delegates to a child that
+     * asks the user and then bails out exactly as the `dynamic/human_input`
+     * sample documents: "still waiting on the human", so return nothing.
+     */
+    function buildWorkflow(ran: string[]) {
+      const worker = new FunctionNode('worker', (ctx, item) => {
+        const answer = ctx.resumeInputs['approve-beta'];
+        if (answer === undefined) {
+          return new RequestInput({
+            interruptId: 'approve-beta',
+            message: `approve ${item}?`,
+          });
+        }
+        return `${item}:${answer}`;
+      });
+      const supervisor = new FunctionNode(
+        'supervisor',
+        async (ctx, input) => {
+          ran.push('supervisor');
+          const result = await ctx.runNode(worker, input);
+          if (result.interruptIds.length > 0) {
+            return undefined;
+          }
+          return [result.output];
+        },
+        {rerunOnResume: true},
+      );
+      const summarize = new FunctionNode('summarize', (_c, input) => {
+        ran.push('summarize');
+        return (input as string[]).map((item) => `<${item}>`).join(',');
+      });
+      return new Workflow({
+        name: 'swallowed_interrupt',
+        edges: [
+          ['START', supervisor],
+          [supervisor, summarize],
+        ],
+      });
+    }
+
+    it('holds the parent, so the successor does not run on undefined', async () => {
+      // The interrupt id is on the `ctx.runNode` result, not on the
+      // supervisor's own context, so the engine used to mark the supervisor
+      // COMPLETED and schedule `summarize` with the `undefined` the supervisor
+      // returned — which threw before the human could answer, making the
+      // documented resume cycle unreachable.
+      const ran: string[] = [];
+
+      const paused = await drive(buildWorkflow(ran), 'beta');
+
+      expect(paused.interruptIds).toEqual(['approve-beta']);
+      expect(ran).toEqual(['supervisor']);
+      expect(paused.output).toBeUndefined();
+    });
+
+    it('runs the successor once the reply arrives', async () => {
+      const ran: string[] = [];
+
+      const resumed = await drive(buildWorkflow(ran), 'beta', {
+        'approve-beta': 'yes',
+      });
+
+      expect(resumed.interruptIds).toEqual([]);
+      expect(resumed.output).toBe('<beta:yes>');
+      expect(ran).toEqual(['supervisor', 'summarize']);
+    });
+  });
+
   it('supports HITL in an imperative dynamicEntry workflow', async () => {
     // Re-entry HITL node: it re-runs on resume and reads the reply itself, so
     // it declares `rerunOnResume: true`. Under the default the dynamic


### PR DESCRIPTION
Fixes #734

## The bug

`handleCompletion` marks a node WAITING when its own `interruptIds` are populated, but an interrupt raised inside a `ctx.runNode` child lands on the **result handed back to the caller**, not on the caller's context.

So a node that delegated to a child and then bailed out — exactly as `samples/workflows/dynamic/human_input/agent.ts:44-51` documents:

```ts
if (result.interruptIds.length > 0) return undefined; // "still waiting on the human"
```

— was recorded COMPLETED, and its successor was scheduled with the `undefined` it had just returned:

```
--- [analyze_item] is waiting for your input ---
approve beta?
[summarize] error: UNKNOWN_ERROR: Cannot read properties of undefined (reading 'map')
```

The CLI exits before the human can answer, so the documented resume cycle is unreachable: **doing the prescribed thing is what triggers the crash.** Not parallel-specific — one sequential child fails identically. The only escape was `waitForOutput: true` on the parent, which is neither documented for this nor what the situation is about.

## The fix

A child's unresolved interrupt is reported to the caller's context at the `ctx.runNode` seam, so the existing WAITING branch sees it and holds the graph where it already knew how to.

This is not a new rule: `ParallelWorker` has always copied its items' interrupt ids onto its own context (`core/src/workflow/nodes/parallel_worker.ts:156-162`) for exactly this reason. The change generalizes that to every caller rather than only the one that remembered to do it.

Only unresolved interrupts propagate. A child fast-forwarded from a checkpoint, or handed a resolved reply as its output, reports none — so a resumed run is unaffected.

## Tests

Two cases in `core/test/workflow/hitl_flow_test.ts` over a `supervisor -> summarize` graph where the supervisor delegates and bails:

- the parent holds, so the successor does not run on `undefined`
- the successor runs once the reply arrives

Reverting the source change reproduces the issue's exact failure: `TypeError: Cannot read properties of undefined (reading 'map')`.

Full unit + integration suites pass (3400 unit, 235 integration).
