### PR TITLE
docs: state an explicit minimum Node.js version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ web runtimes.
 
 ## 🚀 Installation
 
-> **Prerequisite:** ADK for TypeScript requires a current Node.js LTS release.
+> **Prerequisite:** ADK for TypeScript requires Node.js 20.19 or newer.
 
 ```bash
 npm install @google/adk


### PR DESCRIPTION
<!-- foundry:automerge -->
> ## This pull request will be merged automatically
>
> **Scheduled merge: 2026-08-24 21:16 UTC** (about 24h from opening).
>
> It was selected by [ADK Foundry] because the merge critic approved
> the change, it is small, it touches no sensitive path, and CI is
> green. No human has reviewed it.
>
> **To stop it:** close this pull request, add the `status/on-hold`
> label, or leave a review comment. Any of the three cancels the
> merge; pushing a commit restarts the clock. Nothing is merged while
> a question is open.
>
> **Approving does not stop it.** An approval, or a comment that says
> only `lgtm`, lets the merge run on schedule. Add any other text and
> the merge stops.
>
> Staged from fork PR #443.

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No open issue tracks this. The wording being replaced came from review feedback
on #526.

**2. Or, if no issue exists, describe the change:**

**Problem:** `README.md` says ADK for TypeScript requires "a current Node.js LTS
release". A reader cannot check that sentence against `node -v`. The sentence
also asserts a higher floor every time a new LTS line opens, with no commit to
point at. #526 dropped the explicit number because a hardcoded "18 or newer"
went stale, which left no number at all.

**Solution:** The README now requires Node.js 20.19 or newer. 20.19.0 is the
smallest version that satisfies every `engines.node` constraint in the committed
`package-lock.json`. The binding constraints are `vite` (`^20.19.0 ||
>=22.12.0`) and five copies of `eslint-visitor-keys` (`^20.19.0 || ^22.13.0 ||
>=24`). The repository has no `engines` field, no `.nvmrc` and no pinned CI Node
version, so the lockfile is the only source of truth.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npm run test:unit` passes: 242 files, 3662 tests. No test is added. A test that
matches the README text would pin prose and verify nothing about ADK behaviour.

**Manual End-to-End (E2E) Tests:**

`npx prettier --check README.md` passes. To reproduce the number from the
lockfile:

```bash
node -e '
const semver = require("semver"), lock = require("./package-lock.json");
const unsatisfied = (v) => Object.entries(lock.packages)
  .filter(([, p]) => p.engines?.node && !semver.satisfies(v, p.engines.node)).length;
for (const v of ["20.18.9", "20.19.0"]) console.log(v, unsatisfied(v));
'
```

20.18.9 leaves 6 constraints unsatisfied. 20.19.0 leaves 0.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The title uses `docs:` on purpose. `release-please` reads the squashed PR title,
and a `feat:` or `fix:` title would cut a release of all four packages for a
one-line docs edit.

Declaring the floor as `engines.node` in the manifests, plus a pinned CI
`node-version`, is the enforceable version of this claim. That is a user-visible
change and belongs in its own pull request.
