### PR TITLE
chore: ignore generated api-reference/ docs output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 !.vscode/settings.json
 tests/**/package-lock.json
 coverage/
+api-reference/
 .env
 go.sum
 dev/.cache/


### PR DESCRIPTION
<!-- foundry:automerge -->
> ## This pull request will be merged automatically
>
> **Scheduled merge: 2026-08-21 21:19 UTC** (about 24h from opening).
>
> It was selected by [ADK Foundry] because the merge critic approved
> the change, it is small, it touches no sensitive path, and CI is
> green. No human has reviewed it.
>
> **To stop it:** close this pull request, add the `status/on-hold`
> label, or leave any review comment. Any of the three cancels the
> merge; pushing a commit restarts the clock. Nothing is merged while
> a question is open.
>
> Staged from fork PR #668.

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
TypeDoc writes its rendered site to `api-reference/typescript/`, set by `"out"` in `typedoc.json`. The root `.gitignore` has no entry that matches this path. A local `npm run docs:generate` therefore leaves the generated site untracked in `git status`. A later `git add -A` stages the whole site.

**Solution:**
I added `api-reference/` to the root `.gitignore`, next to `coverage/`. The repository already ignores its other generated directories this way, `dist/` and `coverage/`. `npm run docs:clean` still removes the directory. `npm run docs:check` runs TypeDoc with `--emit none`, so CI behaviour does not change.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

The change adds no executable code, so no new unit test applies. Git reads `.gitignore`, and the published packages do not.

```
$ npm run test:unit
 Test Files  241 passed (241)
      Tests  3637 passed (3637)
```

**Manual End-to-End (E2E) Tests:**

The rule matches the TypeDoc output path:

```
$ git check-ignore -v api-reference/typescript/index.html
.gitignore:10:api-reference/	api-reference/typescript/index.html
```

A full docs build now leaves the working tree clean:

```
$ npm run docs:generate
[info] html generated at ./api-reference/typescript

$ find api-reference -type f | wc -l
468

$ git status --porcelain
                     # empty
```

The same build without the change reports the generated site as untracked:

```
$ git status --porcelain
?? api-reference/
```

`npm run docs:clean` still deletes the directory, and `npm run docs:check` exits 0.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
