### PR TITLE
fix(sessions): decode Cloud SQL Unix-socket URIs in getConnectionOptionsFromUri

### DIFF
--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -5,6 +5,7 @@
  */
 
 import {MikroORM, Options as MikroORMOptions} from '@mikro-orm/core';
+import {logger} from '../../utils/logger.js';
 import {loadOptionalPeer} from '../../utils/optional_peer.js';
 import {redactUriPassword} from '../../utils/redact_uri.js';
 import {
@@ -35,17 +36,34 @@ interface PostgresSocketUri {
  * cannot represent at all: an instance connection name with unescaped
  * colons (`project:region:instance`), or the `?host=/cloudsql/...`
  * query-param convention `pg`/`libpq` use for sockets, which `URL` has no
- * concept of. Userinfo is split on the *last* `@` (mirroring the WHATWG
- * URL algorithm) so a userinfo value that itself contains `@` — e.g. a
- * Cloud SQL IAM user in `user@project.iam` form — still parses correctly.
+ * concept of. Any authority or `?host=` value beginning with `/` is
+ * treated as a Unix socket path, not only `/cloudsql/...`. Userinfo is
+ * split on the *last* `@` within the authority region (mirroring the
+ * WHATWG URL algorithm), so a userinfo value that itself contains `@` —
+ * e.g. a Cloud SQL IAM user in `user@project.iam` form — still parses
+ * correctly, while an unrelated `@` later in the path or query no longer
+ * gets swallowed into it.
  */
 function parsePostgresSocketUri(uri: string): PostgresSocketUri | null {
-  const match =
-    /^postgres(?:ql)?:\/\/(?:(.*)@)?([^/?]*)(\/[^?]*)?(?:\?(.*))?$/.exec(uri);
-  if (!match) {
+  const schemeEnd = uri.indexOf('://');
+  if (schemeEnd === -1) {
     return null;
   }
-  const [, rawUserinfo, rawAuthority, rawPath, rawQuery] = match;
+  const afterScheme = uri.slice(schemeEnd + 3);
+  const authorityEnd = afterScheme.search(/[/?#]/);
+  const authorityRegion =
+    authorityEnd === -1 ? afterScheme : afterScheme.slice(0, authorityEnd);
+  const rest = authorityEnd === -1 ? '' : afterScheme.slice(authorityEnd);
+
+  const atIndex = authorityRegion.lastIndexOf('@');
+  const rawUserinfo =
+    atIndex === -1 ? undefined : authorityRegion.slice(0, atIndex);
+  const rawAuthority =
+    atIndex === -1 ? authorityRegion : authorityRegion.slice(atIndex + 1);
+
+  const restMatch = /^(\/[^?#]*)?(?:\?([^#]*))?/.exec(rest);
+  const rawPath = restMatch?.[1];
+  const rawQuery = restMatch?.[2];
 
   const params = new URLSearchParams(rawQuery ?? '');
   const queryHost = params.get('host');
@@ -54,7 +72,7 @@ function parsePostgresSocketUri(uri: string): PostgresSocketUri | null {
   if (queryHost?.startsWith('/')) {
     host = queryHost;
   } else {
-    const decodedAuthority = decodeURIComponent(rawAuthority ?? '');
+    const decodedAuthority = decodeURIComponent(rawAuthority);
     if (decodedAuthority.startsWith('/')) {
       host = decodedAuthority;
     }
@@ -107,6 +125,12 @@ function buildPostgresOptions(uri: string, driver: unknown): MikroORMOptions {
   if (parsedUrl) {
     const queryHost = parsedUrl.searchParams.get('host');
     if (queryHost?.startsWith('/')) {
+      if (parsedUrl.hostname) {
+        logger.warn(
+          `Connection URI names host '${parsedUrl.hostname}' but the ?host= parameter ` +
+            `overrides it with the Unix socket '${queryHost}'; connecting to the socket.`,
+        );
+      }
       const schema = parsedUrl.searchParams.get('schema');
       return {
         entities: ENTITIES,

--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -119,6 +119,7 @@ function buildPostgresOptions(uri: string, driver: unknown): MikroORMOptions {
           ? decodeURIComponent(parsedUrl.password)
           : undefined,
         dbName: decodeURIComponent(parsedUrl.pathname.slice(1)) || undefined,
+        ...(parsedUrl.port ? {port: Number(parsedUrl.port)} : {}),
         ...(schema ? {schema} : {}),
       } as MikroORMOptions;
     }

--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -22,6 +22,49 @@ function driverPeer(packageName: string, scheme: string) {
   };
 }
 
+interface PostgresSocketUri {
+  host: string;
+  user?: string;
+  password?: string;
+  dbName?: string;
+  schema?: string;
+}
+
+function parsePostgresSocketUri(uri: string): PostgresSocketUri | null {
+  const match =
+    /^postgres(?:ql)?:\/\/(?:([^:@/]*)(?::([^@/]*))?@)?([^/?]*)(\/[^?]*)?(?:\?(.*))?$/.exec(
+      uri,
+    );
+  if (!match) {
+    return null;
+  }
+  const [, rawUser, rawPassword, rawAuthority, rawPath, rawQuery] = match;
+
+  const params = new URLSearchParams(rawQuery ?? '');
+  const queryHost = params.get('host') ?? params.get('socket');
+
+  let host: string | undefined;
+  if (queryHost?.startsWith('/')) {
+    host = queryHost;
+  } else {
+    const decodedAuthority = decodeURIComponent(rawAuthority ?? '');
+    if (decodedAuthority.startsWith('/')) {
+      host = decodedAuthority;
+    }
+  }
+  if (!host) {
+    return null;
+  }
+
+  return {
+    host,
+    user: rawUser ? decodeURIComponent(rawUser) : undefined,
+    password: rawPassword ? decodeURIComponent(rawPassword) : undefined,
+    dbName: rawPath ? decodeURIComponent(rawPath.slice(1)) : undefined,
+    schema: params.get('schema') ?? undefined,
+  };
+}
+
 /**
  * Parses a database connection URI and returns MikroORM Options.
  *
@@ -77,6 +120,21 @@ export async function getConnectionOptionsFromUri(
           : uri.substring('sqlite://'.length),
       driver,
     } as MikroORMOptions;
+  }
+
+  if (uri.startsWith('postgres://') || uri.startsWith('postgresql://')) {
+    const socket = parsePostgresSocketUri(uri);
+    if (socket) {
+      return {
+        entities: ENTITIES,
+        driver,
+        host: socket.host,
+        user: socket.user,
+        password: socket.password,
+        dbName: socket.dbName,
+        ...(socket.schema ? {schema: socket.schema} : {}),
+      } as MikroORMOptions;
+    }
   }
 
   return {

--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -30,18 +30,25 @@ interface PostgresSocketUri {
   schema?: string;
 }
 
+/**
+ * Manually parses a `postgres://`/`postgresql://` URI that `new URL()`
+ * cannot represent at all: an instance connection name with unescaped
+ * colons (`project:region:instance`), or the `?host=/cloudsql/...`
+ * query-param convention `pg`/`libpq` use for sockets, which `URL` has no
+ * concept of. Userinfo is split on the *last* `@` (mirroring the WHATWG
+ * URL algorithm) so a userinfo value that itself contains `@` — e.g. a
+ * Cloud SQL IAM user in `user@project.iam` form — still parses correctly.
+ */
 function parsePostgresSocketUri(uri: string): PostgresSocketUri | null {
   const match =
-    /^postgres(?:ql)?:\/\/(?:([^:@/]*)(?::([^@/]*))?@)?([^/?]*)(\/[^?]*)?(?:\?(.*))?$/.exec(
-      uri,
-    );
+    /^postgres(?:ql)?:\/\/(?:(.*)@)?([^/?]*)(\/[^?]*)?(?:\?(.*))?$/.exec(uri);
   if (!match) {
     return null;
   }
-  const [, rawUser, rawPassword, rawAuthority, rawPath, rawQuery] = match;
+  const [, rawUserinfo, rawAuthority, rawPath, rawQuery] = match;
 
   const params = new URLSearchParams(rawQuery ?? '');
-  const queryHost = params.get('host') ?? params.get('socket');
+  const queryHost = params.get('host');
 
   let host: string | undefined;
   if (queryHost?.startsWith('/')) {
@@ -56,13 +63,82 @@ function parsePostgresSocketUri(uri: string): PostgresSocketUri | null {
     return null;
   }
 
+  let user: string | undefined;
+  let password: string | undefined;
+  if (rawUserinfo) {
+    const colonIndex = rawUserinfo.indexOf(':');
+    const rawUser =
+      colonIndex === -1 ? rawUserinfo : rawUserinfo.slice(0, colonIndex);
+    const rawPassword =
+      colonIndex === -1 ? undefined : rawUserinfo.slice(colonIndex + 1);
+    user = rawUser ? decodeURIComponent(rawUser) : undefined;
+    password = rawPassword ? decodeURIComponent(rawPassword) : undefined;
+  }
+
   return {
     host,
-    user: rawUser ? decodeURIComponent(rawUser) : undefined,
-    password: rawPassword ? decodeURIComponent(rawPassword) : undefined,
-    dbName: rawPath ? decodeURIComponent(rawPath.slice(1)) : undefined,
+    user,
+    password,
+    dbName: rawPath
+      ? decodeURIComponent(rawPath.slice(1)) || undefined
+      : undefined,
     schema: params.get('schema') ?? undefined,
   };
+}
+
+/**
+ * Builds MikroORM options for a `postgres://`/`postgresql://` URI. A
+ * percent-encoded Unix-socket host already round-trips correctly through
+ * MikroORM's own `clientUrl` handling (`Connection.getConnectionOptions()`
+ * calls `decodeURIComponent(url.hostname)`), so any URI `new URL()` can
+ * parse — including ordinary TCP URIs, and sockets with every colon
+ * percent-encoded — is left as `clientUrl`, unchanged from before this
+ * fix, to avoid diverging from existing port/query-param handling. Only
+ * URIs `new URL()` genuinely can't represent fall back to a manual parse.
+ */
+function buildPostgresOptions(uri: string, driver: unknown): MikroORMOptions {
+  let parsedUrl: URL | null;
+  try {
+    parsedUrl = new URL(uri);
+  } catch {
+    parsedUrl = null;
+  }
+
+  if (parsedUrl) {
+    const queryHost = parsedUrl.searchParams.get('host');
+    if (queryHost?.startsWith('/')) {
+      const schema = parsedUrl.searchParams.get('schema');
+      return {
+        entities: ENTITIES,
+        driver,
+        host: queryHost,
+        user: parsedUrl.username
+          ? decodeURIComponent(parsedUrl.username)
+          : undefined,
+        password: parsedUrl.password
+          ? decodeURIComponent(parsedUrl.password)
+          : undefined,
+        dbName: decodeURIComponent(parsedUrl.pathname.slice(1)) || undefined,
+        ...(schema ? {schema} : {}),
+      } as MikroORMOptions;
+    }
+    return {entities: ENTITIES, clientUrl: uri, driver} as MikroORMOptions;
+  }
+
+  const socket = parsePostgresSocketUri(uri);
+  if (socket) {
+    return {
+      entities: ENTITIES,
+      driver,
+      host: socket.host,
+      user: socket.user,
+      password: socket.password,
+      dbName: socket.dbName,
+      ...(socket.schema ? {schema: socket.schema} : {}),
+    } as MikroORMOptions;
+  }
+
+  return {entities: ENTITIES, clientUrl: uri, driver} as MikroORMOptions;
 }
 
 /**
@@ -75,73 +151,66 @@ function parsePostgresSocketUri(uri: string): PostgresSocketUri | null {
 export async function getConnectionOptionsFromUri(
   uri: string,
 ): Promise<MikroORMOptions> {
-  let driver: unknown;
-
   if (uri.startsWith('postgres://') || uri.startsWith('postgresql://')) {
     const {PostgreSqlDriver} = await loadOptionalPeer(
       driverPeer('@mikro-orm/postgresql', 'postgres'),
       () => import('@mikro-orm/postgresql'),
     );
-    driver = PostgreSqlDriver;
-  } else if (uri.startsWith('mysql://')) {
+    return buildPostgresOptions(uri, PostgreSqlDriver);
+  }
+
+  if (uri.startsWith('mysql://')) {
     const {MySqlDriver} = await loadOptionalPeer(
       driverPeer('@mikro-orm/mysql', 'mysql'),
       () => import('@mikro-orm/mysql'),
     );
-    driver = MySqlDriver;
-  } else if (uri.startsWith('mariadb://')) {
+    return {
+      entities: ENTITIES,
+      clientUrl: uri,
+      driver: MySqlDriver,
+    } as MikroORMOptions;
+  }
+
+  if (uri.startsWith('mariadb://')) {
     const {MariaDbDriver} = await loadOptionalPeer(
       driverPeer('@mikro-orm/mariadb', 'mariadb'),
       () => import('@mikro-orm/mariadb'),
     );
-    driver = MariaDbDriver;
-  } else if (uri.startsWith('sqlite://')) {
+    return {
+      entities: ENTITIES,
+      clientUrl: uri,
+      driver: MariaDbDriver,
+    } as MikroORMOptions;
+  }
+
+  if (uri.startsWith('sqlite://')) {
     const {SqliteDriver} = await loadOptionalPeer(
       driverPeer('@mikro-orm/sqlite', 'sqlite'),
       () => import('@mikro-orm/sqlite'),
     );
-    driver = SqliteDriver;
-  } else if (uri.startsWith('mssql://')) {
-    const {MsSqlDriver} = await loadOptionalPeer(
-      driverPeer('@mikro-orm/mssql', 'mssql'),
-      () => import('@mikro-orm/mssql'),
-    );
-    driver = MsSqlDriver;
-  } else {
-    throw new Error(`Unsupported database URI: ${redactUriPassword(uri)}`);
-  }
-
-  if (uri.startsWith('sqlite://')) {
     return {
       entities: ENTITIES,
       dbName:
         uri === 'sqlite://:memory:'
           ? ':memory:'
           : uri.substring('sqlite://'.length),
-      driver,
+      driver: SqliteDriver,
     } as MikroORMOptions;
   }
 
-  if (uri.startsWith('postgres://') || uri.startsWith('postgresql://')) {
-    const socket = parsePostgresSocketUri(uri);
-    if (socket) {
-      return {
-        entities: ENTITIES,
-        driver,
-        host: socket.host,
-        user: socket.user,
-        password: socket.password,
-        dbName: socket.dbName,
-        ...(socket.schema ? {schema: socket.schema} : {}),
-      } as MikroORMOptions;
-    }
+  if (uri.startsWith('mssql://')) {
+    const {MsSqlDriver} = await loadOptionalPeer(
+      driverPeer('@mikro-orm/mssql', 'mssql'),
+      () => import('@mikro-orm/mssql'),
+    );
+    return {
+      entities: ENTITIES,
+      clientUrl: uri,
+      driver: MsSqlDriver,
+    } as MikroORMOptions;
   }
 
-  return {
-    entities: ENTITIES,
-    clientUrl: uri,
-    driver,
-  } as MikroORMOptions;
+  throw new Error(`Unsupported database URI: ${redactUriPassword(uri)}`);
 }
 
 /**

--- a/core/test/sessions/db/operations_test.ts
+++ b/core/test/sessions/db/operations_test.ts
@@ -110,7 +110,7 @@ describe('operations', () => {
             }
           },
           discovery: {},
-        } as unknown as Parameters<typeof Configuration>[0],
+        } as unknown as ConstructorParameters<typeof Configuration>[0],
         false,
       );
       const driver = new PostgreSqlDriver(config);

--- a/core/test/sessions/db/operations_test.ts
+++ b/core/test/sessions/db/operations_test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {MikroORM} from '@mikro-orm/core';
+import {Configuration, MikroORM} from '@mikro-orm/core';
 import {SqliteDriver} from '@mikro-orm/sqlite';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
@@ -84,48 +84,99 @@ describe('operations', () => {
       expect(options.clientUrl).toBe(uri);
     });
 
-    it('should drop query params other than schema for TCP URIs, same as before this change', async () => {
+    it('should keep the full URI, including extra query params, intact in clientUrl for TCP URIs', async () => {
       const uri =
         'postgres://user:pass@localhost:5432/db?sslmode=require&connect_timeout=10';
       const options = await getConnectionOptionsFromUri(uri);
-      expect(options.clientUrl).toContain('sslmode=require');
-      expect(options).not.toHaveProperty('sslmode');
-      expect(options).not.toHaveProperty('connect_timeout');
+      expect(options.clientUrl).toBe(uri);
+      expect(options).not.toHaveProperty('host');
     });
 
-    it('should resolve a percent-encoded Unix-socket host to a socket path', async () => {
+    it('should drop query params other than schema when MikroORM resolves the real driver connection options', async () => {
+      const {PostgreSqlDriver} = await vi.importActual<
+        typeof import('@mikro-orm/postgresql')
+      >('@mikro-orm/postgresql');
+      const uri =
+        'postgres://user:pass@localhost:5432/db?sslmode=require&connect_timeout=10';
+      const options = await getConnectionOptionsFromUri(uri);
+      const config = new Configuration(
+        {
+          ...options,
+          driver: PostgreSqlDriver,
+          entities: [],
+          metadataProvider: class {
+            useCache() {
+              return false;
+            }
+          },
+          discovery: {},
+        } as unknown as Parameters<typeof Configuration>[0],
+        false,
+      );
+      const driver = new PostgreSqlDriver(config);
+      const resolved = driver.getConnection().getConnectionOptions();
+      expect(resolved.port).toBe(5432);
+      expect(resolved).not.toHaveProperty('sslmode');
+      expect(resolved).not.toHaveProperty('connect_timeout');
+    });
+
+    it('should leave a percent-encoded Unix-socket host with escaped colons as clientUrl, since MikroORM already decodes it correctly', async () => {
       const uri =
         'postgresql://user:pass@%2Fcloudsql%2Fmy-project%3Aus-central1%3Amy-instance/mydb';
       const options = await getConnectionOptionsFromUri(uri);
       expect(options.driver).toBeDefined();
-      expect(options).not.toHaveProperty('clientUrl');
-      expect((options as {host?: string}).host).toBe(
-        '/cloudsql/my-project:us-central1:my-instance',
-      );
-      expect((options as {user?: string}).user).toBe('user');
-      expect((options as {password?: string}).password).toBe('pass');
-      expect(options.dbName).toBe('mydb');
+      expect(options.clientUrl).toBe(uri);
+      expect(options).not.toHaveProperty('host');
+    });
+
+    it('should leave a Unix-socket host with an explicit pg port as clientUrl, preserving the port MikroORM already resolves', async () => {
+      const uri = 'postgresql://user:pass@%2Fvar%2Frun%2Fpostgresql:5433/mydb';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.clientUrl).toBe(uri);
+      expect(options).not.toHaveProperty('host');
     });
 
     it('should resolve a Unix-socket host with unescaped colons in the instance name', async () => {
       const uri =
         'postgresql://user:pass@%2Fcloudsql%2Fmy-project:us-central1:my-instance/mydb';
       const options = await getConnectionOptionsFromUri(uri);
-      expect((options as {host?: string}).host).toBe(
-        '/cloudsql/my-project:us-central1:my-instance',
-      );
+      expect(options).not.toHaveProperty('clientUrl');
+      expect(options.host).toBe('/cloudsql/my-project:us-central1:my-instance');
+      expect(options.user).toBe('user');
+      expect((options as {password?: string}).password).toBe('pass');
       expect(options.dbName).toBe('mydb');
+    });
+
+    it('should split userinfo on the last @ so a password containing @ (e.g. a Cloud SQL IAM user) still parses', async () => {
+      const uri =
+        'postgresql://svc@project.iam:pass@%2Fcloudsql%2Fproj:region:inst/mydb';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.user).toBe('svc@project.iam');
+      expect((options as {password?: string}).password).toBe('pass');
+      expect(options.host).toBe('/cloudsql/proj:region:inst');
+    });
+
+    it('should treat an empty database path as no dbName for Unix-socket URIs', async () => {
+      const uri = 'postgresql://u:p@%2Fcloudsql%2Fproj:region:inst/';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.dbName).toBeUndefined();
     });
 
     it('should resolve a Unix-socket path passed via the host query param', async () => {
       const uri =
         'postgresql://user:pass@/mydb?host=/cloudsql/my-project:us-central1:my-instance';
       const options = await getConnectionOptionsFromUri(uri);
-      expect((options as {host?: string}).host).toBe(
-        '/cloudsql/my-project:us-central1:my-instance',
-      );
-      expect((options as {user?: string}).user).toBe('user');
+      expect(options.host).toBe('/cloudsql/my-project:us-central1:my-instance');
+      expect(options.user).toBe('user');
       expect((options as {password?: string}).password).toBe('pass');
+      expect(options.dbName).toBe('mydb');
+    });
+
+    it('should resolve the host query param even when new URL() otherwise succeeds', async () => {
+      const uri =
+        'postgresql://user:pass@localhost/mydb?host=/cloudsql/proj:region:inst';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.host).toBe('/cloudsql/proj:region:inst');
       expect(options.dbName).toBe('mydb');
     });
 
@@ -133,7 +184,7 @@ describe('operations', () => {
       const uri =
         'postgresql://user:pass@%2Fcloudsql%2Fproj:region:inst/mydb?schema=custom';
       const options = await getConnectionOptionsFromUri(uri);
-      expect((options as {schema?: string}).schema).toBe('custom');
+      expect(options.schema).toBe('custom');
     });
 
     it('should parse mysql URI', async () => {

--- a/core/test/sessions/db/operations_test.ts
+++ b/core/test/sessions/db/operations_test.ts
@@ -20,6 +20,7 @@ import {
   StorageEvent,
   StorageMetadata,
 } from '../../../src/sessions/db/schema.js';
+import {logger} from '../../../src/utils/logger.js';
 
 // Mock dynamic imports for drivers that might not be installed in dev
 vi.mock('@mikro-orm/postgresql', () => ({
@@ -186,6 +187,26 @@ describe('operations', () => {
         'postgresql://user:pass@%2Fcloudsql%2Fproj:region:inst/mydb?schema=custom';
       const options = await getConnectionOptionsFromUri(uri);
       expect(options.schema).toBe('custom');
+    });
+
+    it('should bound userinfo to the authority so an @ later in the query does not get swallowed into it', async () => {
+      const uri = 'postgresql://%2Fcloudsql%2Fproj:region:inst/db?opt=x@y';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.host).toBe('/cloudsql/proj:region:inst');
+      expect(options.user).toBeUndefined();
+      expect(options.dbName).toBe('db');
+    });
+
+    it('should warn when ?host= overrides a real TCP hostname', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const uri =
+        'postgresql://u:secret@real-db.example.com:5432/db?host=/tmp/evil';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.host).toBe('/tmp/evil');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('real-db.example.com'),
+      );
+      warnSpy.mockRestore();
     });
 
     it('should parse mysql URI', async () => {

--- a/core/test/sessions/db/operations_test.ts
+++ b/core/test/sessions/db/operations_test.ts
@@ -174,10 +174,11 @@ describe('operations', () => {
 
     it('should resolve the host query param even when new URL() otherwise succeeds', async () => {
       const uri =
-        'postgresql://user:pass@localhost/mydb?host=/cloudsql/proj:region:inst';
+        'postgresql://user:pass@localhost:5433/mydb?host=/cloudsql/proj:region:inst';
       const options = await getConnectionOptionsFromUri(uri);
       expect(options.host).toBe('/cloudsql/proj:region:inst');
       expect(options.dbName).toBe('mydb');
+      expect(options.port).toBe(5433);
     });
 
     it('should preserve the schema query param for Unix-socket URIs', async () => {

--- a/core/test/sessions/db/operations_test.ts
+++ b/core/test/sessions/db/operations_test.ts
@@ -84,18 +84,56 @@ describe('operations', () => {
       expect(options.clientUrl).toBe(uri);
     });
 
-    it('should parse postgresql Unix-socket URI with percent-encoded host', async () => {
+    it('should drop query params other than schema for TCP URIs, same as before this change', async () => {
+      const uri =
+        'postgres://user:pass@localhost:5432/db?sslmode=require&connect_timeout=10';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect(options.clientUrl).toContain('sslmode=require');
+      expect(options).not.toHaveProperty('sslmode');
+      expect(options).not.toHaveProperty('connect_timeout');
+    });
+
+    it('should resolve a percent-encoded Unix-socket host to a socket path', async () => {
       const uri =
         'postgresql://user:pass@%2Fcloudsql%2Fmy-project%3Aus-central1%3Amy-instance/mydb';
       const options = await getConnectionOptionsFromUri(uri);
-      expect(options.clientUrl).toBe(uri);
+      expect(options.driver).toBeDefined();
+      expect(options).not.toHaveProperty('clientUrl');
+      expect((options as {host?: string}).host).toBe(
+        '/cloudsql/my-project:us-central1:my-instance',
+      );
+      expect((options as {user?: string}).user).toBe('user');
+      expect((options as {password?: string}).password).toBe('pass');
+      expect(options.dbName).toBe('mydb');
     });
 
-    it('should parse postgresql Unix-socket URI with query param host', async () => {
+    it('should resolve a Unix-socket host with unescaped colons in the instance name', async () => {
+      const uri =
+        'postgresql://user:pass@%2Fcloudsql%2Fmy-project:us-central1:my-instance/mydb';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect((options as {host?: string}).host).toBe(
+        '/cloudsql/my-project:us-central1:my-instance',
+      );
+      expect(options.dbName).toBe('mydb');
+    });
+
+    it('should resolve a Unix-socket path passed via the host query param', async () => {
       const uri =
         'postgresql://user:pass@/mydb?host=/cloudsql/my-project:us-central1:my-instance';
       const options = await getConnectionOptionsFromUri(uri);
-      expect(options.clientUrl).toBe(uri);
+      expect((options as {host?: string}).host).toBe(
+        '/cloudsql/my-project:us-central1:my-instance',
+      );
+      expect((options as {user?: string}).user).toBe('user');
+      expect((options as {password?: string}).password).toBe('pass');
+      expect(options.dbName).toBe('mydb');
+    });
+
+    it('should preserve the schema query param for Unix-socket URIs', async () => {
+      const uri =
+        'postgresql://user:pass@%2Fcloudsql%2Fproj:region:inst/mydb?schema=custom';
+      const options = await getConnectionOptionsFromUri(uri);
+      expect((options as {schema?: string}).schema).toBe('custom');
     });
 
     it('should parse mysql URI', async () => {


### PR DESCRIPTION
### Link to Issue or Description of Change
**1. Link to an existing issue (if applicable):**
- Closes: #799

**Problem:**
`getConnectionOptionsFromUri()` passes Postgres URIs to MikroORM as `clientUrl`. Cloud SQL Unix-socket URIs aren't handled: they either cause `Invalid URL`, or the socket path gets treated as a hostname and sent to DNS instead of being used as a Unix socket. The `?host=/cloudsql/...` form is also not handled.

**Solution:**
Added `parsePostgresSocketUri()` to detect the supported Unix-socket forms and return the socket path as an explicit `host`, along with the other connection fields. Normal TCP Postgres URIs are unaffected.

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`core/test/sessions/db/operations_test.ts` — added coverage for:
- Unix-socket host with unescaped colons in the instance name (throws under
  `new URL()`, resolved via manual parsing to an explicit `host`)
- The `?host=/cloudsql/...` query-param form (same, explicit `host`)
- Percent-encoded colons (`%3A`) in the instance name — already resolve
  correctly today via MikroORM's own `clientUrl` handling, left untouched
- `schema` query param preservation for socket URIs
- Parity: non-`schema` query params (e.g. `sslmode`) were already dropped by
  MikroORM before this change and still are — not a regression

**Manual Verification (URI resolution, not a live Cloud SQL connection):**
No live Cloud SQL instance was available, so this verifies `getConnectionOptionsFromUri()` resolves the correct options rather than testing an actual socket connection.

```js
import('./dist/esm/sessions/db/operations.js').then(async (m) => {
  const uri = 'postgresql://USER:PASS@%2Fcloudsql%2Fmy-project:us-central1:my-instance/mydb';
  const options = await m.getConnectionOptionsFromUri(uri);
  console.log(options.host, options.user, options.password, options.dbName, options.clientUrl);
});
```

```text
/cloudsql/my-project:us-central1:my-instance USER PASS mydb undefined
```

Confirmed for the unescaped-colon form shown above: resolves to an explicit `host` with no `Invalid URL` and no `clientUrl` set. The `?host=` form behaves the same way (see unit tests). Percent-encoded colons and a plain TCP URI both resolve via the existing `clientUrl` path, unaffected by this change.

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context
Root cause: `new URL(clientUrl)` throws on unescaped colons and on the `?host=/cloudsql/...` query-param convention. Percent-encoded colons (`%3A`) already resolve correctly today via `decodeURIComponent(url.hostname)`, so only the two throwing forms are handled here.