### PR TITLE
fix(core): make built-in tools resolvable by name

### DIFF
--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -328,7 +328,7 @@ const RESOLUTION_FAILURE_CAUSES = `Possible causes:
   1. The model hallucinated the name.
   2. The tool is not registered on this agent, or a plugin filtered it out of this request.
   3. The name does not match the registered tool's name exactly.
-  4. The tool is registered but never enters the toolsDict, because its \`_getDeclaration()\` returns undefined (as \`ExampleTool\` does).`;
+  4. The tool is registered but never enters the toolsDict, because its \`_getDeclaration()\` returns undefined (as prompt-injecting tools like \`ExampleTool\` and \`PreloadMemoryTool\` do).`;
 
 const TOOL_NOT_FOUND_SYMBOL = Symbol.for('google.adk.toolNotFound');
 

--- a/core/src/agents/functions.ts
+++ b/core/src/agents/functions.ts
@@ -328,7 +328,7 @@ const RESOLUTION_FAILURE_CAUSES = `Possible causes:
   1. The model hallucinated the name.
   2. The tool is not registered on this agent, or a plugin filtered it out of this request.
   3. The name does not match the registered tool's name exactly.
-  4. The tool is registered but never enters the toolsDict, because its \`_getDeclaration()\` returns undefined or it is a built-in tool that runs inside the model (\`google_search\`, \`url_context\`, ...).`;
+  4. The tool is registered but never enters the toolsDict, because its \`_getDeclaration()\` returns undefined (as \`ExampleTool\` does).`;
 
 const TOOL_NOT_FOUND_SYMBOL = Symbol.for('google.adk.toolNotFound');
 

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -277,6 +277,7 @@ export type {
 } from './tools/base_tool.js';
 export {BaseToolset, isBaseToolset} from './tools/base_toolset.js';
 export type {ToolPredicate} from './tools/base_toolset.js';
