### PR TITLE
fix(dev): stop an empty node response vanishing from the transcript

### DIFF
--- a/core/src/workflow/run_llm_agent_as_node.ts
+++ b/core/src/workflow/run_llm_agent_as_node.ts
@@ -20,6 +20,7 @@ import {
   FINISH_TASK_SUCCESS_RESULT,
   FINISH_TASK_TOOL_NAME,
 } from '../tools/finish_task_tool.js';
+import {logger} from '../utils/logger.js';
 import {isContent} from './base_node.js';
 import {NodeContext} from './node_context.js';
 
@@ -173,6 +174,18 @@ function maybeSetOutput(agent: LlmAgent, event: Event): void {
     } catch {
       output = text;
     }
+  }
+
+  if (output === '') {
+    // Logged at debug rather than warn, for the reason `getNextPendingNodes`
+    // logs its unmatched route there: an empty answer is the model's to give,
+    // so a correct run must not complain. It exists for the case it was
+    // written for — an empty value turning up several nodes downstream with
+    // nothing in the transcript to say which node produced it.
+    logger.debug(
+      `Agent '${agent.name}' returned an empty response, so this node's ` +
+        `output is the empty string and that is what the next node receives.`,
+    );
   }
 
   event.output = output;

--- a/core/test/workflow/llm_agent_test.ts
+++ b/core/test/workflow/llm_agent_test.ts
@@ -112,6 +112,33 @@ describe('LlmAgent as a node (single_turn)', () => {
     expect(events.some((e) => e.author === 'echo')).toBe(true);
   });
 
+  it('still emits an attributable event when the model answers with nothing', async () => {
+    // The node runs, its output is the empty string, and that empty value
+    // reaches the next node. What was missing is any way to see that from the
+    // transcript: the event carries no text, so a text-only renderer dropped
+    // it and the node looked as though it had never run.
+    const emptyAgent = new LlmAgent({
+      name: 'city_generator_agent',
+      model: new ScriptedLlm(() => ''),
+    });
+    const downstream = node(
+      (_c: NodeContext, input: unknown) => `city=${JSON.stringify(input)}`,
+      {name: 'downstream'},
+    );
+    const wf = new Workflow({
+      name: 'empty_wf',
+      edges: [['START', emptyAgent, downstream]],
+    });
+
+    const {output, events} = await driveWorkflow(wf, 'go');
+
+    const agentEvent = events.find((e) => e.author === 'city_generator_agent');
+    expect(agentEvent).toBeDefined();
+    expect(agentEvent!.output).toBe('');
+    expect(agentEvent!.nodeInfo?.path).toBe('empty_wf.city_generator_agent');
+    expect(output).toBe('city=""');
+  });
+
   it('lets an agent be used directly in edges, feeding a downstream node (baseline bug #3)', async () => {
     const upper = node(
       (_c: NodeContext, input: string) => input.toUpperCase(),

--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -108,6 +108,13 @@ function printEvent(event: Event, options: PrintEventOptions = {}): void {
     .join('');
   if (text) {
     console.log(`[${author}]: ${text}`);
+  } else if (event.output === '' && !event.partial) {
+    // A node whose result is the empty string still ran, and that empty value
+    // still travels on to the next node and into the final answer. Printing
+    // nothing for it left the node out of the transcript entirely, reading as
+    // though it had been skipped — the one thing the transcript must not say,
+    // since the reader is using it to find where the empty value came from.
+    console.log(`[${author}]: (empty response)`);
   }
 
   // Reported on the event, not as a text part, so text-only printing drops it.

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -547,5 +547,27 @@ describe('cli_run', () => {
 
       expect(output).not.toContain('is waiting');
     });
+
+    it('attributes a node whose response was empty', async () => {
+      // The node ran and handed the empty string to its successor, but with
+      // no text to print it vanished from the transcript, which then read as
+      // though it had been skipped.
+      const output = await runOneTurn({
+        author: 'city_generator_agent',
+        content: {role: 'model', parts: [{text: ''}]},
+        output: '',
+      });
+
+      expect(output).toContain('[city_generator_agent]: (empty response)');
+    });
+
+    it('stays quiet for an event that carries no output at all', async () => {
+      const output = await runOneTurn({
+        author: 'bookkeeping',
+        content: {role: 'model', parts: []},
+      });
+
+      expect(output).not.toContain('[bookkeeping]');
+    });
   });
 });


### PR DESCRIPTION
Fixes #728

## What actually happens

The issue reports that the node "emits no event at all". The event **is** emitted and is correct on the wire — I reproduced it:

```
{"author":"empty_agent","path":"wf.empty_agent","content":{"role":"model","parts":[{"text":""}]},"output":""}
{"author":"downstream","path":"wf.downstream","content":{"role":"model","parts":[{"text":"got=\"\""}]},"output":"got=\"\""}
```

The defect is in the renderer. `printEvent` prints text and nothing else, and `if (text)` is false for `''`, so an event with no text printed nothing at all. The node was then absent from the transcript entirely, reading exactly as though it had been skipped — while the empty string it produced went on to the next node and into the final answer.

That is the worst shape for this failure: the reader turns to the transcript precisely to find out which node produced the empty value, and the transcript answers that no node did.

## The fix

The node is attributed explicitly:

```
[city_generator_agent]: (empty response)
```

Only a result of `''` gets the line, so an event carrying no output at all stays silent as before, and nothing else about the renderer changes.

Also logs the promotion in `run_llm_agent_as_node`, at **debug** for the same reason `getNextPendingNodes` logs an unmatched route there: an empty answer is the model's to give, so a correct run must not complain — but the case is otherwise impossible to trace back to its node, which is exactly the "root cause not located" the issue describes.

## Not changed

The empty value still flows downstream. The model genuinely returned nothing, and inventing a value or throwing would both be worse than reporting it accurately. If a node wants to reject an empty upstream answer, that is what its `outputSchema` / its own body is for.

## Tests

- `dev/test/cli/cli_run_test.ts`: an empty-response event is attributed; an event with no output stays silent.
- `core/test/workflow/llm_agent_test.ts`: pins what the wire actually carries — the agent event exists, is attributed to `empty_wf.city_generator_agent`, has `output === ''`, and the successor receives `''`.

Full unit suite passes (3401).
