### PR TITLE
fix(workflow): refuse a reply that answers no open interrupt

### DIFF
--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -19,6 +19,7 @@ import {RouteValue} from '../graph.js';
 import type {NodeContext, NodeResult} from '../node_context.js';
 import {
   interruptResponseMismatch,
+  REQUEST_INPUT_FUNCTION_CALL_NAME,
   responseSchemasByInterruptId,
 } from './hitl_utils.js';
 
@@ -185,14 +186,39 @@ export function resolvedInterruptResponses(
 ): Map<string, unknown> {
   const responseSchemas = responseSchemasByInterruptId(events);
   const newestUserTurn = lastUserEvent(events);
+  // Every id this run has ever raised, and the subset still awaiting an answer.
+  // They differ because an id can be re-raised: the revise loop in the
+  // request-input samples asks `review` again after the first answer sent it
+  // back to redraft, so "already answered" only means anything until the node
+  // asks again.
   const raised = new Set<string>();
+  const open = new Set<string>();
   const resolved = new Map<string, unknown>();
 
   for (const event of events) {
     if (event.author === 'user' && event.content?.parts) {
       for (const part of event.content.parts) {
         const fr = part.functionResponse;
-        if (!fr?.id || !raised.has(fr.id)) {
+        if (!fr?.id) {
+          continue;
+        }
+        if (!open.has(fr.id)) {
+          // A reply addressed to the interrupt mechanism that answers nothing
+          // currently open. Skipping it silently let the turn fall through and
+          // be served as a brand-new user message, so the waiting node re-ran
+          // and raised a SECOND interrupt — and with two pending, plain text no
+          // longer resolves either, so every later turn added one more and the
+          // count could never come back down.
+          if (
+            fr.name === REQUEST_INPUT_FUNCTION_CALL_NAME &&
+            event === newestUserTurn
+          ) {
+            throw new Error(
+              raised.has(fr.id)
+                ? alreadyAnsweredMessage(fr.id, open)
+                : unroutableReplyMessage(fr.id, open),
+            );
+          }
           continue;
         }
         const schema = responseSchemas.get(fr.id);
@@ -204,16 +230,57 @@ export function resolvedInterruptResponses(
           }
           continue;
         }
+        open.delete(fr.id);
         resolved.set(fr.id, response);
       }
       continue;
     }
     for (const id of event.longRunningToolIds ?? []) {
       raised.add(id);
+      open.add(id);
     }
   }
 
   return resolved;
+}
+
+/** Names the interrupts still awaiting an answer, for a refusal message. */
+function waitingList(open: ReadonlySet<string>): string {
+  return open.size
+    ? `Still waiting: ${[...open].map((id) => `'${id}'`).join(', ')}.`
+    : 'This run has no interrupt waiting for an answer.';
+}
+
+/**
+ * Explains a reply whose interrupt id names nothing this run raised.
+ *
+ * Worded like the schema-mismatch refusal, and for the same reason: the caller
+ * hears about it once, on the turn that carried it, nothing is resolved, and
+ * the interrupts that genuinely are waiting stay answerable.
+ */
+function unroutableReplyMessage(
+  interruptId: string,
+  open: ReadonlySet<string>,
+): string {
+  return (
+    `The reply carries interrupt id '${interruptId}', which does not match ` +
+    `any interrupt this run raised. ${waitingList(open)} A reply must use the ` +
+    `id from the 'adk_request_input' function call it answers. Nothing was ` +
+    `resolved, so any waiting interrupt can still be answered.`
+  );
+}
+
+/** Explains a reply to an interrupt that has already been answered. */
+function alreadyAnsweredMessage(
+  interruptId: string,
+  open: ReadonlySet<string>,
+): string {
+  return (
+    `Interrupt '${interruptId}' has already been answered, so this reply ` +
+    `resolves nothing. Sending it again does not change the earlier answer, ` +
+    `and it would otherwise be served as a new message, restarting the node ` +
+    `that asked. ${waitingList(open)}`
+  );
 }
 
 /**

--- a/core/src/workflow/utils/rehydration_utils.ts
+++ b/core/src/workflow/utils/rehydration_utils.ts
@@ -186,11 +186,6 @@ export function resolvedInterruptResponses(
 ): Map<string, unknown> {
   const responseSchemas = responseSchemasByInterruptId(events);
   const newestUserTurn = lastUserEvent(events);
-  // Every id this run has ever raised, and the subset still awaiting an answer.
-  // They differ because an id can be re-raised: the revise loop in the
-  // request-input samples asks `review` again after the first answer sent it
-  // back to redraft, so "already answered" only means anything until the node
-  // asks again.
   const raised = new Set<string>();
   const open = new Set<string>();
   const resolved = new Map<string, unknown>();
@@ -203,12 +198,6 @@ export function resolvedInterruptResponses(
           continue;
         }
         if (!open.has(fr.id)) {
-          // A reply addressed to the interrupt mechanism that answers nothing
-          // currently open. Skipping it silently let the turn fall through and
-          // be served as a brand-new user message, so the waiting node re-ran
-          // and raised a SECOND interrupt — and with two pending, plain text no
-          // longer resolves either, so every later turn added one more and the
-          // count could never come back down.
           if (
             fr.name === REQUEST_INPUT_FUNCTION_CALL_NAME &&
             event === newestUserTurn
@@ -251,13 +240,7 @@ function waitingList(open: ReadonlySet<string>): string {
     : 'This run has no interrupt waiting for an answer.';
 }
 
-/**
- * Explains a reply whose interrupt id names nothing this run raised.
- *
- * Worded like the schema-mismatch refusal, and for the same reason: the caller
- * hears about it once, on the turn that carried it, nothing is resolved, and
- * the interrupts that genuinely are waiting stay answerable.
- */
+/** Explains a reply whose interrupt id names nothing this run raised. */
 function unroutableReplyMessage(
   interruptId: string,
   open: ReadonlySet<string>,

--- a/core/test/workflow/resume_test.ts
+++ b/core/test/workflow/resume_test.ts
@@ -289,6 +289,116 @@ describe('Phase 5b — rehydration utility', () => {
   });
 });
 
