### PR TITLE
fix: pin auth scheme and credential fields to the issued request

### DIFF
--- a/core/src/auth/auth_preprocessor.ts
+++ b/core/src/auth/auth_preprocessor.ts
@@ -20,6 +20,7 @@ import {
 import {State} from '../sessions/state.js';
 import {BaseTool} from '../tools/base_tool.js';
 import {camelCaseKeys} from '../utils/case_utils.js';
+import {AuthCredential} from './auth_credential.js';
 import {AuthHandler} from './auth_handler.js';
 import {AuthConfig} from './auth_tool.js';
 
@@ -28,6 +29,36 @@ const TOOLSET_AUTH_CREDENTIAL_ID_PREFIX = '_adk_toolset_auth_';
 interface RequestCredentialArgs {
   authConfig?: AuthConfig;
   functionCallId?: string;
+}
+
+/**
+ * Merges OAuth2 fields from `source` into `target` for fields where `target`
+ * is unset. Mirrors adk-python's `_merge_credential_oauth2_fields`.
+ */
+function mergeCredentialOAuth2Fields(
+  target: AuthCredential | undefined,
+  source: AuthCredential | undefined,
+): AuthCredential | undefined {
+  if (!source) {
+    return target;
+  }
+  if (!target) {
+    return source;
+  }
+  if (!target.oauth2 && source.oauth2) {
+    target.oauth2 = {...source.oauth2};
+  } else if (target.oauth2 && source.oauth2) {
+    const targetOauth2 = target.oauth2;
+    const sourceOauth2 = source.oauth2;
+    for (const key of Object.keys(sourceOauth2) as Array<
+      keyof typeof sourceOauth2
+    >) {
+      if (targetOauth2[key] === undefined && sourceOauth2[key] !== undefined) {
+        (targetOauth2 as Record<string, unknown>)[key] = sourceOauth2[key];
+      }
+    }
+  }
+  return target;
 }
 
 async function storeAuthAndCollectResumeTargets(
@@ -54,12 +85,33 @@ async function storeAuthAndCollectResumeTargets(
     }
   }
 
+  // Step 2: Store credentials. The client's response supplies the result of
+  // the user's browser round trip; the auth scheme and the credential key
+  // come from the request this server issued.
   for (const fcId of authFcIds) {
-    const authConfig = authResponses[fcId] as AuthConfig;
     const requestedAuthConfig = requestedAuthConfigById[fcId];
-    if (requestedAuthConfig && requestedAuthConfig.credentialKey) {
+    if (!requestedAuthConfig) {
+      // Nothing to pin against, so the response would get to choose both
+      // the credential it is exchanged with and the endpoint that goes to.
+      continue;
+    }
+
+    const authConfig = authResponses[fcId] as AuthConfig;
+    // The scheme names the token endpoint the developer's secret is posted
+    // to -- it must come from the request this server issued, never from
+    // the client's response.
+    authConfig.authScheme = requestedAuthConfig.authScheme;
+    if (requestedAuthConfig.credentialKey) {
       authConfig.credentialKey = requestedAuthConfig.credentialKey;
     }
+    authConfig.rawAuthCredential = mergeCredentialOAuth2Fields(
+      authConfig.rawAuthCredential,
+      requestedAuthConfig.rawAuthCredential,
+    );
+    authConfig.exchangedAuthCredential = mergeCredentialOAuth2Fields(
+      authConfig.exchangedAuthCredential,
+      requestedAuthConfig.exchangedAuthCredential,
+    );
     await new AuthHandler(authConfig).parseAndStoreAuthResponse(state);
   }
 

--- a/core/test/auth/auth_preprocessor_test.ts
+++ b/core/test/auth/auth_preprocessor_test.ts
@@ -26,9 +26,13 @@ vi.mock('../../src/agents/functions.js', async (importOriginal) => {
   };
 });
 
+const authHandlerConstructorCalls: unknown[] = [];
 vi.mock('../../src/auth/auth_handler.js', () => ({
   AuthHandler: class {
     parseAndStoreAuthResponse = vi.fn().mockResolvedValue(undefined);
+    constructor(authConfig: unknown) {
+      authHandlerConstructorCalls.push(authConfig);
+    }
   },
 }));
 
@@ -502,5 +506,122 @@ describe('AuthPreprocessor', () => {
     const result = await generator.next();
 
     expect(result.done).toBe(true);
+  });
+
+  it('takes the auth scheme from the request, not the response', async () => {
+    // Taking the scheme from the response would let a client redirect the
+    // token exchange, and the developer's secret with it, to itself.
+    authHandlerConstructorCalls.length = 0;
+
+    const issuedAuthScheme = {
+      type: 'openIdConnect',
+      tokenEndpoint: 'https://example.com/token',
+      authorizationEndpoint: 'https://example.com/auth',
+    };
+    const forgedAuthScheme = {
+      type: 'openIdConnect',
+      tokenEndpoint: 'https://attacker.example/token',
+      authorizationEndpoint: 'https://attacker.example/auth',
+    };
+
+    const invocationContext = {
+      agent: {[LLM_AGENT_SYMBOL]: true, canonicalTools: vi.fn()},
+      session: {
+        state: {},
+        events: [
+          createEvent({
+            author: 'model',
+            id: 'originalEvent',
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc1',
+                    name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+                    args: {
+                      authConfig: {
+                        authScheme: issuedAuthScheme,
+                        credentialKey: 'testKey',
+                      },
+                      functionCallId: 'toolFc1',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+          createEvent({
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'fc1',
+                    name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+                    response: {
+                      authScheme: forgedAuthScheme,
+                      credentialKey: 'testKey',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    await generator.next();
+
+    expect(authHandlerConstructorCalls).toHaveLength(1);
+    const usedConfig = authHandlerConstructorCalls[0] as {
+      authScheme: {tokenEndpoint: string};
+    };
+    expect(usedConfig.authScheme.tokenEndpoint).toBe(
+      'https://example.com/token',
+    );
+  });
+
+  it('ignores a response with no matching request', async () => {
+    // With no matching request there is nothing to pin against, so the
+    // response would choose both the credential key and the endpoint.
+    authHandlerConstructorCalls.length = 0;
+
+    const forgedAuthScheme = {
+      type: 'openIdConnect',
+      tokenEndpoint: 'https://attacker.example/token',
+    };
+
+    const invocationContext = {
+      agent: {[LLM_AGENT_SYMBOL]: true, canonicalTools: vi.fn()},
+      session: {
+        state: {},
+        events: [
+          createEvent({
+            author: 'user',
+            content: {
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'fc-never-issued',
+                    name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+                    response: {
+                      authScheme: forgedAuthScheme,
+                      credentialKey: 'testKey',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    } as unknown as InvocationContext;
+
+    const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+    await generator.next();
+
+    expect(authHandlerConstructorCalls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
`storeAuthAndCollectResumeTargets` took `authConfig.authScheme` (and `rawAuthCredential`/`exchangedAuthCredential`, except `credentialKey`) directly from `authResponses[fcId]` — the CLIENT's response to an `adk_request_credential` call — rather than from the request this server originally issued.

`authScheme` names the OAuth2 token endpoint that `OAuth2CredentialExchanger.exchange()` POSTs the developer's `clientSecret` and the authorization code to (`getTokenEndpoint(authScheme)` → `fetchOAuth2Tokens(tokenEndpoint, body)`). A malicious or compromised client could therefore forge a response with `authScheme.tokenEndpoint` pointed at an attacker-controlled server, causing the token exchange — including the developer's real OAuth2 client secret — to be sent there instead of the legitimate provider, enabling an authorization-code interception attack.

Mirrors adk-python's identical, already-fixed vulnerability in the same-named `auth_preprocessor.py` ("fix(auth): take the auth scheme from the request, not the client's response", commit `8989aead`), whose own test docstring states the risk explicitly: *taking the scheme from the response would let a client redirect the token exchange, and the developer's secret with it, to itself.* Also ports `_merge_credential_oauth2_fields` as `mergeCredentialOAuth2Fields`, since adk-js had no equivalent helper and `rawAuthCredential`/`exchangedAuthCredential` were similarly unpinned.

Also adds a fail-closed guard: a response with no matching request in history is now skipped entirely (previously it would still reach `AuthHandler` with an `authConfig` entirely controlled by the response).

Adds two regression tests: one confirming the token endpoint used is the one the server issued even when the response claims a different one, and one confirming an unmatched response never reaches `AuthHandler`. Both were verified to fail against the pre-fix code (exact assertion failure: expected the attacker's forged endpoint to equal the real one) before the fix was applied, and pass after.

Verified: both new tests fail against the pre-fix code with the exact expected assertion failure, and pass after the fix. Broader `core/test/auth/` suite passes clean (12 files, 176/176 tests). `tsc --noEmit` clean.