### PR TITLE
perf(core): import MikroORM on first database use, not on import '@google/adk'

### DIFF
--- a/core/src/sessions/database_session_service.ts
+++ b/core/src/sessions/database_session_service.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
+import type {
   FilterQuery,
-  LockMode,
+  LockMode as LockModeEnum,
   Options as MikroDBOptions,
-  MikroORM,
+  MikroORM as MikroORMClass,
 } from '@mikro-orm/core';
 
 import {Event} from '../events/event.js';
@@ -24,20 +24,56 @@ import {
   mergeStates,
   trimTempDeltaState,
 } from './base_session_service.js';
-import {
-  ensureDatabaseCreated,
-  getConnectionOptionsFromUri,
-  validateDatabaseSchemaVersion,
-} from './db/operations.js';
-import {
-  ENTITIES,
-  StorageAppState,
-  StorageEvent,
-  StorageSession,
-  StorageUserState,
-} from './db/schema.js';
 import {createSession, Session} from './session.js';
 import {State} from './state.js';
+
+type SchemaModule = typeof import('./db/schema.js');
+type OperationsModule = typeof import('./db/operations.js');
+type StorageEventEntity = InstanceType<SchemaModule['StorageEvent']>;
+type StorageSessionEntity = InstanceType<SchemaModule['StorageSession']>;
+
+let MikroORM: typeof MikroORMClass;
+let LockMode: typeof LockModeEnum;
+let ENTITIES: SchemaModule['ENTITIES'];
+let StorageAppState: SchemaModule['StorageAppState'];
+let StorageEvent: SchemaModule['StorageEvent'];
+let StorageSession: SchemaModule['StorageSession'];
+let StorageUserState: SchemaModule['StorageUserState'];
+let ensureDatabaseCreated: OperationsModule['ensureDatabaseCreated'];
+let getConnectionOptionsFromUri: OperationsModule['getConnectionOptionsFromUri'];
+let validateDatabaseSchemaVersion: OperationsModule['validateDatabaseSchemaVersion'];
+
+let mikroOrmLoad: Promise<void> | undefined;
+
+/**
+ * Resolves (and memoizes) MikroORM plus the ADK database modules.
+ *
+ * These stay off the static import graph so that `@mikro-orm/core` is not
+ * evaluated when an agent imports `@google/adk` and never opens a database.
+ * A rejected promise stays cached, so a broken install keeps producing the
+ * same error instead of retrying module resolution on every call.
+ */
+function loadMikroOrm(): Promise<void> {
+  mikroOrmLoad ??= importMikroOrm();
+  return mikroOrmLoad;
+}
+
+async function importMikroOrm(): Promise<void> {
+  const [core, schema, operations] = await Promise.all([
+    import('@mikro-orm/core'),
+    import('./db/schema.js'),
+    import('./db/operations.js'),
+  ]);
+
+  ({MikroORM, LockMode} = core);
+  ({ENTITIES, StorageAppState, StorageEvent, StorageSession, StorageUserState} =
+    schema);
+  ({
+    ensureDatabaseCreated,
+    getConnectionOptionsFromUri,
+    validateDatabaseSchemaVersion,
+  } = operations);
+}
 
 /**
  * Checks if a URI is a database connection URI.
@@ -64,7 +100,7 @@ export function isDatabaseConnectionString(uri?: string): boolean {
  * A session service that uses a SQL database for storage via MikroORM.
  */
 export class DatabaseSessionService extends BaseSessionService {
-  private orm?: MikroORM;
+  private orm?: MikroORMClass;
   private initialized = false;
   private options?: MikroDBOptions;
   private connectionString?: string;
@@ -78,10 +114,7 @@ export class DatabaseSessionService extends BaseSessionService {
         throw new Error('Driver is required when passing options object.');
       }
 
-      this.options = {
-        ...connectionStringOrOptions,
-        entities: ENTITIES,
-      };
+      this.options = connectionStringOrOptions;
     }
   }
 
@@ -90,11 +123,15 @@ export class DatabaseSessionService extends BaseSessionService {
       return;
     }
 
-    if (this.connectionString && (!this.options || !this.options.driver)) {
-      this.options = await getConnectionOptionsFromUri(this.connectionString);
-    }
+    await loadMikroOrm();
 
-    this.orm = await MikroORM.init(this.options!);
+    // ENTITIES overrides a caller-supplied `entities`, exactly as the
+    // constructor did before the schema module became lazy.
+    this.options = this.connectionString
+      ? await getConnectionOptionsFromUri(this.connectionString)
+      : {...this.options, entities: ENTITIES};
+
+    this.orm = await MikroORM.init(this.options);
     await ensureDatabaseCreated(this.orm!);
     await validateDatabaseSchemaVersion(this.orm!);
     this.initialized = true;
