### PR TITLE
test(core): restore the default timeout for the code executor tests

### DIFF
--- a/core/test/code_executors/unsafe_local_code_executor_test.ts
+++ b/core/test/code_executors/unsafe_local_code_executor_test.ts
@@ -19,21 +19,6 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
-/**
- * Most of these tests spawn a real interpreter. On Windows the shell case means
- * Windows PowerShell, whose cold start on a loaded CI runner costs seconds --
- * enough that `should execute shell code and return stdout` intermittently blew
- * Vitest's 5s default and, through fail-fast, took the macOS and Linux jobs down
- * with it. A healthy Windows run needs ~5.3s for the file as a whole, so the
- * default left no margin.
- *
- * Budget by what is actually under test: the executor's own default timeout is
- * 30s, and a harness that gives up sooner can never observe the behaviour it
- * covers. This is a ceiling, not a delay -- a passing test still finishes in
- * milliseconds.
- */
-vi.setConfig({testTimeout: 30_000});
-
 // Only `spawn` is mocked; it defaults to the real implementation (see
 // `beforeEach`) so the pre-existing tests still execute real scripts.
 const spawnMock = vi.hoisted(() => vi.fn());


### PR DESCRIPTION
### Link to Issue or Description of Change

- Bug: #622 (**2 of 2**)
- **Stacked on #793** — base branch is `fix/code-executor-process-teardown`, not `main`. Merge #793 first; GitHub will retarget this to `main` automatically.

**Problem:**

`vi.setConfig({testTimeout: 30_000})` was added in #662 to stop the Windows flake in #622, on the theory that a cold PowerShell start was blowing Vitest's 5s default. It did not work, because the failure was never slowness — a surviving grandchild held the stdio pipes open so `'close'` never fired, and the wait was unbounded. #793 fixes that at the source, which makes the inflated budget both unnecessary and actively harmful:

1. **It masks real regressions.** With #793 a hang now fails in ~0.5s carrying the executor's own `Code execution timed out` message. Under a 30s harness budget the same hang sits for 30s and reports a harness abort instead — which is exactly what made #622 so hard to read for two months.
2. **30s collided exactly with the executor's own default `timeoutSeconds = 30`.** Even a merely-slow run was a coin flip between the two deadlines, which is why the CI failures alternated between `Test timed out in 30000ms` and `Code execution timed out after 30 seconds`. A harness budget must be strictly greater than the thing under test, never equal.

**Solution:**

Delete the override and its comment, restoring the pre-#662 state (Vitest's 5000ms default).

**Headroom at the restored default.** The whole file runs in ~2.0s locally, and the only two cases over 100ms are bounded by their own explicit executor timeouts rather than by interpreter start-up, so they do not stretch on a loaded runner:

```
✓ times out even when the script leaves a child holding the pipes open   510ms   (0.5s executor timeout)
✓ should respect timeout                                                1009ms   (1s executor timeout)
```

The real-interpreter cases finish in tens of milliseconds.

**What this deliberately does not touch.** `tests/integration/app_loader/app_loader_test.ts` keeps its 60s. It runs a genuine `npm install` per fixture (`app_loader_test.ts:65,112`), it did not fail in the runs behind #622, and its pre-#633 value of `40000` sat *below* the project's own `INTEGRATION_TEST_TIMEOUT_MS = 60000` — #622 itself flagged that as unintentional, so "restoring" it would restore a bug.

**Residual risk, stated plainly.** A cold PowerShell or Python start on a loaded Windows runner can take 1–3s, so 5s has less margin than 30s. That is the point: with #793 in place a genuine hang is impossible, so a 5s failure would be real signal about Windows spawn latency rather than noise. If CI disagrees, the follow-up is a deliberate intermediate (10s — still clear of the executor's 30s so the deadlines cannot race), chosen from data rather than pre-emptively.

Suggested sequencing: merge #793, let `main` soak a few Windows runs, then merge this and watch `run-tests (windows-latest)` for ~10 runs before closing #622.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

At the restored 5s default: `unsafe_local_code_executor_test.ts` — **29 passed**, file total 1959ms. Full `npm run test:unit` — 241 files, 3643 tests passed. `ts:check` clean.

**Manual End-to-End (E2E) Tests:**

Not applicable — test-configuration only, no source change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.