### PR TITLE
fix(auth): bind a credential response to the request that asked for it

### DIFF
--- a/core/src/auth/auth_preprocessor.ts
+++ b/core/src/auth/auth_preprocessor.ts
@@ -23,6 +23,7 @@ import {camelCaseKeys} from '../utils/case_utils.js';
 import {logger} from '../utils/logger.js';
 import {AuthHandler} from './auth_handler.js';
 import {AuthConfig} from './auth_tool.js';
+import {bindCredentialResponse} from './credential_response_binding.js';
 
 const TOOLSET_AUTH_CREDENTIAL_ID_PREFIX = '_adk_toolset_auth_';
 
@@ -91,9 +92,18 @@ async function storeAuthAndCollectResumeTargets(
       continue;
     }
 
-    const authConfig = authResponses[fcId] as AuthConfig;
-    if (request.config.credentialKey) {
-      authConfig.credentialKey = request.config.credentialKey;
+    // The response answers the request; it does not get to restate it. The
+    // scheme, the client identity and the key all come from the request, and
+    // only the credential material comes from the response.
+    const authConfig = bindCredentialResponse(
+      request.config,
+      authResponses[fcId],
+    );
+    if (!authConfig) {
+      logger.warn(
+        `Ignoring credential response '${fcId}': it carries no credential for the request this agent raised.`,
+      );
+      continue;
     }
     await new AuthHandler(authConfig).parseAndStoreAuthResponse(state);
 

--- a/core/src/auth/credential_response_binding.ts
+++ b/core/src/auth/credential_response_binding.ts
@@ -47,11 +47,15 @@ function readString(source: unknown, name: string): string | undefined {
  * `state`, which is what makes the exchanger's CSRF check mean something: the
  * state it compares against the redirect is now the one the agent issued, not
  * one the same message chose.
+ *
+ * Returns `undefined` when a pending authorization-code flow gets no answer at
+ * all, so that shape is refused here alongside every other unusable response
+ * rather than travelling on to fail deeper in the exchanger.
  */
 function bindCredential(
   request: Partial<AuthConfig>,
   supplied: unknown,
-): AuthCredential {
+): AuthCredential | undefined {
   const requested = request.exchangedAuthCredential;
   if (!requested?.oauth2?.authUri) {
     return supplied as AuthCredential;
@@ -66,6 +70,9 @@ function bindCredential(
   const authCode = readString(suppliedOAuth2, 'authCode');
   if (authCode !== undefined) {
     answer.authCode = authCode;
+  }
+  if (authResponseUri === undefined && authCode === undefined) {
+    return undefined;
   }
 
   return {
@@ -88,7 +95,7 @@ function bindCredential(
  * The request is typed loosely on purpose: it is read back off the wire out of
  * a function call's args, so it can arrive missing the fields its type
  * promises. Returns `undefined` when it is too incomplete to be an authority,
- * or when the response carries no credential material — either way there is
+ * or when the response carries nothing that answers it — either way there is
  * nothing that can safely be stored.
  */
 export function bindCredentialResponse(
@@ -105,10 +112,15 @@ export function bindCredentialResponse(
     return undefined;
   }
 
+  const exchangedAuthCredential = bindCredential(request, supplied);
+  if (!exchangedAuthCredential) {
+    return undefined;
+  }
+
   return {
     authScheme,
     credentialKey,
     rawAuthCredential: request.rawAuthCredential,
-    exchangedAuthCredential: bindCredential(request, supplied),
+    exchangedAuthCredential,
   };
 }

--- a/core/src/auth/credential_response_binding.ts
+++ b/core/src/auth/credential_response_binding.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {AuthCredential, OAuth2Auth} from './auth_credential.js';
+import {AuthConfig} from './auth_tool.js';
+
+/**
+ * Reads a field that may arrive in either casing.
+ *
+ * Request args are normalised by `camelCaseKeys` before they get here, but a
+ * response is whatever the client sent, and the two producers of an
+ * `adk_request_credential` call already disagree on casing.
+ */
+function readField(source: unknown, name: string): unknown {
+  if (typeof source !== 'object' || source === null) {
+    return undefined;
+  }
+  const record = source as Record<string, unknown>;
+  if (name in record) {
+    return record[name];
+  }
+  return record[name.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`)];
+}
+
+/** Reads a field only if the client sent it as a string. */
+function readString(source: unknown, name: string): string | undefined {
+  const value = readField(source, name);
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Builds the credential to store from the one the client supplied.
+ *
+ * Two shapes, matching the two an agent can raise. If the request carries an
+ * `authUri` then an authorization-code flow is in progress: the credential is
+ * the agent's, and the only thing the client is answering with is the redirect
+ * it landed on. Otherwise nothing was pinned to answer — an API key, an HTTP
+ * credential, a service account — and the supplied credential is the answer.
+ *
+ * On the authorization-code path this deliberately drops a supplied
+ * `accessToken`. The agent asked for a code; a response bearing a ready-made
+ * token is not an answer to that question but a way to skip it, and the
+ * exchanger returns early on any token it finds. It also drops a supplied
+ * `state`, which is what makes the exchanger's CSRF check mean something: the
+ * state it compares against the redirect is now the one the agent issued, not
+ * one the same message chose.
+ */
+function bindCredential(
+  request: Partial<AuthConfig>,
+  supplied: unknown,
+): AuthCredential {
+  const requested = request.exchangedAuthCredential;
+  if (!requested?.oauth2?.authUri) {
+    return supplied as AuthCredential;
+  }
+
+  const suppliedOAuth2 = readField(supplied, 'oauth2');
+  const answer: Partial<OAuth2Auth> = {};
+  const authResponseUri = readString(suppliedOAuth2, 'authResponseUri');
+  if (authResponseUri !== undefined) {
+    answer.authResponseUri = authResponseUri;
+  }
+  const authCode = readString(suppliedOAuth2, 'authCode');
+  if (authCode !== undefined) {
+    answer.authCode = authCode;
+  }
+
+  return {
+    ...requested,
+    oauth2: {...requested.oauth2, ...answer},
+  };
+}
+
+/**
+ * Reconciles a credential response with the request that asked for it.
+ *
+ * The request is agent-authored and defines the question: which scheme, from
+ * which authorization server, under which key, on behalf of which client. The
+ * response is client-authored and carries one thing — the credential material
+ * the user obtained. Everything else it contains is discarded, because a
+ * response that gets to restate the question also decides whether the
+ * credential is exchanged at all, where the exchange sends the client secret,
+ * and which waiting tool picks the result up.
+ *
+ * The request is typed loosely on purpose: it is read back off the wire out of
+ * a function call's args, so it can arrive missing the fields its type
+ * promises. Returns `undefined` when it is too incomplete to be an authority,
+ * or when the response carries no credential material — either way there is
+ * nothing that can safely be stored.
+ */
+export function bindCredentialResponse(
+  request: Partial<AuthConfig>,
+  response: unknown,
+): AuthConfig | undefined {
+  const {authScheme, credentialKey} = request;
+  if (!authScheme || !credentialKey) {
+    return undefined;
+  }
+
+  const supplied = readField(response, 'exchangedAuthCredential');
+  if (typeof supplied !== 'object' || supplied === null) {
+    return undefined;
+  }
+
+  return {
+    authScheme,
+    credentialKey,
+    rawAuthCredential: request.rawAuthCredential,
+    exchangedAuthCredential: bindCredential(request, supplied),
+  };
+}

--- a/core/src/workflow/utils/hitl_utils.ts
+++ b/core/src/workflow/utils/hitl_utils.ts
@@ -22,8 +22,10 @@ import {
 } from '../../auth/auth_credential.js';
 import {AuthHandler} from '../../auth/auth_handler.js';
 import {AuthConfig} from '../../auth/auth_tool.js';
+import {bindCredentialResponse} from '../../auth/credential_response_binding.js';
 import {createEvent, Event} from '../../events/event.js';
 import {State} from '../../sessions/state.js';
+import {logger} from '../../utils/logger.js';
 import {compileJsonSchema, toJsonSchema} from '../../utils/schema.js';
 import {RequestInput} from '../request_input.js';
 
@@ -267,12 +269,11 @@ export async function processAuthResume({
   authConfig,
   state,
 }: ProcessAuthResumeParams): Promise<void> {
-  let responseConfig: AuthConfig;
+  let responseConfig: AuthConfig | undefined;
   if (isAuthConfigLike(responseData)) {
-    responseConfig = {
-      ...(responseData as AuthConfig),
-      credentialKey: authConfig.credentialKey,
-    };
+    // A full config from the web UI flow answers the request; it does not get
+    // to restate it. Same reconciliation the LLM-agent resume path applies.
+    responseConfig = bindCredentialResponse(authConfig, responseData);
   } else {
     responseConfig = {
       ...authConfig,
@@ -281,6 +282,12 @@ export async function processAuthResume({
         responseData,
       ),
     };
+  }
+  if (!responseConfig) {
+    logger.warn(
+      `Ignoring auth resume response for '${authConfig.credentialKey}': it carries no credential for the request that was raised.`,
+    );
+    return;
   }
   await new AuthHandler(responseConfig).parseAndStoreAuthResponse(state);
 }

--- a/core/test/auth/auth_preprocessor_test.ts
+++ b/core/test/auth/auth_preprocessor_test.ts
@@ -39,6 +39,16 @@ vi.mock('../../src/auth/auth_handler.js', () => ({
 describe('AuthPreprocessor', () => {
   const LLM_AGENT_SYMBOL = Symbol.for('google.adk.llmAgent');
 
+  /**
+   * A credential request is only an authority if it says what is being
+   * collected, so these fixtures carry a scheme and the response carries its
+   * material under `exchangedAuthCredential`, as a real client sends it.
+   */
+  const API_KEY_SCHEME = {type: 'apiKey', in: 'header', name: 'X-API-Key'};
+  const CREDENTIAL_RESPONSE = {
+    exchangedAuthCredential: {authType: 'apiKey', apiKey: 'test'},
+  };
+
   it('skips if agent is not LlmAgent', async () => {
     const invocationContext = {
       agent: {}, // Not an LlmAgent
@@ -142,7 +152,10 @@ describe('AuthPreprocessor', () => {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
                     args: {
-                      authConfig: {credentialKey: 'testKey'},
+                      authConfig: {
+                        credentialKey: 'testKey',
+                        authScheme: API_KEY_SCHEME,
+                      },
                       functionCallId: 'toolFc1',
                     },
                   },
@@ -158,7 +171,7 @@ describe('AuthPreprocessor', () => {
                   functionResponse: {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                    response: {authType: 'apiKey', apiKey: 'test'},
+                    response: CREDENTIAL_RESPONSE,
                   },
                 },
               ],
@@ -217,7 +230,10 @@ describe('AuthPreprocessor', () => {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
                     args: {
-                      auth_config: {credentialKey: 'testKey'},
+                      auth_config: {
+                        credentialKey: 'testKey',
+                        authScheme: API_KEY_SCHEME,
+                      },
                       function_call_id: 'toolFc1',
                     },
                   },
@@ -233,7 +249,7 @@ describe('AuthPreprocessor', () => {
                   functionResponse: {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                    response: {authType: 'apiKey', apiKey: 'test'},
+                    response: CREDENTIAL_RESPONSE,
                   },
                 },
               ],
@@ -292,7 +308,10 @@ describe('AuthPreprocessor', () => {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
                     args: {
-                      auth_config: {credential_key: 'testKey'},
+                      auth_config: {
+                        credential_key: 'testKey',
+                        auth_scheme: API_KEY_SCHEME,
+                      },
                       function_call_id: 'toolFc1',
                     },
                   },
@@ -308,7 +327,7 @@ describe('AuthPreprocessor', () => {
                   functionResponse: {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                    response: {authType: 'apiKey', apiKey: 'test'},
+                    response: CREDENTIAL_RESPONSE,
                   },
                 },
               ],
@@ -379,7 +398,10 @@ describe('AuthPreprocessor', () => {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
                     args: {
-                      authConfig: {credentialKey: 'testKey'},
+                      authConfig: {
+                        credentialKey: 'testKey',
+                        authScheme: API_KEY_SCHEME,
+                      },
                       functionCallId: '_adk_toolset_auth_something',
                     },
                   },
@@ -395,7 +417,7 @@ describe('AuthPreprocessor', () => {
                   functionResponse: {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                    response: {authType: 'apiKey', apiKey: 'test'},
+                    response: CREDENTIAL_RESPONSE,
                   },
                 },
               ],
@@ -431,7 +453,7 @@ describe('AuthPreprocessor', () => {
                   functionResponse: {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                    response: {authType: 'apiKey', apiKey: 'test'},
+                    response: CREDENTIAL_RESPONSE,
                   },
                 },
               ],
@@ -482,7 +504,10 @@ describe('AuthPreprocessor', () => {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
                     args: {
-                      authConfig: {credentialKey: 'testKey'},
+                      authConfig: {
+                        credentialKey: 'testKey',
+                        authScheme: API_KEY_SCHEME,
+                      },
                       functionCallId: 'toolFc1',
                     },
                   },
@@ -498,7 +523,7 @@ describe('AuthPreprocessor', () => {
                   functionResponse: {
                     id: 'fc1',
                     name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                    response: {authType: 'apiKey', apiKey: 'test'},
+                    response: CREDENTIAL_RESPONSE,
                   },
                 },
               ],
@@ -548,7 +573,10 @@ describe('AuthPreprocessor', () => {
                       id: 'fc1',
                       name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
                       args: {
-                        authConfig: {credentialKey: 'testKey'},
+                        authConfig: {
+                          credentialKey: 'testKey',
+                          authScheme: API_KEY_SCHEME,
+                        },
                         functionCallId: 'toolFc1',
                       },
                     },
@@ -564,7 +592,7 @@ describe('AuthPreprocessor', () => {
                     functionResponse: {
                       id: 'fc1',
                       name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                      response: {authType: 'apiKey', apiKey: 'test'},
+                      response: CREDENTIAL_RESPONSE,
                     },
                   },
                 ],
@@ -626,7 +654,12 @@ describe('AuthPreprocessor', () => {
                     functionResponse: {
                       id: 'never-requested',
                       name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
-                      response: {authType: 'apiKey', apiKey: 'attacker-key'},
+                      response: {
+                        exchangedAuthCredential: {
+                          authType: 'apiKey',
+                          apiKey: 'attacker-key',
+                        },
+                      },
                     },
                   },
                 ],
@@ -637,6 +670,102 @@ describe('AuthPreprocessor', () => {
       } as unknown as InvocationContext;
 
       const generator = AUTH_PREPROCESSOR.runAsync(invocationContext);
+
+      expect((await generator.next()).done).toBe(true);
+      expect(storeCredential).not.toHaveBeenCalled();
+    });
+  });
+
+  // The request is the authority for what is being collected and where it goes.
+  // If it cannot play that part, there is nothing to reconcile the response
+  // against, and storing what arrived would be taking the client's word for it.
+  describe('credential request completeness', () => {
+    /** A session pairing an arbitrary request config with a response. */
+    function contextFor(
+      authConfig: Record<string, unknown>,
+      response: Record<string, unknown>,
+    ): InvocationContext {
+      return {
+        agent: {
+          [LLM_AGENT_SYMBOL]: true,
+          name: 'agent',
+          canonicalTools: vi.fn().mockResolvedValue([{name: 'someTool'}]),
+          canonicalBeforeToolCallbacks: [],
+          canonicalAfterToolCallbacks: [],
+        },
+        session: {
+          state: {},
+          events: [
+            createEvent({
+              author: 'agent',
+              content: {
+                parts: [
+                  {functionCall: {id: 'toolFc1', name: 'someTool', args: {}}},
+                ],
+              },
+            }),
+            createEvent({
+              author: 'agent',
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: 'fc1',
+                      name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+                      args: {authConfig, functionCallId: 'toolFc1'},
+                    },
+                  },
+                ],
+              },
+            }),
+            createEvent({
+              author: 'user',
+              content: {
+                parts: [
+                  {
+                    functionResponse: {
+                      id: 'fc1',
+                      name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+                      response,
+                    },
+                  },
+                ],
+              },
+            }),
+          ],
+        },
+      } as unknown as InvocationContext;
+    }
+
+    beforeEach(() => {
+      storeCredential.mockClear();
+    });
+
+    it('refuses a request that names no auth scheme', async () => {
+      const generator = AUTH_PREPROCESSOR.runAsync(
+        contextFor({credentialKey: 'testKey'}, CREDENTIAL_RESPONSE),
+      );
+
+      expect((await generator.next()).done).toBe(true);
+      expect(storeCredential).not.toHaveBeenCalled();
+    });
+
+    it('refuses a request that names no credential key', async () => {
+      const generator = AUTH_PREPROCESSOR.runAsync(
+        contextFor({authScheme: API_KEY_SCHEME}, CREDENTIAL_RESPONSE),
+      );
+
+      expect((await generator.next()).done).toBe(true);
+      expect(storeCredential).not.toHaveBeenCalled();
+    });
+
+    it('refuses a response carrying no credential material', async () => {
+      const generator = AUTH_PREPROCESSOR.runAsync(
+        contextFor(
+          {credentialKey: 'testKey', authScheme: API_KEY_SCHEME},
+          {authScheme: API_KEY_SCHEME},
+        ),
+      );
 
       expect((await generator.next()).done).toBe(true);
       expect(storeCredential).not.toHaveBeenCalled();

--- a/core/test/auth/credential_response_binding_test.ts
+++ b/core/test/auth/credential_response_binding_test.ts
@@ -208,7 +208,9 @@ describe('credential response binding', () => {
   });
 
   // A response carrying a ready-made token short-circuits the exchanger. The
-  // agent asked for an authorization code, so a token is not an answer to it.
+  // agent asked for an authorization code, so a token is not an answer to it —
+  // and having no answer at all, the response is refused outright rather than
+  // carried as far as the exchanger.
   it('does not store an access token in place of an authorization code', async () => {
     const {invocationContext, state} = sessionAnswering(pendingOAuthRequest(), {
       authScheme: oauth2Scheme(),
@@ -218,11 +220,11 @@ describe('credential response binding', () => {
       },
     });
 
-    await resume(invocationContext);
+    const error = await resume(invocationContext);
 
-    expect(storedCredential(state)?.oauth2?.accessToken).not.toBe(
-      'attacker-token',
-    );
+    expect(error).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(storedCredential(state)).toBeUndefined();
   });
 
   // The token endpoint lives in the scheme, so a response that restates the
@@ -378,17 +380,49 @@ describe('bindCredentialResponse', () => {
     });
   });
 
-  it('ignores an answer field that is not a string', () => {
-    const bound = bindCredentialResponse(pendingOAuthRequest(), {
-      exchangedAuthCredential: {oauth2: {authCode: {nested: 'object'}}},
-    });
-
-    expect(bound?.exchangedAuthCredential?.oauth2?.authCode).toBeUndefined();
+  it('refuses an answer field that is not a string', () => {
+    expect(
+      bindCredentialResponse(pendingOAuthRequest(), {
+        exchangedAuthCredential: {oauth2: {authCode: {nested: 'object'}}},
+      }),
+    ).toBeUndefined();
   });
 
   it('returns nothing when the response carries no credential', () => {
     expect(
       bindCredentialResponse(pendingOAuthRequest(), {authScheme: 'anything'}),
     ).toBeUndefined();
+  });
+
+  // The shape the nit on #775 named: a credential is present, but nothing in it
+  // answers the pending authorization-code flow.
+  it('refuses a credential that answers nothing', () => {
+    expect(
+      bindCredentialResponse(pendingOAuthRequest(), {
+        exchangedAuthCredential: {
+          authType: 'oauth2',
+          oauth2: {redirectUri: 'https://app.example.com/callback'},
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  // The other path is unaffected: with no authorization code pending, the
+  // supplied credential is the answer and carries no code fields at all.
+  it('still accepts a credential when no authorization code is pending', () => {
+    const request: AuthConfig = {
+      credentialKey: CREDENTIAL_KEY,
+      authScheme: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-API-Key',
+      } as AuthConfig['authScheme'],
+    };
+
+    const bound = bindCredentialResponse(request, {
+      exchangedAuthCredential: {authType: 'apiKey', apiKey: 'user-key'},
+    });
+
+    expect(bound?.exchangedAuthCredential?.apiKey).toBe('user-key');
   });
 });

--- a/core/test/auth/credential_response_binding_test.ts
+++ b/core/test/auth/credential_response_binding_test.ts
@@ -1,0 +1,394 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for the binding between an `adk_request_credential` request
+ * and the response that answers it.
+ *
+ * Threat model, as in the HITL confirmation tests: an actor that can write
+ * messages into a live session — a malicious A2A peer, a second client on a
+ * shared context, anything that reaches `/run` — but that is not the human the
+ * credential belongs to and cannot author model turns.
+ *
+ * The request is raised by the agent and says what is being collected: which
+ * scheme, from which authorization server, under which key. The response is
+ * written by the client and should carry one thing only — the credential
+ * material the user obtained. These tests probe what happens when the response
+ * tries to redefine the question instead of answering it.
+ *
+ * Unlike `auth_preprocessor_test.ts`, the real `AuthHandler` and the real
+ * OAuth2 exchanger run here, against a stubbed `fetch`. The assertions are
+ * about what lands in session state and where the exchange was sent, because
+ * that is what a waiting tool goes on to use.
+ */
+
+import {
+  AUTH_PREPROCESSOR,
+  Event,
+  InvocationContext,
+  createEvent,
+} from '@google/adk';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {REQUEST_CREDENTIAL_FUNCTION_CALL_NAME} from '../../src/agents/functions.js';
+import {AuthCredential} from '../../src/auth/auth_credential.js';
+import {AuthConfig} from '../../src/auth/auth_tool.js';
+import {bindCredentialResponse} from '../../src/auth/credential_response_binding.js';
+
+// Resuming the waiting tool is a separate concern; stub it so each test is
+// about the credential that gets stored. `AuthHandler` is deliberately left
+// alone — it is the thing under test here.
+vi.mock('../../src/agents/functions.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    handleFunctionCallsAsync: vi
+      .fn()
+      .mockResolvedValue({id: 'resumedTool', author: 'agent'}),
+  };
+});
+
+const LLM_AGENT_SYMBOL = Symbol.for('google.adk.llmAgent');
+
+const ISSUER_TOKEN_URL = 'https://issuer.example.com/token';
+const ATTACKER_TOKEN_URL = 'https://attacker.example.com/token';
+const CREDENTIAL_KEY = 'issuer-credential';
+
+/** The OAuth2 scheme the agent asks against. */
+function oauth2Scheme(tokenUrl = ISSUER_TOKEN_URL) {
+  return {
+    type: 'oauth2',
+    flows: {
+      authorizationCode: {
+        authorizationUrl: 'https://issuer.example.com/auth',
+        tokenUrl,
+        scopes: {'read': 'read'},
+      },
+    },
+  };
+}
+
+/**
+ * The request the agent raises, as `AuthHandler.generateAuthRequest` builds it
+ * for an authorization-code flow: the scheme, the client identity, and an
+ * `authUri` carrying the CSRF `state` the client is expected to echo back.
+ */
+function pendingOAuthRequest(overrides: Partial<AuthConfig> = {}): AuthConfig {
+  return {
+    credentialKey: CREDENTIAL_KEY,
+    authScheme: oauth2Scheme() as AuthConfig['authScheme'],
+    rawAuthCredential: {
+      authType: 'oauth2',
+      oauth2: {clientId: 'real-client', clientSecret: 'real-secret'},
+    } as unknown as AuthCredential,
+    exchangedAuthCredential: {
+      authType: 'oauth2',
+      oauth2: {
+        clientId: 'real-client',
+        clientSecret: 'real-secret',
+        redirectUri: 'https://app.example.com/callback',
+        state: 'server-issued-state',
+        authUri:
+          'https://issuer.example.com/auth?state=server-issued-state&client_id=real-client',
+      },
+    } as unknown as AuthCredential,
+    ...overrides,
+  };
+}
+
+/**
+ * A session in which `request` was raised by the agent and `response` came back
+ * from the client, plus the state object the credential will land in.
+ */
+function sessionAnswering(request: AuthConfig, response: unknown) {
+  const state: Record<string, unknown> = {};
+  const invocationContext = {
+    agent: {
+      [LLM_AGENT_SYMBOL]: true,
+      name: 'agent',
+      canonicalTools: vi.fn().mockResolvedValue([{name: 'securedTool'}]),
+      canonicalBeforeToolCallbacks: [],
+      canonicalAfterToolCallbacks: [],
+    },
+    session: {
+      state,
+      events: [
+        createEvent({
+          author: 'agent',
+          content: {
+            parts: [
+              {functionCall: {id: 'toolFc1', name: 'securedTool', args: {}}},
+            ],
+          },
+        }),
+        createEvent({
+          author: 'agent',
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  id: 'authFc1',
+                  name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+                  args: {authConfig: request, functionCallId: 'toolFc1'},
+                },
+              },
+            ],
+          },
+        }),
+        createEvent({
+          author: 'user',
+          content: {
+            parts: [
+              {
+                functionResponse: {
+                  id: 'authFc1',
+                  name: REQUEST_CREDENTIAL_FUNCTION_CALL_NAME,
+                  response: response as Record<string, unknown>,
+                },
+              },
+            ],
+          },
+        }),
+      ] as Event[],
+    },
+  } as unknown as InvocationContext;
+
+  return {invocationContext, state};
+}
+
+/** Runs the preprocessor to completion, returning any error it raised. */
+async function resume(invocationContext: InvocationContext): Promise<unknown> {
+  const yielded: Event[] = [];
+  try {
+    for await (const event of AUTH_PREPROCESSOR.runAsync(invocationContext)) {
+      // Drained rather than asserted on: the resumed tool call is stubbed, and
+      // these tests are about the credential that reached state before it.
+      yielded.push(event);
+    }
+    return undefined;
+  } catch (e) {
+    return e;
+  }
+}
+
+/** The credential the waiting tool will read. */
+function storedCredential(state: Record<string, unknown>) {
+  return state[`temp:${CREDENTIAL_KEY}`] as AuthCredential | undefined;
+}
+
+describe('credential response binding', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({access_token: 'issuer-token', expires_in: 3600}),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // The request says "oauth2, from this issuer". The scheme decides whether the
+  // credential is exchanged or stored as-is, so a response that gets to restate
+  // it decides that too.
+  it('ignores an auth scheme supplied by the response', async () => {
+    const {invocationContext, state} = sessionAnswering(pendingOAuthRequest(), {
+      authScheme: {type: 'apiKey', in: 'header', name: 'X-API-Key'},
+      exchangedAuthCredential: {authType: 'apiKey', apiKey: 'attacker-key'},
+    });
+
+    await resume(invocationContext);
+
+    expect(storedCredential(state)?.apiKey).toBeUndefined();
+  });
+
+  // A response carrying a ready-made token short-circuits the exchanger. The
+  // agent asked for an authorization code, so a token is not an answer to it.
+  it('does not store an access token in place of an authorization code', async () => {
+    const {invocationContext, state} = sessionAnswering(pendingOAuthRequest(), {
+      authScheme: oauth2Scheme(),
+      exchangedAuthCredential: {
+        authType: 'oauth2',
+        oauth2: {accessToken: 'attacker-token'},
+      },
+    });
+
+    await resume(invocationContext);
+
+    expect(storedCredential(state)?.oauth2?.accessToken).not.toBe(
+      'attacker-token',
+    );
+  });
+
+  // The token endpoint lives in the scheme, so a response that restates the
+  // scheme picks where the exchange POSTs the client secret.
+  it('exchanges against the token endpoint from the request', async () => {
+    const {invocationContext} = sessionAnswering(pendingOAuthRequest(), {
+      authScheme: oauth2Scheme(ATTACKER_TOKEN_URL),
+      exchangedAuthCredential: {
+        authType: 'oauth2',
+        oauth2: {
+          clientId: 'real-client',
+          clientSecret: 'real-secret',
+          state: 'server-issued-state',
+          authResponseUri:
+            'https://app.example.com/callback?code=abc&state=server-issued-state',
+        },
+      },
+    });
+
+    await resume(invocationContext);
+
+    const endpoints = fetchMock.mock.calls.map((call) => call[0]);
+    expect(endpoints).not.toContain(ATTACKER_TOKEN_URL);
+  });
+
+  // The CSRF check compares the state in `authResponseUri` against the state on
+  // the credential. Both arriving in the same response makes it a comparison
+  // the sender controls on both sides.
+  it('checks the returned state against the state the agent issued', async () => {
+    const {invocationContext, state} = sessionAnswering(pendingOAuthRequest(), {
+      authScheme: oauth2Scheme(),
+      exchangedAuthCredential: {
+        authType: 'oauth2',
+        oauth2: {
+          clientId: 'real-client',
+          clientSecret: 'real-secret',
+          state: 'attacker-state',
+          authResponseUri:
+            'https://app.example.com/callback?code=stolen&state=attacker-state',
+        },
+      },
+    });
+
+    const error = await resume(invocationContext);
+
+    expect(error).toBeDefined();
+    expect(storedCredential(state)).toBeUndefined();
+  });
+
+  // `credentialKey` is where the credential is filed, and so which tool picks
+  // it up. It was pinned from the request only when the request had one.
+  it('refuses a request that names no credential key', async () => {
+    const request = pendingOAuthRequest();
+    delete (request as Partial<AuthConfig>).credentialKey;
+    const {invocationContext, state} = sessionAnswering(request, {
+      credentialKey: 'attacker-chosen-key',
+      authScheme: {type: 'apiKey', in: 'header', name: 'X-API-Key'},
+      exchangedAuthCredential: {authType: 'apiKey', apiKey: 'attacker-key'},
+    });
+
+    await resume(invocationContext);
+
+    expect(state['temp:attacker-chosen-key']).toBeUndefined();
+  });
+
+  // The legitimate flow has to keep working: the client answers with the
+  // redirect it received, and the code in it is exchanged for a real token.
+  it('exchanges an authorization code the client answers with', async () => {
+    const {invocationContext, state} = sessionAnswering(pendingOAuthRequest(), {
+      exchangedAuthCredential: {
+        authType: 'oauth2',
+        oauth2: {
+          authResponseUri:
+            'https://app.example.com/callback?code=real-code&state=server-issued-state',
+        },
+      },
+    });
+
+    await resume(invocationContext);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0][0]).toBe(ISSUER_TOKEN_URL);
+    expect(storedCredential(state)?.oauth2?.accessToken).toBe('issuer-token');
+  });
+
+  // An API-key scheme has no exchange: the credential in the response is the
+  // whole answer, and pinning must not get in the way of storing it.
+  it('stores the credential for a scheme with no exchange', async () => {
+    const request: AuthConfig = {
+      credentialKey: CREDENTIAL_KEY,
+      authScheme: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-API-Key',
+      } as AuthConfig['authScheme'],
+    };
+    const {invocationContext, state} = sessionAnswering(request, {
+      authScheme: request.authScheme,
+      exchangedAuthCredential: {authType: 'apiKey', apiKey: 'user-key'},
+    });
+
+    await resume(invocationContext);
+
+    expect(storedCredential(state)?.apiKey).toBe('user-key');
+  });
+});
+
+// The cases above drive the binder through the preprocessor, which is how it is
+// reached in production. These cover the shapes a client can send that the
+// preprocessor path does not exercise on its own.
+describe('bindCredentialResponse', () => {
+  it('reads a snake_case response', () => {
+    const bound = bindCredentialResponse(pendingOAuthRequest(), {
+      'exchanged_auth_credential': {
+        'oauth2': {
+          'auth_response_uri':
+            'https://app.example.com/callback?code=snake&state=server-issued-state',
+        },
+      },
+    });
+
+    expect(bound?.exchangedAuthCredential?.oauth2?.authResponseUri).toContain(
+      'code=snake',
+    );
+  });
+
+  it('accepts an authorization code sent on its own', () => {
+    const bound = bindCredentialResponse(pendingOAuthRequest(), {
+      exchangedAuthCredential: {oauth2: {authCode: 'bare-code'}},
+    });
+
+    expect(bound?.exchangedAuthCredential?.oauth2?.authCode).toBe('bare-code');
+  });
+
+  // The pinned values are the ones the exchanger authenticates and CSRF-checks
+  // with, so a response restating them must not win.
+  it('keeps the client identity and state from the request', () => {
+    const bound = bindCredentialResponse(pendingOAuthRequest(), {
+      exchangedAuthCredential: {
+        oauth2: {
+          clientId: 'attacker-client',
+          clientSecret: 'attacker-secret',
+          state: 'attacker-state',
+          authCode: 'code',
+        },
+      },
+    });
+
+    expect(bound?.exchangedAuthCredential?.oauth2).toMatchObject({
+      clientId: 'real-client',
+      clientSecret: 'real-secret',
+      state: 'server-issued-state',
+    });
+  });
+
+  it('ignores an answer field that is not a string', () => {
+    const bound = bindCredentialResponse(pendingOAuthRequest(), {
+      exchangedAuthCredential: {oauth2: {authCode: {nested: 'object'}}},
+    });
+
+    expect(bound?.exchangedAuthCredential?.oauth2?.authCode).toBeUndefined();
+  });
+
+  it('returns nothing when the response carries no credential', () => {
+    expect(
+      bindCredentialResponse(pendingOAuthRequest(), {authScheme: 'anything'}),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

Closes: #772

**Problem**

#771 closed the provenance half of the credential resume path: an
`adk_request_credential` request is honoured only if this agent raised it. What
the response then *says* was still taken at face value. Only `credentialKey` was
pinned back from the request, and only when the request happened to carry one:

```ts
const authConfig = authResponses[fcId] as AuthConfig;
if (request.config.credentialKey) {
  authConfig.credentialKey = request.config.credentialKey;
}
```

Everything else on the `AuthConfig` — the scheme, the client identity, the
credential itself — came from the client. The destination was trusted and the
credential was not, so a session writer who is not the user could file a
credential of its choosing under the key a waiting tool reads. That tool then
authenticates with it: reads and writes landing in someone else's account while
the agent believes it is acting for the user.

`authScheme` is the load-bearing field, because it decides what happens next:

| restated as | consequence |
| --- | --- |
| `apiKey` | `parseAndStoreAuthResponse` takes the branch that stores the supplied credential verbatim — an OAuth2 request answered with no exchange at all |
| `oauth2` | still names the token endpoint, so the same message chose where the exchange posted |

A response bearing an `accessToken` skipped the exchange regardless, because the
exchanger returns early on any token it finds.

The CSRF check had the same shape. `exchangeAuthorizationCode` compares the
`state` in `authResponseUri` against the `state` on the credential — both of
which arrived in the same client message, so it compared the sender against
itself, and a response that simply omitted `state` skipped the check entirely.

Scope note, since #772 overstated this: the token endpoint is caller-choosable
but **not** an unrestricted SSRF primitive. `fetchOAuth2Tokens` already runs
`validateDiscoveryUrl` (HTTPS only; loopback, private ranges, CGNAT, IPv6
ULA/link-local and cloud-metadata hosts blocked) and sets `redirect: 'error'`.
It is a public HTTPS host of the sender's choosing. Worth fixing, not the
metadata-server reach the issue implied — I've corrected the issue too.

**Solution**

Reconcile request and response before storing anything, in one new module,
`auth/credential_response_binding.ts`.

The request defines the question — scheme, client identity, credential key — and
is now the only source for it. The response answers, and what counts as an
answer depends on what was asked:

- the request carries an `authUri` → an authorization-code flow is pending, so
  only `authResponseUri` and `authCode` are read from the response; the rest of
  the credential is the agent's;
- otherwise nothing was pinned to answer — an API key, an HTTP credential, a
  service account — and the supplied credential is the answer.

Pinning `state` this way is what makes the CSRF check mean something: the state
compared against the redirect is now the one the agent issued, and it can no
longer be skipped by omission.

A request too incomplete to be an authority, or a response carrying no
credential material, is refused rather than guessed at.

`processAuthResume` on the workflow path had the same three lines and gets the
same treatment. Its plain-value branch already built from the request and is
unchanged, so the `auth_api_key` sample flow (`{result: '...'}`) is untouched.

Three judgement calls worth a reviewer's attention:

- **`accessToken` is deliberately not an accepted answer** to a pending
  authorization-code flow. A client that has already done its own exchange and
  wants to hand over a token can still do so through a request that never issued
  an `authUri`. If anyone is relying on the other shape, this is the line that
  breaks them, and I would rather find that out here.
- **`state` pinning is a behaviour change.** A client that previously sent its
  own `state` now gets a `CredentialExchangeError` instead of silent success.
  That is the point, but it is the most likely source of a surprise.
- **The binder takes `Partial<AuthConfig>`** rather than `AuthConfig`. The
  request is read back off the wire out of a function call's args, so it can
  arrive missing the fields its type promises; typing it honestly is what makes
  the two guard clauses legitimate rather than dead code.

### Testing Plan

**Unit Tests**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
npm run test:unit          239 files, 3559 passed
npm run test:integration    77 files,  240 passed | 8 skipped
npm run ts:check / lint / format:check    all clean
```

**Manual End-to-End (E2E) Tests**

The demonstration is that the new assertions fail against the current tree.
Revert just the call site and run the file:

```
git show HEAD~1:core/src/auth/auth_preprocessor.ts > core/src/auth/auth_preprocessor.ts
npx vitest run --project unit:core core/test/auth/credential_response_binding_test.ts
```

```
× ignores an auth scheme supplied by the response
  → expected 'attacker-key' to be undefined
× does not store an access token in place of an authorization code
  → expected 'attacker-token' not to be 'attacker-token'
× exchanges against the token endpoint from the request
  → expected [ Array(1) ] to not include 'https://attacker.example.com/token'
× checks the returned state against the state the agent issued
  → expected undefined to be defined
× refuses a request that names no credential key
  → expected { authType: 'apiKey', …(1) } to be undefined
× exchanges an authorization code the client answers with
  → expected "spy" to be called once, but got 0 times
✓ stores the credential for a scheme with no exchange
```

The last two are worth reading together with the first five. `stores the
credential for a scheme with no exchange` passes both before and after — it is
the no-regression guard for the API-key flow. `exchanges an authorization code
the client answers with` fails before the fix only because today a client *must*
echo the scheme back for the resume to work at all; after the fix the scheme is
pinned, so the clean response shape works.

No credentials or network needed: `fetch` is stubbed, and the real `AuthHandler`
and `OAuth2CredentialExchanger` run.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Test fixtures in `auth_preprocessor_test.ts` that asked for a credential without
saying what kind were under-specifying a real session — both producers of an
`adk_request_credential` call put the whole config in the args — and have been
completed, the same way #771 completed the gate fixtures. Those tests mock
`AuthHandler`, so they never noticed; the new file does not mock it, which is
why it catches this.

Review round 1 (`d6b7446`): on the authorization-code path, a response whose
`exchangedAuthCredential` was present but answered nothing — no
`authResponseUri`, no `authCode` — was not refused. It reached the exchanger and
threw there, aborting the invocation, where every other unusable response gets a
warn and a skip. Nothing client-controlled was ever stored, so it was safe rather
than a gap, but it reported one condition two different ways. `bindCredential`
now refuses that shape at the same place as the rest. The no-authorization-code
path is untouched, and there is a test for each side of the split.

Still open from the #771 review, unaffected by this change: #773, the fabricated
`ToolConfirmation` on the request-input resume path.

