### PR TITLE
fix(core): stop a surviving grandchild from hanging code execution

### DIFF
--- a/core/src/code_executors/unsafe_local_code_executor.ts
+++ b/core/src/code_executors/unsafe_local_code_executor.ts
@@ -230,14 +230,25 @@ export class UnsafeLocalCodeExecutor extends BaseCodeExecutor {
         stderr: string;
         exitCode: number | null;
       }>((resolve) => {
-        const child = spawn(command, args, {
-          timeout: this.timeoutSeconds * 1000,
-          killSignal: 'SIGKILL',
-          cwd: tempDir,
-        });
+        const child = spawn(command, args, {cwd: tempDir});
 
         let stdout = '';
         let stderr = '';
+        let timedOut = false;
+
+        // `spawn`'s own `timeout` option kills the interpreter and then leaves
+        // us waiting on 'close', which only fires once every stdio stream is
+        // closed. An interpreter that forked rather than exec'd leaves a
+        // survivor holding those pipes, so 'close' never arrives and this
+        // promise never settles -- no timeout value bounds that wait. Run the
+        // timer here instead and release the read ends along with the kill, so
+        // the timeout is actually enforced. Mirrors LocalEnvironment.execute.
+        const timer = setTimeout(() => {
+          timedOut = true;
+          child.kill('SIGKILL');
+          child.stdout?.destroy();
+          child.stderr?.destroy();
+        }, this.timeoutSeconds * 1000);
 
         if (child.stdout) {
           child.stdout.on('data', (data) => {
@@ -256,7 +267,11 @@ export class UnsafeLocalCodeExecutor extends BaseCodeExecutor {
         });
 
         child.on('close', (exitCode, signal) => {
-          if (signal === 'SIGKILL' || signal === 'SIGTERM') {
+          clearTimeout(timer);
+          // Prefer the flag over the signal: Windows does not report a
+          // terminating signal the way POSIX does, so a killed child can close
+          // with signal `null` there.
+          if (timedOut || signal === 'SIGKILL' || signal === 'SIGTERM') {
             stderr += `\nCode execution timed out after ${this.timeoutSeconds} seconds.`;
           } else if (exitCode !== 0 && exitCode !== null) {
             if (!stderr) {

--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -107,6 +107,40 @@ describe('UnsafeLocalCodeExecutor', () => {
     expect(result.stderr).toBe('');
   });
 
+  it('times out even when the script leaves a child holding the pipes open', async () => {
+    // An interpreter that forks rather than exec's its work leaves a survivor
+    // that keeps stdout/stderr open after the kill. 'close' waits on those
+    // streams, so before the read ends were released this hung forever and no
+    // timeout value bounded it -- the flake behind #622 on Windows.
+    const timeoutSeconds = 0.5;
+    const survivorLifetimeMs = 60_000;
+    const timedOutExecutor = new UnsafeLocalCodeExecutor({timeoutSeconds});
+    const params: ExecuteCodeParams = {
+      invocationContext,
+      codeExecutionInput: {
+        code: [
+          'const {spawn} = require("node:child_process");',
+          `spawn(process.execPath, ['-e', 'setTimeout(() => {}, ${survivorLifetimeMs})'], {`,
+          '  stdio: "inherit",',
+          '});',
+          `setTimeout(() => {}, ${survivorLifetimeMs});`,
+        ].join('\n'),
+        language: CodeExecutionLanguage.JAVASCRIPT,
+        inputFiles: [],
+      },
+    };
+
+    const startedAt = Date.now();
+    const result = await timedOutExecutor.executeCode(params);
+
+    expect(result.stderr).toContain(
+      `Code execution timed out after ${timeoutSeconds} seconds.`,
+    );
+    // Comfortably under the survivor's lifetime: the point is that the wait is
+    // bounded by our timer rather than by the survivor exiting on its own.
+    expect(Date.now() - startedAt).toBeLessThan(15_000);
+  });
+
   // The script runs with the temporary directory as its cwd, so it can report
   // the name and mode the executor actually created.
   it('creates a private, unpredictable temporary directory', async () => {


### PR DESCRIPTION
### Link to Issue or Description of Change

- Bug: #622 (root cause; this is **1 of 2** — see the stack below)
- Related: #782 (same defect class in `LocalEnvironment`, still open)

**Problem:**

`UnsafeLocalCodeExecutor` used `spawn`'s own `timeout` option, which kills the interpreter and then leaves the promise waiting on `'close'`. `'close'` only fires once every stdio stream is closed, so an interpreter that **forked rather than exec'd** its work leaves a survivor holding those pipes — `'close'` never arrives, the promise never settles, and the executor's own timeout branch never runs.

**No timeout value bounds that wait.** That is why raising the harness budget twice (#633 5s→…, #662 →30s) never stopped the flake: the wait is unbounded at 5s, at 30s, and at any other number. Windows is where it surfaces because `powershell` and `python` there are far likelier to leave a live descendant than `bash`/`python3`.

Reproduced locally with the executor's exact spawn shape:

```
grandchild holds pipes: { how: 'NEVER-CLOSED', ms: 7004 }   <- timeout was 3000ms
control, no grandchild: { how: 'close',  ms: 3004, signal: 'SIGKILL' }
```

Evidence from CI run [32415850940](https://github.com/google/adk-js/actions/runs/32415850940) (windows-latest, sha `540fa763`) — all five failures are this executor, and three return **empty output** rather than slow output:

```
unsafe_local_code_executor_test › execute python code   Test timed out in 30000ms
unsafe_local_code_executor_test › execute shell code    Test timed out in 30000ms
run_skill_inline_script_tool_test › real Shell script   expected '' to contain 'hello from real sh'
run_skill_script_tool_test › real Python skill script   expected '' to contain 'hello from skill python'
run_skill_script_tool_test › failing Python script      expected '\nCode execution timed out after 30 s…'
```

**Solution:**

Run the timer here rather than delegating to `spawn`, and release the read ends along with the kill so the timeout is *enforced* rather than merely requested.

This is exactly the treatment `LocalEnvironment.execute` already applies, for the same reason, with a comment describing the same failure (`core/src/environment/local_environment.ts:139-148`). The executor simply never got it.

Also prefers an explicit `timedOut` flag over inferring the timeout from the close signal — Windows does not report a terminating signal the way POSIX does, so a killed child can close there with `signal === null` and silently skip the timeout message.

**Alternative considered and rejected.** Keeping `spawn`'s `timeout` and destroying the pipes on `'exit'` is a smaller diff and also works (`{how:'close', ms:3006}`), but `'exit'` fires on *every* exit including healthy ones, and Node does not guarantee all `'data'` events have been delivered by then. It survived 3×20 000 lines locally without truncating — but that is a timing assumption, which is precisely how you get a Windows-only flake. Destroying only on the timeout path is correct by construction.

### The stack

| | PR | What |
|---|---|---|
| 1 | **this PR** | fix the root cause |
| 2 | #NEXT | restore the test timeout the flake forced up |

PR 2 is stacked on this branch and should merge after it. It is deliberately separate: this one is a behaviour fix worth reviewing on its own, and the revert is only safe once this lands.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `times out even when the script leaves a child holding the pipes open`, mirroring the existing `LocalEnvironment` regression test. It reproduces the CI symptom exactly — on the unfixed executor it fails with `Test timed out in 30000ms`, the same string seen on windows-latest:

```
# without the fix
❯ unsafe_local_code_executor_test.ts (29 tests | 1 failed | 28 skipped) 30010ms
  → Test timed out in 30000ms.

# with the fix
✓ UnsafeLocalCodeExecutor > times out even when the script leaves a child holding the pipes open  509ms
  Tests  29 passed (29)
```

`npm run test:unit` — 241 files, 3643 tests passed. Also clean: `build`, `ts:check`, `lint`, `format:check`.

**Manual End-to-End (E2E) Tests:**

Not applicable — the behaviour change is entirely inside the spawn teardown and is covered by the regression test above.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is the same defect class as #782, now confirmed in a second location. Worth considering a shared spawn helper that owns teardown once, rather than open-coding it a third time. #782 is still worth fixing, but it will not fix #622 — different file, no shared code, and its proposed `detached` + process-group remedy relies on POSIX process groups that Node does not implement on Windows.