### PR TITLE
fix(dev): stop dropping piped stdin lines, and keep the prompt on its own line

### DIFF
--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -139,18 +139,47 @@ interface InputFile {
   queries: string[];
 }
 
-async function getUserInput(prompt: string): Promise<string> {
-  const rl = readline.createInterface({
+/**
+ * The one readline interface for the run, created on first prompt.
+ *
+ * A fresh interface per prompt loses piped input: readline reads ahead from the
+ * stream, so lines already sitting in the pipe when a turn ends are buffered
+ * inside the interface, and `close()` throws them away. The next prompt then
+ * built a new interface over a stream those lines had already left. Only the
+ * first line of `printf 'hello\n21\nexit\n' | adk run …` ever reached the
+ * agent, which is every scripted and CI use of the command.
+ */
+let sharedReadline: readline.Interface | undefined;
+
+function getReadline(): readline.Interface {
+  sharedReadline ??= readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
+  return sharedReadline;
+}
 
-  return new Promise<string>((resolve) => {
-    rl.question(prompt, (answer) => {
-      rl.close();
-      resolve(answer);
-    });
+/** Releases the shared interface, so an idle stdin stops holding the process open. */
+function closeUserInput(): void {
+  sharedReadline?.close();
+  sharedReadline = undefined;
+}
+
+async function getUserInput(prompt: string): Promise<string> {
+  const rl = getReadline();
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(prompt, resolve);
   });
+
+  // A terminal echoes what was typed; a pipe does not, so the prompt sat
+  // unterminated and whatever printed next landed on the same line —
+  // `[user]: [hello_node]: Hello World`, reading as though the user had typed
+  // the node's output. Echo it so a piped transcript reads like the session it
+  // was.
+  if (!process.stdin.isTTY) {
+    console.log(answer);
+  }
+  return answer;
 }
 
 interface RunFromInputFileOptions {
@@ -418,4 +447,6 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
 
     console.log('Session saved to', sessionPath);
   }
+
+  closeUserInput();
 }

--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -140,14 +140,9 @@ interface InputFile {
 }
 
 /**
- * The one readline interface for the run, created on first prompt.
- *
- * A fresh interface per prompt loses piped input: readline reads ahead from the
- * stream, so lines already sitting in the pipe when a turn ends are buffered
- * inside the interface, and `close()` throws them away. The next prompt then
- * built a new interface over a stream those lines had already left. Only the
- * first line of `printf 'hello\n21\nexit\n' | adk run …` ever reached the
- * agent, which is every scripted and CI use of the command.
+ * The one readline interface for the run, created on first prompt. A fresh
+ * interface per prompt discards the lines readline had already read ahead from
+ * a pipe.
  */
 let sharedReadline: readline.Interface | undefined;
 
@@ -171,11 +166,6 @@ async function getUserInput(prompt: string): Promise<string> {
     rl.question(prompt, resolve);
   });
 
-  // A terminal echoes what was typed; a pipe does not, so the prompt sat
-  // unterminated and whatever printed next landed on the same line —
-  // `[user]: [hello_node]: Hello World`, reading as though the user had typed
-  // the node's output. Echo it so a piped transcript reads like the session it
-  // was.
   if (!process.stdin.isTTY) {
     console.log(answer);
   }

--- a/dev/src/cli/cli_run.ts
+++ b/dev/src/cli/cli_run.ts
@@ -414,29 +414,30 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
           : undefined,
       });
     }
+
+    if (options.saveSession) {
+      const sessionId =
+        options.sessionId || (await getUserInput('Session ID to save: '));
+      // Sibling of the agent file, not inside it: joining onto the agent path
+      // itself yields `<cwd>/agent.ts/<id>.session.json`, and saveToFile does
+      // no mkdir, so the write failed with ENOTDIR.
+      const sessionPath = path.join(
+        path.dirname(options.agentPath),
+        `${sessionId}.session.json`,
+      );
+      const sessionToStore = await sessionService.getSession({
+        appName: session.appName,
+        userId: session.userId,
+        sessionId: session.id,
+      });
+      await saveToFile(getAbsolutePath(sessionPath), sessionToStore);
+
+      console.log('Session saved to', sessionPath);
+    }
   } finally {
+    // A throw out of the run or the save step must still release these, or the
+    // shared interface holds stdin open for an in-process caller.
     watcher?.close();
+    closeUserInput();
   }
-
-  if (options.saveSession) {
-    const sessionId =
-      options.sessionId || (await getUserInput('Session ID to save: '));
-    // Sibling of the agent file, not inside it: joining onto the agent path
-    // itself yields `<cwd>/agent.ts/<id>.session.json`, and saveToFile does
-    // no mkdir, so the write failed with ENOTDIR.
-    const sessionPath = path.join(
-      path.dirname(options.agentPath),
-      `${sessionId}.session.json`,
-    );
-    const sessionToStore = await sessionService.getSession({
-      appName: session.appName,
-      userId: session.userId,
-      sessionId: session.id,
-    });
-    await saveToFile(getAbsolutePath(sessionPath), sessionToStore);
-
-    console.log('Session saved to', sessionPath);
-  }
-
-  closeUserInput();
 }

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -144,6 +144,62 @@ describe('cli_run', () => {
       }),
     }) as unknown as BaseSessionService;
 
