### PR TITLE
ci: check the PR title against release-please's commit notation

### DIFF
--- a/.github/workflows/commit-convention.yml
+++ b/.github/workflows/commit-convention.yml
@@ -1,0 +1,30 @@
+name: commit-convention
+
+# A pull request lands on main as a squash commit whose subject is the PR
+# title, so the PR title is the line release-please parses to pick the next
+# version and write the changelog.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    # release-please titles its own PRs "Release: v1.2.3", which is deliberately
+    # not a conventional commit.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/check_commit_message.mjs --label "PR title" "$PR_TITLE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,42 @@ To maintain high code quality and consistency:
 The project uses `husky` and `lint-staged` to automatically lint and format
 your changes before each commit.
 
+### Commit notation
+
+Pull requests are squash merged, so the PR title becomes the commit subject on
+`main`. `release-please` reads those subjects to pick the next version and
+write the changelog, so the PR title must follow
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <description>
+```
+
+- **Types**: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`,
+  `revert`, `style`, `test`. `feat` cuts a minor release, `fix` and `perf` a
+  patch, and the rest appear in the changelog only.
+- **Breaking changes**: add `!` before the colon, as in `feat(core)!: ...`, or
+  add a `BREAKING CHANGE: <what broke>` footer to the commit body.
+- **Scope** is optional and free-form, but lowercase — `dev`, `workflow`,
+  `sessions`. It groups the changelog, so `fix(Dev)` and `fix(dev)` would split
+  into two sections.
+- Keep the subject to 100 characters, and leave off the trailing period.
+
+Examples:
+
+```
+fix(dev): stop dropping piped stdin lines
+feat(core): implement Runner.runLive
+refactor(workflow)!: collapse LLMAgentWrapper into LlmAgent
+```
+
+The `commit-convention` CI check enforces this on every pull request. To check
+a subject before you open one:
+
+```bash
+node scripts/check_commit_message.mjs "fix(dev): stop dropping piped stdin lines"
+```
+
 ### Sign our Contributor License Agreement
 
 Contributions to this project must be accompanied by a

