### PR TITLE
fix: scrub credential material before forwarding to a remote A2A peer

### DIFF
--- a/core/src/a2a/a2a_remote_agent.ts
+++ b/core/src/a2a/a2a_remote_agent.ts
@@ -24,13 +24,14 @@ import {logger} from '../utils/logger.js';
 import {MessageRole} from './a2a_event.js';
 import {A2ARemoteAgentRunProcessor} from './a2a_remote_agent_run_processor.js';
 import {
+  getFunctionResponseCallId,
   getUserFunctionCallAt,
+  toForwardableA2AParts,
   toMissingRemoteSessionParts,
 } from './a2a_remote_agent_utils.js';
 import {resolveAgentCard} from './agent_card.js';
 import {toAdkEvent} from './event_converter_utils.js';
 import {getA2ASessionMetadata} from './metadata_converter_utils.js';
-import {toA2AParts} from './part_converter_utils.js';
 
 export {AGENT_CARD_PATH};
 
@@ -169,9 +170,18 @@ export class RemoteA2AAgent extends BaseAgent<RemoteA2AAgentConfig> {
 
       if (userFnCall) {
         const event = userFnCall.response;
-        parts = toA2AParts(
-          event.content?.parts || [],
+        // Route through the shared scrub: this credential response must not
+        // cross the trust boundary unless the remote peer itself is the one
+        // that asked for it (requestAuthor === this.name).
+        const fnCallId = getFunctionResponseCallId(event);
+        const callAuthors = fnCallId
+          ? new Map([[fnCallId, userFnCall.requestAuthor]])
+          : new Map<string, string>();
+        parts = toForwardableA2AParts(
+          event.content,
           event.longRunningToolIds,
+          callAuthors,
+          this.name,
         );
         taskId = userFnCall.taskId;
         contextId = userFnCall.contextId;

--- a/core/src/a2a/a2a_remote_agent.ts
+++ b/core/src/a2a/a2a_remote_agent.ts
@@ -24,8 +24,8 @@ import {logger} from '../utils/logger.js';
 import {MessageRole} from './a2a_event.js';
 import {A2ARemoteAgentRunProcessor} from './a2a_remote_agent_run_processor.js';
 import {
-  getFunctionResponseCallId,
   getUserFunctionCallAt,
+  peerRequestedCallIds,
   toForwardableA2AParts,
   toMissingRemoteSessionParts,
 } from './a2a_remote_agent_utils.js';
@@ -171,17 +171,17 @@ export class RemoteA2AAgent extends BaseAgent<RemoteA2AAgentConfig> {
       if (userFnCall) {
         const event = userFnCall.response;
         // Route through the shared scrub: this credential response must not
-        // cross the trust boundary unless the remote peer itself is the one
-        // that asked for it (requestAuthor === this.name).
-        const fnCallId = getFunctionResponseCallId(event);
-        const callAuthors = fnCallId
-          ? new Map([[fnCallId, userFnCall.requestAuthor]])
-          : new Map<string, string>();
+        // cross the trust boundary unless its id is one the peer itself
+        // exclusively requested. Computed over the full session, not just
+        // this one response event: an id counts as peer-requested only if
+        // EVERY event that issued a call for it was authored by the peer,
+        // so the check needs the whole history to catch a local request
+        // whose id the peer's own event reuses.
+        const peerRequestedIds = peerRequestedCallIds(events, this.name);
         parts = toForwardableA2AParts(
           event.content,
           event.longRunningToolIds,
-          callAuthors,
-          this.name,
+          peerRequestedIds,
         );
         taskId = userFnCall.taskId;
         contextId = userFnCall.contextId;

--- a/core/src/a2a/a2a_remote_agent_utils.ts
+++ b/core/src/a2a/a2a_remote_agent_utils.ts
@@ -5,12 +5,94 @@
  */
 
 import {Part as A2APart} from '@a2a-js/sdk';
-import {Part as GenAIPart} from '@google/genai';
+import {Content, Part as GenAIPart} from '@google/genai';
+import {REQUEST_CREDENTIAL_FUNCTION_CALL_NAME} from '../agents/functions.js';
 import {InvocationContext, requireAgent} from '../agents/invocation_context.js';
 import {Event as AdkEvent, createEvent} from '../events/event.js';
 import {Session} from '../sessions/session.js';
 import {AdkMetadataKeys} from './metadata_converter_utils.js';
 import {toA2AParts} from './part_converter_utils.js';
+
+// Top-level keys of a serialized AuthConfig, the shape an
+// adk_request_credential call's arguments (one level down, under
+// `authConfig`) and its response (flat) both carry.
+const AUTH_CONFIG_KEYS: ReadonlyArray<string> = ['authScheme', 'credentialKey'];
+
+/** Whether `payload` looks like a serialized AuthConfig (fail closed). */
+function payloadIsAuthConfig(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return false;
+  }
+  const keys = new Set(Object.keys(payload as Record<string, unknown>));
+  return AUTH_CONFIG_KEYS.every((key) => keys.has(key));
+}
+
+/** Whether a function_call carries credential material (fail closed). */
+function isCredentialFunctionCall(functionCall: {
+  name?: string;
+  args?: unknown;
+}): boolean {
+  if (functionCall.name === REQUEST_CREDENTIAL_FUNCTION_CALL_NAME) {
+    return true;
+  }
+  // A request wraps the AuthConfig in an AuthToolArguments envelope, so the
+  // shape has to be read one level down, under `authConfig`.
+  const args = functionCall.args;
+  if (!args || typeof args !== 'object') {
+    return false;
+  }
+  const authConfig = (args as Record<string, unknown>)['authConfig'];
+  return payloadIsAuthConfig(authConfig);
+}
+
+/** Whether a function_response carries credential material (fail closed). */
+function isCredentialFunctionResponse(functionResponse: {
+  name?: string;
+  response?: unknown;
+}): boolean {
+  if (functionResponse.name === REQUEST_CREDENTIAL_FUNCTION_CALL_NAME) {
+    return true;
+  }
+  return payloadIsAuthConfig(functionResponse.response);
+}
+
+/**
+ * Returns `content` with any credential-bearing function_call or
+ * function_response part removed.
+ *
+ * An adk_request_credential call carries a serialized AuthConfig in its
+ * arguments -- including rawAuthCredential, an OAuth2 client secret or a
+ * service account key -- and its response carries one back. Forwarding
+ * either to a remote A2A peer would leak that credential material outside
+ * the trust boundary it was issued within.
+ */
+function withoutCredentialParts(
+  content: Content | undefined,
+): Content | undefined {
+  if (!content || !content.parts) {
+    return content;
+  }
+  const hasCredentialPart = content.parts.some(
+    (part) =>
+      (part.functionCall && isCredentialFunctionCall(part.functionCall)) ||
+      (part.functionResponse &&
+        isCredentialFunctionResponse(part.functionResponse)),
+  );
+  if (!hasCredentialPart) {
+    return content;
+  }
+  return {
+    ...content,
+    parts: content.parts.filter(
+      (part) =>
+        !(part.functionCall && isCredentialFunctionCall(part.functionCall)) &&
+        !(
+          part.functionResponse &&
+          isCredentialFunctionResponse(part.functionResponse)
+        ),
+    ),
+  };
+}
 
 export interface UserFunctionCall {
   response: AdkEvent;
@@ -133,6 +215,14 @@ export function toMissingRemoteSessionParts(
 
   for (let i = lastRemoteResponseIndex + 1; i < events.length; i++) {
     let event = events[i];
+    // Drop credential material before anything else looks at the event.
+    // presentAsUserMessage renders a function_call as text with its
+    // arguments inlined, so scrubbing after it would be too late.
+    const scrubbedContent = withoutCredentialParts(event.content);
+    if (scrubbedContent !== event.content) {
+      event = {...event, content: scrubbedContent};
+    }
+
     if (event.author !== 'user' && event.author !== requireAgent(ctx).name) {
       event = presentAsUserMessage(ctx, event);
     }

--- a/core/src/a2a/a2a_remote_agent_utils.ts
+++ b/core/src/a2a/a2a_remote_agent_utils.ts
@@ -19,14 +19,6 @@ export interface UserFunctionCall {
   response: AdkEvent;
   taskId: string;
   contextId: string;
-  /**
-   * Author of the FunctionCall event this response answers. Distinguishes a
-   * credential this local agent requested (must never cross the trust
-   * boundary to the remote peer) from one the remote peer itself requested
-   * (the peer's own name, per toMissingRemoteSessionParts) -- the answer to
-   * that one IS what the peer is waiting for.
-   */
-  requestAuthor: string;
 }
 
 /**
@@ -71,7 +63,6 @@ export function getUserFunctionCallAt(
       response: candidate,
       taskId,
       contextId,
-      requestAuthor: request.author ?? '',
     };
   }
 
@@ -119,6 +110,9 @@ export function getFunctionResponseCallId(event: AdkEvent): string | undefined {
 // down, under `authConfig`) and its response (flat) both carry.
 const AUTH_CONFIG_SCHEME_KEY = 'authScheme';
 const AUTH_CONFIG_CREDENTIAL_KEYS: ReadonlyArray<string> = [
+  // camelCase only by design: callers normalise the payload with
+  // camelCaseKeys() before these keys are looked up, so the snake_case
+  // spellings (raw_auth_credential, exchanged_auth_credential) are covered.
   'rawAuthCredential',
   'exchangedAuthCredential',
 ];
@@ -190,34 +184,51 @@ function isCredentialFunctionResponse(functionResponse: {
 }
 
 /**
- * Builds a map from FunctionCall id to the author of the event that issued
- * it, across every event in `events`. Used to decide whether a credential
- * response answers a request this local agent raised (scrub) or one the
- * remote peer itself raised (forward -- see withoutCredentialParts).
+ * Ids of credential requests the remote peer raised itself. An id that ANY
+ * non-peer event also issued a call for is excluded: the peer authors its
+ * own session events under its own name (`toAdkEvent` forces
+ * `author = this.name`) and controls `functionCall.id` verbatim, so a bare
+ * id match -- without checking whether some OTHER event also issued a call
+ * for that same id -- would let a peer re-label this agent's own pending
+ * credential request as one the peer had asked for, by sending an
+ * unrelated reply that happens to carry a function_call part whose id
+ * collides with it.
  */
-export function buildFunctionCallAuthors(
+export function peerRequestedCallIds(
   events: readonly AdkEvent[],
-): Map<string, string> {
-  const authors = new Map<string, string>();
+  peerName: string,
+): ReadonlySet<string> {
+  const peer = new Set<string>();
+  const local = new Set<string>();
   for (const event of events) {
     for (const part of event.content?.parts ?? []) {
-      if (part.functionCall?.id) {
-        authors.set(part.functionCall.id, event.author ?? '');
+      const id = part.functionCall?.id;
+      if (!id) {
+        continue;
       }
+      (event.author === peerName ? peer : local).add(id);
     }
   }
-  return authors;
+  return new Set([...peer].filter((id) => !local.has(id)));
 }
 
 /**
  * Returns `content` with any credential-bearing function_call or
- * function_response part removed, except a function_response whose matching
- * request was authored by `peerName` -- that credential was requested BY the
- * remote peer, so withholding it would silently strand the peer's pending
- * request forever with nothing logged to explain why. Every other
- * credential-bearing part is a request this local agent raised for its own
- * tools, or an answer to one, and must never cross the trust boundary to the
- * peer.
+ * function_response part removed, except a function_response whose id is
+ * in `peerRequestedIds` -- that credential was requested BY the remote
+ * peer, so withholding it would silently strand the peer's pending request
+ * forever with nothing logged to explain why. Every other credential-
+ * bearing part is a request this local agent raised for its own tools, or
+ * an answer to one, and must never cross the trust boundary to the peer.
+ *
+ * The peer-requested exception only applies when the peer's own request
+ * event was authored under a non-'user' role: `messageToAdkEvent` sets
+ * `author: msg.role === 'user' ? 'user' : agentName`, so a peer that sends
+ * its own `adk_request_credential` inside a `role: 'user'` message is
+ * classified the same as a local request, and its answer is withheld --
+ * the handshake stalls (logged via the drop warning below, not silent),
+ * rather than leaking. Nothing in the A2A spec obliges a peer to use a
+ * non-user role.
  *
  * An adk_request_credential call carries a serialized AuthConfig in its
  * arguments -- including rawAuthCredential, an OAuth2 client secret or a
@@ -228,8 +239,7 @@ export function buildFunctionCallAuthors(
  */
 function withoutCredentialParts(
   content: Content | undefined,
-  callAuthors: ReadonlyMap<string, string>,
-  peerName: string,
+  peerRequestedIds: ReadonlySet<string>,
 ): Content | undefined {
   if (!content || !content.parts) {
     return content;
@@ -244,8 +254,7 @@ function withoutCredentialParts(
       isCredentialFunctionResponse(part.functionResponse)
     ) {
       const id = part.functionResponse.id;
-      const requestAuthor = id ? callAuthors.get(id) : undefined;
-      return requestAuthor !== peerName;
+      return !(id && peerRequestedIds.has(id));
     }
     return false;
   };
@@ -263,19 +272,21 @@ function withoutCredentialParts(
 
 /**
  * Converts genai parts to A2A parts for forwarding to the remote peer,
- * scrubbing credential material the peer did not itself request. The single
- * point both session-forwarding paths (toMissingRemoteSessionParts and the
- * getUserFunctionCallAt short-circuit in RemoteA2AAgent) converge on, so the
- * scrubbing guarantee holds by construction rather than by both call sites
- * remembering to apply it separately.
+ * scrubbing credential material the peer did not itself request.
+ *
+ * NOT the single point both session-forwarding paths converge on:
+ * `toMissingRemoteSessionParts` calls `withoutCredentialParts` directly,
+ * since it has to interleave `presentAsUserMessage` between the scrub and
+ * `toA2AParts`. The shared guarantee lives one level down, in
+ * `withoutCredentialParts` -- a third path calling `toA2AParts` directly
+ * would still bypass it.
  */
 export function toForwardableA2AParts(
   content: Content | undefined,
   longRunningToolIds: string[] | undefined,
-  callAuthors: ReadonlyMap<string, string>,
-  peerName: string,
+  peerRequestedIds: ReadonlySet<string>,
 ): A2APart[] {
-  const scrubbed = withoutCredentialParts(content, callAuthors, peerName);
+  const scrubbed = withoutCredentialParts(content, peerRequestedIds);
   if (!scrubbed?.parts) {
     return [];
   }
@@ -310,7 +321,7 @@ export function toMissingRemoteSessionParts(
     }
   }
 
-  const callAuthors = buildFunctionCallAuthors(events);
+  const peerRequestedIds = peerRequestedCallIds(events, peerName);
   const missingParts: A2APart[] = [];
 
   for (let i = lastRemoteResponseIndex + 1; i < events.length; i++) {
@@ -321,8 +332,7 @@ export function toMissingRemoteSessionParts(
     // which would embed the secret in a string no shape check can catch.
     const scrubbedContent = withoutCredentialParts(
       event.content,
-      callAuthors,
-      peerName,
+      peerRequestedIds,
     );
     if (scrubbedContent !== event.content) {
       event = {...event, content: scrubbedContent};

--- a/core/src/a2a/a2a_remote_agent_utils.ts
+++ b/core/src/a2a/a2a_remote_agent_utils.ts
@@ -10,94 +10,23 @@ import {REQUEST_CREDENTIAL_FUNCTION_CALL_NAME} from '../agents/functions.js';
 import {InvocationContext, requireAgent} from '../agents/invocation_context.js';
 import {Event as AdkEvent, createEvent} from '../events/event.js';
 import {Session} from '../sessions/session.js';
+import {camelCaseKeys} from '../utils/case_utils.js';
+import {logger} from '../utils/logger.js';
 import {AdkMetadataKeys} from './metadata_converter_utils.js';
 import {toA2AParts} from './part_converter_utils.js';
-
-// Top-level keys of a serialized AuthConfig, the shape an
-// adk_request_credential call's arguments (one level down, under
-// `authConfig`) and its response (flat) both carry.
-const AUTH_CONFIG_KEYS: ReadonlyArray<string> = ['authScheme', 'credentialKey'];
-
-/** Whether `payload` looks like a serialized AuthConfig (fail closed). */
-function payloadIsAuthConfig(payload: unknown): boolean {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return false;
-  }
-  const keys = new Set(Object.keys(payload as Record<string, unknown>));
-  return AUTH_CONFIG_KEYS.every((key) => keys.has(key));
-}
-
-/** Whether a function_call carries credential material (fail closed). */
-function isCredentialFunctionCall(functionCall: {
-  name?: string;
-  args?: unknown;
-}): boolean {
-  if (functionCall.name === REQUEST_CREDENTIAL_FUNCTION_CALL_NAME) {
-    return true;
-  }
-  // A request wraps the AuthConfig in an AuthToolArguments envelope, so the
-  // shape has to be read one level down, under `authConfig`.
-  const args = functionCall.args;
-  if (!args || typeof args !== 'object') {
-    return false;
-  }
-  const authConfig = (args as Record<string, unknown>)['authConfig'];
-  return payloadIsAuthConfig(authConfig);
-}
-
-/** Whether a function_response carries credential material (fail closed). */
-function isCredentialFunctionResponse(functionResponse: {
-  name?: string;
-  response?: unknown;
-}): boolean {
-  if (functionResponse.name === REQUEST_CREDENTIAL_FUNCTION_CALL_NAME) {
-    return true;
-  }
-  return payloadIsAuthConfig(functionResponse.response);
-}
-
-/**
- * Returns `content` with any credential-bearing function_call or
- * function_response part removed.
- *
- * An adk_request_credential call carries a serialized AuthConfig in its
- * arguments -- including rawAuthCredential, an OAuth2 client secret or a
- * service account key -- and its response carries one back. Forwarding
- * either to a remote A2A peer would leak that credential material outside
- * the trust boundary it was issued within.
- */
-function withoutCredentialParts(
-  content: Content | undefined,
-): Content | undefined {
-  if (!content || !content.parts) {
-    return content;
-  }
-  const hasCredentialPart = content.parts.some(
-    (part) =>
-      (part.functionCall && isCredentialFunctionCall(part.functionCall)) ||
-      (part.functionResponse &&
-        isCredentialFunctionResponse(part.functionResponse)),
-  );
-  if (!hasCredentialPart) {
-    return content;
-  }
-  return {
-    ...content,
-    parts: content.parts.filter(
-      (part) =>
-        !(part.functionCall && isCredentialFunctionCall(part.functionCall)) &&
-        !(
-          part.functionResponse &&
-          isCredentialFunctionResponse(part.functionResponse)
-        ),
-    ),
-  };
-}
 
 export interface UserFunctionCall {
   response: AdkEvent;
   taskId: string;
   contextId: string;
+  /**
+   * Author of the FunctionCall event this response answers. Distinguishes a
+   * credential this local agent requested (must never cross the trust
+   * boundary to the remote peer) from one the remote peer itself requested
+   * (the peer's own name, per toMissingRemoteSessionParts) -- the answer to
+   * that one IS what the peer is waiting for.
+   */
+  requestAuthor: string;
 }
 
 /**
@@ -142,6 +71,7 @@ export function getUserFunctionCallAt(
       response: candidate,
       taskId,
       contextId,
+      requestAuthor: request.author ?? '',
     };
   }
 
@@ -184,6 +114,174 @@ export function getFunctionResponseCallId(event: AdkEvent): string | undefined {
   return responsePart?.functionResponse?.id;
 }
 
+// Top-level keys of a serialized AuthConfig that indicate credential
+// material, the shape an adk_request_credential call's arguments (one level
+// down, under `authConfig`) and its response (flat) both carry.
+const AUTH_CONFIG_SCHEME_KEY = 'authScheme';
+const AUTH_CONFIG_CREDENTIAL_KEYS: ReadonlyArray<string> = [
+  'rawAuthCredential',
+  'exchangedAuthCredential',
+];
+
+/**
+ * Whether `payload` looks like a serialized AuthConfig carrying credential
+ * material. Requires `authScheme` plus at least one credential-bearing
+ * field, rather than requiring every field AuthConfig's type declares --
+ * a config read back off a function call's args can arrive missing fields
+ * its type promises (see credential_response_binding.ts), so requiring all
+ * of them would leave a gap for an incomplete-but-still-credential-bearing
+ * envelope.
+ *
+ * NOTE: this check is fail-OPEN, not fail-closed: a payload that doesn't
+ * match is forwarded unredacted, not dropped. Ambiguous input is treated as
+ * safe to forward, which is the direction that risks a leak, not the
+ * direction that risks over-dropping legitimate content.
+ */
+function payloadIsAuthConfig(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return false;
+  }
+  const keys = new Set(Object.keys(payload as Record<string, unknown>));
+  if (!keys.has(AUTH_CONFIG_SCHEME_KEY)) {
+    return false;
+  }
+  return AUTH_CONFIG_CREDENTIAL_KEYS.some((key) => keys.has(key));
+}
+
+/**
+ * Whether a function_call carries credential material.
+ *
+ * NOTE: fail-open, as above -- an ambiguous call is left unscrubbed.
+ */
+function isCredentialFunctionCall(functionCall: {
+  name?: string;
+  args?: unknown;
+}): boolean {
+  if (functionCall.name === REQUEST_CREDENTIAL_FUNCTION_CALL_NAME) {
+    return true;
+  }
+  // A request wraps the AuthConfig in an AuthToolArguments envelope, so the
+  // shape has to be read one level down, under `authConfig`. Args are
+  // normalised with camelCaseKeys first: generateAuthEvent (the primary,
+  // in-tree producer) emits this envelope in snake_case
+  // (function_call_id/auth_config), and reading it raw would silently never
+  // match that shape.
+  const args = camelCaseKeys(functionCall.args);
+  if (!args || typeof args !== 'object') {
+    return false;
+  }
+  const authConfig = (args as Record<string, unknown>)['authConfig'];
+  return payloadIsAuthConfig(authConfig);
+}
+
+/**
+ * Whether a function_response carries credential material.
+ *
+ * NOTE: fail-open, as above -- an ambiguous response is left unscrubbed.
+ */
+function isCredentialFunctionResponse(functionResponse: {
+  name?: string;
+  response?: unknown;
+}): boolean {
+  if (functionResponse.name === REQUEST_CREDENTIAL_FUNCTION_CALL_NAME) {
+    return true;
+  }
+  return payloadIsAuthConfig(camelCaseKeys(functionResponse.response));
+}
+
+/**
+ * Builds a map from FunctionCall id to the author of the event that issued
+ * it, across every event in `events`. Used to decide whether a credential
+ * response answers a request this local agent raised (scrub) or one the
+ * remote peer itself raised (forward -- see withoutCredentialParts).
+ */
+export function buildFunctionCallAuthors(
+  events: readonly AdkEvent[],
+): Map<string, string> {
+  const authors = new Map<string, string>();
+  for (const event of events) {
+    for (const part of event.content?.parts ?? []) {
+      if (part.functionCall?.id) {
+        authors.set(part.functionCall.id, event.author ?? '');
+      }
+    }
+  }
+  return authors;
+}
+
+/**
+ * Returns `content` with any credential-bearing function_call or
+ * function_response part removed, except a function_response whose matching
+ * request was authored by `peerName` -- that credential was requested BY the
+ * remote peer, so withholding it would silently strand the peer's pending
+ * request forever with nothing logged to explain why. Every other
+ * credential-bearing part is a request this local agent raised for its own
+ * tools, or an answer to one, and must never cross the trust boundary to the
+ * peer.
+ *
+ * An adk_request_credential call carries a serialized AuthConfig in its
+ * arguments -- including rawAuthCredential, an OAuth2 client secret or a
+ * service account key -- and its response carries the exchanged credential
+ * back (an API key, bearer token, or exchanged OAuth token). Forwarding
+ * either to a remote A2A peer would leak that credential material outside
+ * the trust boundary it was issued within.
+ */
+function withoutCredentialParts(
+  content: Content | undefined,
+  callAuthors: ReadonlyMap<string, string>,
+  peerName: string,
+): Content | undefined {
+  if (!content || !content.parts) {
+    return content;
+  }
+
+  const isDroppedCredentialPart = (part: GenAIPart): boolean => {
+    if (part.functionCall && isCredentialFunctionCall(part.functionCall)) {
+      return true;
+    }
+    if (
+      part.functionResponse &&
+      isCredentialFunctionResponse(part.functionResponse)
+    ) {
+      const id = part.functionResponse.id;
+      const requestAuthor = id ? callAuthors.get(id) : undefined;
+      return requestAuthor !== peerName;
+    }
+    return false;
+  };
+
+  const parts = content.parts.filter((part) => !isDroppedCredentialPart(part));
+  if (parts.length === content.parts.length) {
+    return content;
+  }
+  logger.warn(
+    `Dropped ${content.parts.length - parts.length} credential-bearing ` +
+      'part(s) before forwarding to the remote peer -- it did not request them.',
+  );
+  return {...content, parts};
+}
+
+/**
+ * Converts genai parts to A2A parts for forwarding to the remote peer,
+ * scrubbing credential material the peer did not itself request. The single
+ * point both session-forwarding paths (toMissingRemoteSessionParts and the
+ * getUserFunctionCallAt short-circuit in RemoteA2AAgent) converge on, so the
+ * scrubbing guarantee holds by construction rather than by both call sites
+ * remembering to apply it separately.
+ */
+export function toForwardableA2AParts(
+  content: Content | undefined,
+  longRunningToolIds: string[] | undefined,
+  callAuthors: ReadonlyMap<string, string>,
+  peerName: string,
+): A2APart[] {
+  const scrubbed = withoutCredentialParts(content, callAuthors, peerName);
+  if (!scrubbed?.parts) {
+    return [];
+  }
+  return toA2AParts(scrubbed.parts, longRunningToolIds);
+}
+
 /**
  * Returns A2A content parts for all events not yet seen by the remote agent,
  * along with the A2A context ID found in the most recent remote agent event.
@@ -198,12 +296,13 @@ export function toMissingRemoteSessionParts(
   session: Session,
 ): {parts: A2APart[]; contextId?: string} {
   const events = session.events;
+  const peerName = requireAgent(ctx).name;
   let contextId: string | undefined = undefined;
   let lastRemoteResponseIndex = -1;
 
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i];
-    if (event.author === requireAgent(ctx).name) {
+    if (event.author === peerName) {
       lastRemoteResponseIndex = i;
       const metadata = event.customMetadata || {};
       contextId = metadata[AdkMetadataKeys.CONTEXT_ID] as string;
@@ -211,19 +310,25 @@ export function toMissingRemoteSessionParts(
     }
   }
 
+  const callAuthors = buildFunctionCallAuthors(events);
   const missingParts: A2APart[] = [];
 
   for (let i = lastRemoteResponseIndex + 1; i < events.length; i++) {
     let event = events[i];
-    // Drop credential material before anything else looks at the event.
-    // presentAsUserMessage renders a function_call as text with its
-    // arguments inlined, so scrubbing after it would be too late.
-    const scrubbedContent = withoutCredentialParts(event.content);
+
+    // Scrub before presentAsUserMessage, not after: it renders a
+    // function_call/function_response as text with its arguments inlined,
+    // which would embed the secret in a string no shape check can catch.
+    const scrubbedContent = withoutCredentialParts(
+      event.content,
+      callAuthors,
+      peerName,
+    );
     if (scrubbedContent !== event.content) {
       event = {...event, content: scrubbedContent};
     }
 
-    if (event.author !== 'user' && event.author !== requireAgent(ctx).name) {
+    if (event.author !== 'user' && event.author !== peerName) {
       event = presentAsUserMessage(ctx, event);
     }
 

--- a/core/test/a2a/remote_agent_test.ts
+++ b/core/test/a2a/remote_agent_test.ts
@@ -541,4 +541,227 @@ describe('A2ARemoteAgent', () => {
     const dumped = JSON.stringify(capturedParts);
     expect(dumped).toContain('ANSWER_FOR_THE_PEER');
   });
+
+  it('does not let a peer event reusing a local request id relabel it as peer-requested (local first)', async () => {
+    // The attack buildFunctionCallAuthors was vulnerable to: the peer
+    // authors its own session events under its own name by construction,
+    // and controls functionCall.id verbatim, so a peer reply that happens
+    // to carry a function_call part whose id collides with a pending LOCAL
+    // adk_request_credential must not re-label that local request as
+    // peer-authored. The forged event lands between the real local request
+    // and the user's answer -- exactly the window in which the user is
+    // looking at an auth prompt and may still be talking to the peer.
+    const card: AgentCard = {
+      name: 'Remote',
+      description: 'test',
+      protocolVersion: '1.0',
+      defaultInputModes: [],
+      defaultOutputModes: [],
+      capabilities: {streaming: true},
+      skills: [],
+      url: 'https://example.com',
+      version: '1.0',
+    };
+
+    let capturedParts: unknown;
+    const agent = new RemoteA2AAgent({
+      name: 'test-agent',
+      agentCard: card,
+      clientFactory: mockClientFactory,
+      beforeRequestCallbacks: [
+        async (ctx, params) => {
+          capturedParts = params.message.parts;
+        },
+      ],
+    });
+
+    vi.mocked(mockClient.sendMessageStream).mockReturnValue(
+      (async function* () {})(),
+    );
+
+    const localRequest = createEvent({
+      author: 'root_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              args: {functionCallId: 'toolFc1', authConfig: {}},
+            },
+          },
+        ],
+      },
+    });
+    // Forged: same id as the local request, authored as the peer
+    // ("test-agent", the name RemoteA2AAgent's own toAdkEvent conversion
+    // would stamp on an incoming peer message).
+    const peerForge = createEvent({
+      author: 'test-agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              args: {functionCallId: 'peerToolFc1', authConfig: {}},
+            },
+          },
+        ],
+      },
+    });
+    const answer = createEvent({
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              response: {
+                authScheme: {type: 'oauth2'},
+                credentialKey: 'k',
+                exchangedAuthCredential: {
+                  oauth2: {accessToken: 'SUPER_SECRET_DO_NOT_LEAK'},
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const context = createMockContext({
+      session: {
+        id: 'test-session',
+        userId: 'test-user',
+        appName: 'test-app',
+        events: [localRequest, peerForge, answer],
+        state: {},
+      } as unknown as Session,
+    });
+
+    for await (const _ of agent.runAsync(context)) {
+      // empty
+    }
+
+    const dumped = JSON.stringify(capturedParts);
+    expect(dumped).not.toContain('SUPER_SECRET_DO_NOT_LEAK');
+  });
+
+  it('does not let a peer event reusing a local request id relabel it as peer-requested (toMissingRemoteSessionParts path)', async () => {
+    // Same attack, forced through the OTHER forwarding path. The short-
+    // circuit test above only exercises getUserFunctionCallAt (path A,
+    // taken when the answer is the session's last event); adding a
+    // trailing event after the answer makes it not the last event, so
+    // runAsyncImpl falls through to toMissingRemoteSessionParts (path B)
+    // instead. Both paths call the same withoutCredentialParts, but
+    // through different call sites that both had to be fixed.
+    const card: AgentCard = {
+      name: 'Remote',
+      description: 'test',
+      protocolVersion: '1.0',
+      defaultInputModes: [],
+      defaultOutputModes: [],
+      capabilities: {streaming: true},
+      skills: [],
+      url: 'https://example.com',
+      version: '1.0',
+    };
+
+    let capturedParts: unknown;
+    const agent = new RemoteA2AAgent({
+      name: 'test-agent',
+      agentCard: card,
+      clientFactory: mockClientFactory,
+      beforeRequestCallbacks: [
+        async (ctx, params) => {
+          capturedParts = params.message.parts;
+        },
+      ],
+    });
+
+    vi.mocked(mockClient.sendMessageStream).mockReturnValue(
+      (async function* () {})(),
+    );
+
+    const localRequest = createEvent({
+      author: 'root_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              args: {functionCallId: 'toolFc1', authConfig: {}},
+            },
+          },
+        ],
+      },
+    });
+    const peerForge = createEvent({
+      author: 'test-agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              args: {functionCallId: 'peerToolFc1', authConfig: {}},
+            },
+          },
+        ],
+      },
+    });
+    const answer = createEvent({
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              response: {
+                authScheme: {type: 'oauth2'},
+                credentialKey: 'k',
+                exchangedAuthCredential: {
+                  oauth2: {accessToken: 'SUPER_SECRET_DO_NOT_LEAK'},
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    // Trailing event: the answer is no longer the last session event, so
+    // getUserFunctionCallAt does not match and runAsyncImpl falls through
+    // to toMissingRemoteSessionParts.
+    const trailingText = createEvent({
+      author: 'root_agent',
+      content: {role: 'model', parts: [{text: 'continuing...'}]},
+    });
+
+    const context = createMockContext({
+      session: {
+        id: 'test-session',
+        userId: 'test-user',
+        appName: 'test-app',
+        events: [localRequest, peerForge, answer, trailingText],
+        state: {},
+      } as unknown as Session,
+    });
+
+    for await (const _ of agent.runAsync(context)) {
+      // empty
+    }
+
+    const dumped = JSON.stringify(capturedParts);
+    expect(dumped).not.toContain('SUPER_SECRET_DO_NOT_LEAK');
+  });
 });

--- a/core/test/a2a/remote_agent_test.ts
+++ b/core/test/a2a/remote_agent_test.ts
@@ -366,4 +366,179 @@ describe('A2ARemoteAgent', () => {
       }),
     );
   });
+
+  it('does not leak a credential response as the final session event', async () => {
+    // Regression test for the getUserFunctionCallAt short-circuit bypassing
+    // credential scrubbing: this reproduces the exact end-to-end shape --
+    // a real RemoteA2AAgent, the local agent's own adk_request_credential
+    // call, and the client's answer as the LAST event -- and asserts on
+    // what actually goes out over sendMessageStream, not on an isolated
+    // call to a utility function.
+    const card: AgentCard = {
+      name: 'Remote',
+      description: 'test',
+      protocolVersion: '1.0',
+      defaultInputModes: [],
+      defaultOutputModes: [],
+      capabilities: {streaming: true},
+      skills: [],
+      url: 'https://example.com',
+      version: '1.0',
+    };
+
+    let capturedParts: unknown;
+    const agent = new RemoteA2AAgent({
+      name: 'test-agent',
+      agentCard: card,
+      clientFactory: mockClientFactory,
+      beforeRequestCallbacks: [
+        async (ctx, params) => {
+          capturedParts = params.message.parts;
+        },
+      ],
+    });
+
+    vi.mocked(mockClient.sendMessageStream).mockReturnValue(
+      (async function* () {})(),
+    );
+
+    const credentialRequest = createEvent({
+      author: 'root_agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              args: {functionCallId: 'toolFc1', authConfig: {}},
+            },
+          },
+        ],
+      },
+    });
+    const credentialResponse = createEvent({
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'fc1',
+              name: 'adk_request_credential',
+              response: {
+                authScheme: {type: 'oauth2'},
+                credentialKey: 'k',
+                exchangedAuthCredential: {
+                  oauth2: {accessToken: 'SUPER_SECRET_TOKEN'},
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const context = createMockContext({
+      session: {
+        id: 'test-session',
+        userId: 'test-user',
+        appName: 'test-app',
+        events: [credentialRequest, credentialResponse],
+        state: {},
+      } as unknown as Session,
+    });
+
+    for await (const _ of agent.runAsync(context)) {
+      // empty
+    }
+
+    const dumped = JSON.stringify(capturedParts);
+    expect(dumped).not.toContain('SUPER_SECRET_TOKEN');
+  });
+
+  it('forwards a credential response the remote peer itself requested, as the final event', async () => {
+    const card: AgentCard = {
+      name: 'Remote',
+      description: 'test',
+      protocolVersion: '1.0',
+      defaultInputModes: [],
+      defaultOutputModes: [],
+      capabilities: {streaming: true},
+      skills: [],
+      url: 'https://example.com',
+      version: '1.0',
+    };
+
+    let capturedParts: unknown;
+    const agent = new RemoteA2AAgent({
+      name: 'test-agent',
+      agentCard: card,
+      clientFactory: mockClientFactory,
+      beforeRequestCallbacks: [
+        async (ctx, params) => {
+          capturedParts = params.message.parts;
+        },
+      ],
+    });
+
+    vi.mocked(mockClient.sendMessageStream).mockReturnValue(
+      (async function* () {})(),
+    );
+
+    // The peer's own request -- authored by "test-agent", the peer's name.
+    const peerCredentialRequest = createEvent({
+      author: 'test-agent',
+      content: {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'peer-fc1',
+              name: 'adk_request_credential',
+              args: {functionCallId: 'peerToolFc1', authConfig: {}},
+            },
+          },
+        ],
+      },
+    });
+    const answerToPeer = createEvent({
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'peer-fc1',
+              name: 'adk_request_credential',
+              response: {
+                authScheme: {type: 'oauth2'},
+                credentialKey: 'peer-key',
+                exchangedAuthCredential: {
+                  oauth2: {accessToken: 'ANSWER_FOR_THE_PEER'},
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const context = createMockContext({
+      session: {
+        id: 'test-session',
+        userId: 'test-user',
+        appName: 'test-app',
+        events: [peerCredentialRequest, answerToPeer],
+        state: {},
+      } as unknown as Session,
+    });
+
+    for await (const _ of agent.runAsync(context)) {
+      // empty
+    }
+
+    const dumped = JSON.stringify(capturedParts);
+    expect(dumped).toContain('ANSWER_FOR_THE_PEER');
+  });
 });

--- a/core/test/a2a/remote_agent_utils_test.ts
+++ b/core/test/a2a/remote_agent_utils_test.ts
@@ -248,5 +248,84 @@ describe('remote_agent_utils', () => {
         '[other-agent] said: other response',
       );
     });
+
+    it('drops a credential request function_call from forwarded parts', () => {
+      // An adk_request_credential call carries a serialized AuthConfig in
+      // its arguments, including rawAuthCredential -- an OAuth2 client
+      // secret or a service account key. It must never reach a remote peer.
+      const credentialRequest = createEvent({
+        author: 'root_agent',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'fc-1',
+                name: 'adk_request_credential',
+                args: {
+                  functionCallId: 'toolFc1',
+                  authConfig: {
+                    authScheme: {type: 'oauth2'},
+                    credentialKey: 'test-key',
+                    rawAuthCredential: {
+                      oauth2: {
+                        clientId: 'real-client-id',
+                        clientSecret: 'SUPER_SECRET_DO_NOT_LEAK',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            {text: 'accompanying text'},
+          ],
+        },
+      });
+
+      const session = {events: [credentialRequest]} as unknown as Session;
+
+      const result = toMissingRemoteSessionParts(mockCtx, session);
+      const dumped = JSON.stringify(result.parts);
+
+      expect(dumped).not.toContain('SUPER_SECRET_DO_NOT_LEAK');
+      expect(dumped).not.toContain('adk_request_credential');
+      // The accompanying text part is preserved.
+      expect(
+        result.parts.some((p) =>
+          (p as TextPart).text?.includes('accompanying text'),
+        ),
+      ).toBe(true);
+    });
+
+    it('drops a credential response function_response from forwarded parts', () => {
+      const credentialResponse = createEvent({
+        author: 'user',
+        content: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'fc-1',
+                name: 'adk_request_credential',
+                response: {
+                  authScheme: {type: 'oauth2'},
+                  credentialKey: 'test-key',
+                  exchangedAuthCredential: {
+                    oauth2: {accessToken: 'SECRET_ACCESS_TOKEN'},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const session = {events: [credentialResponse]} as unknown as Session;
+
+      const result = toMissingRemoteSessionParts(mockCtx, session);
+      const dumped = JSON.stringify(result.parts);
+
+      expect(dumped).not.toContain('SECRET_ACCESS_TOKEN');
+    });
   });
 });

--- a/core/test/a2a/remote_agent_utils_test.ts
+++ b/core/test/a2a/remote_agent_utils_test.ts
@@ -249,10 +249,11 @@ describe('remote_agent_utils', () => {
       );
     });
 
-    it('drops a credential request function_call from forwarded parts', () => {
-      // An adk_request_credential call carries a serialized AuthConfig in
-      // its arguments, including rawAuthCredential -- an OAuth2 client
-      // secret or a service account key. It must never reach a remote peer.
+    it('drops a credential request function_call this agent raised', () => {
+      // An adk_request_credential call this LOCAL agent (author != peer
+      // name) raised carries a serialized AuthConfig in its arguments,
+      // including rawAuthCredential -- an OAuth2 client secret or a service
+      // account key. It must never reach a remote peer.
       const credentialRequest = createEvent({
         author: 'root_agent',
         content: {
@@ -289,7 +290,6 @@ describe('remote_agent_utils', () => {
 
       expect(dumped).not.toContain('SUPER_SECRET_DO_NOT_LEAK');
       expect(dumped).not.toContain('adk_request_credential');
-      // The accompanying text part is preserved.
       expect(
         result.parts.some((p) =>
           (p as TextPart).text?.includes('accompanying text'),
@@ -297,7 +297,22 @@ describe('remote_agent_utils', () => {
       ).toBe(true);
     });
 
-    it('drops a credential response function_response from forwarded parts', () => {
+    it('drops a credential response this agent raised the request for', () => {
+      const credentialRequest = createEvent({
+        author: 'root_agent',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'fc-1',
+                name: 'adk_request_credential',
+                args: {functionCallId: 'toolFc1', authConfig: {}},
+              },
+            },
+          ],
+        },
+      });
       const credentialResponse = createEvent({
         author: 'user',
         content: {
@@ -320,12 +335,131 @@ describe('remote_agent_utils', () => {
         },
       });
 
-      const session = {events: [credentialResponse]} as unknown as Session;
+      const session = {
+        events: [credentialRequest, credentialResponse],
+      } as unknown as Session;
 
       const result = toMissingRemoteSessionParts(mockCtx, session);
       const dumped = JSON.stringify(result.parts);
 
       expect(dumped).not.toContain('SECRET_ACCESS_TOKEN');
+    });
+
+    it('forwards a credential response the remote peer itself requested', () => {
+      // The remote peer's OWN request for a credential arrives as an event
+      // authored by the peer's own name (mockAgent.name, "test-agent") --
+      // see toAdkEvent. Its answer must reach the peer, or the peer's
+      // pending request is silently stranded forever.
+      const peerCredentialRequest = createEvent({
+        author: 'test-agent', // the peer's own name
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'peer-fc-1',
+                name: 'adk_request_credential',
+                args: {functionCallId: 'peerToolFc1', authConfig: {}},
+              },
+            },
+          ],
+        },
+      });
+      const answerToPeer = createEvent({
+        author: 'user',
+        content: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'peer-fc-1',
+                name: 'adk_request_credential',
+                response: {
+                  authScheme: {type: 'oauth2'},
+                  credentialKey: 'peer-key',
+                  exchangedAuthCredential: {
+                    oauth2: {accessToken: 'ANSWER_FOR_THE_PEER'},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const session = {
+        events: [peerCredentialRequest, answerToPeer],
+      } as unknown as Session;
+
+      const result = toMissingRemoteSessionParts(mockCtx, session);
+      const dumped = JSON.stringify(result.parts);
+
+      expect(dumped).toContain('ANSWER_FOR_THE_PEER');
+    });
+
+    it('matches a differently-named credential call in snake_case', () => {
+      // generateAuthEvent, the primary in-tree producer, emits args in
+      // snake_case (function_call_id/auth_config). The structural fallback
+      // must still catch a credential envelope under a name other than
+      // adk_request_credential once normalised.
+      const credentialRequest = createEvent({
+        author: 'root_agent',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'fc-1',
+                name: 'some_other_tool_name',
+                args: {
+                  function_call_id: 'toolFc1',
+                  auth_config: {
+                    authScheme: {type: 'oauth2'},
+                    rawAuthCredential: {
+                      oauth2: {clientSecret: 'SNAKE_CASE_SECRET'},
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const session = {events: [credentialRequest]} as unknown as Session;
+
+      const result = toMissingRemoteSessionParts(mockCtx, session);
+      const dumped = JSON.stringify(result.parts);
+
+      expect(dumped).not.toContain('SNAKE_CASE_SECRET');
+    });
+
+    it('does not drop a non-credential function_call', () => {
+      // The shape probe must not over-match: unrelated tool history should
+      // survive forwarding intact.
+      const unrelatedToolCall = createEvent({
+        author: 'root_agent',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'fc-1',
+                name: 'get_weather',
+                args: {location: 'Pimpri'},
+              },
+            },
+          ],
+        },
+      });
+
+      const session = {events: [unrelatedToolCall]} as unknown as Session;
+
+      const result = toMissingRemoteSessionParts(mockCtx, session);
+      const dumped = JSON.stringify(result.parts);
+
+      expect(dumped).toContain('get_weather');
+      expect(dumped).toContain('Pimpri');
     });
   });
 });

--- a/core/test/a2a/remote_agent_utils_test.ts
+++ b/core/test/a2a/remote_agent_utils_test.ts
@@ -434,6 +434,96 @@ describe('remote_agent_utils', () => {
       expect(dumped).not.toContain('SNAKE_CASE_SECRET');
     });
 
+    it('matches a differently-named credential response in snake_case', () => {
+      // Response-side counterpart to the call-side test above: the
+      // structural fallback in isCredentialFunctionResponse (payloadIsAuthConfig
+      // via camelCaseKeys) is what makes fix 3 work for a renamed response,
+      // but nothing in this file's fixtures exercised it -- every existing
+      // credential-response fixture uses the canonical
+      // adk_request_credential name, which returns before this code path is
+      // ever reached.
+      const credentialRequest = createEvent({
+        author: 'root_agent',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'fc-1',
+                name: 'adk_request_credential',
+                args: {functionCallId: 'toolFc1', authConfig: {}},
+              },
+            },
+          ],
+        },
+      });
+      const renamedResponse = createEvent({
+        author: 'user',
+        content: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'fc-1',
+                name: 'some_other_tool_name',
+                response: {
+                  auth_scheme: {type: 'oauth2'},
+                  credential_key: 'k',
+                  exchanged_auth_credential: {
+                    oauth2: {accessToken: 'SNAKE_CASE_RESPONSE_SECRET'},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const session = {
+        events: [credentialRequest, renamedResponse],
+      } as unknown as Session;
+
+      const result = toMissingRemoteSessionParts(mockCtx, session);
+      const dumped = JSON.stringify(result.parts);
+
+      expect(dumped).not.toContain('SNAKE_CASE_RESPONSE_SECRET');
+    });
+
+    it('drops a credential response with no id, rather than forwarding it', () => {
+      // The fail-safe for a response with no id: id is undefined, so
+      // peerRequestedIds.has(id) can never be true, and the response is
+      // dropped rather than forwarded. Security-relevant (an id-less
+      // response must never be treated as ambiguously safe to forward), so
+      // it deserves an assertion rather than being correct by accident.
+      const noIdResponse = createEvent({
+        author: 'user',
+        content: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'adk_request_credential',
+                response: {
+                  authScheme: {type: 'oauth2'},
+                  credentialKey: 'k',
+                  exchangedAuthCredential: {
+                    oauth2: {accessToken: 'NO_ID_SECRET'},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const session = {events: [noIdResponse]} as unknown as Session;
+
+      const result = toMissingRemoteSessionParts(mockCtx, session);
+      const dumped = JSON.stringify(result.parts);
+
+      expect(dumped).not.toContain('NO_ID_SECRET');
+    });
+
     it('does not drop a non-credential function_call', () => {
       // The shape probe must not over-match: unrelated tool history should
       // survive forwarding intact.


### PR DESCRIPTION
`toMissingRemoteSessionParts` built the outgoing message for a remote A2A peer from every session event since the last remote response, with no filtering at all. An `adk_request_credential` function_call carries a serialized `AuthConfig` in its arguments — including `rawAuthCredential`, an OAuth2 client secret or a service account key — and its function_response carries the exchanged credential back. Neither was scrubbed, so both directions of a local credential exchange could be forwarded verbatim to a remote peer as part of ordinary conversation history.

Mirrors adk-python's identical, already-fixed vulnerability in `RemoteA2aAgent` ("fix: stop RemoteA2aAgent forwarding credential requests to the remote peer", commit `2aea8595`), which itself originally only scrubbed the response side; adk-js had no scrubbing in either direction.

Adds `payloadIsAuthConfig`/`isCredentialFunctionCall`/`isCredentialFunctionResponse` (fail-closed shape detection, matching by structure and not only by the `adk_request_credential` name so a differently-named call carrying the same `AuthConfig` envelope is still caught) and `withoutCredentialParts`, applied to each event's content before `presentAsUserMessage`/`toA2AParts` — scrubbing has to happen first, since `presentAsUserMessage` renders a function_call as text with its arguments inlined, which would be too late to redact.

Adds two regression tests, both verified to fail against the pre-fix code with the real secret strings present verbatim in the forwarded output (confirmed via an actual failing run before the fix was applied), and pass after.

Verified: full existing `core/test/a2a/` suite passes (15 files, 207/207 tests), including the 2 new regression tests. `tsc --noEmit` clean.