### PR TITLE
feat: execute tool calls in parallel

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -5,7 +5,7 @@
  */
 
 import {Content, createUserContent, FunctionCall, Part} from '@google/genai';
-import {isEmpty} from 'lodash-es';
+import {cloneDeep, isEmpty} from 'lodash-es';
 
 import {InvocationContext} from '../agents/invocation_context.js';
 import {
@@ -307,9 +307,187 @@ function normalizeCallbackResponse(
 }
 
 /**
+ * Executes a single function call through the full tool pipeline:
+ * before-tool callbacks, the tool itself, error callbacks, and after-tool
+ * callbacks. Returns the function response event, or null when a long-running
+ * tool defers its response.
+ *
+ * Mirrors Python ADK's `_execute_single_function_call_async`.
+ */
+async function executeSingleFunctionCall({
+  invocationContext,
+  functionCall,
+  toolsDict,
+  beforeToolCallbacks,
+  afterToolCallbacks,
+  toolConfirmation,
+}: {
+  invocationContext: InvocationContext;
+  functionCall: FunctionCall;
+  toolsDict: Record<string, BaseTool>;
+  beforeToolCallbacks: SingleBeforeToolCallback[];
+  afterToolCallbacks: SingleAfterToolCallback[];
+  toolConfirmation?: ToolConfirmation;
+}): Promise<Event | null> {
+  const {tool, toolContext} = getToolAndContext({
+    invocationContext,
+    functionCall,
+    toolsDict,
+    toolConfirmation,
+  });
+
+  // TODO - b/436079721: implement [tracer.start_as_current_span]
+  logger.debug(`execute_tool ${tool.name}`);
+  // Deep-copy args (Python ADK: copy.deepcopy) so callback/tool mutations
+  // stay within this call and never leak back into the FunctionCall.
+  const functionArgs = functionCall.args ? cloneDeep(functionCall.args) : {};
+
+  // Step 1: Check if plugin before_tool_callback overrides the function
+  // response.
+  let functionResponse = null;
+  let functionResponseError: unknown;
+  functionResponse =
+    await invocationContext.pluginManager.runBeforeToolCallback({
+      tool: tool,
+      toolArgs: functionArgs,
+      toolContext: toolContext,
+    });
+
+  // Step 2: If no overrides are provided from the plugins, further run the
+  // canonical callback.
+  if (functionResponse == null) {
+    // Cover both null and undefined
+    for (const callback of beforeToolCallbacks) {
+      functionResponse = await callback({
+        tool: tool,
+        args: functionArgs,
+        context: toolContext,
+      });
+      if (functionResponse) {
+        break;
+      }
+    }
+  }
+
+  // An override from step 1 or 2 bypasses the tool call and is handed to the
+  // after-tool callbacks as-is, so normalize it before they see it.
+  functionResponse = normalizeCallbackResponse(functionResponse);
+
+  // Step 3: Otherwise, proceed calling the tool normally.
+  if (functionResponse == null) {
+    // Cover both null and undefined
+    try {
+      functionResponse = await callToolAsync(tool, functionArgs, toolContext);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        const onToolErrorResponse =
+          await invocationContext.pluginManager.runOnToolErrorCallback({
+            tool: tool,
+            toolArgs: functionArgs,
+            toolContext: toolContext,
+            error: e,
+          });
+
+        // Set function response to the result of the error callback and
+        // continue execution, do not shortcut
+        if (onToolErrorResponse != null) {
+          functionResponse = normalizeCallbackResponse(onToolErrorResponse);
+        } else {
+          // If the error callback returns undefined, use the error message
+          // as the function response error.
+          functionResponseError = e.message;
+        }
+      } else {
+        // If the error is not an Error, use the error object as the function
+        // response error.
+        functionResponseError = e;
+      }
+    }
+  }
+
+  // Step 4: Check if plugin after_tool_callback overrides the function
+  // response.
+  let alteredFunctionResponse =
+    await invocationContext.pluginManager.runAfterToolCallback({
+      tool: tool,
+      toolArgs: functionArgs,
+      toolContext: toolContext,
+      result: functionResponse,
+    });
+
+  // Step 5: If no overrides are provided from the plugins, further run the
+  // canonical after_tool_callbacks.
+  if (alteredFunctionResponse == null) {
+    // Cover both null and undefined
+    for (const callback of afterToolCallbacks) {
+      alteredFunctionResponse = await callback({
+        tool: tool,
+        args: functionArgs,
+        context: toolContext,
+        response: functionResponse,
+      });
+      if (alteredFunctionResponse) {
+        break;
+      }
+    }
+  }
+
+  // Step 6: If alternative response exists from after_tool_callback, use it
+  // instead of the original function response.
+  if (alteredFunctionResponse != null) {
+    functionResponse = normalizeCallbackResponse(alteredFunctionResponse);
+  }
+
+  // Allow long running function to return None as response.
+  // Only a nullish response defers the event. A falsy-but-present response
+  // ('', 0, false) is a real result and still emits one, so long-running
+  // tools that return such a value now produce a response event where they
+  // previously produced none.
+  if (tool.isLongRunning && functionResponse == null) {
+    return null;
+  }
+
+  if (functionResponseError) {
+    functionResponse = {error: functionResponseError};
+  } else if (functionResponse == null) {
+    functionResponse = {result: functionResponse};
+  } else {
+    functionResponse = normalizeCallbackResponse(functionResponse);
+  }
+
+  const functionResponseEvent = createEvent({
+    invocationId: invocationContext.invocationId,
+    author: toolEventAuthor(invocationContext),
+    content: createUserContent({
+      functionResponse: {
+        id: toolContext.functionCallId,
+        name: tool.name,
+        response: functionResponse,
+      },
+    }),
+    actions: toolContext.actions,
+    branch: invocationContext.branch,
+  });
+
+  // TODO - b/436079721: implement [traceToolCall]
+  logger.debug('traceToolCall', {
+    tool: tool.name,
+    args: functionArgs,
+    functionResponseEvent: functionResponseEvent.id,
+  });
+  return functionResponseEvent;
+}
+
+/**
  * The underlying implementation of handleFunctionCalls, but takes a list of
  * function calls instead of an event.
  * This is also used by llm_agent execution flow in preprocessing.
+ *
+ * Function calls are executed in parallel, mirroring Python ADK's
+ * `handle_function_call_list_async` (`asyncio.gather`). Response events keep
+ * the input order of the function calls regardless of completion order. If any
+ * call throws, the error propagates only after all calls have settled, so no
+ * execution is left dangling mid-flight.
  */
 export async function handleFunctionCallList({
   invocationContext,
@@ -328,165 +506,35 @@ export async function handleFunctionCallList({
   filters?: Set<string>;
   toolConfirmationDict?: Record<string, ToolConfirmation>;
 }): Promise<Event | null> {
-  const functionResponseEvents: Event[] = [];
-
   // Note: only function ids INCLUDED in the filters will be executed.
   const filteredFunctionCalls = functionCalls.filter((functionCall) => {
     return !filters || (functionCall.id && filters.has(functionCall.id));
   });
 
-  for (const functionCall of filteredFunctionCalls) {
-    let toolConfirmation = undefined;
-    if (toolConfirmationDict && functionCall.id) {
-      toolConfirmation = toolConfirmationDict[functionCall.id];
-    }
-
-    const {tool, toolContext} = getToolAndContext({
+  const tasks = filteredFunctionCalls.map((functionCall) =>
+    executeSingleFunctionCall({
       invocationContext,
       functionCall,
       toolsDict,
-      toolConfirmation,
-    });
+      beforeToolCallbacks,
+      afterToolCallbacks,
+      toolConfirmation:
+        toolConfirmationDict && functionCall.id
+          ? toolConfirmationDict[functionCall.id]
+          : undefined,
+    }),
+  );
 
-    // TODO - b/436079721: implement [tracer.start_as_current_span]
-    logger.debug(`execute_tool ${tool.name}`);
-    const functionArgs = functionCall.args ?? {};
-
-    // Step 1: Check if plugin before_tool_callback overrides the function
-    // response.
-    let functionResponse = null;
-    let functionResponseError: unknown;
-    functionResponse =
-      await invocationContext.pluginManager.runBeforeToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-      });
-
-    // Step 2: If no overrides are provided from the plugins, further run the
-    // canonical callback.
-    if (functionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of beforeToolCallbacks) {
-        functionResponse = await callback({
-          tool: tool,
-          args: functionArgs,
-          context: toolContext,
-        });
-        if (functionResponse) {
-          break;
-        }
-      }
-    }
-
-    // An override from step 1 or 2 bypasses the tool call and is handed to the
-    // after-tool callbacks as-is, so normalize it before they see it.
-    functionResponse = normalizeCallbackResponse(functionResponse);
-
-    // Step 3: Otherwise, proceed calling the tool normally.
-    if (functionResponse == null) {
-      // Cover both null and undefined
-      try {
-        functionResponse = await callToolAsync(tool, functionArgs, toolContext);
-      } catch (e: unknown) {
-        if (e instanceof Error) {
-          const onToolErrorResponse =
-            await invocationContext.pluginManager.runOnToolErrorCallback({
-              tool: tool,
-              toolArgs: functionArgs,
-              toolContext: toolContext,
-              error: e,
-            });
-
-          // Set function response to the result of the error callback and
-          // continue execution, do not shortcut
-          if (onToolErrorResponse != null) {
-            functionResponse = normalizeCallbackResponse(onToolErrorResponse);
-          } else {
-            // If the error callback returns undefined, use the error message
-            // as the function response error.
-            functionResponseError = e.message;
-          }
-        } else {
-          // If the error is not an Error, use the error object as the function
-          // response error.
-          functionResponseError = e;
-        }
-      }
-    }
-
-    // Step 4: Check if plugin after_tool_callback overrides the function
-    // response.
-    let alteredFunctionResponse =
-      await invocationContext.pluginManager.runAfterToolCallback({
-        tool: tool,
-        toolArgs: functionArgs,
-        toolContext: toolContext,
-        result: functionResponse,
-      });
-
-    // Step 5: If no overrides are provided from the plugins, further run the
-    // canonical after_tool_callbacks.
-    if (alteredFunctionResponse == null) {
-      // Cover both null and undefined
-      for (const callback of afterToolCallbacks) {
-        alteredFunctionResponse = await callback({
-          tool: tool,
-          args: functionArgs,
-          context: toolContext,
-          response: functionResponse,
-        });
-        if (alteredFunctionResponse) {
-          break;
-        }
-      }
-    }
-
-    // Step 6: If alternative response exists from after_tool_callback, use it
-    // instead of the original function response.
-    if (alteredFunctionResponse != null) {
-      functionResponse = normalizeCallbackResponse(alteredFunctionResponse);
-    }
-
-    // Allow long running function to return None as response.
-    // Only a nullish response defers the event. A falsy-but-present response
-    // ('', 0, false) is a real result and still emits one, so long-running
-    // tools that return such a value now produce a response event where they
-    // previously produced none.
-    if (tool.isLongRunning && functionResponse == null) {
-      continue;
-    }
-
-    if (functionResponseError) {
-      functionResponse = {error: functionResponseError};
-    } else if (functionResponse == null) {
-      functionResponse = {result: functionResponse};
-    } else {
-      functionResponse = normalizeCallbackResponse(functionResponse);
-    }
-
-    const functionResponseEvent = createEvent({
-      invocationId: invocationContext.invocationId,
-      author: toolEventAuthor(invocationContext),
-      content: createUserContent({
-        functionResponse: {
-          id: toolContext.functionCallId,
-          name: tool.name,
-          response: functionResponse,
-        },
-      }),
-      actions: toolContext.actions,
-      branch: invocationContext.branch,
-    });
-
-    // TODO - b/436079721: implement [traceToolCall]
-    logger.debug('traceToolCall', {
-      tool: tool.name,
-      args: functionArgs,
-      functionResponseEvent: functionResponseEvent.id,
-    });
-    functionResponseEvents.push(functionResponseEvent);
+  const settled = await Promise.allSettled(tasks);
+  const firstRejection = settled.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  if (firstRejection) {
+    throw firstRejection.reason;
   }
+  const functionResponseEvents = settled
+    .map((result) => (result as PromiseFulfilledResult<Event | null>).value)
+    .filter((event): event is Event => event !== null);
 
   if (!functionResponseEvents.length) {
     return null;
@@ -536,7 +584,7 @@ function getToolAndContext({
 
   const toolContext = new Context({
     invocationContext: invocationContext,
-    functionCallId: functionCall.id || undefined,
+    functionCallId: functionCall.id,
     toolConfirmation,
   });
 

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -437,6 +437,190 @@ describe('handleFunctionCallList', () => {
       }),
     ]);
   });
