### PR TITLE
fix(core): gracefully handle unregistered tool calls

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -257,6 +257,9 @@ function buildResponseEvent(
  * Handles function calls.
  * Runtime behavior to pay attention to:
  * - Iterate through each function call in the `functionCallEvent`:
+ *   - Resolve the named tool. If the name is not callable, run the on-tool-
+ *     error callbacks and answer the call with their response, or with the
+ *     resolution error when none handles it.
  *   - Execute before tool callbacks !!if a callback provides a response, short
  *     circuit the rest.
  *   - Execute the tool.
@@ -313,6 +316,21 @@ function normalizeCallbackResponse(
 }
 
 /**
+ * Stands in for a tool the model named but that the agent does not have, so
+ * the on-tool-error callbacks get something to inspect. It is never run.
+ * Mirrors the bare `BaseTool` Python builds in the same spot.
+ */
+class ToolNotFoundPlaceholder extends BaseTool {
+  constructor(name: string) {
+    super({name, description: 'Tool not found'});
+  }
+
+  override async runAsync(): Promise<unknown> {
+    throw new Error(`Function ${this.name} is not found in the toolsDict.`);
+  }
+}
+
+/**
  * The underlying implementation of handleFunctionCalls, but takes a list of
  * function calls instead of an event.
  * This is also used by llm_agent execution flow in preprocessing.
@@ -347,12 +365,52 @@ export async function handleFunctionCallList({
       toolConfirmation = toolConfirmationDict[functionCall.id];
     }
 
-    const {tool, toolContext} = getToolAndContext({
-      invocationContext,
-      functionCall,
-      toolsDict,
-      toolConfirmation,
-    });
+    let tool: BaseTool;
+    let toolContext: Context;
+    try {
+      ({tool, toolContext} = getToolAndContext({
+        invocationContext,
+        functionCall,
+        toolsDict,
+        toolConfirmation,
+      }));
+    } catch (e: unknown) {
+      if (!(e instanceof Error)) {
+        throw e;
+      }
+      // Failing to resolve the tool is a tool error, not a model error, so it
+      // goes through the same on-tool-error callbacks, and then the same
+      // error response, that a registered tool throwing would.
+      const notFoundTool = new ToolNotFoundPlaceholder(
+        functionCall.name || '<unnamed>',
+      );
+      const notFoundContext = new Context({
+        invocationContext,
+        functionCallId: functionCall.id || undefined,
+        toolConfirmation,
+      });
+      const onToolErrorResponse =
+        await invocationContext.pluginManager.runOnToolErrorCallback({
+          tool: notFoundTool,
+          toolArgs: functionCall.args ?? {},
+          toolContext: notFoundContext,
+          error: e,
+        });
+      // With no plugin response, hand the model the error as this call's
+      // result, the same shape a registered tool's failure takes. Rethrowing
+      // instead would leave the call unanswered, and since nothing else in the
+      // request changes between iterations the model re-issues it until
+      // `maxLlmCalls` trips.
+      functionResponseEvents.push(
+        buildResponseEvent(
+          notFoundTool,
+          onToolErrorResponse ?? {error: e.message},
+          notFoundContext,
+          invocationContext,
+        ),
+      );
+      continue;
+    }
 
     // TODO - b/436079721: implement [tracer.start_as_current_span]
     logger.debug(`execute_tool ${tool.name}`);
@@ -535,8 +593,14 @@ function getToolAndContext({
   toolConfirmation?: ToolConfirmation;
 }): {tool: BaseTool; toolContext: Context} {
   if (!functionCall.name || !(functionCall.name in toolsDict)) {
+    const callableTools = Object.keys(toolsDict);
     throw new Error(
-      `Function ${functionCall.name} is not found in the toolsDict.`,
+      `Function ${functionCall.name} is not found in the toolsDict. ` +
+        `Callable tools: ${callableTools.length ? callableTools.join(', ') : '(none)'}. ` +
+        'A built-in tool such as `google_search` runs inside the model and is ' +
+        'never callable from here, so a function call naming one lands here ' +
+        'even though the tool is registered; otherwise the model named a tool ' +
+        'this agent does not have.',
     );
   }
 

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -259,7 +259,9 @@ function buildResponseEvent(
  * - Iterate through each function call in the `functionCallEvent`:
  *   - Resolve the named tool. If the name is not callable, run the on-tool-
  *     error callbacks and answer the call with their response, or with the
- *     resolution error when none handles it.
+ *     resolution error when none handles it, then move to the next call. That
+ *     answer skips the before/after tool callbacks below, so a plugin auditing
+ *     every response does not observe it — as in Python.
  *   - Execute before tool callbacks !!if a callback provides a response, short
  *     circuit the rest.
  *   - Execute the tool.
@@ -316,17 +318,34 @@ function normalizeCallbackResponse(
 }
 
 /**
- * Stands in for a tool the model named but that the agent does not have, so
- * the on-tool-error callbacks get something to inspect. It is never run.
- * Mirrors the bare `BaseTool` Python builds in the same spot.
+ * Why a name the model called may be missing from `toolsDict`. Operator-facing
+ * only — the model gets the short form, since none of this is actionable to it.
+ */
+const RESOLUTION_FAILURE_CAUSES = `Possible causes:
+  1. The model hallucinated the name.
+  2. The tool is not registered on this agent, or a plugin filtered it out of this request.
+  3. The name does not match the registered tool's name exactly.
+  4. The tool is registered but never enters the toolsDict, because its \`_getDeclaration()\` returns undefined or it is a built-in tool that runs inside the model (\`google_search\`, \`url_context\`, ...).`;
+
+/**
+ * Stands in for a tool the model named but that the agent cannot call, so the
+ * on-tool-error callbacks get something to inspect. Mirrors the bare
+ * `BaseTool` Python builds in the same spot.
+ *
+ * The framework never runs it, but a plugin receiving it as `tool` can, so
+ * `runAsync` rethrows the resolution error rather than inventing a second
+ * message that could drift from the first.
  */
 class ToolNotFoundPlaceholder extends BaseTool {
-  constructor(name: string) {
+  constructor(
+    name: string,
+    private readonly resolutionError: Error,
+  ) {
     super({name, description: 'Tool not found'});
   }
 
-  override async runAsync(): Promise<unknown> {
-    throw new Error(`Function ${this.name} is not found in the toolsDict.`);
+  override async runAsync(): Promise<never> {
+    throw this.resolutionError;
   }
 }
 
@@ -375,15 +394,23 @@ export async function handleFunctionCallList({
         toolConfirmation,
       }));
     } catch (e: unknown) {
+      // `getToolAndContext` has a single throw site and it throws an `Error`,
+      // so this only guards a future one added there.
       if (!(e instanceof Error)) {
         throw e;
       }
+      const toolName = functionCall.name || '<unnamed>';
+      // The model gets a short answer it can act on; the operator gets the
+      // diagnosis. Without this line a misconfigured agent degrades into a
+      // string only the model ever sees.
+      logger.warn(
+        `Could not resolve tool '${toolName}' for function call ` +
+          `'${functionCall.id ?? ''}'. ${e.message}\n${RESOLUTION_FAILURE_CAUSES}`,
+      );
       // Failing to resolve the tool is a tool error, not a model error, so it
       // goes through the same on-tool-error callbacks, and then the same
       // error response, that a registered tool throwing would.
-      const notFoundTool = new ToolNotFoundPlaceholder(
-        functionCall.name || '<unnamed>',
-      );
+      const notFoundTool = new ToolNotFoundPlaceholder(toolName, e);
       const notFoundContext = new Context({
         invocationContext,
         functionCallId: functionCall.id || undefined,
@@ -595,12 +622,9 @@ function getToolAndContext({
   if (!functionCall.name || !(functionCall.name in toolsDict)) {
     const callableTools = Object.keys(toolsDict);
     throw new Error(
-      `Function ${functionCall.name} is not found in the toolsDict. ` +
-        `Callable tools: ${callableTools.length ? callableTools.join(', ') : '(none)'}. ` +
-        'A built-in tool such as `google_search` runs inside the model and is ' +
-        'never callable from here, so a function call naming one lands here ' +
-        'even though the tool is registered; otherwise the model named a tool ' +
-        'this agent does not have.',
+      `Function ${functionCall.name || '<unnamed>'} is not found in the ` +
+        `toolsDict. Callable tools: ` +
+        `${callableTools.length ? callableTools.join(', ') : '(none)'}.`,
     );
   }
 

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -327,6 +327,23 @@ const RESOLUTION_FAILURE_CAUSES = `Possible causes:
   3. The name does not match the registered tool's name exactly.
   4. The tool is registered but never enters the toolsDict, because its \`_getDeclaration()\` returns undefined or it is a built-in tool that runs inside the model (\`google_search\`, \`url_context\`, ...).`;
 
+const TOOL_NOT_FOUND_SYMBOL = Symbol.for('google.adk.toolNotFound');
+
+/**
+ * Whether `tool` is the placeholder handed to the on-tool-error callbacks for a
+ * function call naming a tool this agent cannot call.
+ *
+ * Lets a plugin tell an unresolvable name from a registered tool that threw
+ * without matching on the error message.
+ */
+export function isToolNotFound(tool: unknown): boolean {
+  return (
+    typeof tool === 'object' &&
+    tool !== null &&
+    (tool as Record<symbol, unknown>)[TOOL_NOT_FOUND_SYMBOL] === true
+  );
+}
+
 /**
  * Stands in for a tool the model named but that the agent cannot call, so the
  * on-tool-error callbacks get something to inspect. Mirrors the bare
@@ -337,6 +354,8 @@ const RESOLUTION_FAILURE_CAUSES = `Possible causes:
  * message that could drift from the first.
  */
 class ToolNotFoundPlaceholder extends BaseTool {
+  readonly [TOOL_NOT_FOUND_SYMBOL] = true;
+
   constructor(
     name: string,
     private readonly resolutionError: Error,
@@ -347,6 +366,63 @@ class ToolNotFoundPlaceholder extends BaseTool {
   override async runAsync(): Promise<never> {
     throw this.resolutionError;
   }
+}
+
+/**
+ * Answers a function call naming a tool this agent cannot call.
+ *
+ * Failing to resolve the tool is a tool error, not a model error, so it runs
+ * through the same on-tool-error callbacks a registered tool that throws does.
+ * With no plugin response the model is handed the error as the call's result:
+ * leaving the call unanswered makes the next request identical to this one, and
+ * the model re-issues it until `maxLlmCalls` trips.
+ */
+async function answerUnresolvableCall({
+  invocationContext,
+  functionCall,
+  toolsDict,
+  toolContext,
+}: {
+  invocationContext: InvocationContext;
+  functionCall: FunctionCall;
+  toolsDict: Record<string, BaseTool>;
+  toolContext: Context;
+}): Promise<Event> {
+  const toolName = functionCall.name || '<unnamed>';
+  const error = new Error(
+    `Function ${toolName} is not found in the toolsDict.`,
+  );
+  const tool = new ToolNotFoundPlaceholder(toolName, error);
+
+  const onToolErrorResponse =
+    await invocationContext.pluginManager.runOnToolErrorCallback({
+      tool,
+      toolArgs: functionCall.args ?? {},
+      toolContext,
+      error,
+    });
+
+  if (onToolErrorResponse == null) {
+    // Only an unhandled failure is the operator's problem; a plugin that
+    // answers these has made them an expected condition. The tool inventory
+    // belongs here rather than in the model's payload — the model already has
+    // its declarations, and a large toolset would cost kilobytes per
+    // occurrence.
+    const callableTools = Object.keys(toolsDict);
+    logger.warn(
+      `Could not resolve tool '${toolName}' for function call ` +
+        `'${functionCall.id ?? ''}'. Callable tools: ` +
+        `${callableTools.length ? callableTools.join(', ') : '(none)'}.\n` +
+        RESOLUTION_FAILURE_CAUSES,
+    );
+  }
+
+  return buildResponseEvent(
+    tool,
+    onToolErrorResponse ?? {error: error.message},
+    toolContext,
+    invocationContext,
+  );
 }
 
 /**
@@ -384,57 +460,21 @@ export async function handleFunctionCallList({
       toolConfirmation = toolConfirmationDict[functionCall.id];
     }
 
-    let tool: BaseTool;
-    let toolContext: Context;
-    try {
-      ({tool, toolContext} = getToolAndContext({
-        invocationContext,
-        functionCall,
-        toolsDict,
-        toolConfirmation,
-      }));
-    } catch (e: unknown) {
-      // `getToolAndContext` has a single throw site and it throws an `Error`,
-      // so this only guards a future one added there.
-      if (!(e instanceof Error)) {
-        throw e;
-      }
-      const toolName = functionCall.name || '<unnamed>';
-      // The model gets a short answer it can act on; the operator gets the
-      // diagnosis. Without this line a misconfigured agent degrades into a
-      // string only the model ever sees.
-      logger.warn(
-        `Could not resolve tool '${toolName}' for function call ` +
-          `'${functionCall.id ?? ''}'. ${e.message}\n${RESOLUTION_FAILURE_CAUSES}`,
-      );
-      // Failing to resolve the tool is a tool error, not a model error, so it
-      // goes through the same on-tool-error callbacks, and then the same
-      // error response, that a registered tool throwing would.
-      const notFoundTool = new ToolNotFoundPlaceholder(toolName, e);
-      const notFoundContext = new Context({
-        invocationContext,
-        functionCallId: functionCall.id || undefined,
-        toolConfirmation,
-      });
-      const onToolErrorResponse =
-        await invocationContext.pluginManager.runOnToolErrorCallback({
-          tool: notFoundTool,
-          toolArgs: functionCall.args ?? {},
-          toolContext: notFoundContext,
-          error: e,
-        });
-      // With no plugin response, hand the model the error as this call's
-      // result, the same shape a registered tool's failure takes. Rethrowing
-      // instead would leave the call unanswered, and since nothing else in the
-      // request changes between iterations the model re-issues it until
-      // `maxLlmCalls` trips.
+    const toolContext = new Context({
+      invocationContext,
+      functionCallId: functionCall.id || undefined,
+      toolConfirmation,
+    });
+    const tool = functionCall.name ? toolsDict[functionCall.name] : undefined;
+
+    if (!tool) {
       functionResponseEvents.push(
-        buildResponseEvent(
-          notFoundTool,
-          onToolErrorResponse ?? {error: e.message},
-          notFoundContext,
+        await answerUnresolvableCall({
           invocationContext,
-        ),
+          functionCall,
+          toolsDict,
+          toolContext,
+        }),
       );
       continue;
     }
@@ -605,38 +645,6 @@ export async function handleFunctionCallList({
     });
   }
   return mergedEvent;
-}
-
-// TODO - b/425992518: consider inline, which is much cleaner.
-function getToolAndContext({
-  invocationContext,
-  functionCall,
-  toolsDict,
-  toolConfirmation,
-}: {
-  invocationContext: InvocationContext;
-  functionCall: FunctionCall;
-  toolsDict: Record<string, BaseTool>;
-  toolConfirmation?: ToolConfirmation;
-}): {tool: BaseTool; toolContext: Context} {
-  if (!functionCall.name || !(functionCall.name in toolsDict)) {
-    const callableTools = Object.keys(toolsDict);
-    throw new Error(
-      `Function ${functionCall.name || '<unnamed>'} is not found in the ` +
-        `toolsDict. Callable tools: ` +
-        `${callableTools.length ? callableTools.join(', ') : '(none)'}.`,
-    );
-  }
-
-  const toolContext = new Context({
-    invocationContext: invocationContext,
-    functionCallId: functionCall.id || undefined,
-    toolConfirmation,
-  });
-
-  const tool = toolsDict[functionCall.name];
-
-  return {tool, toolContext};
 }
 
 /**

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -388,40 +388,52 @@ async function answerUnresolvableCall({
   toolsDict: Record<string, BaseTool>;
   toolContext: Context;
 }): Promise<Event> {
-  const toolName = functionCall.name || '<unnamed>';
-  const error = new Error(
-    `Function ${toolName} is not found in the toolsDict.`,
-  );
-  const tool = new ToolNotFoundPlaceholder(toolName, error);
+  // The sibling path opens `execute_tool <name>` inside `callToolAsync`.
+  // Without this an unresolvable call is the one tool interaction that
+  // leaves no span, which is the worst case to be missing from a waterfall.
+  return tracer.startActiveSpan(
+    `execute_tool ${functionCall.name || '<unnamed>'}`,
+    async (span) => {
+      try {
+        const toolName = functionCall.name || '<unnamed>';
+        const error = new Error(
+          `Function ${toolName} is not found in the toolsDict.`,
+        );
+        const tool = new ToolNotFoundPlaceholder(toolName, error);
 
-  const onToolErrorResponse =
-    await invocationContext.pluginManager.runOnToolErrorCallback({
-      tool,
-      toolArgs: functionCall.args ?? {},
-      toolContext,
-      error,
-    });
+        const onToolErrorResponse =
+          await invocationContext.pluginManager.runOnToolErrorCallback({
+            tool,
+            toolArgs: functionCall.args ?? {},
+            toolContext,
+            error,
+          });
 
-  if (onToolErrorResponse == null) {
-    // Only an unhandled failure is the operator's problem; a plugin that
-    // answers these has made them an expected condition. The tool inventory
-    // belongs here rather than in the model's payload — the model already has
-    // its declarations, and a large toolset would cost kilobytes per
-    // occurrence.
-    const callableTools = Object.keys(toolsDict);
-    logger.warn(
-      `Could not resolve tool '${toolName}' for function call ` +
-        `'${functionCall.id ?? ''}'. Callable tools: ` +
-        `${callableTools.length ? callableTools.join(', ') : '(none)'}.\n` +
-        RESOLUTION_FAILURE_CAUSES,
-    );
-  }
+        if (onToolErrorResponse == null) {
+          // Only an unhandled failure is the operator's problem; a plugin that
+          // answers these has made them an expected condition. The tool inventory
+          // belongs here rather than in the model's payload — the model already has
+          // its declarations, and a large toolset would cost kilobytes per
+          // occurrence.
+          const callableTools = Object.keys(toolsDict);
+          logger.warn(
+            `Could not resolve tool '${toolName}' for function call ` +
+              `'${functionCall.id ?? ''}'. Callable tools: ` +
+              `${callableTools.length ? callableTools.join(', ') : '(none)'}.\n` +
+              RESOLUTION_FAILURE_CAUSES,
+          );
+        }
 
-  return buildResponseEvent(
-    tool,
-    onToolErrorResponse ?? {error: error.message},
-    toolContext,
-    invocationContext,
+        return buildResponseEvent(
+          tool,
+          onToolErrorResponse ?? {error: error.message},
+          toolContext,
+          invocationContext,
+        );
+      } finally {
+        span.end();
+      }
+    },
   );
 }
 
@@ -465,7 +477,13 @@ export async function handleFunctionCallList({
       functionCallId: functionCall.id || undefined,
       toolConfirmation,
     });
-    const tool = functionCall.name ? toolsDict[functionCall.name] : undefined;
+    // `functionCall.name` comes from the model, and `toolsDict` is a plain
+    // object, so an unguarded lookup would resolve `toString` or `constructor`
+    // to a function on `Object.prototype` and treat the call as found.
+    const tool =
+      functionCall.name && Object.hasOwn(toolsDict, functionCall.name)
+        ? toolsDict[functionCall.name]
+        : undefined;
 
     if (!tool) {
       functionResponseEvents.push(

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -21,6 +21,7 @@ export {
   findEventByFunctionCallId,
   findMatchingFunctionCall,
   functionsExportedForTestingOnly,
+  isToolNotFound,
 } from './agents/functions.js';
 export {InvocationContext, requireAgent} from './agents/invocation_context.js';
 export type {

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -346,6 +346,93 @@ describe('handleFunctionCallList', () => {
     });
   });
 
+  it('should route an unregistered tool name through plugin onToolErrorCallback', async () => {
+    const plugin = new TestPlugin('testPlugin');
+    plugin.onToolErrorCallbackResponse = {
+      error: 'no such tool, try testTool',
+    };
+    pluginManager.registerPlugin(plugin);
+    const onToolErrorCallback = vi.spyOn(plugin, 'onToolErrorCallback');
+    const hallucinatedCall: FunctionCall = {
+      id: randomIdForTestingOnly(),
+      name: 'google_search',
+      args: {query: 'anything'},
+    };
+
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [hallucinatedCall],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    expect(onToolErrorCallback).toHaveBeenCalledTimes(1);
+    const {tool, toolArgs} = onToolErrorCallback.mock.calls[0][0];
+    expect(tool.name).toBe('google_search');
+    expect(toolArgs).toEqual({query: 'anything'});
+
+    const functionResponse = event!.content!.parts![0].functionResponse!;
+    expect(functionResponse.id).toBe(hallucinatedCall.id);
+    expect(functionResponse.name).toBe('google_search');
+    expect(functionResponse.response).toEqual({
+      error: 'no such tool, try testTool',
+    });
+  });
+
+  it('should answer an unregistered tool name with the resolution error when no plugin handles it', async () => {
+    const unresolvableCall: FunctionCall = {
+      id: randomIdForTestingOnly(),
+      name: 'google_search',
+      args: {},
+    };
+
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [unresolvableCall],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    // The call has to be answered, not left dangling: the request is otherwise
+    // identical next iteration, and Gemini rejects an unpaired functionCall.
+    const functionResponse = event!.content!.parts![0].functionResponse!;
+    expect(functionResponse.id).toBe(unresolvableCall.id);
+    expect(functionResponse.name).toBe('google_search');
+    const {error} = functionResponse.response as {error: string};
+    expect(error).toContain(
+      'Function google_search is not found in the toolsDict.',
+    );
+    expect(error).toContain('Callable tools: testTool.');
+    // A built-in tool is registered on the agent yet absent here, so the
+    // message must not pin the blame on the model naming something unknown.
+    expect(error).toContain('runs inside the model');
+  });
+
+  it('should answer every call in a batch when one name is unresolvable', async () => {
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [
+        callFor(testTool),
+        {id: randomIdForTestingOnly(), name: 'google_search', args: {}},
+        callFor(testTool),
+      ],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    const responses = event!.content!.parts!.map((p) => p.functionResponse!);
+    expect(responses.map((r) => r.name)).toEqual([
+      'testTool',
+      'google_search',
+      'testTool',
+    ]);
+    expect(responses[0].response).toEqual({result: 'tool executed'});
+    expect(responses[2].response).toEqual({result: 'tool executed'});
+  });
+
   it('should pass abortSignal to tool execution', async () => {
     const abortController = new AbortController();
     const signal = abortController.signal;

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -510,6 +510,38 @@ describe('handleFunctionCallList', () => {
     ).rejects.toThrow('Function google_search is not found in the toolsDict.');
   });
 
+  // `functionCall.name` is model-supplied and `toolsDict` is a plain object, so
+  // an unguarded lookup reaches `Object.prototype`. These names would resolve
+  // to a JS builtin, be treated as found, and skip the whole recovery path —
+  // `constructor` even answers under the name `Object`, breaking the pairing.
+  it.each([
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    'isPrototypeOf',
+    'propertyIsEnumerable',
+    'toLocaleString',
+    '__proto__',
+  ])('should treat the inherited name %s as unresolvable', async (name) => {
+    const event = await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call-1', name, args: {}}],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    const functionResponse = event!.content!.parts![0].functionResponse!;
+    // The response has to name the call, or the pair dangles.
+    expect(functionResponse.name).toBe(name);
+    expect(functionResponse.id).toBe('call-1');
+    expect((functionResponse.response as {error: string}).error).toBe(
+      `Function ${name} is not found in the toolsDict.`,
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('should answer every call in a batch when one name is unresolvable', async () => {
     const unresolvableId = randomIdForTestingOnly();
     const event = await handleFunctionCallList({

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -29,6 +29,7 @@ import {
   getLongRunningFunctionCalls,
   mergeParallelFunctionResponseEvents,
 } from '../../src/agents/functions.js';
+import {logger} from '../../src/utils/logger.js';
 
 // Get the test target function
 const {
@@ -405,17 +406,41 @@ describe('handleFunctionCallList', () => {
       'Function google_search is not found in the toolsDict.',
     );
     expect(error).toContain('Callable tools: testTool.');
-    // A built-in tool is registered on the agent yet absent here, so the
-    // message must not pin the blame on the model naming something unknown.
-    expect(error).toContain('runs inside the model');
+    // The enumerated causes are for an operator, not the model — keep them out
+    // of the payload the model pays for on every occurrence.
+    expect(error).not.toContain('Possible causes');
+  });
+
+  it('should warn the operator with the possible causes', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call-1', name: 'google_search', args: {}}],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    // Without this the only trace of a misconfigured agent is a string the
+    // model sees and the operator never does.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warning = warnSpy.mock.calls[0][0] as string;
+    expect(warning).toContain("Could not resolve tool 'google_search'");
+    expect(warning).toContain('call-1');
+    expect(warning).toContain('Possible causes:');
+    // The cause this PR tripped over in SleepyTool has to be listed.
+    expect(warning).toContain('_getDeclaration()');
+    warnSpy.mockRestore();
   });
 
   it('should answer every call in a batch when one name is unresolvable', async () => {
+    const unresolvableId = randomIdForTestingOnly();
     const event = await handleFunctionCallList({
       invocationContext,
       functionCalls: [
         callFor(testTool),
-        {id: randomIdForTestingOnly(), name: 'google_search', args: {}},
+        {id: unresolvableId, name: 'google_search', args: {}},
         callFor(testTool),
       ],
       toolsDict,
@@ -431,6 +456,10 @@ describe('handleFunctionCallList', () => {
     ]);
     expect(responses[0].response).toEqual({result: 'tool executed'});
     expect(responses[2].response).toEqual({result: 'tool executed'});
+    // The id is what keeps the pairing balanced, so pin it on the
+    // unresolvable slot too — that is the one built off the placeholder.
+    expect(responses[1].id).toBe(unresolvableId);
+    expect(responses[1].response).toHaveProperty('error');
   });
 
   it('should pass abortSignal to tool execution', async () => {

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -6,12 +6,14 @@
 import {
   BasePlugin,
   BaseTool,
+  Context,
   createEvent,
   createEventActions,
   Event,
   functionsExportedForTestingOnly,
   FunctionTool,
   InvocationContext,
+  isToolNotFound,
   LlmAgent,
   PluginManager,
   Session,
@@ -20,7 +22,8 @@ import {
   ToolConfirmation,
 } from '@google/adk';
 import {FunctionCall} from '@google/genai';
-import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {MockInstance} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
   findEventByFunctionCallId,
@@ -120,8 +123,16 @@ describe('handleFunctionCallList', () => {
   let pluginManager: PluginManager;
   let functionCall: FunctionCall;
   let toolsDict: Record<string, BaseTool>;
+  let warnSpy: MockInstance<typeof logger.warn>;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   beforeEach(() => {
+    // These tests deliberately provoke resolution failures; keep the expected
+    // diagnostics out of the suite output.
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     pluginManager = new PluginManager();
     const agent = new LlmAgent({name: 'test_agent', model: 'test_model'});
     invocationContext = new InvocationContext({
@@ -405,15 +416,14 @@ describe('handleFunctionCallList', () => {
     expect(error).toContain(
       'Function google_search is not found in the toolsDict.',
     );
-    expect(error).toContain('Callable tools: testTool.');
-    // The enumerated causes are for an operator, not the model — keep them out
-    // of the payload the model pays for on every occurrence.
+    // The inventory and the causes are for an operator, not the model: the
+    // model already has its declarations and would otherwise pay for the whole
+    // toolset on every occurrence.
+    expect(error).not.toContain('Callable tools');
     expect(error).not.toContain('Possible causes');
   });
 
-  it('should warn the operator with the possible causes', async () => {
-    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-
+  it('should warn the operator with the inventory and the possible causes', async () => {
     await handleFunctionCallList({
       invocationContext,
       functionCalls: [{id: 'call-1', name: 'google_search', args: {}}],
@@ -428,10 +438,76 @@ describe('handleFunctionCallList', () => {
     const warning = warnSpy.mock.calls[0][0] as string;
     expect(warning).toContain("Could not resolve tool 'google_search'");
     expect(warning).toContain('call-1');
+    expect(warning).toContain('Callable tools: testTool.');
     expect(warning).toContain('Possible causes:');
-    // The cause this PR tripped over in SleepyTool has to be listed.
+    // The cause this change tripped over in SleepyTool has to be listed.
     expect(warning).toContain('_getDeclaration()');
-    warnSpy.mockRestore();
+  });
+
+  it('should not warn when a plugin handles the unresolvable call', async () => {
+    const plugin = new TestPlugin('testPlugin');
+    plugin.onToolErrorCallbackResponse = {result: 'handled'};
+    pluginManager.registerPlugin(plugin);
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call-1', name: 'google_search', args: {}}],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    // A plugin that answers these has made them an expected condition; the
+    // sibling path for a registered tool that throws is silent too.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should skip the before and after tool callbacks for an unresolvable call', async () => {
+    const plugin = new TestPlugin('testPlugin');
+    pluginManager.registerPlugin(plugin);
+    const beforeToolCallback = vi.spyOn(plugin, 'beforeToolCallback');
+    const afterToolCallback = vi.spyOn(plugin, 'afterToolCallback');
+    const canonicalAfter = vi.fn().mockResolvedValue(undefined);
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call-1', name: 'google_search', args: {}}],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [canonicalAfter],
+    });
+
+    // Documented asymmetry with the registered-tool error path, which does run
+    // them. Pin it so the doc comment and the code cannot drift apart.
+    expect(beforeToolCallback).not.toHaveBeenCalled();
+    expect(afterToolCallback).not.toHaveBeenCalled();
+    expect(canonicalAfter).not.toHaveBeenCalled();
+  });
+
+  it('should hand plugins a placeholder that identifies itself and rethrows', async () => {
+    const plugin = new TestPlugin('testPlugin');
+    plugin.onToolErrorCallbackResponse = {result: 'handled'};
+    pluginManager.registerPlugin(plugin);
+    const onToolErrorCallback = vi.spyOn(plugin, 'onToolErrorCallback');
+
+    await handleFunctionCallList({
+      invocationContext,
+      functionCalls: [{id: 'call-1', name: 'google_search', args: {}}],
+      toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    const {tool} = onToolErrorCallback.mock.calls[0][0];
+    // A plugin can tell an unresolvable name from a registered tool that threw
+    // without matching on the error message.
+    expect(isToolNotFound(tool)).toBe(true);
+    expect(isToolNotFound(testTool)).toBe(false);
+    // Nothing in the framework runs it, but a plugin holding it can, and it
+    // must not invent a second, different message.
+    await expect(
+      tool.runAsync({args: {}, toolContext: {} as Context}),
+    ).rejects.toThrow('Function google_search is not found in the toolsDict.');
   });
 
   it('should answer every call in a batch when one name is unresolvable', async () => {

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -1224,3 +1224,102 @@ describe('LlmAgent usage metadata on content-less responses', () => {
     expect(events.find((e) => e.usageMetadata)).toBeUndefined();
   });
 });
+
+describe('LlmAgent unresolvable tool calls', () => {
+  /**
+   * Calls a name that cannot resolve, then reacts to whatever came back — the
+   * behaviour a real model has and the stub in the bug report deliberately
+   * lacks.
+   */
+  class GhostCallerLlm extends BaseLlm {
+    calls = 0;
+
+    constructor() {
+      super({model: 'mock-llm'});
+    }
+
+    async *generateContentAsync(
+      request: LlmRequest,
+    ): AsyncGenerator<LlmResponse, void, void> {
+      this.calls++;
+      const answered = (request.contents ?? []).some((content) =>
+        (content.parts ?? []).some(
+          (part) =>
+            (part.functionResponse?.response as {error?: string} | undefined)
+              ?.error,
+        ),
+      );
+      yield answered
+        ? {content: {role: 'model', parts: [{text: 'Recovered.'}]}}
+        : {
+            content: {
+              role: 'model',
+              parts: [
+                {functionCall: {id: 'call-1', name: 'ghost_tool', args: {}}},
+              ],
+            },
+          };
+    }
+
+    async connect(): Promise<BaseLlmConnection> {
+      return new MockLlmConnection();
+    }
+  }
+
+  // The unit tests cover `handleFunctionCallList` directly, but #789 is a
+  // whole-invocation symptom: the throw reached `runAndHandleError`, the turn
+  // reported UNKNOWN_ERROR, and the unanswered call was re-issued until
+  // `maxLlmCalls` tripped. Assert it here so reintroducing the escape one
+  // layer up cannot stay green.
+  it('completes the invocation instead of erroring and re-issuing the call', async () => {
+    const mockLlm = new GhostCallerLlm();
+    const agent = new LlmAgent({
+      name: 'ghost_agent',
+      model: mockLlm,
+      tools: [
+        new FunctionTool({
+          name: 'real_tool',
+          description: 'The only registered tool.',
+          parameters: z3.object({}),
+          execute: async () => ({result: 'ok'}),
+        }),
+      ],
+    });
+
+    const sessionService = new InMemorySessionService();
+    const runner = new Runner({appName: 'test_app', agent, sessionService});
+    const session = await sessionService.createSession({
+      appName: 'test_app',
+      userId: 'test_user',
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: session.userId,
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'go'}]},
+    })) {
+      events.push(event);
+    }
+
+    // No error event: this is a tool failure the turn recovers from, not a
+    // model error that fails the invocation.
+    expect(events.filter((e) => e.errorMessage)).toHaveLength(0);
+    expect(events.filter((e) => e.errorCode)).toHaveLength(0);
+
+    // Two model calls, not `maxLlmCalls` worth.
+    expect(mockLlm.calls).toBe(2);
+
+    const parts = events.flatMap((e) => e.content?.parts ?? []);
+    const calls = parts.filter((p) => p.functionCall);
+    const responses = parts.filter((p) => p.functionResponse);
+    // Gemini rejects a dangling functionCall, so the pairing has to balance.
+    expect(calls).toHaveLength(1);
+    expect(responses).toHaveLength(1);
+    expect(responses[0].functionResponse!.id).toBe('call-1');
+    expect(responses[0].functionResponse!.name).toBe('ghost_tool');
+    expect(responses[0].functionResponse!.response).toHaveProperty('error');
+
+    expect(parts.some((p) => p.text === 'Recovered.')).toBe(true);
+  });
+});

--- a/core/test/agents/llm_agent_test.ts
+++ b/core/test/agents/llm_agent_test.ts
@@ -31,7 +31,15 @@ import {
   ToolProcessLlmRequest,
 } from '@google/adk';
 import {Content, Schema, Type} from '@google/genai';
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from 'vitest';
 import {z as z3} from 'zod/v3';
 import {z as z4} from 'zod/v4';
 import {logger} from '../../src/utils/logger.js';
@@ -1272,6 +1280,8 @@ describe('LlmAgent unresolvable tool calls', () => {
   // `maxLlmCalls` tripped. Assert it here so reintroducing the escape one
   // layer up cannot stay green.
   it('completes the invocation instead of erroring and re-issuing the call', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    onTestFinished(() => warnSpy.mockRestore());
     const mockLlm = new GhostCallerLlm();
     const agent = new LlmAgent({
       name: 'ghost_agent',

--- a/core/test/agents/processors/tool_filter_request_processor_test.ts
+++ b/core/test/agents/processors/tool_filter_request_processor_test.ts
@@ -16,7 +16,7 @@ import {
   ReadonlyContext,
   createSession,
 } from '@google/adk';
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it, onTestFinished, vi} from 'vitest';
 import {handleFunctionCallsAsync} from '../../../src/agents/functions.js';
 import {TOOL_FILTER_REQUEST_PROCESSOR} from '../../../src/agents/processors/tool_filter_request_processor.js';
 import {createEvent} from '../../../src/events/event.js';
@@ -168,8 +168,10 @@ describe('ToolFilterRequestProcessor', () => {
 
   it('should answer with an error if model tries to call a filtered tool', async () => {
     // A filtered tool is an expected resolution failure here; keep the
-    // diagnostic out of the suite output.
+    // diagnostic out of the suite output. Restored via `onTestFinished` so a
+    // failing assertion below cannot leave `logger.warn` stubbed.
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    onTestFinished(() => warnSpy.mockRestore());
     const tool1 = new MockTool('tool1');
     const agent = new LlmAgent({
       name: 'test_agent',
@@ -229,6 +231,5 @@ describe('ToolFilterRequestProcessor', () => {
     expect((functionResponse.response as {error: string}).error).toContain(
       'Function tool1 is not found in the toolsDict.',
     );
-    warnSpy.mockRestore();
   });
 });

--- a/core/test/agents/processors/tool_filter_request_processor_test.ts
+++ b/core/test/agents/processors/tool_filter_request_processor_test.ts
@@ -16,10 +16,11 @@ import {
   ReadonlyContext,
   createSession,
 } from '@google/adk';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {handleFunctionCallsAsync} from '../../../src/agents/functions.js';
 import {TOOL_FILTER_REQUEST_PROCESSOR} from '../../../src/agents/processors/tool_filter_request_processor.js';
 import {createEvent} from '../../../src/events/event.js';
+import {logger} from '../../../src/utils/logger.js';
 
 class MockTool extends BaseTool {
   constructor(name: string) {
@@ -166,6 +167,9 @@ describe('ToolFilterRequestProcessor', () => {
   });
 
   it('should answer with an error if model tries to call a filtered tool', async () => {
+    // A filtered tool is an expected resolution failure here; keep the
+    // diagnostic out of the suite output.
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const tool1 = new MockTool('tool1');
     const agent = new LlmAgent({
       name: 'test_agent',
@@ -225,5 +229,6 @@ describe('ToolFilterRequestProcessor', () => {
     expect((functionResponse.response as {error: string}).error).toContain(
       'Function tool1 is not found in the toolsDict.',
     );
+    warnSpy.mockRestore();
   });
 });

--- a/core/test/agents/processors/tool_filter_request_processor_test.ts
+++ b/core/test/agents/processors/tool_filter_request_processor_test.ts
@@ -165,7 +165,7 @@ describe('ToolFilterRequestProcessor', () => {
     expect(llmRequest.allowedTools).toBeUndefined();
   });
 
-  it('should fail if model tries to call a filtered tool', async () => {
+  it('should answer with an error if model tries to call a filtered tool', async () => {
     const tool1 = new MockTool('tool1');
     const agent = new LlmAgent({
       name: 'test_agent',
@@ -212,14 +212,18 @@ describe('ToolFilterRequestProcessor', () => {
       },
     });
 
-    await expect(
-      handleFunctionCallsAsync({
-        invocationContext,
-        functionCallEvent,
-        toolsDict: llmRequest.toolsDict,
-        beforeToolCallbacks: [],
-        afterToolCallbacks: [],
-      }),
-    ).rejects.toThrow('Function tool1 is not found in the toolsDict.');
+    const event = await handleFunctionCallsAsync({
+      invocationContext,
+      functionCallEvent,
+      toolsDict: llmRequest.toolsDict,
+      beforeToolCallbacks: [],
+      afterToolCallbacks: [],
+    });
+
+    const functionResponse = event!.content!.parts![0].functionResponse!;
+    expect(functionResponse.name).toBe('tool1');
+    expect((functionResponse.response as {error: string}).error).toContain(
+      'Function tool1 is not found in the toolsDict.',
+    );
   });
 });

--- a/core/test/runner/streaming_runner_test.ts
+++ b/core/test/runner/streaming_runner_test.ts
@@ -74,6 +74,11 @@ class SleepyTool extends BaseTool {
   constructor() {
     super({name: 'sleepy_tool', description: 'sleepy tool'});
   }
+  // Without a declaration the tool never lands in `toolsDict`, so the call
+  // below would fail to resolve and the tool would never actually run.
+  override _getDeclaration() {
+    return {name: this.name, description: this.description};
+  }
   async runAsync(
     request: RunAsyncToolRequest,
     abortSignal?: AbortSignal,

--- a/core/test/runner/streaming_runner_test.ts
+++ b/core/test/runner/streaming_runner_test.ts
@@ -71,6 +71,11 @@ class AbortMockLlm extends BaseLlm {
 }
 
 class SleepyTool extends BaseTool {
+  /** Whether the tool ran and observed the abort on its context. */
+  sawAbort = false;
+  /** Whether the tool ran all the way through without seeing an abort. */
+  finished = false;
+
   constructor() {
     super({name: 'sleepy_tool', description: 'sleepy tool'});
   }
@@ -79,14 +84,15 @@ class SleepyTool extends BaseTool {
   override _getDeclaration() {
     return {name: this.name, description: this.description};
   }
-  async runAsync(
-    request: RunAsyncToolRequest,
-    abortSignal?: AbortSignal,
-  ): Promise<unknown> {
+  // `callToolAsync` invokes `runAsync({args, toolContext})` with one argument;
+  // the abort signal rides on the context, not a second parameter.
+  async runAsync(request: RunAsyncToolRequest): Promise<unknown> {
     await new Promise((resolve) => setTimeout(resolve, 50));
-    if (abortSignal?.aborted) {
+    if (request.toolContext.abortSignal?.aborted) {
+      this.sawAbort = true;
       throw new Error('Tool aborted');
     }
+    this.finished = true;
     return {result: 'slept'};
   }
 }
@@ -312,6 +318,18 @@ describe('Runner Streaming and Ephemeral', () => {
       expect(events.some((e) => e.content?.parts?.[0].text === 'Done')).toBe(
         false,
       );
+      // 'Done' is absent either way once the runner aborts, so assert the
+      // tool-level abort where it is actually observable: the tool ran, read
+      // the signal off its context, and bailed instead of returning.
+      expect(sleepyTool.sawAbort).toBe(true);
+      expect(sleepyTool.finished).toBe(false);
+      // The runner stops at the functionCall; the tool's error response never
+      // reaches the caller.
+      expect(
+        events.flatMap((e) =>
+          (e.content?.parts ?? []).filter((p) => p.functionResponse),
+        ),
+      ).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION

### Link to Issue or Description of Change

- Closes: #789.


**Problem:**
A function call whose name is absent from toolsDict throws out of getToolAndContext before the try/catch that makes a real tool's failure recoverable. The throw escapes handleFunctionCallList and is caught by LlmAgent.runAndHandleError — the model error handler — so the turn reports UNKNOWN_ERROR and onToolErrorCallback never runs. Worse, the call is left unanswered, and since nothing else in the request changes between iterations the model re-issues it until maxLlmCalls trips: 500 billed calls and 500 error events for one user turn.


**Solution:**
Wrap the lookup. The error runs through the on-tool-error callbacks, and their response — or the resolution error itself when no plugin handles it — is emitted as that call's functionResponse. continue keeps the rest of the batch running, so every functionCall still gets a response and the pairing stays balanced (Gemini rejects a dangling functionCall).

**Why this diverges from adk-python**

adk-python re-raises when no plugin handles it, but the common trigger isn't a hallucinated name, it's a built-in tool.

GoogleSearchTool.processLlmRequest adds itself to config.tools without adding itself to toolsDict (core/src/tools/google_search_tool.ts:30) — as do enterprise_web_search, url_context, google_maps_grounding, vertex_ai_search, and vertex_rag_retrieval, none of which mention toolsDict at all. So tools: [GOOGLE_SEARCH] primes the model with a name that structurally cannot resolve. With GOOGLE_SEARCH genuinely registered, ADK on main says:

Function google_search is not found in the toolsDict. ... Available tools: search_web.

The user registered google_search. Gemini sometimes returns grounding as an explicit functionCall instead of running it server-side, and the user is then billed 500 calls for an inconsistency ADK created.

Re-raising is hard to justify for that, so the message also drops the hallucination claim it can't support. Happy to file the parity question upstream alongside google/adk-python#4775.


### Testing Plan

Three new tests in core/test/agents/functions_test.ts: plugin recovery (callback receives a tool named for the call, with its args), the no-plugin path (response carries the resolution error and the corrected message), and a mixed batch asserting all three calls are answered in order with the real tools' results intact. tool_filter_request_processor_test updated — a filtered tool now returns an error response rather than throwing.

Also fixes an unrelated latent bug the change exposed: SleepyTool in streaming_runner_test.ts had no _getDeclaration(), so sleepy_tool never entered toolsDict and the abort test passed only because the resolution throw ended the run before the tool executed. It now has a declaration and exercises the abort it claims to.

Full core suite passes (226 files / 3342 tests). Verified end-to-end against the issue's repro: per-iteration error events 500 → 0, and a model that reacts to the error resolves in 2 calls.


**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
 Test Files  241 passed (241)
      Tests  3643 passed (3643)
   Start at  10:57:41
   Duration  20.65s (transform 2.58s, setup 0ms, collect 108.93s, tests 13.30s, environment 19ms, prepare 7.94s)
```

**Manual End-to-End (E2E) Tests:**

See the issue for a self-contained repro.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

core/test doesn't run on a clean checkout — agent_engine_sandbox_code_executor.ts imports @google-cloud/vertexai, which isn't in node_modules and isn't declared in core/package.json's optional peers. Pre-existing (reproduces on a clean git stash), looks like a gap from a5cdc38. I installed it with --no-save --no-package-lock to run the suite.
