### PR TITLE
fix(core): keep winston out of the published browser build by splitting the logger by platform

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {installNodeLogger} from './utils/logger_node.js';
+
+// The Node entry point installs the winston-backed logger. `utils/logger.ts`
+// itself must stay free of Node-only imports so that the browser entry point
+// can reach it; see https://github.com/google/adk-js/issues/611.
+// This call runs after the modules re-exported below are evaluated, so a module
+// must log through the `logger` facade instead of holding the result of
+// `getLogger()`.
+installNodeLogger();
+
 // Also available as `@google/adk/a2a`, which does not evaluate the rest of
 // this barrel.
 export * from './a2a/index.js';

--- a/core/src/index_web.ts
+++ b/core/src/index_web.ts
@@ -4,4 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {installBrowserLogger} from './utils/logger_browser.js';
+
+// The browser entry point installs the colour-aware browser logger, in the same
+// manner as the Node entry point installs the winston-backed logger. Keeping
+// this out of `utils/logger.ts` lets that module stay free of any environment
+// assumptions; see https://github.com/google/adk-js/issues/611.
+installBrowserLogger();
+
 export * from './common.js';

--- a/core/src/tools/load_artifacts_tool.ts
+++ b/core/src/tools/load_artifacts_tool.ts
@@ -8,14 +8,12 @@ import {FunctionDeclaration, Part, Type} from '@google/genai';
 
 import {Context} from '../agents/context.js';
 import {appendInstructions, LlmRequest} from '../models/llm_request.js';
-import {getLogger} from '../utils/logger.js';
+import {logger} from '../utils/logger.js';
 import {
   BaseTool,
   RunAsyncToolRequest,
   ToolProcessLlmRequest,
 } from './base_tool.js';
-
-const logger = getLogger();
 
 const GEMINI_SUPPORTED_INLINE_MIME_PREFIXES = ['image/', 'audio/', 'video/'];
 const GEMINI_SUPPORTED_INLINE_MIME_TYPES = new Set(['application/pdf']);

--- a/core/src/tools/vertex_ai_search_tool.ts
+++ b/core/src/tools/vertex_ai_search_tool.ts
@@ -6,15 +6,13 @@
 
 import {GenerateContentConfig, Tool} from '@google/genai';
 import {ReadonlyContext} from '../agents/readonly_context.js';
-import {getLogger} from '../utils/logger.js';
+import {logger} from '../utils/logger.js';
 import {
   isGemini1Model,
   isGeminiModel,
   isGeminiModelIdCheckDisabled,
 } from '../utils/model_name.js';
 import {BaseTool, ToolProcessLlmRequest} from './base_tool.js';
