### PR TITLE
feat(core): graduate RoutedAgent and RoutedLlm out of experimental

### DIFF
--- a/core/src/agents/routed_agent.ts
+++ b/core/src/agents/routed_agent.ts
@@ -8,7 +8,6 @@ import {Event} from '../events/event.js';
 import {BaseAgent, BaseAgentConfig} from './base_agent.js';
 import {InvocationContext} from './invocation_context.js';
 
-import {experimental} from '../utils/experimental.js';
 import {runWithRouting} from '../utils/failover_utils.js';
 
 /**
@@ -66,7 +65,6 @@ export interface RoutedAgentConfig extends BaseAgentConfig {
  * so the clone is a detached root that routes identically to the original while
  * leaving the original agent tree untouched.
  */
-@experimental
 export class RoutedAgent extends BaseAgent<RoutedAgentConfig> {
   readonly [ROUTED_AGENT_SIGNATURE_SYMBOL] = true;
 

--- a/core/src/models/routed_llm.ts
+++ b/core/src/models/routed_llm.ts
@@ -9,7 +9,6 @@ import {BaseLlmConnection} from './base_llm_connection.js';
 import {LlmRequest} from './llm_request.js';
 import {LlmResponse} from './llm_response.js';
 
-import {experimental} from '../utils/experimental.js';
 import {runWithRouting} from '../utils/failover_utils.js';
 import {logger} from '../utils/logger.js';
 
@@ -25,7 +24,6 @@ export type LlmRouter = (
 /**
  * A BaseLlm implementation that delegates to one of multiple models based on a router function.
  */
-@experimental
 export class RoutedLlm extends BaseLlm {
   private readonly models: Readonly<Record<string, BaseLlm>>;
   private readonly router: LlmRouter;

--- a/core/test/agents/routed_agent_test.ts
+++ b/core/test/agents/routed_agent_test.ts
@@ -17,7 +17,6 @@ import {
   isRoutedAgent,
 } from '@google/adk';
 import {beforeEach, describe, expect, it} from 'vitest';
-import {Logger, setLogger} from '../../src/utils/logger.js';
 
 class MockAgent extends BaseAgent {
   constructor(name: string) {
@@ -79,30 +78,6 @@ describe('RoutedAgent', () => {
     agentA = new MockAgent('agent-a');
     agentB = new MockAgent('agent-b');
     agents = [agentA, agentB];
-  });
-
-  describe('experimental check', () => {
-    const warnCalls: string[] = [];
-    const mockLogger: Logger = {
-      setLogLevel: () => {},
-      log: () => {},
-      debug: () => {},
-      info: () => {},
-      warn: (...args: unknown[]) => {
-        warnCalls.push(args.map((a) => String(a)).join(' '));
-      },
-      error: () => {},
-    };
-
-    it('warns when instantiated', () => {
-      setLogger(mockLogger);
-
-      const router = async () => 'agent-a';
-      new RoutedAgent({name: 'router', agents: [], router});
-
-      expect(warnCalls).toHaveLength(1);
-      expect(warnCalls[0]).toContain('Class RoutedAgent is experimental');
-    });
   });
 
   it('should route runAsync to the selected agent A', async () => {

--- a/core/test/models/routed_llm_test.ts
+++ b/core/test/models/routed_llm_test.ts
@@ -12,7 +12,6 @@ import {
   RoutedLlm,
 } from '@google/adk';
 import {describe, expect, it} from 'vitest';
-import {Logger, setLogger} from '../../src/utils/logger.js';
 
 class MockLlm extends BaseLlm {
   receivedStream: boolean | undefined;
@@ -43,30 +42,6 @@ describe('RoutedLlm', () => {
   const modelA = new MockLlm('model-a');
   const modelB = new MockLlm('model-b');
   const models = [modelA, modelB];
-
-  describe('experimental check', () => {
-    const warnCalls: string[] = [];
-    const mockLogger: Logger = {
-      setLogLevel: () => {},
-      log: () => {},
-      debug: () => {},
-      info: () => {},
-      warn: (...args: unknown[]) => {
-        warnCalls.push(args.map((a) => String(a)).join(' '));
-      },
-      error: () => {},
-    };
-
-    it('warns when instantiated', () => {
-      setLogger(mockLogger);
-
-      const router = async () => 'model-a';
-      new RoutedLlm({models: [], router});
-
-      expect(warnCalls).toHaveLength(1);
-      expect(warnCalls[0]).toContain('Class RoutedLlm is experimental');
-    });
-  });
 
   it('should route generateContentAsync to the selected model A', async () => {
     let routerCalledWithModels: Readonly<Record<string, BaseLlm>> | null = null;


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`RoutedAgent` and `RoutedLlm` were marked `@experimental` in #241, shortly after they landed in #215. Since then their public surface has only grown additively — `RoutedLlm` is untouched, and `RoutedAgent` gained `clone()` via #545/#556.

The decorator's only runtime effect is a `Class RoutedAgent is experimental and may change in the future.` warning on first construction. Callers cannot silence it short of swapping the global logger, and at this point it no longer tells them anything actionable.

**Solution:**

Drop `@experimental` from both classes and remove the now-unused imports.

The two `experimental check` tests that asserted the warning go with it. Those tests installed a mock logger via `setLogger` and never restored it, so removing them also stops that mock leaking into the rest of the cases in each file.

No behavioral change beyond the warning: the decorator only wrapped construction to log, so routing, failover, and cloning are untouched.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npm run test:unit` — 239 files, 3575 tests passed (was 3577; the two removed assertions are the delta).

Also run clean, matching the `validation` workflow: `npm run build`, `npm run ts:check`, `npm run ts:check:samples`, `npm run lint`, `npm run format:check`, `npm run docs:check`.

**Manual End-to-End (E2E) Tests:**

Not applicable — no behavior changes. The `tests/e2e/routing/` suite exercises these classes and is unmodified; it is `skipIf`-gated on an API key.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

`@experimental` and the feature registry are separate mechanisms; this touches only the former. `PROGRESSIVE_SSE_STREAMING` remains the sole entry in `core/src/features/feature_registry.ts`, and the decorator itself stays in use by the workflow, skill, environment, and OpenAPI surfaces.