### PR TITLE
fix(dev): remove the no-op @ts-ignore on the esbuild-shim-plugin import

### DIFF
--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -6,8 +6,6 @@
 
 import {App, isApp, isRunnableRoot, RunnableRoot} from '@google/adk';
 import esbuild from 'esbuild';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import {shimPlugin} from 'esbuild-shim-plugin';
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';


### PR DESCRIPTION
<!-- foundry:automerge -->
> ## This pull request will be merged automatically
>
> **Scheduled merge: 2026-08-25 21:30 UTC** (about 24h from opening).
>
> It was selected by [ADK Foundry] because the merge critic approved
> the change, it is small, it touches no sensitive path, and CI is
> green. No human has reviewed it.
>
> **To stop it:** close this pull request, add the `status/on-hold`
> label, or leave a review comment. Any of the three cancels the
> merge; pushing a commit restarts the clock. Nothing is merged while
> a question is open.
>
> **Approving does not stop it.** An approval, or a comment that says
> only `lgtm`, lets the merge run on schedule. Add any other text and
> the merge stops.
>
> Staged from fork PR #381.

**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A — no existing issue.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`dev/src/utils/agent_loader.ts` suppresses the type checker on the `esbuild-shim-plugin` import with `@ts-ignore`. The directive suppresses nothing, because the package ships its own types in `dist/index.d.ts` and TypeScript resolves them under `moduleResolution: nodenext`. Replacing the directive with `@ts-expect-error` makes `tsc` report `TS2578: Unused '@ts-expect-error' directive`, which proves there is no error on that line. A dead directive still hides any future breakage of this import.

**Solution:**

I deleted the `@ts-ignore` line and the `eslint-disable-next-line @typescript-eslint/ban-ts-comment` line above it. The `eslint-disable` exists only to permit the `@ts-ignore`, so removing one without the other leaves a stale directive. `shimPlugin()` stays wired into the esbuild `plugins` array, unchanged.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

The change deletes two comment lines and adds no executable code, so no unit test can distinguish the old code from the new.

Commands run on the rebased branch:

- `npx tsc --noEmit` — exit 0, no error on `agent_loader.ts`.
- `npx eslint dev/src/utils/agent_loader.ts` — exit 0, no stale directive.
- `npx prettier dev/src/utils/agent_loader.ts --check` — exit 0.

**Manual End-to-End (E2E) Tests:**

Not applicable. The compiler erases both deleted lines, so the emitted JavaScript does not change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