-
-const logger = getLogger();
 
 export interface VertexAISearchDataStoreSpec {
   dataStore?: string;

--- a/core/src/utils/logger.ts
+++ b/core/src/utils/logger.ts
@@ -3,7 +3,6 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as winston from 'winston';
 
 /** Log levels for the logger. */
 export enum LogLevel {
@@ -30,34 +29,23 @@ export interface Logger {
   setLogLevel(level: LogLevel): void;
 }
 
-class SimpleLogger implements Logger {
-  private readonly logger: winston.Logger;
-  private logLevel: LogLevel = LogLevel.INFO;
+/** The `console` method each level is written with. */
+const CONSOLE_METHOD = {
+  [LogLevel.DEBUG]: 'debug',
+  [LogLevel.INFO]: 'info',
+  [LogLevel.WARN]: 'warn',
+  [LogLevel.ERROR]: 'error',
+} as const;
 
-  constructor() {
-    this.logger = winston.createLogger({
-      levels: {
-        'debug': LogLevel.DEBUG,
-        'info': LogLevel.INFO,
-        'warn': LogLevel.WARN,
-        'error': LogLevel.ERROR,
-      },
-      level: 'error',
-      format: winston.format.combine(
-        winston.format.label({label: 'ADK'}),
-        winston.format((info) => {
-          info.level = info.level.toUpperCase();
-          return info;
-        })(),
-        winston.format.colorize(),
-        winston.format.timestamp(),
-        winston.format.printf((info) => {
-          return `${info.level}: [${info.label}] ${info.timestamp} ${info.message}`;
-        }),
-      ),
-      transports: [new winston.transports.Console()],
-    });
-  }
+/**
+ * The default logger. Writes through `console` so that it works unchanged in
+ * Node and in the browser. This module is reachable from the browser entry
+ * point, so it must not name a Node-only package; the Node entry point
+ * installs the winston-backed logger instead.
+ * See https://github.com/google/adk-js/issues/611.
+ */
+class SimpleLogger implements Logger {
+  private logLevel: LogLevel = LogLevel.INFO;
 
   setLogLevel(level: LogLevel): void {
     this.logLevel = level;
@@ -68,39 +56,26 @@ class SimpleLogger implements Logger {
       return;
     }
 
-    this.logger.log(level.toString(), messages.join(' '));
+    const timestamp = new Date().toISOString();
+    const line = `${LogLevel[level]}: [ADK] ${timestamp} ${messages.join(' ')}`;
+
+    console[CONSOLE_METHOD[level]](line);
   }
 
   debug(...messages: unknown[]): void {
-    if (this.logLevel > LogLevel.DEBUG) {
-      return;
-    }
-
-    this.logger.debug(messages.join(' '));
+    this.log(LogLevel.DEBUG, ...messages);
   }
 
   info(...messages: unknown[]): void {
-    if (this.logLevel > LogLevel.INFO) {
-      return;
-    }
-
-    this.logger.info(messages.join(' '));
+    this.log(LogLevel.INFO, ...messages);
   }
 
   warn(...messages: unknown[]): void {
-    if (this.logLevel > LogLevel.WARN) {
-      return;
-    }
-
-    this.logger.warn(messages.join(' '));
+    this.log(LogLevel.WARN, ...messages);
   }
 
   error(...messages: unknown[]): void {
-    if (this.logLevel > LogLevel.ERROR) {
-      return;
-    }
-
-    this.logger.error(messages.join(' '));
+    this.log(LogLevel.ERROR, ...messages);
   }
 }
 
@@ -133,7 +108,8 @@ export function getLogger(): Logger {
 }
 
 /**
- * Resets the logger to the default SimpleLogger.
+ * Resets the logger to the built-in console logger. On Node this replaces the
+ * winston-backed logger that the Node entry point installs.
  */
 export function resetLogger(): void {
   currentLogger = new SimpleLogger();

--- a/core/src/utils/logger.ts
+++ b/core/src/utils/logger.ts
@@ -30,7 +30,7 @@ export interface Logger {
 }
 
 /** The `console` method each level is written with. */
-const CONSOLE_METHOD = {
+export const CONSOLE_METHOD = {
   [LogLevel.DEBUG]: 'debug',
   [LogLevel.INFO]: 'info',
   [LogLevel.WARN]: 'warn',

--- a/core/src/utils/logger_browser.ts
+++ b/core/src/utils/logger_browser.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The browser logger implementation.
+ *
+ * It mirrors the Node logger (`logger_node.ts`): a dedicated `Logger` class plus
+ * an `install*` function that the browser entry point (`core/src/index_web.ts`)
+ * wires in through `setLogger`. It writes through `console` and colours the
+ * level with a `%c` CSS directive, which browser dev consoles render (ANSI
+ * escape codes, as winston emits on Node, are not rendered there).
+ * See https://github.com/google/adk-js/issues/611.
+ */
+
+import {CONSOLE_METHOD, Logger, LogLevel, setLogger} from './logger.js';
+
+/** The CSS colour each level's label is rendered with. */
+const LEVEL_COLOR = {
+  [LogLevel.DEBUG]: 'blue',
+  [LogLevel.INFO]: 'green',
+  [LogLevel.WARN]: 'orange',
+  [LogLevel.ERROR]: 'red',
+} as const;
+
+/** The default logger in the browser. Writes coloured lines through `console`. */
+export class BrowserLogger implements Logger {
+  private logLevel: LogLevel = LogLevel.INFO;
+
+  setLogLevel(level: LogLevel): void {
+    this.logLevel = level;
+  }
+
+  log(level: LogLevel, ...messages: unknown[]): void {
+    if (this.logLevel > level) {
+      return;
+    }
+
+    const timestamp = new Date().toISOString();
+    const rest = `: [ADK] ${timestamp} ${messages.join(' ')}`;
+
+    console[CONSOLE_METHOD[level]](
+      `%c${LogLevel[level]}%c${rest}`,
+      `color: ${LEVEL_COLOR[level]}`,
+      'color: inherit',
+    );
+  }
+
+  debug(...messages: unknown[]): void {
+    this.log(LogLevel.DEBUG, ...messages);
+  }
+
+  info(...messages: unknown[]): void {
+    this.log(LogLevel.INFO, ...messages);
+  }
+
+  warn(...messages: unknown[]): void {
+    this.log(LogLevel.WARN, ...messages);
+  }
+
+  error(...messages: unknown[]): void {
+    this.log(LogLevel.ERROR, ...messages);
+  }
+}
+
+/** Makes the colour-aware browser logger the current ADK logger. */
+export function installBrowserLogger(): void {
+  setLogger(new BrowserLogger());
+}

--- a/core/src/utils/logger_node.ts
+++ b/core/src/utils/logger_node.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The Node-only logger implementation.
+ *
+ * This module is the only place under `core/src` that may name `winston`.
+ * `winston` needs Node built-ins, so no browser bundler can resolve it: this
+ * module must never become reachable from `core/src/index_web.ts`. The Node
+ * entry point (`core/src/index.ts`) wires it in through `setLogger`.
+ * See https://github.com/google/adk-js/issues/611.
+ */
+
+import * as winston from 'winston';
+import {Logger, LogLevel, setLogger} from './logger.js';
+
+/** The default logger on Node. Writes through winston. */
+export class WinstonLogger implements Logger {
+  private readonly logger: winston.Logger;
+  private logLevel: LogLevel = LogLevel.INFO;
+
+  constructor() {
+    this.logger = winston.createLogger({
+      levels: {
+        'debug': LogLevel.DEBUG,
+        'info': LogLevel.INFO,
+        'warn': LogLevel.WARN,
+        'error': LogLevel.ERROR,
+      },
+      level: 'error',
+      format: winston.format.combine(
+        winston.format.label({label: 'ADK'}),
+        winston.format((info) => {
+          info.level = info.level.toUpperCase();
+          return info;
+        })(),
+        winston.format.colorize(),
+        winston.format.timestamp(),
+        winston.format.printf((info) => {
+          return `${info.level}: [${info.label}] ${info.timestamp} ${info.message}`;
+        }),
+      ),
+      transports: [new winston.transports.Console()],
+    });
+  }
+
+  setLogLevel(level: LogLevel): void {
+    this.logLevel = level;
+  }
+
+  log(level: LogLevel, ...messages: unknown[]): void {
+    if (this.logLevel > level) {
+      return;
+    }
+
+    this.logger.log(level.toString(), messages.join(' '));
+  }
+
+  debug(...messages: unknown[]): void {
+    if (this.logLevel > LogLevel.DEBUG) {
+      return;
+    }
+
+    this.logger.debug(messages.join(' '));
+  }
+
+  info(...messages: unknown[]): void {
+    if (this.logLevel > LogLevel.INFO) {
+      return;
+    }
+
+    this.logger.info(messages.join(' '));
+  }
+
+  warn(...messages: unknown[]): void {
+    if (this.logLevel > LogLevel.WARN) {
+      return;
+    }
+
+    this.logger.warn(messages.join(' '));
+  }
+
+  error(...messages: unknown[]): void {
+    if (this.logLevel > LogLevel.ERROR) {
+      return;
+    }
+
+    this.logger.error(messages.join(' '));
+  }
+}
+
+/** Makes the winston-backed logger the current ADK logger. */
+export function installNodeLogger(): void {
+  setLogger(new WinstonLogger());
+}

--- a/core/test/tools/tool_logging_test.ts
+++ b/core/test/tools/tool_logging_test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Context,
+  InMemoryArtifactService,
+  InMemorySessionService,
+  InvocationContext,
+  LlmAgent,
+  LlmRequest,
+  LOAD_ARTIFACTS,
+  Logger,
+  LogLevel,
+  PluginManager,
+  setLogger,
+  setLogLevel,
+  VertexAiSearchTool,
+} from '@google/adk';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+// ScopedArtifactService is how the runner scopes an artifact service to one
+// session, and it is not part of the public surface.
+import {ScopedArtifactService} from '../../src/artifacts/scoped_artifact_service.js';
+import {resetLogger} from '../../src/utils/logger.js';
+import {installNodeLogger} from '../../src/utils/logger_node.js';
+
+const APP_NAME = 'logging-test-app';
+const USER_ID = 'logging-test-user';
+
+/** A record of one call made on the {@link RecordingLogger}. */
+interface LogRecord {
+  level: LogLevel;
+  message: string;
+}
+
+/** A {@link Logger} that keeps every record it is given. */
+class RecordingLogger implements Logger {
+  readonly records: LogRecord[] = [];
+
+  setLogLevel(_level: LogLevel): void {}
+
+  log(level: LogLevel, ...messages: unknown[]): void {
+    this.records.push({level, message: messages.join(' ')});
+  }
+
+  debug(...messages: unknown[]): void {
+    this.log(LogLevel.DEBUG, ...messages);
+  }
+
+  info(...messages: unknown[]): void {
+    this.log(LogLevel.INFO, ...messages);
+  }
+
+  warn(...messages: unknown[]): void {
+    this.log(LogLevel.WARN, ...messages);
+  }
+
+  error(...messages: unknown[]): void {
+    this.log(LogLevel.ERROR, ...messages);
+  }
+}
+
+/** Builds a real invocation context backed by the in-memory services. */
+async function createInvocationContext(): Promise<InvocationContext> {
+  const sessionService = new InMemorySessionService();
+  const session = await sessionService.createSession({
+    appName: APP_NAME,
+    userId: USER_ID,
+  });
+  const artifactService = new InMemoryArtifactService();
+  await artifactService.saveArtifact({
+    appName: APP_NAME,
+    userId: USER_ID,
+    sessionId: session.id,
+    filename: 'present.txt',
+    artifact: {text: 'hello'},
+  });
+
+  return new InvocationContext({
+    invocationId: 'logging-test-invocation',
+    agent: new LlmAgent({name: 'logging_test_agent'}),
+    session,
+    sessionService,
+    artifactService: new ScopedArtifactService(
+      artifactService,
+      APP_NAME,
+      USER_ID,
+      session.id,
+    ),
+    pluginManager: new PluginManager(),
+  });
+}
+
+/** A request that asks `load_artifacts` for an artifact that does not exist. */
+function createMissingArtifactRequest(): LlmRequest {
+  return {
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'load_artifacts',
+              response: {artifact_names: ['missing.txt']},
+            },
+          },
+        ],
+      },
+    ],
+    toolsDict: {},
+    liveConnectConfig: {},
+  };
+}
+
+describe('tool logging', () => {
+  let toolContext: Context;
+
+  beforeEach(async () => {
+    toolContext = new Context({
+      invocationContext: await createInvocationContext(),
+    });
+    installNodeLogger();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetLogger();
+  });
+
+  describe('LoadArtifactsTool', () => {
+    it('sends the missing-artifact warning to the current logger', async () => {
+      const recorded = new RecordingLogger();
+      setLogger(recorded);
+
+      await LOAD_ARTIFACTS.processLlmRequest({
+        toolContext,
+        llmRequest: createMissingArtifactRequest(),
+      });
+
+      expect(recorded.records).toEqual([
+        {
+          level: LogLevel.WARN,
+          message: 'Artifact "missing.txt" not found, skipping',
+        },
+      ]);
+    });
+
+    it('drops the missing-artifact warning at ERROR level', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      setLogLevel(LogLevel.ERROR);
+
+      await LOAD_ARTIFACTS.processLlmRequest({
+        toolContext,
+        llmRequest: createMissingArtifactRequest(),
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('VertexAiSearchTool', () => {
+    it('sends the search-config debug line to the current logger', async () => {
+      const recorded = new RecordingLogger();
+      setLogger(recorded);
+
+      await new VertexAiSearchTool({dataStoreId: 'ds'}).processLlmRequest({
+        toolContext,
+        llmRequest: {
+          model: 'gemini-2.0-flash',
+          contents: [],
+          toolsDict: {},
+          liveConnectConfig: {},
+        },
+      });
+
+      expect(recorded.records).toEqual([
+        {
+          level: LogLevel.DEBUG,
+          message: expect.stringContaining(
+            'Adding Vertex AI Search tool config to LLM request',
+          ),
+        },
+      ]);
+    });
+  });
+});

--- a/core/test/utils/logger_browser_test.ts
+++ b/core/test/utils/logger_browser_test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  getLogger,
+  LogLevel,
+  resetLogger,
+  setLogLevel,
+} from '../../src/utils/logger.js';
+import {
+  BrowserLogger,
+  installBrowserLogger,
+} from '../../src/utils/logger_browser.js';
+
+/** Removes the `%c` colour directives so the rendered text can be matched. */
+function stripColorDirectives(line: string): string {
+  return line.replace(/%c/g, '');
+}
+
+describe('BrowserLogger', () => {
+  beforeEach(() => {
+    installBrowserLogger();
+    setLogLevel(LogLevel.DEBUG);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetLogger();
+  });
+
+  it('is installed by installBrowserLogger()', () => {
+    expect(getLogger()).toBeInstanceOf(BrowserLogger);
+  });
+
+  it('writes the ADK line format', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setLogLevel(LogLevel.ERROR);
+
+    getLogger().error('boom');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(stripColorDirectives(errorSpy.mock.calls[0][0] as string)).toMatch(
+      /^ERROR: \[ADK\] \d{4}-\d{2}-\d{2}T[\d:.]+Z boom$/,
+    );
+  });
+
+  it('colorizes the level', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setLogLevel(LogLevel.ERROR);
+
+    getLogger().error('boom');
+
+    const [message, levelStyle, restStyle] = errorSpy.mock.calls[0];
+    expect(message).toMatch(/^%cERROR%c/);
+    expect(levelStyle).toBe('color: red');
+    expect(restStyle).toBe('color: inherit');
+  });
+
+  it('routes each level to its matching console method', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    getLogger().debug('d');
+    getLogger().info('i');
+    getLogger().warn('w');
+    getLogger().error('e');
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy.mock.calls[0][1]).toBe('color: blue');
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][1]).toBe('color: green');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][1]).toBe('color: orange');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][1]).toBe('color: red');
+  });
+
+  it('suppresses a message below the configured level', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setLogLevel(LogLevel.WARN);
+
+    getLogger().debug('x');
+    getLogger().info('y');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+
+    getLogger().warn('z');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins arguments with a single space', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    setLogLevel(LogLevel.INFO);
+
+    getLogger().info('a', 1, true);
+
+    expect(stripColorDirectives(infoSpy.mock.calls[0][0] as string)).toMatch(
+      /^INFO: \[ADK\] \d{4}-\d{2}-\d{2}T[\d:.]+Z a 1 true$/,
+    );
+  });
+
+  it('log() emits without throwing', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    setLogLevel(LogLevel.INFO);
+
+    expect(() => getLogger().log(LogLevel.INFO, 'via log')).not.toThrow();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('browser safety', () => {
+  it('keeps winston out of the browser logger', async () => {
+    const {readFile} = await import('node:fs/promises');
+    const {fileURLToPath} = await import('node:url');
+    const source = await readFile(
+      fileURLToPath(
+        new URL('../../src/utils/logger_browser.ts', import.meta.url),
+      ),
+      'utf8',
+    );
+
+    expect(source).not.toMatch(/from 'winston'/);
+    expect(source).not.toMatch(/from 'node:/);
+  });
+});

--- a/core/test/utils/logger_browser_wiring_test.ts
+++ b/core/test/utils/logger_browser_wiring_test.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {getLogger} from '../../src/utils/logger.js';
+import {BrowserLogger} from '../../src/utils/logger_browser.js';
+
+/**
+ * Nothing in this file may call `resetLogger()` or `setLogger()`: the point is
+ * that importing the browser entry point is what installs the browser logger.
+ */
+describe('browser entry point', () => {
+  it('installs the browser logger on import', async () => {
+    await import('../../src/index_web.js');
+
+    expect(getLogger()).toBeInstanceOf(BrowserLogger);
+  });
+});

--- a/core/test/utils/logger_node_test.ts
+++ b/core/test/utils/logger_node_test.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  getLogger,
+  LogLevel,
+  resetLogger,
+  setLogLevel,
+} from '../../src/utils/logger.js';
+import {installNodeLogger, WinstonLogger} from '../../src/utils/logger_node.js';
+
+/** The escape character that opens an ANSI colour code. */
+const ESC = String.fromCharCode(27);
+
+/** The colour codes `winston.format.colorize()` wraps the level in. */
+const ANSI_ESCAPE = new RegExp(`${ESC}\\[\\d+m`, 'g');
+
+/**
+ * Node keeps the stream behind `console` on an internal field, and winston's
+ * Console transport writes straight to it. Vitest installs its own `console`,
+ * so capturing the output means spying on that stream rather than on
+ * `process.stdout`.
+ */
+type ConsoleWithStdout = typeof console & {
+  _stdout?: {write(chunk: string): boolean};
+};
+
+/** Lines the Console transport wrote during the test. */
+let lines: string[] = [];
+
+/** Lets winston's stream pipeline flush before the assertions run. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function stripAnsi(line: string): string {
+  return line.replace(ANSI_ESCAPE, '');
+}
+
+describe('WinstonLogger', () => {
+  beforeEach(() => {
+    lines = [];
+    const consoleWithStdout: ConsoleWithStdout = console;
+    const stdout = consoleWithStdout._stdout;
+    if (!stdout) {
+      expect.fail('console has no _stdout stream to capture');
+    }
+    vi.spyOn(stdout, 'write').mockImplementation((chunk: string) => {
+      lines.push(chunk);
+      return true;
+    });
+    installNodeLogger();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetLogger();
+  });
+
+  it('is installed by installNodeLogger()', () => {
+    expect(getLogger()).toBeInstanceOf(WinstonLogger);
+  });
+
+  it('writes the ADK line format', async () => {
+    setLogLevel(LogLevel.ERROR);
+
+    getLogger().error('boom');
+    await flush();
+
+    expect(lines).toHaveLength(1);
+    expect(stripAnsi(lines[0]).trimEnd()).toMatch(
+      /^ERROR: \[ADK\] \d{4}-\d{2}-\d{2}T[\d:.]+Z boom$/,
+    );
+  });
+
+  it('colorizes the level', async () => {
+    setLogLevel(LogLevel.ERROR);
+
+    getLogger().error('boom');
+    await flush();
+
+    expect(lines[0]).toContain(`${ESC}[`);
+  });
+
+  it('suppresses the levels below the configured level', async () => {
+    setLogLevel(LogLevel.WARN);
+
+    getLogger().debug('d');
+    getLogger().info('i');
+    await flush();
+
+    expect(lines).toHaveLength(0);
+
+    getLogger().warn('w');
+    getLogger().error('e');
+    await flush();
+
+    expect(lines.map((line) => stripAnsi(line).trimEnd())).toEqual([
+      expect.stringMatching(/^WARN: \[ADK\] .* w$/),
+      expect.stringMatching(/^ERROR: \[ADK\] .* e$/),
+    ]);
+  });
+
+  it('writes a debug line when the level allows it', async () => {
+    setLogLevel(LogLevel.DEBUG);
+
+    getLogger().debug('trace');
+    await flush();
+
+    expect(stripAnsi(lines[0]).trimEnd()).toMatch(/^DEBUG: \[ADK\] .* trace$/);
+  });
+
+  it('suppresses a warning below the configured level', async () => {
+    setLogLevel(LogLevel.ERROR);
+
+    getLogger().warn('w');
+    await flush();
+
+    expect(lines).toHaveLength(0);
+  });
+
+  it('joins arguments with a single space', async () => {
+    setLogLevel(LogLevel.INFO);
+
+    getLogger().info('a', 1, true);
+    await flush();
+
+    expect(stripAnsi(lines[0]).trimEnd()).toMatch(/ a 1 true$/);
+  });
+
+  it('drops a log() call below the configured level', async () => {
+    setLogLevel(LogLevel.ERROR);
+
+    getLogger().log(LogLevel.INFO, 'quiet');
+    await flush();
+
+    expect(lines).toHaveLength(0);
+  });
+
+  it('throws from log() because winston rejects the numeric level name', () => {
+    setLogLevel(LogLevel.ERROR);
+
+    // Pre-existing behaviour, preserved by this change: `log()` passes the
+    // numeric enum value to winston, which knows only the 'debug'..'error'
+    // names. A separate change fixes it.
+    expect(() => getLogger().log(LogLevel.ERROR, 'boom')).toThrow();
+  });
+});

--- a/core/test/utils/logger_node_wiring_test.ts
+++ b/core/test/utils/logger_node_wiring_test.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {getLogger} from '@google/adk';
+import {describe, expect, it} from 'vitest';
+import {WinstonLogger} from '../../src/utils/logger_node.js';
+
+/**
+ * Nothing in this file may call `resetLogger()` or `setLogger()`: the point is
+ * that importing the Node entry point is what installs the winston logger.
+ */
+describe('Node entry point', () => {
+  it('installs the winston logger on import', () => {
+    expect(getLogger()).toBeInstanceOf(WinstonLogger);
+  });
+});

--- a/core/test/utils/logger_test.ts
+++ b/core/test/utils/logger_test.ts
@@ -5,8 +5,18 @@
  */
 
 import {getLogger, Logger, LogLevel, setLogger, setLogLevel} from '@google/adk';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {resetLogger} from '../../src/utils/logger.js';
+
+/** Reads a module under `core/src/utils` as text. */
+function readCoreSource(name: string): Promise<string> {
+  return readFile(
+    fileURLToPath(new URL(`../../src/utils/${name}`, import.meta.url)),
+    'utf8',
+  );
+}
 
 describe('setLogger', () => {
   beforeEach(() => {
@@ -140,5 +150,140 @@ describe('setLogger', () => {
 
       expect(logger.constructor.name).toBe('SimpleLogger');
     });
+  });
+});
+
+describe('SimpleLogger', () => {
+  const ISO_TIMESTAMP = String.raw`\d{4}-\d{2}-\d{2}T[\d:.]+Z`;
+
+  beforeEach(() => {
+    resetLogger();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetLogger();
+  });
+
+  it('emits a message at the configured level', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    setLogLevel(LogLevel.INFO);
+
+    getLogger().info('hello');
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(`^INFO: \\[ADK\\] ${ISO_TIMESTAMP} hello$`),
+      ),
+    );
+  });
+
+  it('suppresses a message below the configured level', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setLogLevel(LogLevel.WARN);
+
+    getLogger().debug('x');
+    getLogger().info('y');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+
+    getLogger().warn('z');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to INFO', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    getLogger().debug('x');
+    getLogger().info('y');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes each level to its matching console method', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setLogLevel(LogLevel.DEBUG);
+
+    getLogger().debug('d');
+    getLogger().info('i');
+    getLogger().warn('w');
+    getLogger().error('e');
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('DEBUG: [ADK] '),
+    );
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('INFO: [ADK] '),
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('WARN: [ADK] '),
+    );
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ERROR: [ADK] '),
+    );
+  });
+
+  it('joins arguments with a single space', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    setLogLevel(LogLevel.INFO);
+
+    getLogger().info('a', 1, true);
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(`^INFO: \\[ADK\\] ${ISO_TIMESTAMP} a 1 true$`),
+      ),
+    );
+  });
+
+  it('log() emits without throwing', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    setLogLevel(LogLevel.INFO);
+
+    expect(() => getLogger().log(LogLevel.INFO, 'via log')).not.toThrow();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('via log'));
+  });
+
+  it('formats the full line for a warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setLogLevel(LogLevel.WARN);
+
+    getLogger().warn('boom');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(`^WARN: \\[ADK\\] ${ISO_TIMESTAMP} boom$`),
+      ),
+    );
+  });
+});
+
+describe('browser safety', () => {
+  it('keeps the browser-reachable logger free of imports', async () => {
+    const source = await readCoreSource('logger.ts');
+
+    expect(source).not.toMatch(/^\s*import\b/m);
+    expect(source).not.toMatch(/\bimport\(/);
+  });
+
+  it('keeps winston in the Node-only logger', async () => {
+    const source = await readCoreSource('logger_node.ts');
+
+    expect(source).toMatch(/from 'winston'/);
   });
 });


### PR DESCRIPTION
### Link to Issue or Description of Change

1. Link to an existing issue (if applicable):
   Part of: #611
   Related: #607, #785

---

> **⚠️ Reviewer note — this is not #617.** #617 proposed **deleting** winston and was correctly closed with *"No, we need to keep winston!"*. **This PR keeps winston.** It stays a `core` dependency, it stays the logger on Node, and its implementation is moved **byte-for-byte unchanged**. The only thing that changes is that the **browser** build stops naming the package. Verification that winston is still the Node logger is in the Testing Plan below.

---

2. Or, if no issue exists, describe the change:

**Problem**: `core/src/utils/logger.ts` imports `winston`, and the browser entry point reaches that module through `common.ts` (which re-exports `LogLevel`, `getLogger`, `setLogLevel`, `setLogger`). The published web build is transpile-only, so esbuild passes the specifier through unchanged. `core/dist/web/utils/logger.js` therefore ships `import * as winston from "winston"`, which no browser bundler can resolve.

**Solution**: split the logger by platform.

- `utils/logger.ts` now writes through `console`, so it works in both runtimes and names no package at all.
- The winston implementation moves into the new `utils/logger_node.ts`, **unchanged** — the class body is byte-for-byte the one that was in `logger.ts`; only the class name differs (`SimpleLogger` → `WinstonLogger`).
- `core/src/index.ts` (the Node entry point) installs it through the existing `setLogger` seam.

`core/package.json` is untouched: `"winston": "^3.19.0"` stays in `dependencies`.

An esbuild `alias` cannot solve this: esbuild rejects `alias` without `bundle`, and the published web build does not bundle. So the `platform === 'browser' && bundle` gate and the rest of `core/build.js` are left as they are.

**Call-site change**: `load_artifacts_tool.ts` and `vertex_ai_search_tool.ts` held `const logger = getLogger()` at module scope. `installNodeLogger()` runs *after* `index.ts` evaluates its re-exports, so those two modules would have captured the console logger for the process lifetime, out of reach of `setLogLevel()`. Both now log through the `logger` facade that the other importers already use. That is the only call-site change here.

### Behaviour notes

- **Sub-path entry points get the console logger.** `@google/adk/a2a`, `@google/adk/tools/mcp`, `@google/adk/artifacts/gcs` and `@google/adk/telemetry/gcp` deliberately do not evaluate the main barrel, so they do not run `installNodeLogger()`. A consumer importing *only* a sub-path on Node gets the console logger rather than winston. Both emit the same line — `LEVEL: [ADK] <ISO timestamp> <message>` — so the only observable difference is winston's ANSI colouring. I left this alone rather than sprinkling install calls across five modules, which would also let a late sub-path import clobber a user's `setLogger()`. Happy to wire the sub-paths up in a follow-up if you'd prefer them to match.
- `resetLogger()` now installs the console logger on Node too. It is internal: it is not exported from `index.ts`, `common.ts` or `index_web.ts`, and only core's own tests call it.
- A deep import of `dist/esm/utils/logger.js` would get the console logger, but the `exports` map does not expose that path.
- `dist/web` still contains an emitted `utils/logger_node.js`, and it still names `winston`. It is an **orphan** — nothing in the `dist/web` graph imports it (measured below). Excluding it from the transpile-only build would hide the day a `*_node.ts` module *does* become reachable, so the build is left alone. Note it is technically fetchable via the `./dist/web/*` export wildcard, but only by explicitly deep-importing a `_node` file.
- `logger.log(level, ...)` on Node still throws inside winston, because it passes the numeric enum value as the level name. That is pre-existing behaviour, preserved here and pinned by `logger_node_test.ts`. The console logger emits normally.
- The public API surface is unchanged. `common.ts` is untouched and no symbol is added or removed.

### Testing Plan

Unit Tests:
[x] I have added or updated unit tests for my change.
[x] All unit tests pass locally.

`vitest run --project unit:core` — **233 files, 3456 tests, all passing.**

The four files this PR touches: `logger_test.ts`, `logger_node_test.ts`, `logger_node_wiring_test.ts`, `tool_logging_test.ts` — **30 passed**.

- `logger_test.ts` gains the console `SimpleLogger` cases and a `browser safety` block. That block reads both sources: `logger.ts` must contain no `import`, and `logger_node.ts` must still import `winston` — so **the first assertion cannot be satisfied by deleting the dependency**, which is what makes this different from #617 at the test level.
- `logger_node_test.ts` (new) captures the Console transport output and checks the line format, the colorized level, level gating and argument joining.
- `logger_node_wiring_test.ts` (new) imports `@google/adk` and asserts the entry point installed the winston logger.
- `tool_logging_test.ts` (new) drives `LoadArtifactsTool` and `VertexAiSearchTool` against real in-memory session and artifact services, no mocks.

`npm run lint`, `npm run format:check` — clean. `tsc --noEmit` reports the same 4 pre-existing errors on this branch and on `main` (all `Cannot find module '@google/adk-devtools'`, an unbuilt workspace package), with an identical breakdown.

#### Evidence 1 — winston leaves the browser graph

Bundling the browser entry point lists every bare specifier a browser bundler would have to resolve. Same command on `main` and on this branch:

```
npx esbuild ./src/index_web.ts --bundle --platform=browser --format=esm \
  --packages=external --outfile=/dev/null --metafile=/tmp/meta.json
```

Both reach **193 modules**. The external lists are identical except for one entry:

| | externals |
|---|---|
| `main` | `@google-cloud/vertexai, @google/genai, @opentelemetry/api, adm-zip, google-auth-library, js-yaml, jsonpath-plus, lodash-es, node:async_hooks, node:buffer, node:crypto, node:dns/promises, node:fs/promises, node:net, node:os, node:path, uuid, **winston**, zod, zod-to-json-schema, zod/v4` |
| this branch | `@google-cloud/vertexai, @google/genai, @opentelemetry/api, adm-zip, google-auth-library, js-yaml, jsonpath-plus, lodash-es, node:async_hooks, node:buffer, node:crypto, node:dns/promises, node:fs/promises, node:net, node:os, node:path, uuid, zod, zod-to-json-schema, zod/v4` |

`winston` is the single-variable difference. The remaining `node:` specifiers are the other half of #611 and are out of scope here.

Walking the **published** `dist/web` output after `npm run build` confirms the same on the shipped artifact:

```
modules reached from dist/web/index_web.js : 193
winston imported                           : False
logger_node reached                        : False

files under dist/web naming winston        : ['dist/web/utils/logger_node.js']
  ...of those, reachable from the entry    : NONE (orphan, not in the graph)
```

#### Evidence 2 — winston stays on Node

```
$ node -p "require('./core/package.json').dependencies.winston"
^3.19.0

$ grep -rln winston core/dist/esm core/dist/cjs
core/dist/esm/utils/logger_node.js
core/dist/cjs/utils/logger_node.js

$ grep -rn "from 'winston'" core/src
core/src/utils/logger_node.ts:17:import * as winston from 'winston';
```

The active logger on Node is still winston:

```
$ node --input-type=module -e "
  const {getLogger} = await import('./core/dist/esm/index.js');
  const n = await import('./core/dist/esm/utils/logger_node.js');
  console.log(getLogger().constructor.name, getLogger() instanceof n.WinstonLogger);
"
WinstonLogger true
```

And Node output is unchanged. The same script on `main` and on this branch, timestamps normalized, `diff` clean — **including winston's ANSI colour codes**:

```
^[[34mDEBUG^[[39m: [ADK] <ts> d
^[[32mINFO^[[39m:  [ADK] <ts> i
^[[33mWARN^[[39m:  [ADK] <ts> w
^[[31mERROR^[[39m: [ADK] <ts> e
```

`dist/esm`, `dist/cjs` and `dist/web` still mirror `core/src` file for file, as before.

### Checklist

[x] I have read the CONTRIBUTING.md document.
[x] I have performed a self-review of my own code.
[x] I have commented my code, particularly in hard-to-understand areas.
[x] I have added tests that prove my fix is effective or that my feature works.
[x] New and existing unit tests pass locally with my changes.