+export {BuiltInTool} from './tools/built_in_tool.js';
 export {ConsolidateContextTool} from './tools/consolidate_context_tool.js';
 export {
   ENTERPRISE_WEB_SEARCH,

--- a/core/src/tools/base_tool.ts
+++ b/core/src/tools/base_tool.ts
@@ -43,6 +43,25 @@ export interface BaseToolParams {
 const BASE_TOOL_SIGNATURE_SYMBOL = Symbol.for('google.adk.baseTool');
 
 /**
+ * Marks a tool the model runs itself rather than the framework — see
+ * `BuiltInTool`. Such a tool claims its name in the `toolsDict` only so a
+ * function call naming it can be routed, so a genuinely callable tool of the
+ * same name takes precedence over it.
+ */
+export const IN_MODEL_TOOL_SYMBOL = Symbol.for('google.adk.inModelTool');
+
+/**
+ * Whether `tool` is one the model runs itself.
+ */
+export function isInModelTool(tool: unknown): boolean {
+  return (
+    typeof tool === 'object' &&
+    tool !== null &&
+    (tool as Record<symbol, unknown>)[IN_MODEL_TOOL_SYMBOL] === true
+  );
+}
+
+/**
  * Type guard to check if an object is an instance of BaseTool.
  * @param obj The object to check.
  * @returns True if the object is an instance of BaseTool, false otherwise.
@@ -144,7 +163,10 @@ export abstract class BaseTool {
       return;
     }
 
-    if (this.name in llmRequest.toolsDict) {
+    // An in-model tool holds the name only so a call naming it can be routed;
+    // a callable tool of the same name displaces it rather than colliding.
+    const registered = llmRequest.toolsDict[this.name];
+    if (registered && !isInModelTool(registered)) {
       throw new Error(`Duplicate tool name: ${this.name}`);
     }
 

--- a/core/src/tools/base_tool.ts
+++ b/core/src/tools/base_tool.ts
@@ -165,7 +165,11 @@ export abstract class BaseTool {
 
     // An in-model tool holds the name only so a call naming it can be routed;
     // a callable tool of the same name displaces it rather than colliding.
-    const registered = llmRequest.toolsDict[this.name];
+    // `Object.hasOwn` rather than a plain lookup, so a tool named after an
+    // `Object.prototype` member does not collide with the inherited value.
+    const registered = Object.hasOwn(llmRequest.toolsDict, this.name)
+      ? llmRequest.toolsDict[this.name]
+      : undefined;
     if (registered && !isInModelTool(registered)) {
       throw new Error(`Duplicate tool name: ${this.name}`);
     }

--- a/core/src/tools/built_in_tool.ts
+++ b/core/src/tools/built_in_tool.ts
@@ -55,7 +55,9 @@ export abstract class BuiltInTool extends BaseTool {
     // won before this registration existed. `BaseTool.processLlmRequest`
     // handles the reverse order, letting a callable tool replace this entry
     // instead of reporting a duplicate.
-    if (!(this.name in request.llmRequest.toolsDict)) {
+    // `Object.hasOwn` rather than `in`, so a tool named after an
+    // `Object.prototype` member is not read as already registered.
+    if (!Object.hasOwn(request.llmRequest.toolsDict, this.name)) {
       request.llmRequest.toolsDict[this.name] = this;
     }
   }

--- a/core/src/tools/built_in_tool.ts
+++ b/core/src/tools/built_in_tool.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {logger} from '../utils/logger.js';
+import {
+  BaseTool,
+  IN_MODEL_TOOL_SYMBOL,
+  ToolProcessLlmRequest,
+} from './base_tool.js';
+
+/**
+ * A tool the model runs itself. It is switched on through request parameters
+ * — Google Search, URL context, the grounding and retrieval tools — and never
+ * executes here.
+ *
+ * Such a tool has no function declaration, so `BaseTool.processLlmRequest`
+ * returns before the line that registers it in `llmRequest.toolsDict`. That
+ * left the model primed with a name the framework could not route: a model
+ * that returns one as an explicit function call, rather than running it,
+ * produced a call that failed to resolve even though the user had registered
+ * the tool. Registering the name here keeps the call resolvable, and
+ * `runAsync` answers it by telling the model the tool is not callable.
+ *
+ * A tool whose `applyBuiltInConfig` returns without configuring anything —
+ * every one of them does when the request carries no model — still claims its
+ * name. That request never reaches a model, so no function call can come back
+ * for it and the registration is inert.
+ */
+export abstract class BuiltInTool extends BaseTool {
+  /** Marks this tool as one the model runs itself. */
+  readonly [IN_MODEL_TOOL_SYMBOL] = true;
+
+  /**
+   * Adds this tool's configuration to the request.
+   *
+   * @param request The request to process the LLM request.
+   */
+  protected abstract applyBuiltInConfig(
+    request: ToolProcessLlmRequest,
+  ): Promise<void>;
+
+  override async processLlmRequest(
+    request: ToolProcessLlmRequest,
+  ): Promise<void> {
+    await this.applyBuiltInConfig(request);
+    // Registered only after the configuration lands, so a tool that rejects
+    // the model and throws does not leave behind a name claiming it is
+    // callable.
+    //
+    // Never displace a tool already holding the name. A callable tool called
+    // `google_search` is what the model's call almost certainly means, and it
+    // won before this registration existed. `BaseTool.processLlmRequest`
+    // handles the reverse order, letting a callable tool replace this entry
+    // instead of reporting a duplicate.
+    if (!(this.name in request.llmRequest.toolsDict)) {
+      request.llmRequest.toolsDict[this.name] = this;
+    }
+  }
+
+  /**
+   * Answers a function call the model should not have made. The tool is
+   * already configured on the request and its results arrive as grounding
+   * metadata, so the model is told to use those rather than call again.
+   */
+  override async runAsync(): Promise<unknown> {
+    // A model calling an in-model tool as a function is an anomaly worth
+    // surfacing, even though the turn recovers from it.
+    logger.warn(
+      `${this.name} runs inside the model but was called as a function; ` +
+        'answering with guidance instead of executing anything.',
+    );
+    return {
+      error:
+        `${this.name} runs inside the model and cannot be called as a ` +
+        'function. It is already enabled on this request and its results ' +
+        'arrive as grounding metadata; answer from those instead of calling ' +
+        'it.',
+    };
+  }
+}

--- a/core/src/tools/built_in_tool.ts
+++ b/core/src/tools/built_in_tool.ts
@@ -45,6 +45,18 @@ export abstract class BuiltInTool extends BaseTool {
   override async processLlmRequest(
     request: ToolProcessLlmRequest,
   ): Promise<void> {
+    // This override never forwards a declaration to `llmRequest.config.tools`,
+    // because a tool the model runs itself has none. A subclass that returns
+    // one would have it dropped here while the name still registered as
+    // in-model, leaving the model unable to see the function and told the tool
+    // is not callable if it guessed the name. Say so rather than swallow it.
+    if (this._getDeclaration()) {
+      throw new Error(
+        `${this.name} extends BuiltInTool but returns a function ` +
+          'declaration. A tool the model runs itself cannot declare a ' +
+          'callable function; extend BaseTool instead.',
+      );
+    }
     await this.applyBuiltInConfig(request);
     // Registered only after the configuration lands, so a tool that rejects
     // the model and throws does not leave behind a name claiming it is

--- a/core/src/tools/enterprise_web_search_tool.ts
+++ b/core/src/tools/enterprise_web_search_tool.ts
@@ -12,7 +12,8 @@ import {
   isGeminiModelIdCheckDisabled,
 } from '../utils/model_name.js';
 
-import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+import {ToolProcessLlmRequest} from './base_tool.js';
+import {BuiltInTool} from './built_in_tool.js';
 
 /**
  * Appends the Enterprise Web Search built-in tool to the LLM request when the
@@ -57,7 +58,7 @@ export function applyEnterpriseWebSearch(llmRequest: LlmRequest): void {
  * This tool operates internally within the model and does not require or
  * perform local code execution.
  */
-export class EnterpriseWebSearchTool extends BaseTool {
+export class EnterpriseWebSearchTool extends BuiltInTool {
   constructor() {
     super({
       name: 'enterprise_web_search',
@@ -65,13 +66,7 @@ export class EnterpriseWebSearchTool extends BaseTool {
     });
   }
 
-  runAsync(): Promise<unknown> {
-    // This is a built-in tool on server side, it's triggered by setting the
-    // corresponding request parameters.
-    return Promise.resolve();
-  }
-
-  override async processLlmRequest({
+  protected override async applyBuiltInConfig({
     llmRequest,
   }: ToolProcessLlmRequest): Promise<void> {
     applyEnterpriseWebSearch(llmRequest);

--- a/core/src/tools/google_maps_grounding_tool.ts
+++ b/core/src/tools/google_maps_grounding_tool.ts
@@ -12,7 +12,8 @@ import {
   isGeminiModelIdCheckDisabled,
 } from '../utils/model_name.js';
 
-import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+import {ToolProcessLlmRequest} from './base_tool.js';
+import {BuiltInTool} from './built_in_tool.js';
 
 /**
  * Applies Google Maps grounding to the LLM request if supported.
@@ -52,18 +53,12 @@ export function applyGoogleMapsGrounding(llmRequest: LlmRequest): void {
  * This tool operates internally within the model and does not require or
  * perform local code execution.
  */
-export class GoogleMapsGroundingTool extends BaseTool {
+export class GoogleMapsGroundingTool extends BuiltInTool {
   constructor() {
     super({name: 'google_maps', description: 'Google Maps Grounding Tool'});
   }
 
-  runAsync(): Promise<unknown> {
-    // This is a built-in tool on server side, it's triggered by setting the
-    // corresponding request parameters.
-    return Promise.resolve();
-  }
-
-  override async processLlmRequest({
+  protected override async applyBuiltInConfig({
     llmRequest,
   }: ToolProcessLlmRequest): Promise<void> {
     applyGoogleMapsGrounding(llmRequest);

--- a/core/src/tools/google_search_tool.ts
+++ b/core/src/tools/google_search_tool.ts
@@ -7,7 +7,8 @@ import {GenerateContentConfig} from '@google/genai';
 
 import {isGemini1Model, isGeminiModel} from '../utils/model_name.js';
 
-import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+import {ToolProcessLlmRequest} from './base_tool.js';
+import {BuiltInTool} from './built_in_tool.js';
 
 /**
  * A built-in tool that is automatically invoked by Gemini 2 models to retrieve
@@ -16,18 +17,12 @@ import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
  * This tool operates internally within the model and does not require or
  * perform local code execution.
  */
-export class GoogleSearchTool extends BaseTool {
+export class GoogleSearchTool extends BuiltInTool {
   constructor() {
     super({name: 'google_search', description: 'Google Search Tool'});
   }
 
-  runAsync(): Promise<unknown> {
-    // This is a built-in tool on server side, it's triggered by setting the
-    // corresponding request parameters.
-    return Promise.resolve();
-  }
-
-  override async processLlmRequest({
+  protected override async applyBuiltInConfig({
     llmRequest,
   }: ToolProcessLlmRequest): Promise<void> {
     if (!llmRequest.model) {

--- a/core/src/tools/url_context_tool.ts
+++ b/core/src/tools/url_context_tool.ts
@@ -7,7 +7,8 @@ import {GenerateContentConfig} from '@google/genai';
 
 import {isGemini2OrAbove, isGeminiModel} from '../utils/model_name.js';
 
-import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+import {ToolProcessLlmRequest} from './base_tool.js';
+import {BuiltInTool} from './built_in_tool.js';
 
 /**
  * A built-in tool that allows Gemini 2+ models to retrieve content from URLs
@@ -16,18 +17,12 @@ import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
  * This tool operates internally within the model and does not require or
  * perform local code execution.
  */
-export class UrlContextTool extends BaseTool {
+export class UrlContextTool extends BuiltInTool {
   constructor() {
     super({name: 'url_context', description: 'URL Context Tool'});
   }
 
-  runAsync(): Promise<unknown> {
-    // This is a built-in tool on server side, it's triggered by setting the
-    // corresponding request parameters.
-    return Promise.resolve();
-  }
-
-  override async processLlmRequest({
+  protected override async applyBuiltInConfig({
     llmRequest,
   }: ToolProcessLlmRequest): Promise<void> {
     if (!llmRequest.model) {

--- a/core/src/tools/vertex_ai_search_tool.ts
+++ b/core/src/tools/vertex_ai_search_tool.ts
@@ -12,7 +12,8 @@ import {
   isGeminiModel,
   isGeminiModelIdCheckDisabled,
 } from '../utils/model_name.js';
-import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+import {ToolProcessLlmRequest} from './base_tool.js';
+import {BuiltInTool} from './built_in_tool.js';
 
 const logger = getLogger();
 
@@ -51,7 +52,7 @@ export type VertexAiSearchToolParams = DataStoreParams | SearchEngineParams;
 /**
  * A built-in tool using Vertex AI Search.
  */
-export class VertexAiSearchTool extends BaseTool {
+export class VertexAiSearchTool extends BuiltInTool {
   readonly dataStoreId?: string;
   readonly dataStoreSpecs?: VertexAISearchDataStoreSpec[];
   readonly searchEngineId?: string;
@@ -95,12 +96,6 @@ export class VertexAiSearchTool extends BaseTool {
     this.bypassMultiToolsLimit = bypassMultiToolsLimit;
   }
 
-  runAsync(): Promise<unknown> {
-    // This is a built-in tool on server side, it's triggered by setting the
-    // corresponding request parameters.
-    return Promise.resolve();
-  }
-
   /**
    * Builds the VertexAISearch configuration.
    *
@@ -120,7 +115,7 @@ export class VertexAiSearchTool extends BaseTool {
     };
   }
 
-  override async processLlmRequest({
+  protected override async applyBuiltInConfig({
     toolContext,
     llmRequest,
   }: ToolProcessLlmRequest): Promise<void> {

--- a/core/src/tools/vertex_rag_retrieval_tool.ts
+++ b/core/src/tools/vertex_rag_retrieval_tool.ts
@@ -6,7 +6,8 @@
 
 import {GenerateContentConfig, VertexRagStore} from '@google/genai';
 
-import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
+import {ToolProcessLlmRequest} from './base_tool.js';
+import {BuiltInTool} from './built_in_tool.js';
 
 /**
  * A tool that retrieves relevant content from a Vertex AI RAG corpus to ground
@@ -33,7 +34,7 @@ import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
  * const agent = new LlmAgent({ tools: [ragTool], ... });
  * ```
  */
-export class VertexRagRetrievalTool extends BaseTool {
+export class VertexRagRetrievalTool extends BuiltInTool {
   private readonly vertexRagStore: VertexRagStore;
 
   constructor(config: VertexRagStore) {
@@ -44,15 +45,7 @@ export class VertexRagRetrievalTool extends BaseTool {
     this.vertexRagStore = config;
   }
 
-  /**
-   * This tool is executed server-side by the Vertex AI RAG Engine.
-   * Local execution is not required.
-   */
-  runAsync(): Promise<unknown> {
-    return Promise.resolve();
-  }
-
-  override async processLlmRequest({
+  protected override async applyBuiltInConfig({
     llmRequest,
   }: ToolProcessLlmRequest): Promise<void> {
     llmRequest.config = llmRequest.config || ({} as GenerateContentConfig);

--- a/core/test/agents/functions_test.ts
+++ b/core/test/agents/functions_test.ts
@@ -459,6 +459,8 @@ describe('handleFunctionCallList', () => {
     expect(warning).toContain('Possible causes:');
     // The cause this change tripped over in SleepyTool has to be listed.
     expect(warning).toContain('_getDeclaration()');
+    // Built-in tools register themselves now, so they must not be blamed here.
+    expect(warning).not.toContain('google_search`');
   });
 
   it('should not warn when a plugin handles the unresolvable call', async () => {

--- a/core/test/tools/built_in_tool_test.ts
+++ b/core/test/tools/built_in_tool_test.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as adk from '@google/adk';
 import {
   BaseLlm,
+  BaseLlmConnection,
   BaseTool,
   BuiltInTool,
   ENTERPRISE_WEB_SEARCH,
@@ -167,6 +169,49 @@ describe('BuiltInTool', () => {
     });
   });
 
+  // `toolsDict` is a plain object, so a lookup by name walks
+  // `Object.prototype`. Both registration paths ask `Object.hasOwn` instead,
+  // matching how `functions.ts` resolves a call.
+  describe('a tool named after an Object.prototype member', () => {
+    class ToStringBuiltIn extends BuiltInTool {
+      constructor() {
+        super({name: 'toString', description: 'Shares an inherited name.'});
+      }
+
+      protected override async applyBuiltInConfig(): Promise<void> {}
+    }
+
+    it('registers rather than reading the inherited value as taken', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+      const tool = new ToStringBuiltIn();
+
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+
+      expect(Object.hasOwn(llmRequest.toolsDict, 'toString')).toBe(true);
+      expect(llmRequest.toolsDict['toString']).toBe(tool);
+    });
+
+    it('does not report a duplicate for a callable tool', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+      const local = new FunctionTool({
+        name: 'toString',
+        description: 'Shares an inherited name.',
+        parameters: z.object({}),
+        execute: async () => ({result: 'local'}),
+      });
+
+      await local.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+
+      expect(llmRequest.toolsDict['toString']).toBe(local);
+    });
+  });
+
   it('does not register a name when the tool rejects the model', async () => {
     const llmRequest = requestFor('not-a-gemini-model');
 
@@ -179,6 +224,82 @@ describe('BuiltInTool', () => {
       }),
     ).rejects.toThrow();
     expect(llmRequest.toolsDict).toEqual({});
+  });
+});
+
+/**
+ * `BUILT_IN_TOOLS` above is hand-maintained, so it can only test the tools
+ * that exist today. This checks the invariant itself: a tool that can never
+ * produce a function declaration cannot enter `toolsDict` through
+ * `BaseTool.processLlmRequest`, so a call naming it cannot resolve — the #789
+ * failure. Such a tool must be a `BuiltInTool`, which registers itself, or be
+ * listed below with the reason it is safe. A seventh built-in written the way
+ * the first six were then fails here instead of shipping.
+ */
+describe('the declaration-less tool surface', () => {
+  // Prompt mutators: they inject into the prompt and the model never sees a
+  // name for them, so no function call can come back naming one.
+  const NOT_MODEL_ADDRESSABLE = new Set(['ExampleTool', 'PreloadMemoryTool']);
+
+  type ToolClass = (abstract new (...args: never[]) => BaseTool) & {
+    name: string;
+  };
+
+  /**
+   * Whether the class overrides `_getDeclaration`. `BaseTool`'s own
+   * implementation returns undefined, so a subclass that never overrides it
+   * has no declaration whatever its arguments are.
+   */
+  function declaresAFunction(ctor: ToolClass): boolean {
+    for (
+      let proto: object | null = ctor.prototype;
+      proto && proto !== BaseTool.prototype;
+      proto = Object.getPrototypeOf(proto)
+    ) {
+      if (Object.hasOwn(proto, '_getDeclaration')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function isBuiltIn(ctor: ToolClass): boolean {
+    return ctor.prototype instanceof BuiltInTool;
+  }
+
+  /** Every exported tool class, including the ones behind a singleton. */
+  function exportedToolClasses(): Map<string, ToolClass> {
+    const classes = new Map<string, ToolClass>();
+    for (const value of Object.values(adk as Record<string, unknown>)) {
+      const ctor =
+        typeof value === 'function' && value.prototype instanceof BaseTool
+          ? (value as ToolClass)
+          : value instanceof BaseTool
+            ? (value.constructor as ToolClass)
+            : undefined;
+      // `BuiltInTool` itself is abstract, so it holds neither side of the
+      // invariant.
+      if (ctor && (ctor as unknown) !== BuiltInTool) {
+        classes.set(ctor.name, ctor);
+      }
+    }
+    return classes;
+  }
+
+  it('is BuiltInTool subclasses plus the documented exemptions', () => {
+    const unaddressable = [...exportedToolClasses()]
+      .filter(([, ctor]) => !declaresAFunction(ctor) && !isBuiltIn(ctor))
+      .map(([name]) => name);
+
+    expect(new Set(unaddressable)).toEqual(NOT_MODEL_ADDRESSABLE);
+  });
+
+  it('finds the built-in tools it is meant to be checking', () => {
+    // Guards the sweep itself: if the barrel stopped exporting tools, or
+    // `_getDeclaration` were renamed, the assertion above would pass empty.
+    const builtIns = [...exportedToolClasses().values()].filter(isBuiltIn);
+
+    expect(builtIns.length).toBe(BUILT_IN_TOOLS.length);
   });
 });
 
@@ -212,6 +333,10 @@ describe('a built-in tool called as a function', () => {
               ],
             },
           };
+    }
+
+    async connect(): Promise<BaseLlmConnection> {
+      throw new Error('not used in this test');
     }
   }
 

--- a/core/test/tools/built_in_tool_test.ts
+++ b/core/test/tools/built_in_tool_test.ts
@@ -212,6 +212,44 @@ describe('BuiltInTool', () => {
     });
   });
 
+  // `BuiltInTool.processLlmRequest` never forwards a declaration, so a
+  // subclass that returns one would be registered as in-model with its
+  // function invisible to the model. The class is exported, so the mistake is
+  // reachable from outside this repo.
+  describe('a subclass that declares a function', () => {
+    let configured = false;
+
+    class DeclaringBuiltIn extends BuiltInTool {
+      constructor() {
+        super({name: 'declaring_built_in', description: 'Declares one.'});
+      }
+
+      protected override async applyBuiltInConfig(): Promise<void> {
+        configured = true;
+      }
+
+      override _getDeclaration() {
+        return {name: this.name, description: this.description};
+      }
+    }
+
+    it('is reported rather than silently dropped', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+      configured = false;
+
+      await expect(
+        new DeclaringBuiltIn().processLlmRequest({
+          llmRequest,
+          toolContext: undefined as never,
+        }),
+      ).rejects.toThrow('cannot declare a callable function');
+
+      expect(configured).toBe(false);
+      expect(llmRequest.toolsDict).toEqual({});
+      expect(llmRequest.config?.tools).toBeUndefined();
+    });
+  });
+
   it('does not register a name when the tool rejects the model', async () => {
     const llmRequest = requestFor('not-a-gemini-model');
 

--- a/core/test/tools/built_in_tool_test.ts
+++ b/core/test/tools/built_in_tool_test.ts
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseLlm,
+  BaseTool,
+  BuiltInTool,
+  ENTERPRISE_WEB_SEARCH,
+  Event,
+  FunctionTool,
+  GOOGLE_MAPS_GROUNDING,
+  GOOGLE_SEARCH,
+  InMemoryRunner,
+  LlmAgent,
+  LlmRequest,
+  LlmResponse,
+  URL_CONTEXT,
+  VertexAiSearchTool,
+  VertexRagRetrievalTool,
+} from '@google/adk';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {z} from 'zod';
+import {logger} from '../../src/utils/logger.js';
+
+/**
+ * Calling an in-model tool as a function is warned about by design; keep the
+ * expected diagnostics out of the suite output.
+ */
+function silenceExpectedWarnings() {
+  beforeEach(() => {
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+}
+
+function requestFor(model: string): LlmRequest {
+  return {model, contents: [], toolsDict: {}, liveConnectConfig: {}};
+}
+
+/** Every built-in tool, with a model each one accepts. */
+const BUILT_IN_TOOLS: Array<{tool: BuiltInTool; name: string}> = [
+  {tool: GOOGLE_SEARCH, name: 'google_search'},
+  {tool: URL_CONTEXT, name: 'url_context'},
+  {tool: GOOGLE_MAPS_GROUNDING, name: 'google_maps'},
+  {tool: ENTERPRISE_WEB_SEARCH, name: 'enterprise_web_search'},
+  {
+    tool: new VertexAiSearchTool({dataStoreId: 'ds-1'}),
+    name: 'vertex_ai_search',
+  },
+  {
+    tool: new VertexRagRetrievalTool({ragResources: [{ragCorpus: 'corpus-1'}]}),
+    name: 'vertex_rag_retrieval',
+  },
+];
+
+describe('BuiltInTool', () => {
+  silenceExpectedWarnings();
+
+  // These tools have no function declaration, so `BaseTool.processLlmRequest`
+  // returns before registering them. That left the model primed with a name
+  // the framework could not route, which is what #789 reported.
+  describe.each(BUILT_IN_TOOLS)('$name', ({tool, name}) => {
+    it('registers itself so a call naming it can resolve', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+
+      expect(llmRequest.toolsDict[name]).toBe(tool);
+    });
+
+    it('still adds its own configuration to the request', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+
+      await tool.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+
+      expect(llmRequest.config?.tools?.length).toBeGreaterThan(0);
+    });
+
+    it('answers a call by telling the model it is not callable', async () => {
+      const {error} = (await tool.runAsync()) as {error: string};
+
+      expect(error).toContain(`${name} runs inside the model`);
+      expect(error).toContain('grounding metadata');
+    });
+  });
+
+  it('is a BaseTool, so tool plumbing still accepts it', () => {
+    expect(GOOGLE_SEARCH).toBeInstanceOf(BaseTool);
+    expect(GOOGLE_SEARCH).toBeInstanceOf(BuiltInTool);
+  });
+
+  // A built-in tool holds its name only so a call naming it can be routed. A
+  // genuinely callable tool of the same name is what the model's call means,
+  // and it won in both orders before the registration existed — so it still
+  // has to, whichever is processed first.
+  describe('a callable tool of the same name', () => {
+    function googleSearchFunctionTool() {
+      return new FunctionTool({
+        name: 'google_search',
+        description: 'A local tool that happens to share the name.',
+        parameters: z.object({}),
+        execute: async () => ({result: 'local'}),
+      });
+    }
+
+    it('wins when the built-in is processed first', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+      const local = googleSearchFunctionTool();
+
+      await GOOGLE_SEARCH.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+      // Would have thrown `Duplicate tool name` before the in-model entry was
+      // made displaceable.
+      await local.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+
+      expect(llmRequest.toolsDict['google_search']).toBe(local);
+    });
+
+    it('wins when it is processed first', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+      const local = googleSearchFunctionTool();
+
+      await local.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+      await GOOGLE_SEARCH.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+
+      // Silently shadowing this would answer the model with the not-callable
+      // guidance instead of running the user's tool.
+      expect(llmRequest.toolsDict['google_search']).toBe(local);
+    });
+
+    it('still collides with another callable tool of the same name', async () => {
+      const llmRequest = requestFor('gemini-2.5-flash');
+
+      await googleSearchFunctionTool().processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      });
+
+      await expect(
+        googleSearchFunctionTool().processLlmRequest({
+          llmRequest,
+          toolContext: undefined as never,
+        }),
+      ).rejects.toThrow('Duplicate tool name: google_search');
+    });
+  });
+
+  it('does not register a name when the tool rejects the model', async () => {
+    const llmRequest = requestFor('not-a-gemini-model');
+
+    // A tool that refuses the model advertises nothing, so it must not leave
+    // behind a name claiming to be callable.
+    await expect(
+      GOOGLE_SEARCH.processLlmRequest({
+        llmRequest,
+        toolContext: undefined as never,
+      }),
+    ).rejects.toThrow();
+    expect(llmRequest.toolsDict).toEqual({});
+  });
+});
+
+// The reported #789 case: the user registers google_search, Gemini returns it
+// as an explicit function call rather than running it, and the framework had
+// no way to route the call.
+describe('a built-in tool called as a function', () => {
+  silenceExpectedWarnings();
+
+  class GroundingCallerLlm extends BaseLlm {
+    calls = 0;
+
+    constructor() {
+      super({model: 'gemini-2.5-flash'});
+    }
+
+    async *generateContentAsync(
+      request: LlmRequest,
+    ): AsyncGenerator<LlmResponse, void, void> {
+      this.calls++;
+      const answered = (request.contents ?? []).some((content) =>
+        (content.parts ?? []).some((part) => part.functionResponse),
+      );
+      yield answered
+        ? {content: {role: 'model', parts: [{text: 'Grounded answer.'}]}}
+        : {
+            content: {
+              role: 'model',
+              parts: [
+                {functionCall: {id: 'call-1', name: 'google_search', args: {}}},
+              ],
+            },
+          };
+    }
+  }
+
+  it('resolves to the registered tool instead of failing to resolve', async () => {
+    const mockLlm = new GroundingCallerLlm();
+    const agent = new LlmAgent({
+      name: 'grounding_agent',
+      model: mockLlm,
+      tools: [
+        GOOGLE_SEARCH,
+        new FunctionTool({
+          name: 'search_web',
+          description: 'A regular tool.',
+          parameters: z.object({}),
+          execute: async () => ({results: []}),
+        }),
+      ],
+    });
+
+    const runner = new InMemoryRunner({agent, appName: 'grounding_app'});
+    const session = await runner.sessionService.createSession({
+      appName: 'grounding_app',
+      userId: 'u1',
+    });
+
+    const events: Event[] = [];
+    for await (const event of runner.runAsync({
+      userId: 'u1',
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'go'}]},
+    })) {
+      events.push(event);
+    }
+
+    expect(events.filter((e) => e.errorMessage)).toHaveLength(0);
+    expect(mockLlm.calls).toBe(2);
+
+    const responses = events
+      .flatMap((e) => e.content?.parts ?? [])
+      .filter((p) => p.functionResponse)
+      .map((p) => p.functionResponse!);
+    expect(responses).toHaveLength(1);
+    expect(responses[0].name).toBe('google_search');
+    // The tool resolved and answered for itself. Before this change the name
+    // was absent from toolsDict, so the call fell through to the
+    // unresolvable-tool handler instead.
+    expect((responses[0].response as {error: string}).error).toContain(
+      'google_search runs inside the model',
+    );
+    expect((responses[0].response as {error: string}).error).not.toContain(
+      'is not found in the toolsDict',
+    );
+  });
+});

--- a/core/test/tools/enterprise_web_search_tool_test.ts
+++ b/core/test/tools/enterprise_web_search_tool_test.ts
@@ -134,9 +134,10 @@ describe('EnterpriseWebSearchTool', () => {
       }
     });
 
-    it('runAsync returns resolved promise', async () => {
+    it('runAsync tells the model the tool is not callable', async () => {
       const tool = new EnterpriseWebSearchTool();
-      await expect(tool.runAsync()).resolves.toBeUndefined();
+      const {error} = (await tool.runAsync()) as {error: string};
+      expect(error).toContain('enterprise_web_search runs inside the model');
     });
   });
 

--- a/core/test/tools/google_maps_grounding_tool_test.ts
+++ b/core/test/tools/google_maps_grounding_tool_test.ts
@@ -107,9 +107,10 @@ describe('GoogleMapsGroundingTool', () => {
       }
     });
 
-    it('runAsync returns resolved promise', async () => {
+    it('runAsync tells the model the tool is not callable', async () => {
       const tool = new GoogleMapsGroundingTool();
-      await expect(tool.runAsync()).resolves.toBeUndefined();
+      const {error} = (await tool.runAsync()) as {error: string};
+      expect(error).toContain('google_maps runs inside the model');
     });
   });
 

--- a/core/test/tools/vertex_rag_retrieval_tool_test.ts
+++ b/core/test/tools/vertex_rag_retrieval_tool_test.ts
@@ -148,12 +148,12 @@ describe('VertexRagRetrievalTool', () => {
   });
 
   describe('runAsync', () => {
-    it('resolves immediately (server-side tool)', async () => {
+    it('tells the model the server-side tool is not callable', async () => {
       const tool = new VertexRagRetrievalTool({
         ragResources: [{ragCorpus: RAG_CORPUS}],
       });
-      const result = await tool.runAsync();
-      expect(result).toBeUndefined();
+      const {error} = (await tool.runAsync()) as {error: string};
+      expect(error).toContain('vertex_rag_retrieval runs inside the model');
     });
   });
 });


### PR DESCRIPTION
### Link to Issue or Description of Change

Follow-up to #790, addressing the root cause that PR identified.

- Related: #789 

**Problem:**
A built-in tool runs inside the model and is switched on through request parameters rather than executed locally, so it has no function declaration. That means BaseTool.processLlmRequest returns early:

```typescript
const functionDeclaration = this._getDeclaration();
if (!functionDeclaration) {
  return;                                    // ← built-in tools stop here
}
...
llmRequest.toolsDict[this.name] = this;      // ← never reached
```

All six built-ins — google_search, url_context, google_maps, enterprise_web_search, vertex_ai_search, vertex_rag_retrieval — therefore advertise a name to the model that the framework cannot route. Gemini sometimes returns grounding as an explicit functionCall instead of running it server-side, and the user is then told the tool they registered doesn't exist:

```
tools: [GOOGLE_SEARCH, searchWeb]
// → Function google_search is not found in the toolsDict. Callable tools: search_web.
```

This is the trigger behind #789. The reporter observed the bad names "cluster hard around the built-in grounding tool" and read it as model hallucination; it is structural.


**Solution:**
A BuiltInTool base class holding what all six already shared — the identical server-side runAsync stub, and now the toolsDict registration. It applies each tool's own configuration first and registers the name afterwards, so a tool that rejects the model and throws leaves nothing behind claiming to be callable:

```typescript
override async processLlmRequest(request: ToolProcessLlmRequest): Promise<void> {
  await this.applyBuiltInConfig(request);
  request.llmRequest.toolsDict[this.name] = this;
}
```

runAsync now answers instead of resolving to undefined, telling the model the tool is already enabled and its results arrive as grounding metadata.

This fixes the reported case at the source and leaves #790's unresolvable-tool handler for genuine typos and hallucinations.


### Testing Plan

New core/test/tools/built_in_tool_test.ts, parameterized over all six tools: each registers itself, each still applies its own config, and each answers a call with the not-callable guidance. Plus a guard that a tool rejecting the model registers nothing, and a Runner-level test of the reported scenario — GOOGLE_SEARCH registered, model returns it as a functionCall — asserting it resolves to the tool rather than falling through to the unresolvable-tool handler.

Three existing tests asserted runAsync resolves to undefined; updated, since that is the behaviour being changed.

Manual E2E — GOOGLE_SEARCH registered, stub Gemini returning it as a functionCall:

MODEL SEES: {"error":"google_search runs inside the model and cannot be called as a
             function. It is already enabled on this request and its results arrive
             as grounding metadata; answer from those instead of calling it."}
TEXT: Grounded answer.
events: 3  errors: 0  model calls: 2

No warning is logged, because the call now resolves — which is the point.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Unit Tests: 227 files / 3365 tests pass. Typecheck, ESLint, Prettier clean.

**Manual End-to-End (E2E) Tests:**

See #789 for a repro

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

