### PR TITLE
fix(core): make transfer and runtime tool confirmation work across runtimes

### DIFF
--- a/core/src/agents/processors/agent_transfer_llm_request_processor.ts
+++ b/core/src/agents/processors/agent_transfer_llm_request_processor.ts
@@ -23,21 +23,41 @@ import {BaseLlmRequestProcessor} from './base_llm_processor.js';
  */
 export class AgentTransferLlmRequestProcessor extends BaseLlmRequestProcessor {
   private readonly toolName = 'transfer_to_agent' as const;
-  private readonly tool = new FunctionTool({
-    name: this.toolName,
-    description:
-      'Transfer the question to another agent. This tool hands off control to another agent when it is more suitable to answer the user question according to the agent description.',
-    parameters: z.object({
-      agentName: z.string().describe('the agent name to transfer to.'),
-    }),
-    execute: function (args: {agentName: string}, toolContext?: Context) {
-      if (!toolContext) {
-        throw new Error('toolContext is required.');
-      }
-      toolContext.actions.transferToAgent = args.agentName;
-      return 'Transfer queued';
-    },
-  });
+
+  /**
+   * Builds the `transfer_to_agent` tool for one invocation.
+   *
+   * Built per call rather than shared, because the parameter is an enum of the
+   * agents actually reachable from here. That mirrors adk-python's
+   * `TransferToAgentTool`, and it stops the model inventing a target: an
+   * unknown name now fails argument validation and comes back to the model as
+   * a tool error it can retry, instead of silently setting `transferToAgent`
+   * to an agent that does not exist.
+   *
+   * The parameter is `agent_name`, not `agentName`. It is wire format — it
+   * appears in the declaration sent to the model and in the events that get
+   * persisted — and adk-python spells it `agent_name`, so a transcript
+   * produced by one runtime has to be readable by the other.
+   */
+  private buildTool(targetNames: [string, ...string[]]) {
+    return new FunctionTool({
+      name: this.toolName,
+      description:
+        'Transfer the question to another agent. This tool hands off control to another agent when it is more suitable to answer the user question according to the agent description.',
+      parameters: z.object({
+        agent_name: z
+          .enum(targetNames)
+          .describe('the agent name to transfer to.'),
+      }),
+      execute: (args: {agent_name: string}, toolContext?: Context) => {
+        if (!toolContext) {
+          throw new Error('toolContext is required.');
+        }
+        toolContext.actions.transferToAgent = args.agent_name;
+        return 'Transfer queued';
+      },
+    });
+  }
 
   /**
    * Appends transfer instructions and registers the `transfer_to_agent` tool
@@ -68,7 +88,14 @@ export class AgentTransferLlmRequestProcessor extends BaseLlmRequestProcessor {
     ]);
 
     const toolContext = new Context({invocationContext});
-    await this.tool.processLlmRequest({toolContext, llmRequest});
+    const targetNames = transferTargets.map((t) => t.name) as [
+      string,
+      ...string[],
+    ];
+    await this.buildTool(targetNames).processLlmRequest({
+      toolContext,
+      llmRequest,
+    });
   }
 
   private buildTargetAgentsInfo(targetAgent: BaseAgent): string {

--- a/core/src/agents/processors/request_confirmation_llm_request_processor.ts
+++ b/core/src/agents/processors/request_confirmation_llm_request_processor.ts
@@ -403,8 +403,18 @@ function agentAuthoredCalls(
  *
  * Such a tool answers "no" to {@link BaseTool.checkRequireConfirmation} for the
  * very call it paused, so without this the approval it asked for would be
- * refused as unnecessary. The request is only honoured where the framework
- * records it: an agent-authored event whose own response carries the id.
+ * refused as unnecessary.
+ *
+ * The ids are read straight off `requestedToolConfirmations`, whose keys are
+ * the paused calls. An earlier version also required the same event to carry a
+ * matching function *response* part, which no persisted session satisfies: by
+ * the time the run pauses, the response event has been folded away and the map
+ * survives on the event holding the `adk_request_confirmation` *call*. Nothing
+ * matched, so every dynamically requested confirmation was refused with
+ * `confirmation_not_required` — the CLI asked "approve?", the user said yes,
+ * and the run died. Forgery is already excluded by the author check above: the
+ * map is only ever written by `Context.requestConfirmation()` while a tool of
+ * this agent is executing.
  */
 function dynamicallyRequestedCallIds(
   events: Event[],
@@ -415,11 +425,10 @@ function dynamicallyRequestedCallIds(
     if (event.author !== agentName) {
       continue;
     }
-    const confirmations = event.actions.requestedToolConfirmations;
-    for (const functionResponse of getFunctionResponses(event)) {
-      if (functionResponse.id && functionResponse.id in confirmations) {
-        requested.add(functionResponse.id);
-      }
+    for (const functionCallId of Object.keys(
+      event.actions.requestedToolConfirmations ?? {},
+    )) {
+      requested.add(functionCallId);
     }
   }
   return requested;

--- a/core/test/agents/processors/agent_transfer_llm_request_processor_test.ts
+++ b/core/test/agents/processors/agent_transfer_llm_request_processor_test.ts
@@ -257,11 +257,86 @@ describe('AgentTransferLlmRequestProcessor', () => {
 
     const toolContext = new Context({invocationContext});
     const result = await tool.runAsync({
-      args: {agentName: 'sub_agent'},
+      args: {agent_name: 'sub_agent'},
       toolContext,
     });
 
     expect(result).toEqual('Transfer queued');
     expect(toolContext.actions.transferToAgent).toEqual('sub_agent');
+  });
+
+  it('declares agent_name as an enum of the reachable agents', async () => {
+    const agent = new LlmAgent({
+      name: 'root_agent',
+      model: 'gemini-2.5-flash',
+      subAgents: [
+        new LlmAgent({name: 'sub_a', model: 'gemini-2.5-flash'}),
+        new LlmAgent({name: 'sub_b', model: 'gemini-2.5-flash'}),
+      ],
+    });
+
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+    for await (const _ of AGENT_TRANSFER_LLM_REQUEST_PROCESSOR.runAsync(
+      createMockInvocationContext(agent),
+      llmRequest,
+    )) {
+      // Do nothing
+    }
+
+    const declaration = (
+      llmRequest.config?.tools as Array<{
+        functionDeclarations?: Array<{
+          name?: string;
+          parameters?: {properties?: Record<string, {enum?: string[]}>};
+        }>;
+      }>
+    )?.[0];
+    const transfer = declaration?.functionDeclarations?.find(
+      (d) => d.name === 'transfer_to_agent',
+    );
+
+    // `agent_name`, not `agentName`: this is the wire format adk-python uses,
+    // and it is what ends up in persisted events.
+    expect(transfer?.parameters?.properties?.['agent_name']?.enum).toEqual([
+      'sub_a',
+      'sub_b',
+    ]);
+  });
+
+  it('rejects a transfer to an agent that is not reachable', async () => {
+    const agent = new LlmAgent({
+      name: 'root_agent',
+      model: 'gemini-2.5-flash',
+      subAgents: [new LlmAgent({name: 'sub_agent', model: 'gemini-2.5-flash'})],
+    });
+
+    const invocationContext = createMockInvocationContext(agent);
+    const llmRequest: LlmRequest = {
+      contents: [],
+      toolsDict: {},
+      liveConnectConfig: {},
+    };
+    for await (const _ of AGENT_TRANSFER_LLM_REQUEST_PROCESSOR.runAsync(
+      invocationContext,
+      llmRequest,
+    )) {
+      // Do nothing
+    }
+
+    const toolContext = new Context({invocationContext});
+    // A hallucinated target must not reach `transferToAgent`. The throw is
+    // caught by the function-call runner and handed back to the model as a
+    // tool error, so the run continues and the model can pick a real agent.
+    await expect(
+      llmRequest.toolsDict['transfer_to_agent'].runAsync({
+        args: {agent_name: 'no_such_agent'},
+        toolContext,
+      }),
+    ).rejects.toThrow();
+    expect(toolContext.actions.transferToAgent).toBeUndefined();
   });
 });

--- a/core/test/agents/processors/request_confirmation_llm_request_processor_test.ts
+++ b/core/test/agents/processors/request_confirmation_llm_request_processor_test.ts
@@ -64,6 +64,18 @@ const wireTransferTool = new FunctionTool({
   execute: (input) => `Transferred ${input.amount} to ${input.recipient}`,
 });
 
+/**
+ * Asks for confirmation from inside `execute` instead of declaring
+ * `requireConfirmation`, so `checkRequireConfirmation` answers "no" for the
+ * very call it paused.
+ */
+const runtimeGatedTool = new FunctionTool({
+  name: 'runtime_transfer',
+  description: 'Wires money, asking for confirmation only above a threshold.',
+  parameters: z.object({amount: z.number(), recipient: z.string()}),
+  execute: (input) => `Transferred ${input.amount} to ${input.recipient}`,
+});
+
 class MockRootAgent extends BaseAgent {
   constructor(name: string, subAgents: BaseAgent[] = []) {
     super({name, subAgents});
@@ -816,6 +828,62 @@ describe('RequestConfirmationLlmRequestProcessor approval lifecycle', () => {
     await run([...pausedCallEvents(), approvalEvent(['gate-1'])]);
 
     expect(resumedCalls).toEqual([wireTransferCall]);
+  });
+
+  it('resumes a confirmation the tool asked for at runtime', async () => {
+    // The shape a pause actually persists, taken from a real session: there is
+    // no surviving function-response event, and `requestedToolConfirmations`
+    // rides on the event carrying the `adk_request_confirmation` call.
+    //
+    // The tool does not declare `requireConfirmation`, so that map is the only
+    // record that the gate was legitimate. Requiring a response part to carry
+    // it meant nothing matched, every runtime-requested approval was refused
+    // as `confirmation_not_required`, and the CLI died right after asking the
+    // user to approve.
+    const call: FunctionCall = {
+      id: 'call-1',
+      name: 'runtime_transfer',
+      args: {amount: 200, recipient: 'Bob'},
+    };
+    const toolConfirmation = {hint: 'Approve?', confirmed: false};
+    const common = {invocationId: 'test-invocation'};
+
+    await run(
+      [
+        createEvent({
+          ...common,
+          author: AGENT_NAME,
+          content: {role: 'model', parts: [{functionCall: call}]},
+        }),
+        createEvent({
+          ...common,
+          author: AGENT_NAME,
+          content: {
+            role: 'user',
+            parts: [
+              {
+                functionCall: {
+                  id: 'gate-1',
+                  name: REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+                  args: {originalFunctionCall: call, toolConfirmation},
+                },
+              },
+            ],
+          },
+          longRunningToolIds: ['gate-1'],
+          actions: createEventActions({
+            requestedToolConfirmations: {
+              [call.id!]: new ToolConfirmation(toolConfirmation),
+            },
+          }),
+        }),
+        approvalEvent(['gate-1']),
+      ],
+      {tools: [runtimeGatedTool]},
+    );
+
+    expect(resumedCalls).toEqual([call]);
+    expect(decisions['call-1']?.confirmed).toBe(true);
   });
 
   it('spends an approval once, so a replay does not run the tool again', async () => {

--- a/core/test/runner/run_live_test.ts
+++ b/core/test/runner/run_live_test.ts
@@ -858,7 +858,12 @@ describe('Runner.runLive', () => {
     const transferCall: Content = {
       role: 'model',
       parts: [
-        {functionCall: {name: 'transfer_to_agent', args: {agentName: 'child'}}},
+        {
+          functionCall: {
+            name: 'transfer_to_agent',
+            args: {agent_name: 'child'},
+          },
+        },
       ],
     };
     const childText: Content = {

--- a/core/test/workflow/test_helpers.ts
+++ b/core/test/workflow/test_helpers.ts
@@ -123,7 +123,7 @@ export function transferringAgent(
         functionCall: {
           id: `fc-${name}`,
           name: 'transfer_to_agent',
-          args: {agentName: target},
+          args: {agent_name: target},
         },
       },
       reply,

--- a/dev/src/integration/replay_plugin.ts
+++ b/dev/src/integration/replay_plugin.ts
@@ -76,9 +76,12 @@ export class ReplayPlugin extends BasePlugin {
 
     // Handle side effects for built-in tools that modify EventActions
     if (toolName === 'transfer_to_agent') {
-      params.toolContext.actions.transferToAgent = params.toolArgs[
-        'agentName'
-      ] as string;
+      // `agent_name` is the wire spelling, matching adk-python. Recordings
+      // captured before the rename still carry `agentName`, so both are read
+      // here rather than invalidating every recording on disk.
+      const args = params.toolArgs;
+      params.toolContext.actions.transferToAgent = (args['agent_name'] ??
+        args['agentName']) as string;
     }
 
     // The response from a tool call is a plain object.


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

Two bugs found by running the adk-python `contributing/samples` through both
runtimes' `adk run` CLIs and diffing the resulting sessions. Both sit in code
paths the CLI exercises constantly.

**1. `transfer_to_agent` has a different signature in each runtime.**

adk-js declares the parameter as `agentName`; adk-python declares `agent_name`.
Same tool name, incompatible signature — a transcript written by one runtime
cannot be replayed by the other, and *every* multi-agent sample diverged on it.

adk-python additionally enum-constrains the parameter to the valid target
names. adk-js accepted any string, so a hallucinated target silently set
`transferToAgent` to an agent that does not exist.

**2. A tool that asks for confirmation at runtime cannot be approved.**

The documented HITL flow is unusable from the CLI. A tool calling
`toolContext.requestConfirmation()` raises the gate, the CLI prints
`Reply 'yes' to approve or 'no' to reject`, and when the user does exactly
that the run aborts:

```
[user]: Transfer $200 to Bob
--- [money_transfer_assistant] is waiting for confirmation ---
Reply 'yes' to approve or 'no' to reject.
[user]: yes
[ADK CLI] Error running agent: Tool confirmation rejected for
  function call 'adk-…': confirmation_not_required.
```

Exit 1, no session saved. Statically gated tools (`requireConfirmation: true`)
were unaffected; only the runtime-requested path broke.

**Solution:**

**1.** `agent_name` is now the declared parameter, matching adk-python — it is
wire format, appearing in the declaration sent to the model and in persisted
events. The parameter is also now a `z.enum` of the agents actually reachable
from the current one, so the tool is built per invocation rather than shared.
An unknown target fails argument validation and comes back to the model as a
tool error it can retry; `functions.ts` already converts a throwing tool into a
`functionResponseError` without ending the run, so this does not introduce a
new abort path.

**2.** `dynamicallyRequestedCallIds` looked for an agent-authored event
carrying **both** `requestedToolConfirmations` **and** a matching function
*response* part. No persisted session looks like that. Captured from a real
paused run:

```
0 | user                     | text
1 | money_transfer_assistant | CALL:transfer_funds#adk-afb8…
2 | money_transfer_assistant | CALL:adk_request_confirmation#adk-5cf8…
      requestedToolConfirmations keys: ['adk-afb8…']
```

By the time the run pauses the response event has been folded away, and the map
survives on the event holding the `adk_request_confirmation` **call**. Nothing
ever matched, so the gate re-check concluded no confirmation had been requested
and refused the approval.

The ids are now read straight off the map, whose keys are the paused calls.
Forgery was already excluded by the existing `event.author !== agentName`
check: the map is only ever written by `Context.requestConfirmation()` while a
tool of this agent is executing.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
Test Files  246 passed (246)
     Tests  3722 passed (3722)
```

Integration suite also green (`77 files, 243 passed | 8 skipped`).

Three new tests:

- `agent_transfer…_test.ts` — asserts the declaration exposes `agent_name` with
  an `enum` of reachable agents, and that an unreachable target is rejected
  without setting `transferToAgent`.
- `request_confirmation…_test.ts` — resumes a runtime-requested confirmation
  using the event shape a **real** pause writes. The pre-existing fixture put
  the map on a response event, which is the shape the code assumed rather than
  the shape produced in practice — which is why the bug survived. **Verified
  this test fails without the fix and passes with it.**

Four stale `agentName` references were updated (two tests, a workflow test
helper, and the devtools replay plugin, which now reads both spellings so
existing recordings keep working).

**Manual End-to-End (E2E) Tests:**

Against Vertex with `gemini-2.5-flash`, using the `hitl/tool_confirmation`
sample ported from adk-python:

```
$ adk run tool_confirmation.ts --replay '{"queries":["Transfer $200 to Bob","yes"]}'
[user]: Transfer $200 to Bob
--- [money_transfer_assistant] is waiting for confirmation ---
[user]: yes
[money_transfer_assistant]: $200 has been transferred to Bob.

$ ... --replay '{"queries":["Transfer $200 to Bob","no"]}'
[user]: no
[money_transfer_assistant]: I'm sorry, I wasn't able to complete that transfer.
```

Approval and rejection both behave correctly — the fix does not simply approve
everything.

Re-running the cross-runtime comparison (3 repeats per case) after the change:

| Case | Before | After |
|---|---|---|
| `multi_agent_hello_world_ma` | ❌ tool argument names | ✅ identical |
| `multi_agent_three_layer_transfer` | ❌ tool argument names | ✅ identical |
| `multi_agent_sub_agents` | ❌ tool argument names | ⚠️ event count only |
| `hitl_tool_confirmation` | 🚫 blocked (crash) | ⚠️ event count only |
| `hitl_human_tool_confirmation` | 🚫 blocked (crash) | ⚠️ event count only |

The harness that produced this comparison is a separate PR; this change does
not depend on it.

### Checklist

- [x] I have read the contribution guide.
- [x] My code follows the style of this project.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
