### PR TITLE
style(core): correct delimiter variable spelling

### DIFF
--- a/core/src/agents/processors/code_execution_request_processor.ts
+++ b/core/src/agents/processors/code_execution_request_processor.ts
@@ -57,14 +57,14 @@ export class CodeExecutionRequestProcessor extends BaseLlmRequestProcessor {
     }
 
     for (const content of llmRequest.contents) {
-      const delimeters: [string, string] = invocationContext.agent.codeExecutor
+      const delimiters: [string, string] = invocationContext.agent.codeExecutor
         .codeBlockDelimiters.length
         ? invocationContext.agent.codeExecutor.codeBlockDelimiters[0]
         : ['', ''];
 
       convertCodeExecutionParts(
         content,
-        delimeters,
+        delimiters,
         invocationContext.agent.codeExecutor.executionResultDelimiters,
       );
     }


### PR DESCRIPTION
## Summary

- rename the misspelled local `delimeters` variable to `delimiters`
- keep code execution behavior unchanged

## Testing

- `npx vitest run --project unit:core core/test/agents/processors/code_execution_request_processor_test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run ts:check`
- `npm run build`

## Additional verification

- `npm run test:unit -- --run` completed with 3,661 passing tests and one unrelated timeout in `dev/test/utils/agent_loader_test.ts`
- the timed-out test passed when rerun in isolation
