### PR TITLE
fix(sessions): import Client from the @google-cloud/vertexai package root

### DIFF
--- a/core/src/sessions/vertex_ai_session_service.ts
+++ b/core/src/sessions/vertex_ai_session_service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Client} from '@google-cloud/vertexai/build/src/genai/client.js';
+import {Client} from '@google-cloud/vertexai';
 import {Sessions} from '@google-cloud/vertexai/build/src/genai/sessions.js';
 import {
   EventActions as ApiEventActions,

--- a/core/test/sessions/vertex_ai_session_service_test.ts
+++ b/core/test/sessions/vertex_ai_session_service_test.ts
@@ -32,8 +32,10 @@ vi.mock('nodejs-vertexai', () => ({
 
 const clientConstructor = vi.hoisted(() => vi.fn());
 
-// The service imports Client from this deep path, so the mock must target it.
-vi.mock('@google-cloud/vertexai/build/src/genai/client.js', () => ({
+// The service imports Client from the package root, so the mock must target
+// the root. Keep the other root exports for the rest of the module graph.
+vi.mock('@google-cloud/vertexai', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@google-cloud/vertexai')>()),
   Client: class {
     readonly agentEnginesInternal = {sessions: {}};
 


### PR DESCRIPTION
<!-- foundry:automerge -->
> ## This pull request will be merged automatically
>
> **Scheduled merge: 2026-08-24 21:23 UTC** (about 24h from opening).
>
> It was selected by [ADK Foundry] because the merge critic approved
> the change, it is small, it touches no sensitive path, and CI is
> green. No human has reviewed it.
>
> **To stop it:** close this pull request, add the `status/on-hold`
> label, or leave a review comment. Any of the three cancels the
> merge; pushing a commit restarts the clock. Nothing is merged while
> a question is open.
>
> **Approving does not stop it.** An approval, or a comment that says
> only `lgtm`, lets the merge run on schedule. Add any other text and
> the merge stops.
>
> Staged from fork PR #474.

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

None.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`core/src/sessions/vertex_ai_session_service.ts` imports `Client` from `@google-cloud/vertexai/build/src/genai/client.js`. A `build/src/**` path is the compiled output of the dependency, not part of its published API. Any repackaging by `@google-cloud/vertexai` breaks the build, even under a semver-compatible bump, because `core/package.json` declares the dependency as `^1.12.0`.

**Solution:**

Import `Client` from the package root. The root export is the identical class object, verified against the installed `@google-cloud/vertexai@1.12.0`, so this is not a behaviour change. The other deep imports in the file, `Sessions` and the `genai/types` symbols, are not re-exported from the root, so they stay as they are. The unit test mocked the deep specifier, so it moves to the root with the import.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`core/test/sessions/vertex_ai_session_service_test.ts` already covers the edited import. It builds a `VertexAiSessionService` with no injected client, so the test runs `new Client(...)` through the mocked specifier.

```
npm run test:unit
  → Test Files 242 passed (242) | Tests 3662 passed (3662)
```

I add no new test. The change adds no statement and no branch, and a test over the module specifier would pin the text of the diff rather than any behaviour.

**Manual End-to-End (E2E) Tests:**

Not applicable. `npm run build`, `npm run ts:check`, `npm run lint` and `npm run format:check` all pass locally.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

`dev/src/cli/deploy/cli_deploy_agent_engine.ts` and two integration tests use the same deep specifier. They are out of scope here to keep this diff small.