--- a/scripts/check_commit_message.mjs
+++ b/scripts/check_commit_message.mjs
@@ -1,0 +1,311 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Checks that a subject follows the Conventional Commits notation that
+ * release-please parses to pick the next version and write the changelog.
+ *
+ * Pull requests land on main as a squash commit whose subject is the PR title,
+ * so the PR title is what release-please actually reads.
+ *
+ * Usage:
+ *   node scripts/check_commit_message.mjs "fix(dev): stop dropping stdin"
+ *   node scripts/check_commit_message.mjs --file .git/COMMIT_EDITMSG
+ *   git log -1 --pretty=%B | node scripts/check_commit_message.mjs --stdin
+ */
+
+import {appendFileSync, readFileSync} from 'node:fs';
+
+// The types release-please understands. Anything outside this list is treated
+// as an unparseable subject and silently skipped when the release is cut.
+const TYPES = [
+  'build',
+  'chore',
+  'ci',
+  'docs',
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'revert',
+  'style',
+  'test',
+];
+
+const MINOR_TYPES = ['feat'];
+const PATCH_TYPES = ['fix', 'perf'];
+
+const MAX_SUBJECT_LENGTH = 100;
+const MIN_DESCRIPTION_LENGTH = 5;
+
+const SUBJECT_PATTERN =
+  /^(?<type>[A-Za-z]+)(?:\((?<scope>[^()]*)\))?(?<breaking>!)?:(?<spacing> *)(?<description>.*)$/;
+const SCOPE_PATTERN = /^[a-z0-9][a-z0-9._/-]*$/;
+
+// GitHub's "Revert" button quotes the original subject, and a squash merge
+// appends the PR number. Both wrap an otherwise valid subject.
+const REVERT_PATTERN = /^Revert "(?<reverted>.+)"$/;
+const SQUASH_SUFFIX_PATTERN = / *\(#\d+\)$/;
+
+const EXAMPLES = [
+  'fix(dev): stop dropping piped stdin lines',
+  'feat(core): implement Runner.runLive',
+  'docs: describe what a JoinNode barrier waits for',
+  'refactor(workflow)!: collapse LLMAgentWrapper into LlmAgent',
+];
+
+/**
+ * Validates the first line of a commit message.
+ *
+ * @param {string} subject
+ * @return {{errors: string[], type?: string, breaking: boolean}}
+ */
+function checkSubject(subject) {
+  const errors = [];
+
+  // The "(#123)" is machinery GitHub appends, so measure and match the subject
+  // without it. A PR title and the squash commit it becomes then read alike.
+  let core = subject.replace(SQUASH_SUFFIX_PATTERN, '');
+
+  if (core.length > MAX_SUBJECT_LENGTH) {
+    errors.push(
+      `Subject is ${core.length} characters. Keep it to ` +
+        `${MAX_SUBJECT_LENGTH} or fewer so the changelog stays readable.`,
+    );
+  }
+
+  const revert = REVERT_PATTERN.exec(core);
+  if (revert) {
+    core = revert.groups.reverted.replace(SQUASH_SUFFIX_PATTERN, '');
+  }
+
+  const match = SUBJECT_PATTERN.exec(core);
+  if (!match) {
+    errors.push(
+      'Subject does not match "<type>(<optional scope>): <description>".',
+    );
+    return {errors, breaking: false};
+  }
+
+  const {type, scope, breaking, spacing, description} = match.groups;
+
+  if (!TYPES.includes(type)) {
+    const lowered = type.toLowerCase();
+    if (TYPES.includes(lowered)) {
+      errors.push(`Type must be lowercase: write "${lowered}", not "${type}".`);
+    } else {
+      errors.push(
+        `"${type}" is not a known type. Use one of: ${TYPES.join(', ')}.`,
+      );
+    }
+  }
+
+  if (scope !== undefined && !SCOPE_PATTERN.test(scope)) {
+    errors.push(
+      scope.trim() === ''
+        ? 'Scope is empty. Drop the parentheses or name a scope, e.g. "fix(dev):".'
+        : `Scope "${scope}" must be lowercase with no spaces, e.g. "fix(dev):".`,
+    );
+  }
+
+  if (spacing !== ' ') {
+    errors.push('Put exactly one space after the colon.');
+  }
+
+  if (description.trim() === '') {
+    errors.push('Add a description after the colon.');
+  } else if (description.trim().length < MIN_DESCRIPTION_LENGTH) {
+    errors.push('Description is too short to say what changed.');
+  } else if (description.endsWith('.')) {
+    errors.push('Drop the trailing period from the description.');
+  }
+
+  return {
+    errors,
+    type: TYPES.includes(type) ? type : undefined,
+    breaking: breaking === '!',
+  };
+}
+
+/**
+ * Validates the lines after the subject. A PR title has none.
+ *
+ * @param {string[]} lines
+ * @return {{errors: string[], breaking: boolean}}
+ */
+function checkBody(lines) {
+  const errors = [];
+
+  if (lines.length > 0 && lines[0].trim() !== '') {
+    errors.push('Leave a blank line between the subject and the body.');
+  }
+
+  // release-please only honours the footer spelled exactly this way.
+  const breaking = lines.some((line) =>
+    /^BREAKING[ -]CHANGE: .+/.test(line.trim()),
+  );
+  const malformed = lines.some(
+    (line) =>
+      /^breaking[ -]change/i.test(line.trim()) &&
+      !/^BREAKING[ -]CHANGE: .+/.test(line.trim()),
+  );
+  if (malformed && !breaking) {
+    errors.push(
+      'A breaking change footer must read "BREAKING CHANGE: <what broke>", ' +
+        'in capitals, or the release will not be a major one.',
+    );
+  }
+
+  return {errors, breaking};
+}
+
+/**
+ * Describes the release the message will produce, so the author can catch a
+ * wrong type before it ships.
+ *
+ * @param {string | undefined} type
+ * @param {boolean} breaking
+ * @return {string}
+ */
+function describeRelease(type, breaking) {
+  if (breaking) {
+    return 'a major release (breaking change)';
+  }
+  if (MINOR_TYPES.includes(type)) {
+    return 'a minor release';
+  }
+  if (PATCH_TYPES.includes(type)) {
+    return 'a patch release';
+  }
+  return 'no release, changelog only';
+}
+
+/**
+ * @param {string[]} argv
+ * @return {{message: string, label: string}}
+ */
+function readInput(argv) {
+  let label = 'Commit message';
+  let message;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--label') {
+      label = argv[++i] ?? label;
+    } else if (arg === '--file') {
+      const path = argv[++i];
+      if (!path) {
+        throw new Error('--file needs a path.');
+      }
+      message = readFileSync(path, 'utf8');
+    } else if (arg === '--stdin') {
+      message = readFileSync(0, 'utf8');
+    } else if (message === undefined) {
+      message = arg;
+    }
+  }
+
+  if (message === undefined) {
+    throw new Error(
+      'Nothing to check. Pass a message, --file <path> or --stdin.',
+    );
+  }
+
+  return {message, label};
+}
+
+/**
+ * @param {string} text
+ */
+function writeStepSummary(text) {
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (path) {
+    appendFileSync(path, `${text}\n\n`);
+  }
+}
+
+function main() {
+  let input;
+  try {
+    input = readInput(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 2;
+    return;
+  }
+
+  const {message, label} = input;
+
+  // Comment lines are what git leaves in COMMIT_EDITMSG; they never reach the
+  // stored message.
+  const lines = message
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith('#'))
+    .join('\n')
+    .trim()
+    .split('\n');
+
+  const subject = lines[0].trim();
+  if (subject === '') {
+    console.error(`${label} is empty.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const subjectResult = checkSubject(subject);
+  const bodyResult = checkBody(lines.slice(1));
+  const errors = [...subjectResult.errors, ...bodyResult.errors];
+  const breaking = subjectResult.breaking || bodyResult.breaking;
+
+  if (errors.length === 0) {
+    const release = describeRelease(subjectResult.type, breaking);
+    console.log(`${label} follows Conventional Commits: ${subject}`);
+    console.log(`release-please will treat this as ${release}.`);
+    writeStepSummary(`**${label} OK** — release-please reads this as ${release}.
+
+\`\`\`
+${subject}
+\`\`\``);
+    return;
+  }
+
+  const report = [
+    `${label} does not follow Conventional Commits:`,
+    '',
+    `    ${subject}`,
+    '',
+    ...errors.map((error) => `  - ${error}`),
+    '',
+    'release-please derives the version and the changelog from this line, so',
+    'a subject it cannot parse is left out of the release notes entirely.',
+    '',
+    'Expected: <type>(<optional scope>): <description>',
+    `Types:    ${TYPES.join(', ')}`,
+    'Breaking: add "!" before the colon, e.g. "feat(core)!: ...".',
+    '',
+    'Examples:',
+    ...EXAMPLES.map((example) => `  ${example}`),
+  ].join('\n');
+
+  console.error(report);
+  writeStepSummary(`**${label} is not a conventional commit**
+
+\`\`\`
+${subject}
+\`\`\`
+
+${errors.map((error) => `- ${error}`).join('\n')}
+
+release-please derives the version and the changelog from this line. Edit it to
+match \`<type>(<optional scope>): <description>\`, for example:
+
+\`\`\`
+${EXAMPLES[0]}
+\`\`\``);
+  process.exitCode = 1;
+}
+
+main();

