### PR TITLE
fix(workflow): let two route keys share a destination node

### DIFF
--- a/core/src/workflow/utils/graph_validation.ts
+++ b/core/src/workflow/utils/graph_validation.ts
@@ -95,16 +95,49 @@ function validateConnectivity(edges: Edge[], nodeNames: Set<string>): void {
   }
 }
 
+/**
+ * Rejects an edge that repeats a `(from, to, route)` triple already in the
+ * graph — the case where one emitted route would trigger the same target twice.
+ *
+ * The route is part of the identity, not just the pair of endpoints: two route
+ * keys sharing a destination (`[router, {approve: shared, escalate: shared}]`)
+ * are distinct edges that {@link Graph.getNextPendingNodes} already matches
+ * independently, and keying on the endpoints alone rejected the obvious way to
+ * point two decisions at one reusable sub-workflow.
+ *
+ * A multi-route edge is checked per route value, since it is the route that
+ * fires an edge, so `route: ['a', 'b']` and `route: 'b'` to the same target
+ * still collide on `'b'`. Route values are compared as strings, matching how
+ * `getNextPendingNodes` matches them, so `2` and `'2'` are the same route here
+ * too. An unconditional edge (`route: null`) is its own identity and never
+ * collides with a routed one.
+ */
 function validateDuplicateEdges(edges: Edge[]): void {
   const seen = new Set<string>();
   for (const edge of edges) {
-    const key = `${edge.fromNode.name}\u0000${edge.toNode.name}`;
-    if (seen.has(key)) {
-      throw new Error(
-        `Graph validation failed. Duplicate edge found: from=${edge.fromNode.name}, to=${edge.toNode.name}`,
-      );
+    const unconditional = edge.route === null || edge.route === undefined;
+    const routes = unconditional
+      ? [null]
+      : (Array.isArray(edge.route) ? edge.route : [edge.route]).map(String);
+    for (const route of routes) {
+      // JSON so an unconditional edge (`null`) cannot collide with an edge
+      // routed on the literal string "null".
+      const key = JSON.stringify([edge.fromNode.name, edge.toNode.name, route]);
+      if (seen.has(key)) {
+        throw new Error(
+          `Graph validation failed. Duplicate edge found: from=${
+            edge.fromNode.name
+          }, to=${edge.toNode.name}${
+            unconditional ? '' : `, route=${JSON.stringify(route)}`
+          }. ${
+            unconditional
+              ? 'The same pair is already connected unconditionally'
+              : 'That route already points at this node'
+          }, so the target would be triggered twice.`,
+        );
+      }
+      seen.add(key);
     }
-    seen.add(key);
   }
 }
 

--- a/core/test/workflow/graph_validation_test.ts
+++ b/core/test/workflow/graph_validation_test.ts
@@ -73,6 +73,37 @@ describe('graph validation', () => {
     ).toThrow(/duplicate edge/i);
   });
 
