### PR TITLE
fix(workflow): stop reinterpreting a text reply the schema asked for as text

### DIFF
--- a/core/src/agents/processors/request_input_llm_request_processor.ts
+++ b/core/src/agents/processors/request_input_llm_request_processor.ts
@@ -153,12 +153,9 @@ function collectResumeInputs(events: Event[]): Record<string, unknown> {
     let found = false;
     for (const fr of getFunctionResponses(event)) {
       if (fr.name === REQUEST_INPUT_FUNCTION_CALL_NAME && fr.id) {
-        const response = unwrapResponse(fr.response);
-        const mismatch = interruptResponseMismatch(
-          fr.id,
-          response,
-          responseSchemas.get(fr.id),
-        );
+        const schema = responseSchemas.get(fr.id);
+        const response = unwrapResponse(fr.response, schema);
+        const mismatch = interruptResponseMismatch(fr.id, response, schema);
         if (mismatch) {
           if (isCurrentTurn) {
             throw new Error(mismatch);
@@ -215,10 +212,11 @@ function pendingInterruptIds(
       if (!fr.id) {
         continue;
       }
+      const schema = responseSchemas.get(fr.id);
       const mismatch = interruptResponseMismatch(
         fr.id,
-        unwrapResponse(fr.response),
-        responseSchemas.get(fr.id),
+        unwrapResponse(fr.response, schema),
+        schema,
       );
       if (!mismatch) {
         answered.add(fr.id);

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -195,12 +195,9 @@ export function resolvedInterruptResponses(
         if (!fr?.id || !raised.has(fr.id)) {
           continue;
         }
-        const response = unwrapResponse(fr.response);
-        const mismatch = interruptResponseMismatch(
-          fr.id,
-          response,
-          responseSchemas.get(fr.id),
-        );
+        const schema = responseSchemas.get(fr.id);
+        const response = unwrapResponse(fr.response, schema);
+        const mismatch = interruptResponseMismatch(fr.id, response, schema);
         if (mismatch) {
           if (event === newestUserTurn) {
             throw new Error(mismatch);
@@ -443,17 +440,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Unwraps a `{result: value}` FunctionResponse envelope to the bare value.
  *
- * Every string value is JSON-parsed when it parses, because the envelope does
- * not say whether the text is structured: a client answering a `RequestInput`
- * that declared a `responseSchema` sends the object as text (the web frontend
- * wraps whatever the user submitted as `{result: text}`), and the node expects
- * the object back. Text that is not JSON — "approve", "shorter" — is returned
- * as-is, and so a plain answer that happens to be valid JSON is converted too:
- * "42" comes back as a number, "true" as a boolean. That is deliberate parity
- * with Python's `_unwrap_response`, and harmless downstream —
- * {@link interruptResponseMismatch} exempts scalars from the schema check.
+ * A string value is JSON-parsed when it parses, because the envelope does not
+ * say whether the text is structured: a client answering a `RequestInput` that
+ * declared a `responseSchema` sends the object as text (the web frontend wraps
+ * whatever the user submitted as `{result: text}`), and the node expects the
+ * object back. Text that is not JSON — "approve", "shorter" — is returned
+ * as-is. That is parity with Python's `_unwrap_response`.
+ *
+ * `responseSchema`, when the interrupt declared one, decides whether parsing
+ * applies at all. Parsing text the schema asked for as text is destructive
+ * rather than helpful: an answer of "42" to a `z.string()` interrupt reached
+ * the node as the number 42 and crashed it on the first string method, and
+ * every JSON literal did the same — "true", "null", "1e3". So a schema that
+ * accepts a string keeps the text verbatim, and only a schema that cannot
+ * (an object, an array, a number) still parses.
  */
-export function unwrapResponse(response: unknown): unknown {
+export function unwrapResponse(
+  response: unknown,
+  responseSchema?: unknown,
+): unknown {
   if (
     response &&
     typeof response === 'object' &&
@@ -462,9 +467,41 @@ export function unwrapResponse(response: unknown): unknown {
     RESULT_KEY in response
   ) {
     const value = (response as Record<string, unknown>)[RESULT_KEY];
-    return typeof value === 'string' ? parseJsonIfPossible(value) : value;
+    if (typeof value !== 'string' || acceptsString(responseSchema)) {
+      return value;
+    }
+    return parseJsonIfPossible(value);
   }
   return response;
+}
+
+/**
+ * Whether `jsonSchema` accepts a plain string, so text answering it must not be
+ * reinterpreted as JSON.
+ *
+ * Errs towards leaving the text alone: a union is a match if any branch takes a
+ * string, since the text is then already a valid value for the schema and
+ * parsing it could only produce a different one. An absent or unreadable schema
+ * declares nothing and so does not suppress parsing.
+ */
+function acceptsString(jsonSchema: unknown): boolean {
+  if (!isRecord(jsonSchema)) {
+    return false;
+  }
+  const type = jsonSchema['type'];
+  if (type === 'string') {
+    return true;
+  }
+  if (Array.isArray(type) && type.includes('string')) {
+    return true;
+  }
+  for (const key of ['anyOf', 'oneOf']) {
+    const branches = jsonSchema[key];
+    if (Array.isArray(branches) && branches.some(acceptsString)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function parseJsonIfPossible(value: string): unknown {

--- a/core/test/workflow/hitl_test.ts
+++ b/core/test/workflow/hitl_test.ts
@@ -285,12 +285,52 @@ describe('unwrapResponse', () => {
     expect(unwrapResponse({result: 'approve'})).toBe('approve');
   });
 
-  it('parses any string that is JSON, scalars included', () => {
-    // The envelope does not say whether the text is structured, so a plain
-    // answer that happens to be valid JSON is converted too. Python's
-    // `_unwrap_response` does the same, and the schema check exempts scalars.
+  it('parses any string that is JSON when no schema was declared', () => {
+    // The envelope does not say whether the text is structured, so with nothing
+    // else to go on a plain answer that happens to be valid JSON is converted
+    // too. Python's `_unwrap_response` does the same.
     expect(unwrapResponse({result: '42'})).toBe(42);
     expect(unwrapResponse({result: 'true'})).toBe(true);
+  });
+
+  it('keeps text verbatim when the schema declared a string', () => {
+    const stringSchema = toJsonSchema(z4.string());
+    // "42" answering a z.string() interrupt reached the node as the number 42
+    // and crashed it on the first string method.
+    expect(unwrapResponse({result: '42'}, stringSchema)).toBe('42');
+    expect(unwrapResponse({result: 'true'}, stringSchema)).toBe('true');
+    expect(unwrapResponse({result: 'null'}, stringSchema)).toBe('null');
+    expect(unwrapResponse({result: '1e3'}, stringSchema)).toBe('1e3');
+    expect(unwrapResponse({result: '{"a":1}'}, stringSchema)).toBe('{"a":1}');
+  });
+
+  it('keeps text verbatim for an enum or a union that takes a string', () => {
+    expect(unwrapResponse({result: '42'}, toJsonSchema(z4.enum(['42'])))).toBe(
+      '42',
+    );
+    expect(
+      unwrapResponse({result: '42'}, toJsonSchema(z4.string().nullable())),
+    ).toBe('42');
+    expect(
+      unwrapResponse(
+        {result: '42'},
+        toJsonSchema(z4.union([z4.string(), z4.number()])),
+      ),
+    ).toBe('42');
+  });
+
+  it('still parses text when the schema cannot accept a string', () => {
+    expect(unwrapResponse({result: '42'}, toJsonSchema(z4.number()))).toBe(42);
+    expect(
+      unwrapResponse(
+        {result: '{"a":1}'},
+        toJsonSchema(z4.object({a: z4.number()})),
+      ),
+    ).toEqual({a: 1});
+  });
+
+  it('leaves a non-string result alone whatever the schema says', () => {
+    expect(unwrapResponse({result: 42}, toJsonSchema(z4.string()))).toBe(42);
   });
 
   it('passes a value that is not a {result: x} envelope through', () => {

--- a/core/test/workflow/resume_test.ts
+++ b/core/test/workflow/resume_test.ts
@@ -131,6 +131,40 @@ describe('Phase 5b — rehydration utility', () => {
       );
     });
 
+    it('hands a numeric-looking reply to a string interrupt back as text', () => {
+      // "42" answering a z.string() interrupt used to unwrap to the number 42,
+      // which crashed the node on its first string method and left the session
+      // unable to resume. Every JSON literal did the same.
+      const interrupt = createRequestInputEvent(
+        new RequestInput({interruptId: 'gate-1', responseSchema: z.string()}),
+      );
+      interrupt.author = 'gate';
+      interrupt.nodeInfo = {path: 'wf.gate'};
+
+      for (const text of ['42', 'true', 'null', '1e3']) {
+        const states = reconstructNodeStates([
+          interrupt,
+          createEvent({
+            author: 'user',
+            content: {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'gate-1',
+                    name: 'adk_request_input',
+                    response: {result: text},
+                  },
+                },
+              ],
+            },
+          }),
+        ]);
+
+        expect(states.get('gate')?.resolvedResponses.get('gate-1')).toBe(text);
+      }
+    });
+
     it('rejects the wrong envelope instead of passing it to the next node', () => {
       // `{response: x}` is not the `{result: x}` envelope, so it is not
       // unwrapped; before this check it reached the successor whole and


### PR DESCRIPTION
Fixes #737

## The bug

`unwrapResponse` ran every string inside a `{result: …}` envelope through `JSON.parse`, with no regard for the `responseSchema` the interrupt declared (`core/src/workflow/utils/rehydration_utils.ts:465-470`).

So an answer of `"42"` to a `z.string()` interrupt reached the node as the **number** 42 and crashed it on the first string method:

```
{"error": "Failed to run agent: TypeError: e.split is not a function or its return value is not iterable"}
```

And because a reply stays in the session for good, the run could never be resumed — re-answering with a valid string minted a new interrupt each time and `build_itinerary` never ran. Every JSON literal did the same: `true`, `null`, `1e3`.

`interruptResponseMismatch` did not catch it either, since it exempts non-objects (`hitl_utils.ts:136`) — so the violation the unwrap had just manufactured was exempted from the `{"type":"string"}` check that would have caught it.

## The fix

The parse exists so a client that can only send text can still answer a structured interrupt — it is a **guess** about what the text meant. The declared schema settles that guess, so it is now consulted:

| declared schema                                        | `{result: "42"}` becomes                                  |
| ------------------------------------------------------ | --------------------------------------------------------- |
| `z.string()`, `z.enum([...])`, `z.string().nullable()` | `"42"` (verbatim)                                         |
| `z.number()`, `z.object({...})`, an array              | `42` / the parsed object                                  |
| none declared                                          | `42` — unchanged, parity with Python's `_unwrap_response` |

A union counts as accepting a string when any branch does. Erring that way is the safe direction: the text is already a valid value for the schema, so parsing it could only produce a different one.

The three call sites already had the schema in hand (`responseSchemas.get(fr.id)`) and simply pass it through now.

## Scope

Deliberately **not** changed: the scalar exemption in `interruptResponseMismatch`. It is there so a chat box answering an object-schema interrupt is not rejected, which is still right, and the exemption is no longer papering over a type the unwrap invented. A client sending a genuine non-string JSON value against a string schema is a different, honest client error.

## Tests

- `core/test/workflow/hitl_test.ts`: `unwrapResponse` against string / enum / nullable / union / number / object schemas, plus the no-schema case pinned as unchanged.
- `core/test/workflow/resume_test.ts`: end-to-end through session events — `"42"`, `"true"`, `"null"`, `"1e3"` all resolve as text against a `z.string()` interrupt.

Reverting the source change fails these with `expected 42 to be '42'`.

Full unit suite passes (3403).