+describe('Phase 5b — a reply that answers no open interrupt', () => {
+  /** An interrupt raised by `gate`, as a node event would record it. */
+  function raised(interruptId: string): Event {
+    return createEvent({
+      author: 'gate',
+      nodeInfo: {path: 'wf.gate'},
+      longRunningToolIds: [interruptId],
+    });
+  }
+
+  /** A user turn replying to `interruptId`. */
+  function reply(interruptId: string, result: unknown): Event {
+    return createEvent({
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: interruptId,
+              name: 'adk_request_input',
+              response: {result},
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  it('refuses an id that names no interrupt, naming what is waiting', () => {
+    // Silently dropping this let the turn be served as a new user message, so
+    // the waiting node re-ran and raised a SECOND interrupt. From then on two
+    // were pending, plain text resolved neither, and the count only grew.
+    expect(() =>
+      reconstructNodeStates([raised('gate-1'), reply('no-such-interrupt', 21)]),
+    ).toThrow(/'no-such-interrupt'.*does not match any interrupt.*'gate-1'/s);
+  });
+
+  it('leaves the real interrupt answerable after refusing one', () => {
+    const states = reconstructNodeStates([
+      raised('gate-1'),
+      reply('no-such-interrupt', 21),
+      reply('gate-1', 'yes'),
+    ]);
+
+    expect(states.get('gate')?.resolvedResponses.get('gate-1')).toBe('yes');
+  });
+
+  it('refuses a reply to an interrupt that is already answered', () => {
+    // What a stale approval form in the dev UI submits.
+    expect(() =>
+      reconstructNodeStates([
+        raised('gate-1'),
+        reply('gate-1', 'yes'),
+        reply('gate-1', 'no'),
+      ]),
+    ).toThrow(/'gate-1' has already been answered/);
+  });
+
+  it('accepts a second answer once the node has asked again', () => {
+    // The revise loop: `gate` asks, is told to redraft, and asks again under
+    // the same id. The second answer must land, not be read as a duplicate.
+    const states = reconstructNodeStates([
+      raised('gate-1'),
+      reply('gate-1', 'shorter'),
+      raised('gate-1'),
+      reply('gate-1', 'approve'),
+    ]);
+
+    expect(states.get('gate')?.resolvedResponses.get('gate-1')).toBe('approve');
+  });
+
+  it('stops refusing once the turn that carried the bad reply has passed', () => {
+    // The reply stays in the session for good, so re-throwing on every replay
+    // would end the session rather than the turn.
+    expect(() =>
+      reconstructNodeStates([
+        raised('gate-1'),
+        reply('no-such-interrupt', 21),
+        createEvent({
+          author: 'user',
+          content: {role: 'user', parts: [{text: 'yes'}]},
+        }),
+      ]),
+    ).not.toThrow();
+  });
+
+  it('ignores an ordinary tool response that is not an interrupt reply', () => {
+    const toolResponse = createEvent({
+      author: 'user',
+      content: {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'call-1',
+              name: 'get_weather',
+              response: {result: 'sunny'},
+            },
+          },
+        ],
+      },
+    });
+
+    expect(() =>
+      reconstructNodeStates([raised('gate-1'), toolResponse]),
+    ).not.toThrow();
+  });
+});
+
 describe('Phase 5b — HITL resume via the Runner', () => {
   it('resumes an interrupted workflow without re-running completed nodes', async () => {
     let aRuns = 0;

--- a/core/test/workflow/resume_test.ts
+++ b/core/test/workflow/resume_test.ts
@@ -319,9 +319,6 @@ describe('Phase 5b — a reply that answers no open interrupt', () => {
   }
 
   it('refuses an id that names no interrupt, naming what is waiting', () => {
-    // Silently dropping this let the turn be served as a new user message, so
-    // the waiting node re-ran and raised a SECOND interrupt. From then on two
-    // were pending, plain text resolved neither, and the count only grew.
     expect(() =>
       reconstructNodeStates([raised('gate-1'), reply('no-such-interrupt', 21)]),
     ).toThrow(/'no-such-interrupt'.*does not match any interrupt.*'gate-1'/s);
@@ -338,7 +335,6 @@ describe('Phase 5b — a reply that answers no open interrupt', () => {
   });
 
   it('refuses a reply to an interrupt that is already answered', () => {
-    // What a stale approval form in the dev UI submits.
     expect(() =>
       reconstructNodeStates([
         raised('gate-1'),
@@ -349,8 +345,6 @@ describe('Phase 5b — a reply that answers no open interrupt', () => {
   });
 
   it('accepts a second answer once the node has asked again', () => {
-    // The revise loop: `gate` asks, is told to redraft, and asks again under
-    // the same id. The second answer must land, not be read as a duplicate.
     const states = reconstructNodeStates([
       raised('gate-1'),
       reply('gate-1', 'shorter'),
@@ -362,8 +356,6 @@ describe('Phase 5b — a reply that answers no open interrupt', () => {
   });
 
   it('stops refusing once the turn that carried the bad reply has passed', () => {
-    // The reply stays in the session for good, so re-throwing on every replay
-    // would end the session rather than the turn.
     expect(() =>
       reconstructNodeStates([
         raised('gate-1'),


### PR DESCRIPTION
Fixes #717

## The bug

A `functionResponse` whose id matched nothing currently open was skipped with no error and no log (`core/src/workflow/utils/rehydration_utils.ts:195`), so the turn fell through and was served as a brand-new user message. The waiting node re-ran and raised a **second** interrupt — and once two were pending, plain text no longer resolved either (`run_node_as_invocation.ts:167` requires exactly one), so every later turn added one more and the count could never come back down.

The session was wedged permanently; the only escape found was answering every accumulated id in a single message.

## The fix

A reply carrying `adk_request_input` that answers nothing open is refused on the turn that carried it, exactly the way a schema-violating reply already is — one clear error naming the ids that genuinely are waiting, nothing resolved, and the real interrupts still answerable. On later replays it is skipped silently, so one bad reply ends a turn rather than the session.

This covers both shapes the issue describes:

- an id nobody raised → *"does not match any interrupt this run raised"*
- an id already raised and answered → *"has already been answered"*

The second is what a stale approval form in the dev UI submits, and is the framework half that #731 says is filed separately here.

## The subtlety that shaped the fix

My first attempt refused any id already present in `resolved`, and it broke `resume_loopback_test.ts`. The revise loop in the request-input samples asks `review` **again under the same id** after the first answer sends it back to redraft, so "already answered" is only true until the node asks again.

Raised ids and *open* ids are therefore tracked separately, and re-raising re-opens. A test pins that a second answer lands once the node has asked again.

An ordinary tool response is untouched: only a reply addressed to `adk_request_input` can be unroutable.

## Tests

Six cases in `core/test/workflow/resume_test.ts`, covering both refusals, the re-raise case, the real interrupt staying answerable afterwards, silence on replay, and a plain tool response being ignored.

Full unit suite passes (3551).
