### PR TITLE
fix(dev): stop --verbose eating the agent path

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -108,9 +108,15 @@ const ORIGINS_OPTION = new Option(
   '--allow_origins <string>',
   'Optional. The allow origins of the server',
 ).default('');
+// A plain flag, not `[boolean]`: an option declared with an optional value
+// swallows the argument that follows it, so `adk run --verbose <agent>` ate the
+// agent path and commander then reported that path as the missing positional.
+// Nothing reads a value from it either — `getLogLevelFromOptions` only tests it
+// for truth, which made `--verbose=false` turn verbose ON. Use `--log_level`
+// when a level rather than a switch is wanted.
 const VERBOSE_OPTION = new Option(
-  '-v, --verbose [boolean]',
-  'Optional. The verbose level of the server',
+  '-v, --verbose',
+  'Optional. Log at debug level. Shorthand for --log_level debug',
 ).default(false);
 const LOG_LEVEL_OPTION = new Option(
   '--log_level <string>',

--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -108,12 +108,6 @@ const ORIGINS_OPTION = new Option(
   '--allow_origins <string>',
   'Optional. The allow origins of the server',
 ).default('');
-// A plain flag, not `[boolean]`: an option declared with an optional value
-// swallows the argument that follows it, so `adk run --verbose <agent>` ate the
-// agent path and commander then reported that path as the missing positional.
-// Nothing reads a value from it either — `getLogLevelFromOptions` only tests it
-// for truth, which made `--verbose=false` turn verbose ON. Use `--log_level`
-// when a level rather than a switch is wanted.
 const VERBOSE_OPTION = new Option(
   '-v, --verbose',
   'Optional. Log at debug level. Shorthand for --log_level debug',

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -262,6 +262,21 @@ describe('CLI Entrypoint', () => {
       );
     });
 
+    it.each([
+      ['before the path', ['run', '--verbose', 'agent.ts']],
+      ['after the path', ['run', 'agent.ts', '--verbose']],
+    ])('takes --verbose %s', async (_name, args) => {
+      // `--verbose` was declared with an optional value, so placed before the
+      // positional it swallowed the agent path, and commander then reported
+      // the path the user actually supplied as the missing argument.
+      await parse(args);
+
+      expect(runAgent).toHaveBeenCalledWith(
+        expect.objectContaining({agentPath: 'agent.ts'}),
+      );
+      expect(setLogLevel).toHaveBeenCalledWith(LogLevel.DEBUG);
+    });
+
     it('should pass all options to runAgent', async () => {
       await parse([
         'run',

--- a/dev/test/cli/cli_test.ts
+++ b/dev/test/cli/cli_test.ts
@@ -266,9 +266,6 @@ describe('CLI Entrypoint', () => {
       ['before the path', ['run', '--verbose', 'agent.ts']],
       ['after the path', ['run', 'agent.ts', '--verbose']],
     ])('takes --verbose %s', async (_name, args) => {
-      // `--verbose` was declared with an optional value, so placed before the
-      // positional it swallowed the agent path, and commander then reported
-      // the path the user actually supplied as the missing argument.
       await parse(args);
 
       expect(runAgent).toHaveBeenCalledWith(


### PR DESCRIPTION
Fixes #739

## The bug

`--verbose` was declared as `-v, --verbose [boolean]` (`dev/src/cli/cli.ts:111-114`), an option with an _optional value_. Commander hands such an option the following argument whenever it does not look like another option, so the flag ate the agent path:

```bash
npx adk run --verbose ../samples/workflows/routes/loop_escalation/agent.ts
# error: missing required argument 'agent'
```

— naming as missing the very argument the user supplied. Nothing in `--help` hinted the flag had to come after the path.

Nothing reads a value from it either: `getLogLevelFromOptions` only tests it for truth, so `--verbose=false` set the string `"false"` and turned verbose **ON**.

## The fix

It is a switch, so it is declared as one. Flag order no longer matters:

```bash
npx adk run --verbose agent.ts   # ✔
npx adk run agent.ts --verbose   # ✔
```

`--log_level <level>` remains for choosing a level.

## Behaviour change

`--verbose=true` and `--verbose=false` were side effects of the optional-value declaration rather than a documented spelling, and both now fail loudly as unknown options. For `--verbose=false` that is an improvement on silently enabling what it asked to disable.

## Not fixed here

While testing this I found that **`-v` on a subcommand does nothing at all** — the root command's `-v, --version` shadows it, on `main` as well as on this branch:

```
run --verbose agent.ts  ->  agent="agent.ts" verbose=true
run -v agent.ts         ->  agent="agent.ts" verbose=false   <- silently ignored
```

So the `-v` workaround listed in the issue parses without error but never enables verbose. Undoing that means either changing a working root flag (`adk -v` → version) or dropping an advertised short flag, so it is left for its own change rather than smuggled in here. The regression test covers the long form only, and I have noted this on the issue.

The same optional-value declaration affects `--save_session`, `--otel_to_cloud`, `--a2a`, `--reload_agents` and `--with_ui`, which swallow a following positional the same way. Left out to keep this PR to the reported flag; happy to follow up. `--compile`/`--bundle` default to `true` and genuinely need a value form, so they should stay as they are (or move to `--no-*`).

Full unit suite passes (3400).