+  it('reuses one readline interface across prompts', async () => {
+    // A fresh interface per prompt threw away the lines readline had already
+    // read ahead from the pipe, so only the first line of
+    // `printf 'hello\n21\nexit\n' | adk run …` ever reached the agent.
+    (mockRl.question as Mock)
+      .mockImplementationOnce((_p: string, cb: (a: string) => void) =>
+        cb('hello'),
+      )
+      .mockImplementationOnce((_p: string, cb: (a: string) => void) => cb('21'))
+      .mockImplementationOnce((_p: string, cb: (a: string) => void) =>
+        cb('exit'),
+      );
+
+    await runAgent({
+      agentPath: 'agent.ts',
+      sessionService: createMockSessionService(),
+    });
+
+    expect(readline.createInterface as Mock).toHaveBeenCalledTimes(1);
+    expect(mockRl.question as Mock).toHaveBeenCalledTimes(3);
+    expect(mockRl.close as Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('echoes the answer when stdin is not a terminal', async () => {
+    // A pipe does not echo, so the prompt sat unterminated and the next line
+    // printed onto it: `[user]: [hello_node]: Hello World`.
+    const isTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+    try {
+      (mockRl.question as Mock)
+        .mockImplementationOnce((_p: string, cb: (a: string) => void) =>
+          cb('hi'),
+        )
+        .mockImplementationOnce((_p: string, cb: (a: string) => void) =>
+          cb('exit'),
+        );
+
+      await runAgent({
+        agentPath: 'agent.ts',
+        sessionService: createMockSessionService(),
+      });
+
+      expect(
+        (console.log as Mock).mock.calls.map((c) => c.join(' ')),
+      ).toContain('hi');
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: isTTY,
+        configurable: true,
+      });
+    }
+  });
+
   it('should run from input file', async () => {
     const inputFileContent = {
       state: {foo: 'bar'},

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -164,6 +164,27 @@ describe('cli_run', () => {
     expect(mockRl.close as Mock).toHaveBeenCalledTimes(1);
   });
 
+  it('closes the readline interface when the run throws', async () => {
+    (mockRl.question as Mock).mockImplementation(
+      (_p: string, cb: (a: string) => void) => cb('hello'),
+    );
+    (Runner as unknown as Mock).mockImplementation(() => ({
+      runAsync: async function* () {
+        yield runnerState.events[0];
+        throw new Error('runner exploded');
+      },
+    }));
+
+    await expect(
+      runAgent({
+        agentPath: 'agent.ts',
+        sessionService: createMockSessionService(),
+      }),
+    ).rejects.toThrow('runner exploded');
+
+    expect(mockRl.close as Mock).toHaveBeenCalledTimes(1);
+  });
+
   it('echoes the answer when stdin is not a terminal', async () => {
     const isTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, 'isTTY', {

--- a/dev/test/cli/cli_run_test.ts
+++ b/dev/test/cli/cli_run_test.ts
@@ -145,9 +145,6 @@ describe('cli_run', () => {
     }) as unknown as BaseSessionService;
 
   it('reuses one readline interface across prompts', async () => {
-    // A fresh interface per prompt threw away the lines readline had already
-    // read ahead from the pipe, so only the first line of
-    // `printf 'hello\n21\nexit\n' | adk run …` ever reached the agent.
     (mockRl.question as Mock)
       .mockImplementationOnce((_p: string, cb: (a: string) => void) =>
         cb('hello'),
@@ -168,8 +165,6 @@ describe('cli_run', () => {
   });
 
   it('echoes the answer when stdin is not a terminal', async () => {
-    // A pipe does not echo, so the prompt sat unterminated and the next line
-    // printed onto it: `[user]: [hello_node]: Hello World`.
     const isTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, 'isTTY', {
       value: false,


### PR DESCRIPTION
Fixes #722
Fixes #723

Two bugs on one code path, so they are fixed together as agreed.

## #722 — piped lines after the first are dropped

`getUserInput` built a readline interface per prompt and closed it after one answer. readline reads ahead from the stream, so lines already sitting in the pipe when a turn ended were buffered *inside that interface* and thrown away by `close()`; the next prompt then built a fresh interface over a stream those lines had already left.

```bash
printf 'hello\n21\nexit\n' | npx adk run ../samples/workflows/human_input/get_started/agent.ts
# reaches the agent with "hello" and nothing else; step2 never runs
```

Inserting a `sleep` between the lines made it work, which is what pointed at read-ahead rather than at the agent. This broke every scripted and CI use of `adk run`.

**Fix:** one interface, created on the first prompt and reused, so buffered lines are still there for the next turn. It is closed once the run is over so an idle stdin does not hold the process open.

## #723 — the prompt and the node output collide

A terminal echoes what was typed and a pipe does not, so the prompt sat unterminated and whatever printed next landed on the same line:

```
actual:     [user]: [hello_node]: Hello World
expected:   [user]: hi
            [hello_node]: Hello World
```

**Fix:** echo the answer when stdin is not a TTY, so a piped transcript reads like the session it was. Cosmetic, but it is the same function and the same code path.

## Tests

`dev/test/cli/cli_run_test.ts`: one interface is created across three prompts and closed once; and the answer is echoed when `stdin.isTTY` is false. Reverting the source change fails both (`expected 1 times, but got 3 times`, and the missing echo).

Full unit suite passes (3547).
