### PR TITLE
fix(dev): let --bundle false actually load an agent

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -134,7 +134,8 @@ const COMPILE_AGENT_FILE = new Option(
 ).default(true);
 const BUNDLE_AGENT_FILE = new Option(
   '--bundle [boolean]',
-  'Optional. Whether to compile ts agent file to js before execution',
+  'Optional. Whether to inline the agent file dependencies into a single ' +
+    'bundle before execution. Bundling also minifies the result.',
 ).default(true);
 const A2A_OPTION = new Option(
   '--a2a [boolean]',

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -197,30 +197,38 @@ export class AgentFile {
         target: 'node16',
         platform: 'node',
         format: moduleType,
-        packages: 'bundle',
         bundle: this.options.bundle,
         minify: this.options.bundle,
         plugins: [replaceDirnamePlugin(filePath, originalDir), shimPlugin()],
-        // See http://mikro-orm.io/docs/deployment#deploy-a-bundle-of-entities-and-dependencies-with-esbuild for more details
-        external: [
-          'sqlite3',
-          'better-sqlite3',
-          'mysql',
-          'mysql2',
-          // Native addons must remain external so Node can resolve their
-          // platform-specific assets at runtime.
-          'onnxruntime-node',
-          'oracledb',
-          'pg-native',
-          'pg-query-stream',
-          'tedious',
-          'libsql',
-          // Optional peer dependencies of vite and eslint that are not
-          // installed and MUST NOT be bundled.
-          'lightningcss',
-          'jiti',
-          'jiti/package.json',
-        ],
+        // esbuild rejects `packages` and `external` unless it is bundling, so
+        // both have to be withheld when `--bundle false` asks it only to
+        // transpile. Nothing is being inlined in that mode, so there is
+        // nothing to hold out of the bundle either.
+        ...(this.options.bundle
+          ? {
+              packages: 'bundle' as const,
+              // See http://mikro-orm.io/docs/deployment#deploy-a-bundle-of-entities-and-dependencies-with-esbuild for more details
+              external: [
+                'sqlite3',
+                'better-sqlite3',
+                'mysql',
+                'mysql2',
+                // Native addons must remain external so Node can resolve their
+                // platform-specific assets at runtime.
+                'onnxruntime-node',
+                'oracledb',
+                'pg-native',
+                'pg-query-stream',
+                'tedious',
+                'libsql',
+                // Optional peer dependencies of vite and eslint that are not
+                // installed and MUST NOT be bundled.
+                'lightningcss',
+                'jiti',
+                'jiti/package.json',
+              ],
+            }
+          : {}),
       });
 
       this.cleanupDirPath = outputDir;

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -318,6 +318,33 @@ describe('AgentLoader', () => {
       await expect(fs.access(compiledAgentPath)).rejects.toThrow();
     });
 
+    it('withholds bundle-only options when asked only to transpile', async () => {
+      const agentPath = path.join(tempAgentsDir, 'agent2.ts');
+      await fs.writeFile(agentPath, agent2TsContent);
+
+      const compiledAgentPath = compiledPath('agent2.cjs');
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledAgentPath, agent2CjsContentMocked);
+        return Promise.resolve();
+      });
+
+      const agentFile = new AgentFile(agentPath, {
+        compile: true,
+        bundle: false,
+      });
+      await agentFile.load();
+
+      // esbuild rejects `external` and `packages` outside a bundling build
+      // with `Cannot use "external" without "bundle"`, which made
+      // `--bundle false` fail on every agent.
+      const buildOptions = (esbuild.build as Mock).mock.calls[0][0];
+      expect(buildOptions.bundle).toBe(false);
+      expect(buildOptions).not.toHaveProperty('external');
+      expect(buildOptions).not.toHaveProperty('packages');
+
+      await agentFile.dispose();
+    });
+
     it('compiles into a private temp dir without allowing overwrite', async () => {
       const agentPath = path.join(tempAgentsDir, 'agent1.js');
       await fs.writeFile(agentPath, agent1JsContent);


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #714
- Related: #718, #661 (same call site, **separate** defects — see below)

**Problem:**

`adk run --bundle false` fails on every agent:

```
✘ [ERROR] Cannot use "external" without "bundle"
[ADK CLI] Error running agent: Build failed with 1 error
```

`dev/src/utils/agent_loader.ts` passes `packages: 'bundle'` and a 13-entry `external` list unconditionally, while `bundle` follows the CLI flag. esbuild rejects both outside a bundling build. The agent never loads, so there is no REPL and no prompt — the documented flag is unusable, not merely ineffective.

**Solution:**

Withhold `packages` and `external` when not bundling. In transpile-only mode nothing is being inlined, so there is nothing to hold out of the bundle; those lists were only ever meaningful to a bundling build.

Also gave `--bundle` its own help text — it was a verbatim copy of `--compile`'s and described neither bundling nor the minification that rides along with it.

### Scope note: why this does not also close #718 and #661

These three issues all point at the same ~30-line esbuild call, so it is reasonable to expect one fix to close all three. I verified that it does not:

| Issue | Root cause | Fixed here? |
|---|---|---|
| #714 | `external`/`packages` not gated on `bundle` | **yes** |
| #718 | `minify: this.options.bundle`, no `keepNames`, no `sourcemap` | no — **already fixed by open PR #625**, which adds an opt-in `minify` plus a chained inline source map |
| #661 | `packages: 'bundle'` inlines a second `@google/adk`, with its own module-scoped logger at the `INFO` default | no — needs a fix in `core`, not the loader |

On #661 specifically, I confirmed the mechanism both ways against a probe agent that logs one line at `debug` and one at `error`:

```
# main, default bundling, --verbose
ERROR-FROM-AGENT-FILE                 <- DEBUG line filtered by the inlined copy

# with '@google/adk' added to `external`
DEBUG-FROM-AGENT-FILE
ERROR-FROM-AGENT-FILE
```

So externalising `@google/adk` does fix it — **but only when the CLI and the agent project resolve the same physical install**, which is true in this workspace and not guaranteed for a user with a global `@google/adk-devtools` and a local `@google/adk`. The robust fix is a `globalThis`-keyed logger singleton in core, so #661 should stay open and be fixed there.

What this PR *does* give #661 is a working escape hatch: with `--bundle false` now loading, the agent shares the CLI's copy and both lines appear.

```
# this branch, --bundle false --verbose
DEBUG-FROM-AGENT-FILE
ERROR-FROM-AGENT-FILE
```

**Conflict note:** PR #625 edits the same esbuild call. This diff is deliberately minimal to keep that rebase mechanical — whichever lands second re-applies one conditional spread.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `withholds bundle-only options when asked only to transpile` to `dev/test/utils/agent_loader_test.ts`, asserting esbuild receives neither `external` nor `packages` when `bundle: false`.

`npm run test:unit` — 241 files, 3642 tests passed. Also clean: `build`, `ts:check`, `lint`, `format:check`.

**Manual End-to-End (E2E) Tests:**

Against a probe agent, on this branch:

```
$ adk run --bundle false probe/agent.ts     # loads and reaches the REPL (was: build failure)
$ adk run --help | grep -A2 -- --bundle
  --bundle [boolean]   Optional. Whether to inline the agent file
                       dependencies into a single bundle before
                       execution. Bundling also minifies the result.
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Branched off `main` at `4f44910` (Release v2.0.0).