+
+  describe('parallel execution', () => {
+    it('should execute multiple function calls concurrently', async () => {
+      const executionLog: string[] = [];
+      const makeTool = (name: string, delayMs: number) =>
+        new FunctionTool({
+          name,
+          description: name,
+          parameters: z.object({}),
+          execute: async () => {
+            executionLog.push(`${name}:start`);
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            executionLog.push(`${name}:end`);
+            return {result: name};
+          },
+        });
+      const slowTool = makeTool('slowTool', 50);
+      const fastTool = makeTool('fastTool', 5);
+
+      await handleFunctionCallList({
+        invocationContext,
+        functionCalls: [callFor(slowTool), callFor(fastTool)],
+        toolsDict: {slowTool, fastTool},
+        beforeToolCallbacks: [],
+        afterToolCallbacks: [],
+      });
+
+      // Both tools start before either finishes; sequential execution would
+      // log slowTool:end before fastTool:start.
+      expect(executionLog.indexOf('fastTool:start')).toBeLessThan(
+        executionLog.indexOf('slowTool:end'),
+      );
+    });
+
+    it('should keep response parts in input order regardless of completion order', async () => {
+      const slowTool = new FunctionTool({
+        name: 'slowTool',
+        description: 'slow tool',
+        parameters: z.object({}),
+        execute: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          return {result: 'slow'};
+        },
+      });
+      const fastTool = new FunctionTool({
+        name: 'fastTool',
+        description: 'fast tool',
+        parameters: z.object({}),
+        execute: async () => {
+          return {result: 'fast'};
+        },
+      });
+
+      const event = await handleFunctionCallList({
+        invocationContext,
+        functionCalls: [callFor(slowTool), callFor(fastTool)],
+        toolsDict: {slowTool, fastTool},
+        beforeToolCallbacks: [],
+        afterToolCallbacks: [],
+      });
+
+      expect(
+        event?.content?.parts?.map((part) => part.functionResponse?.name),
+      ).toEqual(['slowTool', 'fastTool']);
+    });
+
+    it('should let all calls settle before propagating an error', async () => {
+      let slowToolCompleted = false;
+      const slowTool = new FunctionTool({
+        name: 'slowTool',
+        description: 'slow tool',
+        parameters: z.object({}),
+        execute: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          slowToolCompleted = true;
+          return {result: 'slow'};
+        },
+      });
+
+      await expect(
+        handleFunctionCallList({
+          invocationContext,
+          functionCalls: [
+            callFor(slowTool),
+            {id: randomIdForTestingOnly(), name: 'unknownTool', args: {}},
+          ],
+          toolsDict: {slowTool},
+          beforeToolCallbacks: [],
+          afterToolCallbacks: [],
+        }),
+      ).rejects.toThrow('Function unknownTool is not found in the toolsDict.');
+      expect(slowToolCompleted).toBe(true);
+    });
+
+    it('should deep-copy args so tool mutations do not leak into the FunctionCall', async () => {
+      const mutatingTool = new FunctionTool({
+        name: 'mutatingTool',
+        description: 'mutates its args',
+        parameters: z.object({}).passthrough(),
+        execute: async (args: Record<string, unknown>) => {
+          (args.nested as Record<string, unknown>).value = 'mutated';
+          args.added = true;
+          return {result: 'done'};
+        },
+      });
+      const call: FunctionCall = {
+        id: randomIdForTestingOnly(),
+        name: 'mutatingTool',
+        args: {nested: {value: 'original'}},
+      };
+
+      await handleFunctionCallList({
+        invocationContext,
+        functionCalls: [call],
+        toolsDict: {mutatingTool},
+        beforeToolCallbacks: [],
+        afterToolCallbacks: [],
+      });
+
+      expect(call.args).toEqual({nested: {value: 'original'}});
+    });
+
+    it('should share one args copy per call between callbacks and the tool', async () => {
+      let argsSeenByTool: Record<string, unknown> | undefined;
+      const inspectingTool = new FunctionTool({
+        name: 'inspectingTool',
+        description: 'records its args',
+        parameters: z.object({}).passthrough(),
+        execute: async (args: Record<string, unknown>) => {
+          argsSeenByTool = args;
+          return {result: 'done'};
+        },
+      });
+      const beforeToolCallback: SingleBeforeToolCallback = async ({args}) => {
+        args.injected = 'by-callback';
+        return undefined;
+      };
+      const call: FunctionCall = {
+        id: randomIdForTestingOnly(),
+        name: 'inspectingTool',
+        args: {},
+      };
+
+      await handleFunctionCallList({
+        invocationContext,
+        functionCalls: [call],
+        toolsDict: {inspectingTool},
+        beforeToolCallbacks: [beforeToolCallback],
+        afterToolCallbacks: [],
+      });
+
+      // The callback's mutation is visible to the tool (same per-call copy)
+      // but never to the original FunctionCall.
+      expect(argsSeenByTool).toEqual({injected: 'by-callback'});
+      expect(call.args).toEqual({});
+    });
+
+    it('should isolate a tool error to its own response part', async () => {
+      const event = await handleFunctionCallList({
+        invocationContext,
+        functionCalls: [functionCall, callFor(errorTool)],
+        toolsDict: {testTool, errorTool},
+        beforeToolCallbacks: [],
+        afterToolCallbacks: [],
+      });
+
+      expect(event?.content?.parts).toEqual([
+        expect.objectContaining({
+          functionResponse: expect.objectContaining({
+            name: 'testTool',
+            response: {result: 'tool executed'},
+          }),
+        }),
+        expect.objectContaining({
+          functionResponse: expect.objectContaining({
+            name: 'errorTool',
+            response: {
+              error: "Error in tool 'errorTool': tool error message content",
+            },
+          }),
+        }),
+      ]);
+    });
+  });
 });
 
 describe('generateAuthEvent', () => {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
- Closes: #233
- Related: #167 (earlier attempt, closed; this PR takes the minimal Python-parity approach instead, and applies the review feedback given there)

**Problem:** Every tool call in a model turn runs sequentially, while ADK Python executes them in parallel (`asyncio.gather`). Multi-tool turns in JS pay the full summed latency of every tool.

**Solution:** Mirror Python ADK's `handle_function_call_list_async` exactly, with a minimal diff and no new configuration surface:

- The per-call pipeline (before-tool callbacks → tool → on-error callbacks → after-tool callbacks → response event) is extracted from the loop body of `handleFunctionCallList` into `executeSingleFunctionCall`, mirroring Python's `_execute_single_function_call_async`. The pipeline logic is unchanged — the diff is large only because the loop body moved into a function.
- `handleFunctionCallList` now dispatches all filtered calls concurrently and awaits `Promise.allSettled`.
- Response events keep the **input order** of the function calls regardless of completion order, matching `asyncio.gather` semantics (and identical merged-event ordering to the previous sequential behavior).
- If any call throws (e.g. tool not found), the error propagates only after all calls have settled — the JS analog of Python's cancel-and-drain (`gather(..., return_exceptions=True)` then re-raise), so no execution is left dangling mid-flight.
- Individual tool execution errors are still isolated into per-call `{error: ...}` response parts, exactly as before.
- Args are deep-copied per call via `cloneDeep` from `lodash-es` (Python ADK: `copy.deepcopy(function_call.args)`), so callback/tool mutations stay within the call and never leak back into the `FunctionCall` — important now that sibling calls run concurrently. (`cloneDeep` rather than `structuredClone`, per review feedback on #167.)

Since all call sites (`llm_agent`, `auth_preprocessor`, confirmation/input processors, workflow `ToolNode`) funnel through `handleFunctionCallList`, they all get parallel execution, same as Python.

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New tests in `core/test/agents/functions_test.ts` (`parallel execution` block), written test-first against the sequential baseline:
- multiple function calls execute concurrently (second tool starts before the first finishes)
- response parts keep input order regardless of completion order
- an error (unknown tool) propagates only after in-flight calls settle
- a tool error is isolated to its own response part while sibling tools succeed
- args are deep-copied: tool mutations do not leak back into the `FunctionCall`
- callbacks and the tool share one args copy per call (callback-injected args are visible to the tool, but not to the original `FunctionCall`)

`vitest run --project unit:core`: **220 test files, 3167 tests — all passing.** `tsc --noEmit` and `eslint` clean.

**Manual End-to-End (E2E) Tests:** Run any `LlmAgent` with two independent async tools (e.g. two `fetch`-backed tools with artificial latency) and prompt the model to call both in one turn; the turn latency is max(tool latencies) instead of their sum, and the merged function-response event is unchanged in shape and ordering.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Behavior notes vs. Python, for reviewers:
- No `RunConfig` flags or concurrency caps were added — Python has none, and parity was the request in #233.
- In parallel mode, before/after tool callbacks run concurrently across sibling calls (same as Python). Callbacks must not rely on cross-call ordering.
- `stateDelta` merging across sibling responses is unchanged: `mergeParallelFunctionResponseEvents` / `mergeEventActions` behave exactly as before, and since result order is input order, merge outcomes are identical to the sequential implementation.
- `functionCall.id || undefined` was simplified to `functionCall.id` in `getToolAndContext`, per review feedback on #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)