### PR TITLE
fix(workflow): hand the START node the user's text, attachment or not

### DIFF
--- a/core/src/workflow/run_node_as_invocation.ts
+++ b/core/src/workflow/run_node_as_invocation.ts
@@ -172,16 +172,33 @@ function resumeInputsFromPlainText(
 }
 
 /**
- * Derives the node input from the user message: plain text when the content is
- * text-only, otherwise the raw `Content` (nodes coerce as needed).
+ * Derives the node input from the user message: the text the user wrote when
+ * there is any, otherwise the raw `Content`.
+ *
+ * The text parts are what a node is written against, and they used to be
+ * handed over only when *every* part was text. One attachment alongside the
+ * message — a file dropped into the dev UI — flipped the return type, so a
+ * handler typed `(ctx, input: string)` was given an object and died on its
+ * first string method behind an unattributed HTTP 500, and a handler typed
+ * `unknown` quietly answered `[object Object]` with the user's caption
+ * nowhere in sight. Neither is something the caller can see or act on.
+ *
+ * Non-text parts are not lost by this: the whole message stays on the
+ * invocation as `ctx.invocationContext.userContent`, and it is already in the
+ * session as the user's own event, which is what an `LlmAgent` node reads. A
+ * node that wants the attachment reads it there.
+ *
+ * With no text at all — a bare attachment — there is nothing to prefer, so the
+ * `Content` is passed through as before.
  */
 function extractNodeInput(content?: Content): unknown {
   if (!content) {
     return undefined;
   }
   const parts = content.parts ?? [];
-  if (parts.length > 0 && parts.every((p) => typeof p.text === 'string')) {
-    return parts.map((p) => p.text).join('');
+  const textParts = parts.filter((p) => typeof p.text === 'string');
+  if (textParts.length > 0) {
+    return textParts.map((p) => p.text).join('');
   }
   return content;
 }

--- a/core/src/workflow/run_node_as_invocation.ts
+++ b/core/src/workflow/run_node_as_invocation.ts
@@ -175,21 +175,9 @@ function resumeInputsFromPlainText(
  * Derives the node input from the user message: the text the user wrote when
  * there is any, otherwise the raw `Content`.
  *
- * The text parts are what a node is written against, and they used to be
- * handed over only when *every* part was text. One attachment alongside the
- * message — a file dropped into the dev UI — flipped the return type, so a
- * handler typed `(ctx, input: string)` was given an object and died on its
- * first string method behind an unattributed HTTP 500, and a handler typed
- * `unknown` quietly answered `[object Object]` with the user's caption
- * nowhere in sight. Neither is something the caller can see or act on.
- *
- * Non-text parts are not lost by this: the whole message stays on the
- * invocation as `ctx.invocationContext.userContent`, and it is already in the
- * session as the user's own event, which is what an `LlmAgent` node reads. A
- * node that wants the attachment reads it there.
- *
- * With no text at all — a bare attachment — there is nothing to prefer, so the
- * `Content` is passed through as before.
+ * Non-text parts are not lost, since the whole message stays on the invocation
+ * as `ctx.invocationContext.userContent` and in the session as the user's own
+ * event.
  */
 function extractNodeInput(content?: Content): unknown {
   if (!content) {

--- a/core/test/workflow/run_node_as_invocation_test.ts
+++ b/core/test/workflow/run_node_as_invocation_test.ts
@@ -116,9 +116,11 @@ describe('runNodeAsInvocation — what the START node is handed', () => {
       userContent: {role: 'user', parts},
       pluginManager: new PluginManager(),
     });
-    for await (const _ of runNodeAsInvocation(wf, ic)) {
-      // drain
+    const drained: Event[] = [];
+    for await (const event of runNodeAsInvocation(wf, ic)) {
+      drained.push(event);
     }
+    expect(drained.length).toBeGreaterThan(0);
     return received;
   }
 
@@ -129,9 +131,6 @@ describe('runNodeAsInvocation — what the START node is handed', () => {
   });
 
   it('still hands over the text when an attachment rides along', async () => {
-    // One non-text part used to flip the return type to the raw Content, which
-    // died on the first string method in a handler typed `(ctx, s: string)`
-    // and silently dropped the caption in one typed `unknown`.
     expect(await inputFor([{text: 'gamma'}, image])).toBe('gamma');
   });
 
@@ -143,8 +142,6 @@ describe('runNodeAsInvocation — what the START node is handed', () => {
   });
 
   it('leaves the whole message reachable on the invocation', async () => {
-    // The attachment is not lost by preferring the text: the full Content is
-    // still on the invocation, and in the session as the user's own event.
     let seen: Content | undefined;
     const wf = new Workflow({
       name: 'wf',
@@ -169,10 +166,12 @@ describe('runNodeAsInvocation — what the START node is handed', () => {
       userContent: {role: 'user', parts: [{text: 'gamma'}, image]},
       pluginManager: new PluginManager(),
     });
-    for await (const _ of runNodeAsInvocation(wf, ic)) {
-      // drain
+    const drained: Event[] = [];
+    for await (const event of runNodeAsInvocation(wf, ic)) {
+      drained.push(event);
     }
 
+    expect(drained.length).toBeGreaterThan(0);
     expect(seen?.parts).toEqual([{text: 'gamma'}, image]);
   });
 });

--- a/core/test/workflow/run_node_as_invocation_test.ts
+++ b/core/test/workflow/run_node_as_invocation_test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {Content, Part} from '@google/genai';
 import {describe, expect, it} from 'vitest';
 import {InvocationContext} from '../../src/agents/invocation_context.js';
 import {Event} from '../../src/events/event.js';
@@ -11,6 +12,7 @@ import {PluginManager} from '../../src/plugins/plugin_manager.js';
 import {createSession} from '../../src/sessions/session.js';
 import {node} from '../../src/workflow/node.js';
 import {NodeContext} from '../../src/workflow/node_context.js';
+import {FunctionNode} from '../../src/workflow/nodes/function_node.js';
 import {RequestInput} from '../../src/workflow/request_input.js';
 import {
   asRunnableRoot,
@@ -84,6 +86,94 @@ describe('runNodeAsInvocation — plain-text resume', () => {
     // user never gave it; the ambiguous case is dropped (structured function
     // responses are required to address a specific interrupt).
     expect(await resumeInputsFor(['first', 'second'], 'yes')).toEqual({});
+  });
+});
+
+describe('runNodeAsInvocation — what the START node is handed', () => {
+  /** Runs a one-node workflow over `parts` and returns what the node received. */
+  async function inputFor(parts: Part[]): Promise<unknown> {
+    let received: unknown;
+    const wf = new Workflow({
+      name: 'wf',
+      edges: [
+        [
+          'START',
+          new FunctionNode('start', (_c, input) => {
+            received = input;
+            return 'ok';
+          }),
+        ],
+      ],
+    });
+    const ic = new InvocationContext({
+      invocationId: 'inv-1',
+      session: createSession({
+        id: 's1',
+        appName: 'app',
+        userId: 'u',
+        lastUpdateTime: Date.now(),
+      }),
+      userContent: {role: 'user', parts},
+      pluginManager: new PluginManager(),
+    });
+    for await (const _ of runNodeAsInvocation(wf, ic)) {
+      // drain
+    }
+    return received;
+  }
+
+  const image: Part = {inlineData: {mimeType: 'image/png', data: 'aGk='}};
+
+  it('joins text parts, as before', async () => {
+    expect(await inputFor([{text: 'alpha'}, {text: 'beta'}])).toBe('alphabeta');
+  });
+
+  it('still hands over the text when an attachment rides along', async () => {
+    // One non-text part used to flip the return type to the raw Content, which
+    // died on the first string method in a handler typed `(ctx, s: string)`
+    // and silently dropped the caption in one typed `unknown`.
+    expect(await inputFor([{text: 'gamma'}, image])).toBe('gamma');
+  });
+
+  it('passes the content through when the user sent no text at all', async () => {
+    const received = await inputFor([image]);
+
+    expect(typeof received).toBe('object');
+    expect((received as Content).parts).toEqual([image]);
+  });
+
+  it('leaves the whole message reachable on the invocation', async () => {
+    // The attachment is not lost by preferring the text: the full Content is
+    // still on the invocation, and in the session as the user's own event.
+    let seen: Content | undefined;
+    const wf = new Workflow({
+      name: 'wf',
+      edges: [
+        [
+          'START',
+          new FunctionNode('start', (ctx) => {
+            seen = ctx.invocationContext.userContent;
+            return 'ok';
+          }),
+        ],
+      ],
+    });
+    const ic = new InvocationContext({
+      invocationId: 'inv-1',
+      session: createSession({
+        id: 's1',
+        appName: 'app',
+        userId: 'u',
+        lastUpdateTime: Date.now(),
+      }),
+      userContent: {role: 'user', parts: [{text: 'gamma'}, image]},
+      pluginManager: new PluginManager(),
+    });
+    for await (const _ of runNodeAsInvocation(wf, ic)) {
+      // drain
+    }
+
+    expect(seen?.parts).toEqual([{text: 'gamma'}, image]);
   });
 });
 


### PR DESCRIPTION
Fixes #716

## The bug

`extractNodeInput` joined the text parts only when **every** part was text (`core/src/workflow/run_node_as_invocation.ts:178-187`), so one attachment alongside the message flipped the return type to the raw `Content`.

A handler typed `(ctx, input: string)` was then handed an object and died on its first string method, surfacing as an unattributed `TypeError` behind an HTTP 500:

```
{"error":"Failed to run agent: TypeError: e.toUpperCase is not a function"}
```

A handler typed `unknown` did something worse: it quietly answered `Hello [object Object]` and dropped the caption the user typed alongside the attachment. Nothing fails, and the user's text is simply gone.

Dropping a file into the dev UI is enough to trigger it, and two *text* parts are joined correctly — so the presence of one non-text part was the whole difference.

## The fix

The text is preferred whenever there is any.

Nothing is lost by that: the full message stays on the invocation as `ctx.invocationContext.userContent` and in the session as the user's own event, which is what an `LlmAgent` node reads. A node that wants the attachment reads it there.

With no text at all — a bare attachment — there is nothing to prefer, so the `Content` is passed through as before.

## Tests

Four cases in `core/test/workflow/run_node_as_invocation_test.ts`: text parts still join; text survives an attachment riding along; a text-free message still passes the `Content`; and the whole message stays reachable on the invocation. Reverting the source change fails the second.

Full unit suite passes (3549).
