### PR TITLE
fix(workflow): refuse a numeric custom runId whichever call comes first

### DIFF
--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -139,6 +139,12 @@ export class NodeContext {
   private readonly autoRunIds = new Map<string, Set<string>>();
   /** Every run id used for a node name here, automatic or caller-supplied. */
   private readonly usedRunIds = new Map<string, Set<string>>();
+  /**
+   * Caller-supplied run ids shaped like an automatic one (all digits), per node
+   * name — the set {@link assertNoNumericCustomRunIds} refuses to auto-number
+   * around.
+   */
+  private readonly numericCustomRunIds = new Map<string, Set<string>>();
 
   constructor(opts: NodeContextOptions) {
     this.invocationContext = opts.invocationContext;
@@ -246,14 +252,19 @@ export class NodeContext {
       const used = mapSet(this.usedRunIds, nodeName);
       if (runId !== undefined) {
         assertCustomRunId(runId, nodeName, mapSet(this.autoRunIds, nodeName));
+        if (isAutoNumberShaped(runId)) {
+          mapSet(this.numericCustomRunIds, nodeName).add(runId);
+        }
       }
       if (!runId) {
-        // Skip anything a caller already claimed, so the automatic sequence
-        // cannot grow into a custom id and silently dedup against it.
-        let next = (this.dynamicRunCounters.get(nodeName) ?? 0) + 1;
-        while (used.has(String(next))) {
-          next++;
-        }
+        assertNoNumericCustomRunIds(
+          nodeName,
+          mapSet(this.numericCustomRunIds, nodeName),
+        );
+        // No need to skip ids a caller already claimed: the counter is
+        // monotonic, so the next value was never handed out automatically, and
+        // a custom id that could equal it is refused by the two asserts above.
+        const next = (this.dynamicRunCounters.get(nodeName) ?? 0) + 1;
         this.dynamicRunCounters.set(nodeName, next);
         runId = String(next);
         mapSet(this.autoRunIds, nodeName).add(runId);
@@ -279,8 +290,29 @@ function mapSet(map: Map<string, Set<string>>, key: string): Set<string> {
   return set;
 }
 
+/** Whether a run id is shaped like one of ADK's own: nothing but digits. */
+function isAutoNumberShaped(runId: string): boolean {
+  return /^\d+$/.test(runId);
+}
+
+/** The shared explanation for mixing numeric custom ids with auto-numbering. */
+function numericRunIdMixError(nodeName: string, runId: string): Error {
+  return new Error(
+    `Invalid runId '${runId}' for node '${nodeName}': ADK numbers automatic ` +
+      `runs of a node "1", "2", "3", … per context, so an all-digit custom ` +
+      `id draws from that same namespace. A later turn that issues a ` +
+      `different set of custom ids shifts the automatic sequence onto a ` +
+      `checkpoint path an earlier call already wrote, and the call is ` +
+      `fast-forwarded to that run's cached output with its own input ` +
+      `silently discarded. Give the custom id a non-numeric part, e.g. ` +
+      `'${nodeName}-${runId}', or supply an explicit id for every run of ` +
+      `this node so ADK never numbers one.`,
+  );
+}
+
 /**
- * Rejects a caller-supplied run id that collides with an automatic one.
+ * Rejects a caller-supplied run id that shares the automatic numbering
+ * namespace for a node ADK also numbers automatically.
  *
  * Run ids key the checkpoint lookup that lets a resumed or retried workflow
  * skip work it already did, so an id that names a run the caller never made is
@@ -288,10 +320,16 @@ function mapSet(map: Map<string, Set<string>>, key: string): Set<string> {
  * *its* output, and the input passed here is dropped without executing.
  * Nothing downstream can detect that, so it is refused at the call.
  *
- * Only collisions with ADK's own numbering are refused. Reusing a custom id
- * deliberately is a supported way to dedup concurrent calls onto one run, and
- * `ParallelWorker` keys its fan-out by item index, so neither digits nor
- * repetition can be banned outright.
+ * The refusal is symmetric with {@link assertNoNumericCustomRunIds}, which
+ * covers the other order. Checking only for an id already handed out made the
+ * guard depend on which call ran first: the same program was a hard error when
+ * the automatic run came first and silent data corruption when it came second.
+ *
+ * Digits are refused only for a node that is *also* auto-numbered here, which
+ * is what makes them ambiguous. A caller that names every run itself owns the
+ * whole namespace and cannot collide with anything — `ParallelWorker` keys its
+ * fan-out by item index that way. Reusing a custom id deliberately stays a
+ * supported way to dedup concurrent calls onto one run.
  */
 function assertCustomRunId(
   runId: string,
@@ -304,14 +342,28 @@ function assertCustomRunId(
         `Omit runId to let ADK number the run automatically.`,
     );
   }
-  if (autoRunIds.has(runId)) {
-    throw new Error(
-      `Invalid runId '${runId}' for node '${nodeName}': ADK already numbered ` +
-        `an automatic run of that node '${runId}' in this context, so this ` +
-        `call would resolve to that run's cached output instead of ` +
-        `executing, and the input passed here would be dropped. Automatic ` +
-        `ids are "1", "2", "3" per node; give a custom id a non-numeric ` +
-        `part, e.g. '${nodeName}-${runId}'.`,
-    );
+  if (autoRunIds.size > 0 && isAutoNumberShaped(runId)) {
+    throw numericRunIdMixError(nodeName, runId);
+  }
+}
+
+/**
+ * Refuses to number a run automatically once an all-digit custom id has been
+ * claimed for the same node.
+ *
+ * The mirror image of {@link assertCustomRunId}, and the case the guard used to
+ * miss. Numbering around the claimed id looks harmless within one turn — it
+ * skips to the next free number and everything runs — but the number it skips
+ * to is a function of how many custom ids this turn happened to issue. Issue
+ * one fewer next turn and the automatic call lands on a path a custom run
+ * already wrote, and is answered from that checkpoint instead of executing.
+ */
+function assertNoNumericCustomRunIds(
+  nodeName: string,
+  numericCustomRunIds: ReadonlySet<string>,
+): void {
+  const first = numericCustomRunIds.values().next();
+  if (!first.done) {
+    throw numericRunIdMixError(nodeName, first.value);
   }
 }

--- a/core/src/workflow/node_context.ts
+++ b/core/src/workflow/node_context.ts
@@ -137,8 +137,6 @@ export class NodeContext {
   private readonly dynamicRunCounters = new Map<string, number>();
   /** Run ids this context handed out automatically, per node name. */
   private readonly autoRunIds = new Map<string, Set<string>>();
-  /** Every run id used for a node name here, automatic or caller-supplied. */
-  private readonly usedRunIds = new Map<string, Set<string>>();
   /**
    * Caller-supplied run ids shaped like an automatic one (all digits), per node
    * name — the set {@link assertNoNumericCustomRunIds} refuses to auto-number
@@ -249,7 +247,6 @@ export class NodeContext {
     if (this.scheduler) {
       const nodeName = options?.nodeName ?? node.name;
       let runId = options?.runId;
-      const used = mapSet(this.usedRunIds, nodeName);
       if (runId !== undefined) {
         assertCustomRunId(runId, nodeName, mapSet(this.autoRunIds, nodeName));
         if (isAutoNumberShaped(runId)) {
@@ -269,7 +266,6 @@ export class NodeContext {
         runId = String(next);
         mapSet(this.autoRunIds, nodeName).add(runId);
       }
-      used.add(runId);
       return this.scheduler.schedule(this, node, input, {
         ...options,
         nodeName,

--- a/core/src/workflow/node_runner.ts
+++ b/core/src/workflow/node_runner.ts
@@ -32,8 +32,10 @@ export interface RunNodeOptions {
    * "2", "3" in call order — which is what a resume matches checkpoints on.
    *
    * Supply one only when position is not stable but identity is (a reorderable
-   * collection: key it off the item's own id). It must contain a non-numeric
-   * character so it cannot collide with the automatic sequence.
+   * collection: key it off the item's own id). Give it a non-numeric character
+   * so it cannot collide with the automatic sequence: an all-digit id is
+   * refused for any node ADK also numbers automatically in the same context,
+   * whichever call comes first.
    */
   runId?: string;
   /** If true, the child's output replaces the caller's output. */

--- a/core/test/workflow/dynamic_workflow_test.ts
+++ b/core/test/workflow/dynamic_workflow_test.ts
@@ -162,26 +162,27 @@ describe('Phase 4 — dynamic (imperative) workflows', () => {
       });
     }
 
-    it.each(['order-a91', '42', '007'])(
-      'accepts the non-colliding id %s',
+    it('accepts an id that cannot be mistaken for an automatic one', async () => {
+      expect((await driveWorkflow(workflowUsing('order-a91'))).output).toEqual({
+        auto: 'handled auto',
+        custom: 'handled custom',
+      });
+    });
+
+    it.each(['1', '42', '007'])(
+      'rejects the all-digit id %s for an auto-numbered node',
       async (id) => {
-        // Digits are fine in themselves -- ParallelWorker keys its fan-out by
-        // item index. Only an id ADK already handed out is refused.
-        expect((await driveWorkflow(workflowUsing(id))).output).toEqual({
-          auto: 'handled auto',
-          custom: 'handled custom',
-        });
+        // All three share the automatic namespace, so which one collides is a
+        // function of how many runs this turn happens to make. '1' resolved to
+        // the auto run's cached output outright; the others waited for a turn
+        // that ran the node often enough to reach them.
+        await expect(driveWorkflow(workflowUsing(id))).rejects.toThrow(
+          new RegExp(
+            `Invalid runId '${id}' for node 'child'[\\s\\S]*child-${id}`,
+          ),
+        );
       },
     );
-
-    it('rejects an id ADK already used for an automatic run', async () => {
-      // The auto run above took '1'. Before this check, passing '1' here
-      // resolved to that run's cached output -- returning 'handled auto' and
-      // dropping this call's input without executing.
-      await expect(driveWorkflow(workflowUsing('1'))).rejects.toThrow(
-        /Invalid runId '1' for node 'child'[\s\S]*'child-1'/,
-      );
-    });
 
     it('rejects an empty id rather than silently auto-numbering it', async () => {
       await expect(driveWorkflow(workflowUsing('   '))).rejects.toThrow(
@@ -189,23 +190,48 @@ describe('Phase 4 — dynamic (imperative) workflows', () => {
       );
     });
 
-    it('numbers around a custom id claimed first, instead of deduping onto it', async () => {
+    it('rejects the same mix in the opposite order', async () => {
+      // The case that used to pass. Numbering around the claimed '1' worked
+      // this turn and broke the next one, so the guard has to be symmetric:
+      // the same program must not be an error in one order and silent data
+      // corruption in the other.
       const child = new FunctionNode('child', (_c, item) => `handled ${item}`);
       const wf = new Workflow({
         name: 'run-ids-reverse',
         dynamicEntry: async (ctx) => {
-          // Custom '1' first, so the automatic sequence would otherwise walk
-          // straight into it on its first call.
           const custom = await ctx.runNode(child, 'custom', {runId: '1'});
           const auto = await ctx.runNode(child, 'auto');
           return {custom: custom.output, auto: auto.output};
         },
       });
 
-      expect((await driveWorkflow(wf)).output).toEqual({
-        custom: 'handled custom',
-        auto: 'handled auto',
+      await expect(driveWorkflow(wf)).rejects.toThrow(
+        /Invalid runId '1' for node 'child'[\s\S]*child-1/,
+      );
+    });
+
+    it('lets a caller that names every run keep using indices', async () => {
+      // No automatic run of `child` here, so the caller owns the whole
+      // namespace and nothing can collide -- this is how ParallelWorker keys
+      // its fan-out by item index.
+      const child = new FunctionNode('child', (_c, item) => `handled ${item}`);
+      const wf = new Workflow({
+        name: 'run-ids-all-custom',
+        dynamicEntry: async (ctx) => {
+          const runs = await Promise.all(
+            ['a', 'b', 'c'].map((item, i) =>
+              ctx.runNode(child, item, {runId: String(i)}),
+            ),
+          );
+          return runs.map((run) => run.output);
+        },
       });
+
+      expect((await driveWorkflow(wf)).output).toEqual([
+        'handled a',
+        'handled b',
+        'handled c',
+      ]);
     });
   });
 


### PR DESCRIPTION
Fixes #730

## The bug

`assertCustomRunId` refused a caller-supplied run id only when `autoRunIds` already held that **exact** id (`core/src/workflow/node_context.ts:282-303`) — it never looked at the id's shape. So `{runId: '3'}` sailed through when issued before any automatic run, and the automatic counter quietly numbered around it.

That looks harmless for the turn that does it. But the number it skips to is a function of how many custom ids that turn happened to issue:

```js
for (const i of ids) await ctx.runNode(child, `order-${i}`, { runId: i });
const audit = await ctx.runNode(child, "AUDIT-PAYLOAD"); // auto-numbered

// turn 1, ids = ['1','2','3'] -> audit.output === 'RESULT<AUDIT-PAYLOAD>'   (auto id 4)
// turn 2, ids = ['1','2']     -> audit.output === 'RESULT<order-3>'          (auto id 3)
//   zero executions, zero errors, zero warnings
```

The same two calls in the **opposite** order were already a hard error, stating the rule (_"give a custom id a non-numeric part"_). So one program was either loud or silently corrupt depending on which `runNode` ran first, and the `dynamic/custom_run_ids` docstring stated as an invariant a rule the framework only enforced half the time.

## The fix

Make the guard symmetric. An all-digit custom id and automatic numbering cannot both apply to one node in one context, and **whichever arrives second is refused**, with the same explanation either way.

Digits are still allowed to a caller that names every run itself: it owns the whole namespace and has nothing to collide with. That is how `ParallelWorker` keys its fan-out by item index (`runId: String(i)`), which is why a blanket `/^\d+$/` ban was not the right shape — it would have forced a change to persisted node paths (`inner@0` → `inner@item-0`) and broken resume for any session paused mid-fan-out.

What the docs promised all along — give a custom id a non-numeric part — is now what the framework enforces, and the sample already follows it.

Also removes the auto counter's "skip ids a caller claimed" loop. The counter is monotonic, so its next value was never handed out automatically, and a custom id that could equal it is now refused; the skip was only ever papering over the collision this rejects.

## Behaviour change

Three existing tests pinned the lenient behaviour and are updated. Two now expect rejection:

- `'42'`/`'007'` accepted after an auto run → now refused (they differ from `'1'` only in _how many_ runs it takes to collide)
- custom `'1'` then auto → now refused (this is the silent-corruption order)

A new test covers the all-custom-ids case that must keep working.

Full unit suite passes (3399).