+  it('allows two route keys pointing at the same node', () => {
+    const [router, shared] = [n('router'), n('shared')];
+    const graph = build([
+      ['START', router],
+      [router, {approve: shared, escalate: shared}],
+    ]);
+    expect(graph.getNextPendingNodes('router', 'approve')).toEqual(['shared']);
+    expect(graph.getNextPendingNodes('router', 'escalate')).toEqual(['shared']);
+  });
+
+  it('allows a routed edge alongside an unconditional one to the same node', () => {
+    const [a, b] = [n('a'), n('b')];
+    expect(() =>
+      build([['START', a], [a, b], new Edge(a, b, 'retry')]),
+    ).not.toThrow();
+  });
+
+  it('rejects the same route pointing at the same node twice', () => {
+    const [a, b] = [n('a'), n('b')];
+    expect(() =>
+      build([['START', a], new Edge(a, b, 'go'), new Edge(a, b, 'go')]),
+    ).toThrow(/duplicate edge.*route="go"/i);
+  });
+
+  it('rejects a multi-route edge overlapping a single-route one', () => {
+    const [a, b] = [n('a'), n('b')];
+    expect(() =>
+      build([['START', a], new Edge(a, b, ['x', 'y']), new Edge(a, b, 'y')]),
+    ).toThrow(/duplicate edge.*route="y"/i);
+  });
+
   it('rejects multiple DEFAULT_ROUTE edges from one node', () => {
     const [a, b, c] = [n('a'), n('b'), n('c')];
     expect(() =>

--- a/core/test/workflow/routing_test.ts
+++ b/core/test/workflow/routing_test.ts
@@ -48,6 +48,29 @@ describe('workflow routing values', () => {
     expect((await driveNode(wf, 'x')).output).toBe('target(3)');
   });
 
+  it('reuses one sub-workflow instance across two route keys', async () => {
+    const shared = new Workflow({
+      name: 'shared_sub',
+      edges: [['START', echo('wrapped')]],
+    });
+    const build = (route: RouteValue) => {
+      const router = emit('router', route);
+      return new Workflow({
+        name: 'reuse_parent',
+        edges: [
+          ['START', router],
+          [router, {approve: shared, escalate: shared}],
+        ],
+      });
+    };
+    expect((await driveNode(build('approve'), 'x')).output).toBe(
+      'wrapped(approve)',
+    );
+    expect((await driveNode(build('escalate'), 'x')).output).toBe(
+      'wrapped(escalate)',
+    );
+  });
+
   it('fans out from a single route to multiple nodes, then joins', async () => {
     const router = emit('router', 'go');
     const a = echo('a');

--- a/dev/src/server/agent_graph.ts
+++ b/dev/src/server/agent_graph.ts
@@ -322,17 +322,38 @@ function drawWorkflowEdges(
   path: string,
   highlightsPairs: Array<[string, string]>,
 ) {
-  // No grouping by endpoint pair is needed before emitting into the `strict`
-  // root graph: `validateDuplicateEdges` rejects a second edge with the same
-  // `from`/`to` at construction, so two routes to one node arrive as a single
-  // multi-route `Edge` and are joined by `getRouteLabels`.
+  // Edges are grouped by anchor pair before being emitted into the `strict`
+  // root graph, which merges same-endpoint statements and would keep only the
+  // last one's label. Two route keys can legitimately point at one node
+  // (`{approve: shared, escalate: shared}`), so their routes are joined into a
+  // single label exactly as a multi-route `Edge`'s are.
+  const merged = new Map<
+    string,
+    {tail: string; head: string; routes: string[]; highlighted: boolean}
+  >();
+
   for (const edge of graph.edges) {
     const from = workflowNodeId(edge.fromNode, path);
     const to = workflowNodeId(edge.toNode, path);
     const tail = workflowExitAnchorId(edge.fromNode, path);
     const head = workflowEntryAnchorId(edge.toNode, path);
-    const routes = getRouteLabels(edge.route);
-    const highlighted = isHighlightedEdge(from, to, highlightsPairs);
+    const key = `${tail}\u0000${head}`;
+    const entry = merged.get(key) ?? {
+      tail,
+      head,
+      routes: [],
+      highlighted: false,
+    };
+    for (const label of getRouteLabels(edge.route)) {
+      if (!entry.routes.includes(label)) {
+        entry.routes.push(label);
+      }
+    }
+    entry.highlighted ||= isHighlightedEdge(from, to, highlightsPairs);
+    merged.set(key, entry);
+  }
+
+  for (const {tail, head, routes, highlighted} of merged.values()) {
     const color = highlighted ? LIGHT_GREEN : LIGHT_GRAY;
     cluster.addEdge(
       new Edge([new Node(tail), new Node(head)], {

--- a/dev/test/server/agent_graph_test.ts
+++ b/dev/test/server/agent_graph_test.ts
@@ -343,24 +343,26 @@ describe('AgentGraph — graph Workflow', () => {
     );
   });
 
-  it('cannot be handed two separate edges with the same endpoints', () => {
+  it('merges two routes to the same node into one labelled edge', async () => {
     const classify = node(noopHandler, {name: 'classify'});
     const send = node(noopHandler, {name: 'send'});
 
-    // The renderer emits one DOT statement per `Edge` into a `strict` graph, so
-    // two edges sharing endpoints would be merged by graphviz and lose a label.
-    // Core forbids that shape, so a routing map with two routes to one node
-    // never reaches the renderer at all.
-    expect(
-      () =>
-        new Workflow({
-          name: 'router',
-          edges: [
-            ['START', classify],
-            [classify, {yes: send, no: send}],
-          ],
-        }),
-    ).toThrow(/Duplicate edge found: from=classify, to=send/);
+    // The renderer emits into a `strict` graph, which merges same-endpoint
+    // statements and keeps only the last label. Two route keys pointing at one
+    // node are a supported shape, so the routes are joined before emitting.
+    const workflow = new Workflow({
+      name: 'router',
+      edges: [
+        ['START', classify],
+        [classify, {yes: send, no: send}],
+      ],
+    });
+
+    const dot = await renderDot(workflow);
+
+    expect(edgeBlock(dot, 'router.classify', 'router.send')).toContain(
+      'label = "yes, no"',
+    );
   });
 
   it('renders a nested workflow as a recursive cluster', async () => {


### PR DESCRIPTION
Fixes #740

## The bug

`validateDuplicateEdges` keyed its dedup set on `fromNode.name` and `toNode.name` alone (`core/src/workflow/utils/graph_validation.ts:98-105`), ignoring `edge.route`. Two route-distinct edges that happen to share a destination therefore collided:

```ts
const shared = new Workflow({ name: "shared_sub", edges: [["START", wrap]] });
export const rootAgent = new Workflow({
  name: "reuse_parent",
  edges: [
    ["START", router],
    [router, { B: shared, C: shared }],
  ],
});
// [ADK CLI] Error running agent: Graph validation failed. Duplicate edge found: from=router, to=shared_sub
```

This rejected the obvious way to point two decisions at one reusable sub-process, at graph construction, before any input is read. `RoutingMap` places no restriction on two keys sharing a target and the parser already expands them into two distinct `(from, to, route)` triples the matcher handles correctly. The only workaround was to instantiate two identically-shaped workflows under different names, defeating the reuse the sample teaches — and the message was wrong anyway, since the two edges differ in `route`.

## The fix

The route is part of an edge's identity, so it belongs in the key.

- A multi-route edge is checked **per route value**, since it is the route that fires an edge — `route: ['a','b']` and `route: 'b'` to the same target still collide on `'b'`.
- Route values are compared as strings, matching how `getNextPendingNodes` matches them.
- An unconditional edge (`route: null`) keeps its own identity, so it never collides with a routed one.
- The error now names the route it caught and says what would go wrong.

## Dev UI renderer

This turned up a coupled bug. `drawWorkflowEdges` emits one statement per `Edge` into a **`strict`** graphviz graph, which merges same-endpoint statements and keeps only the last label — and its comment said so explicitly, relying on core forbidding the shape:

> No grouping by endpoint pair is needed before emitting into the `strict` root graph: `validateDuplicateEdges` rejects a second edge with the same `from`/`to` at construction.

With core allowing it, the renderer now groups by anchor pair and joins the routes into one label, exactly as it already did for a multi-route `Edge`. The dev test that asserted core rejects this shape now asserts the label reads `"yes, no"`.

## Tests

`core/test/workflow/graph_validation_test.ts`:

- two route keys to one node are accepted, and each route resolves to it
- a routed edge alongside an unconditional one to the same node is accepted
- the same route twice to the same node is still rejected, naming the route
- a multi-route edge overlapping a single-route one is rejected on the shared value

Plus an end-to-end `routing_test.ts` case reusing one sub-workflow instance across two route keys, and the updated `dev/test/server/agent_graph_test.ts` label case.

Full unit suite passes (3403).