@@ -210,7 +247,7 @@ export class DatabaseSessionService extends BaseSessionService {
       return undefined;
     }
 
-    const eventWhere: FilterQuery<StorageEvent> = {
+    const eventWhere: FilterQuery<StorageEventEntity> = {
       appName,
       userId,
       sessionId,
@@ -262,7 +299,7 @@ export class DatabaseSessionService extends BaseSessionService {
     await this.init();
     const em = this.orm!.em.fork();
 
-    const where: FilterQuery<StorageSession> = {appName};
+    const where: FilterQuery<StorageSessionEntity> = {appName};
     if (userId) {
       where.userId = userId;
     }

--- a/core/src/sessions/db/operations.ts
+++ b/core/src/sessions/db/operations.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {MikroORM, Options as MikroORMOptions} from '@mikro-orm/core';
+import type {MikroORM, Options as MikroORMOptions} from '@mikro-orm/core';
 import {loadOptionalPeer} from '../../utils/optional_peer.js';
 import {redactUriPassword} from '../../utils/redact_uri.js';
 import {

--- a/core/test/sessions/database_session_service_test.ts
+++ b/core/test/sessions/database_session_service_test.ts
@@ -704,6 +704,32 @@ describe('DatabaseSessionService', () => {
   });
 });
 
+describe('DatabaseSessionService entities', () => {
+  let service: DatabaseSessionService;
+
+  afterEach(async () => {
+    await (service as unknown as {orm?: MikroORM}).orm?.close();
+  });
+
+  it('ignores a caller-supplied entities list', async () => {
+    service = new DatabaseSessionService({
+      dbName: ':memory:',
+      driver: SqliteDriver,
+      allowGlobalContext: true,
+      entities: [],
+    });
+
+    await service.init();
+    const session = await service.createSession({
+      appName: 'test-app',
+      userId: 'test-user',
+      sessionId: 'entities-override',
+    });
+
+    expect(session.id).toBe('entities-override');
+  });
+});
+
 describe('isDatabaseConnectionString', () => {
   it('should identify valid URI connection strings', () => {
     expect(

--- a/tests/integration/lazy_load_heavy_deps/lazy_load_heavy_deps_test.ts
+++ b/tests/integration/lazy_load_heavy_deps/lazy_load_heavy_deps_test.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import esbuild from 'esbuild';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {beforeAll, describe, expect, it} from 'vitest';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+
+/** Entry point of the `@google/adk` barrel, relative to the repo root. */
+const BARREL_ENTRY = 'core/src/index.ts';
+
+/**
+ * Packages that must load on first use rather than on `import '@google/adk'`.
+ * Each one costs hundreds of milliseconds to evaluate, and an agent on the
+ * default in-memory services never touches any of them.
+ */
+const DEFERRED_PACKAGES = ['@mikro-orm/core'];
+
+/**
+ * A package the barrel genuinely does load at startup. It proves the trace
+ * below reports reachable packages at all, so an empty result cannot make the
+ * deferred-package assertions pass for the wrong reason.
+ */
+const EAGER_PACKAGE = '@google/genai';
+
+interface StartupGraph {
+  /** Maps a module to the module that statically imports it. */
+  importerOf: Map<string, string>;
+  /** Maps a reachable package to the module that statically imports it. */
+  packageImporter: Map<string, string>;
+}
+
+/**
+ * Walks the static import graph that Node evaluates when it loads the barrel.
+ *
+ * `core/build.js` publishes the package with this same esbuild, so the graph
+ * below is the one the published build produces after type erasure.
+ */
+async function traceStartupGraph(): Promise<StartupGraph> {
+  const result = await esbuild.build({
+    absWorkingDir: REPO_ROOT,
+    entryPoints: [BARREL_ENTRY],
+    bundle: true,
+    packages: 'external',
+    write: false,
+    metafile: true,
+    platform: 'node',
+    format: 'esm',
+    logLevel: 'silent',
+  });
+
+  const {inputs} = result.metafile;
+  const importerOf = new Map<string, string>();
+  const packageImporter = new Map<string, string>();
+  const visited = new Set([BARREL_ENTRY]);
+  const queue = [BARREL_ENTRY];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+
+    for (const imported of inputs[current].imports) {
+      // A `dynamic-import` edge runs on first use, not at startup.
+      if (imported.kind !== 'import-statement') {
+        continue;
+      }
+
+      if (imported.external) {
+        // esbuild also reports a type-erased local import as external, with a
+        // relative path. That edge does not exist at runtime.
+        if (
+          !imported.path.startsWith('.') &&
+          !packageImporter.has(imported.path)
+        ) {
+          packageImporter.set(imported.path, current);
+        }
+        continue;
+      }
+
+      if (visited.has(imported.path)) {
+        continue;
+      }
+      visited.add(imported.path);
+      importerOf.set(imported.path, current);
+      queue.push(imported.path);
+    }
+  }
+
+  return {importerOf, packageImporter};
+}
+
+/** Renders the chain from the barrel down to `module`, for a failure message. */
+function importChain(importerOf: Map<string, string>, module: string): string {
+  const chain = [module];
+
+  for (
+    let importer = importerOf.get(module);
+    importer !== undefined;
+    importer = importerOf.get(importer)
+  ) {
+    chain.unshift(importer);
+  }
+
+  return chain.join(' -> ');
+}
+
+describe('@google/adk startup import graph', () => {
+  let graph: StartupGraph;
+
+  beforeAll(async () => {
+    graph = await traceStartupGraph();
+  });
+
+  it(`reaches ${EAGER_PACKAGE}`, () => {
+    expect(graph.packageImporter.get(EAGER_PACKAGE)).toBeDefined();
+  });
+
+  it.each(DEFERRED_PACKAGES)('does not reach %s', (packageName) => {
+    const importer = graph.packageImporter.get(packageName);
+    const chain =
+      importer === undefined
+        ? undefined
+        : `${importChain(graph.importerOf, importer)} -> ${packageName}`;
+
+    expect(
+      chain,
+      `${packageName} must load on first use, not on import '@google/adk'`,
+    ).toBeUndefined();
+  });
+});

--- a/tests/integration/lazy_load_heavy_deps/missing_mikro_orm_test.ts
+++ b/tests/integration/lazy_load_heavy_deps/missing_mikro_orm_test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createEvent,
+  createSession,
+  DatabaseSessionService,
+  Session,
+} from '@google/adk';
+import {describe, expect, it, vi} from 'vitest';
+
+// Simulate a runtime where @mikro-orm/core cannot be resolved. Importing
+// @google/adk must still succeed: only DatabaseSessionService needs MikroORM,
+// and it reaches for it from init().
+vi.mock('@mikro-orm/core', () => {
+  throw new Error("Cannot find module '@mikro-orm/core'");
+});
+
+// Vitest wraps a throwing mock factory, so the assertions below match its
+// wrapper rather than the module resolution error itself.
+const MOCK_FAILURE = /There was an error when mocking a module/;
+
+const CONNECTION_STRING = 'sqlite://:memory:';
+
+function staleSession(): Session {
+  return createSession({
+    id: 'test-session',
+    appName: 'test-app',
+    userId: 'test-user',
+  });
+}
+
+/**
+ * Every public method funnels through init(), which is what populates the
+ * lazily imported MikroORM bindings. A method that skipped init() would read
+ * an unset binding instead of reporting the missing package.
+ */
+const publicCalls: Array<
+  [string, (svc: DatabaseSessionService) => Promise<unknown>]
+> = [
+  [
+    'createSession',
+    (svc) => svc.createSession({appName: 'test-app', userId: 'test-user'}),
+  ],
+  [
+    'getSession',
+    (svc) =>
+      svc.getSession({
+        appName: 'test-app',
+        userId: 'test-user',
+        sessionId: 'test-session',
+      }),
+  ],
+  [
+    'listSessions',
+    (svc) => svc.listSessions({appName: 'test-app', userId: 'test-user'}),
+  ],
+  [
+    'deleteSession',
+    (svc) =>
+      svc.deleteSession({
+        appName: 'test-app',
+        userId: 'test-user',
+        sessionId: 'test-session',
+      }),
+  ],
+  [
+    'appendEvent',
+    (svc) => svc.appendEvent({session: staleSession(), event: createEvent()}),
+  ],
+];
+
+describe('DatabaseSessionService without @mikro-orm/core', () => {
+  it('constructs without resolving MikroORM', () => {
+    expect(() => new DatabaseSessionService(CONNECTION_STRING)).not.toThrow();
+  });
+
+  it('rejects init() with the module resolution failure', async () => {
+    const service = new DatabaseSessionService(CONNECTION_STRING);
+
+    await expect(service.init()).rejects.toThrow(MOCK_FAILURE);
+  });
+
+  it('keeps reporting the same failure on a second init()', async () => {
+    const service = new DatabaseSessionService(CONNECTION_STRING);
+
+    await expect(service.init()).rejects.toThrow(MOCK_FAILURE);
+    await expect(service.init()).rejects.toThrow(MOCK_FAILURE);
+  });
+
+  it.each(publicCalls)('rejects %s', async (_name, call) => {
+    const service = new DatabaseSessionService(CONNECTION_STRING);
+
+    await expect(call(service)).rejects.toThrow(MOCK_FAILURE);
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change

1. Link to an existing issue (if applicable):

Part of #784 — "perf(core): make MikroORM an optional peer". That issue asks for MikroORM to stop being paid for by every install and every startup; this PR does the startup half.

2. Or, if no issue exists, describe the change:

**Problem.** `DatabaseSessionService` imported `@mikro-orm/core`, `./db/schema.js` and `./db/operations.js` at the top level. The `@google/adk` barrel re-exports that class, so every `adk web` and `adk run` evaluated the whole MikroORM stack — even on the default in-memory session service, which never opens a database. Fixing only the barrel does not help, because `sessions/registry.ts` is a second static importer of the same module.

**Solution.** The three modules now resolve from a single memoized dynamic import in `init()`, which all five public methods already await:

```ts
function loadMikroOrm(): Promise<void> {
  mikroOrmLoad ??= importMikroOrm();
  return mikroOrmLoad;
}
```

Every exported name and every signature is unchanged, so this needs no subpath exports and no deprecation. `ENTITIES` moves from the constructor into `init()` and still overrides a caller-supplied `entities` unconditionally.

Note this is a different layer from #183, which lazy-loads the MikroORM *driver* packages from `db/operations.ts`. That module itself was still on the static graph; this PR takes `@mikro-orm/core` and both ADK db modules off it.

**Measured cost.** Ten interleaved `await import('core/dist/esm/index.js')` runs in cold processes, Node v22.22.2: median 1724 ms before, 1356 ms with this change plus the sibling `@google-cloud/storage` deferral — 21% off barrel load. This change alone accounts for about 159 ms. `node --cpu-prof` on the built barrel shows zero MikroORM frames afterwards.

**One behaviour change to note.** A failure to load `@mikro-orm/core` now surfaces from the first `await` rather than from `new`. The rejected promise stays cached, so a broken install keeps reporting the same error instead of retrying module resolution on every call.

**Provenance.** This is extracted from a stacked branch in my fork whose base defers `@google-cloud/storage` from the same startup path. The MikroORM half is functionally independent of that base — it uses its own memoized dynamic import and shares no helper with it — so it is replayed here directly on `main` and stands alone. The graph guard below asserts only `@mikro-orm/core`, so the other half can add its own package to the same list later without touching this test.

Context, not part of this PR: #804 asks to bump `@mikro-orm` to 7.x for a critical `tar` advisory. This change is orthogonal to that version bump and does not conflict with it.

### Testing Plan

Unit Tests:

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
npx vitest run --project unit:core core/test/sessions           # 166 passed
npx vitest run --project integration tests/integration/lazy_load_heavy_deps   # 10 passed
npx tsc --noEmit                                                # 0 errors
npm run format:check                                            # clean
npx eslint <changed files>                                      # clean
npm run build -w core                                           # clean
```

`tests/integration/lazy_load_heavy_deps/lazy_load_heavy_deps_test.ts` traces the barrel with the same esbuild `core/build.js` publishes with, and fails when `@mikro-orm/core` becomes reachable over `import-statement` edges. It also asserts `@google/genai` *is* reachable, so an empty trace cannot make the deferral assertion pass for the wrong reason.

`missing_mikro_orm_test.ts` makes `@mikro-orm/core` unresolvable and pins that construction still succeeds and that each of the five public methods reports the failure — which is what proves they all funnel through `init()`.

**Proof the new tests fail without the fix.** Reverting only `core/src/sessions/database_session_service.ts` to `main` and rerunning the two integration files:

| test | result without the fix |
| ---- | ---------------------- |
| graph guard | fails: ``@mikro-orm/core must load on first use, not on import '@google/adk': expected 'core/src/index.ts -> core/src/session…' to be undefined`` |
| `missing_mikro_orm_test.ts` | fails to import at all: `Cannot find module '@mikro-orm/core'` |
| `@google/genai` control | still passes, confirming the trace reports reachable packages |

Manual End-to-End (E2E) Tests:

1. `npm install && npm run build -w core` — clean.
2. Timed the built ESM barrel in cold processes, interleaved against `main`, medians as above.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