--- a/scripts/check_commit_message.mjs
+++ b/scripts/check_commit_message.mjs
@@ -66,20 +66,22 @@ const EXAMPLES = [
 function checkSubject(subject) {
   const errors = [];
 
-  // The "(#123)" is machinery GitHub appends, so measure and match the subject
-  // without it. A PR title and the squash commit it becomes then read alike.
+  // The "(#123)" suffix and the "Revert \"...\"" wrapper are both machinery
+  // GitHub adds, so strip them before measuring and matching. A PR title and
+  // the squash commit it becomes then read alike, and a revert is judged on
+  // the subject it quotes rather than on the wrapper's extra characters.
   let core = subject.replace(SQUASH_SUFFIX_PATTERN, '');
+
+  const revert = REVERT_PATTERN.exec(core);
+  if (revert) {
+    core = revert.groups.reverted.replace(SQUASH_SUFFIX_PATTERN, '');
+  }
 
   if (core.length > MAX_SUBJECT_LENGTH) {
     errors.push(
       `Subject is ${core.length} characters. Keep it to ` +
         `${MAX_SUBJECT_LENGTH} or fewer so the changelog stays readable.`,
     );
-  }
-
-  const revert = REVERT_PATTERN.exec(core);
-  if (revert) {
-    core = revert.groups.reverted.replace(SQUASH_SUFFIX_PATTERN, '');
   }
 
   const match = SUBJECT_PATTERN.exec(core);


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

Pull requests here are squash merged, so the PR title becomes the commit subject on `main` — and that subject is the line `release-please` parses to pick the next version and write the changelog. Nothing enforces its shape today, and a subject release-please cannot parse is dropped from the release notes silently, with no failure anywhere.

History shows the cost. Of the last 300 commits, 96 are not conventional commits, including:

- `Feat: Honor GOOGLE_GENAI_USE_ENTERPRISE in getExpressModeApiKey() (#569)` — capitalised type, so not counted as a minor change.
- `feat!(workflow): event model extensions and shared node primitives (#587)` — `!` in the wrong place, so not counted as breaking.
- `StreamingMode.BIDI is accepted but has no effect (#692)` — no type at all.
- `fix(): uses js-yaml instead of yaml for parsing (#293)` — empty scope.

**Solution:**

Add a `commit-convention` workflow that validates the PR title on `opened`, `edited`, `reopened` and `synchronize`, backed by `scripts/check_commit_message.mjs`.

Notes on the choices:

- **A plain script, not commitlint.** Keeps the rules tied to this repo's release config and adds no dependencies. It reads a message from an argument, `--file`, or stdin, so it also works as a `commit-msg` hook if we want local enforcement later.
- **release-please's own PRs are skipped** via the `release-please--*` head ref. Their titles (`Release: v1.6.0`, per `group-pull-request-title-pattern`) are deliberately not conventional and would otherwise fail every release.
- **The title is passed through an env var**, not interpolated into the `run:` block, so a crafted title cannot inject shell.
- **The `(#123)` squash suffix and GitHub's `Revert "..."` titles are understood**, so neither is a false failure. The length limit is measured with the suffix stripped, so a title and the commit it becomes are judged the same way.
- **Scope is free-form but must be lowercase.** It groups the changelog, so `fix(Dev)` and `fix(dev)` would split into two sections.
- **Passing runs report the release impact** ("release-please will treat this as a minor release"), which surfaces a `chore:` that should have been a `fix:` during review.

The 100-character subject limit matches this repo's practice: p95 of the last 300 subjects is 99.

This only blocks merges once `check-pr-title` is added to the branch protection rules for `main`. `synchronize` is in the trigger list so the check reports on every push and won't sit pending as a required check.

`CONTRIBUTING.md` documents the notation and how to check a subject locally.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

No unit tests: the script has no runtime dependency on the packages and `vitest` is not wired up for `scripts/`. It was verified against real data instead.

**Manual End-to-End (E2E) Tests:**

Ran the validator over the last 300 subjects on `main`:

```bash
git log --no-merges --pretty=format:"%s" -n 300 |
  while IFS= read -r s; do
    node scripts/check_commit_message.mjs "$s" >/dev/null || echo "FAIL: $s"
  done
```

96 of 300 fail, all genuine violations, and they are concentrated in older history — the most recent ~60 are nearly all clean. Nothing needs fixing retroactively, since the check only looks at new PRs.

Spot checks:

| Subject | Result |
| --- | --- |
| `fix(dev): release stdin even when the run throws` | pass, patch release |
| `refactor(workflow)!: collapse LLMAgentWrapper into LlmAgent.runImpl (#696)` | pass, major release |
| `chore: remove inline comments that only restate the code (#682)` | pass, changelog only |
| `Revert "fix(dev): stop dropping piped stdin lines (#12)" (#800)` | pass |
| `Feat: Honor GOOGLE_GENAI_USE_ENTERPRISE...` | fail, "write `feat`, not `Feat`" |
| `fix(Dev):no space and a trailing period.` | fail, three distinct errors |
| `Release: v1.6.0` | skipped by the branch guard |

Failure output:

```
PR title does not follow Conventional Commits:

    Feat: Honor GOOGLE_GENAI_USE_ENTERPRISE in getExpressModeApiKey() (#569)

  - Type must be lowercase: write "feat", not "Feat".

release-please derives the version and the changelog from this line, so
a subject it cannot parse is left out of the release notes entirely.

Expected: <type>(<optional scope>): <description>
Types:    build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
Breaking: add "!" before the colon, e.g. "feat(core)!: ...".
```

The same report is written to `$GITHUB_STEP_SUMMARY` so it renders on the run page rather than only in the log. Formatting was checked with `npx prettier --check`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
