### PR TITLE
fix(telemetry): prune credential-bearing httpOptions from the traced llm_request

### DIFF
--- a/core/src/telemetry/tracing.ts
+++ b/core/src/telemetry/tracing.ts
@@ -15,7 +15,7 @@
  *    constructs of the framework that are not observable by the SDK.
  */
 
-import {Content} from '@google/genai';
+import {Content, HttpOptions} from '@google/genai';
 import {context, Context, trace} from '@opentelemetry/api';
 
 import {BaseAgent} from '../agents/base_agent.js';
@@ -373,6 +373,24 @@ export function traceSendData({
 }
 
 /**
+ * Returns a copy of the HTTP options without the caller-supplied fields that
+ * can carry credentials.
+ *
+ * `headers` commonly holds an Authorization bearer token and `extraBody` is a
+ * free-form request-body passthrough, so neither may reach an exported span
+ * attribute. The remaining fields are useful for debugging and stay.
+ *
+ * @param httpOptions The HTTP options taken from the request config.
+ * @returns A new HttpOptions object without `headers` and `extraBody`.
+ */
+function redactHttpOptions(httpOptions: HttpOptions): HttpOptions {
+  const redacted: HttpOptions = {...httpOptions};
+  delete redacted.headers;
+  delete redacted.extraBody;
+  return redacted;
+}
+
+/**
  * Builds a dictionary representation of the LLM request for tracing.
  *
  * This function prepares a dictionary representation of the LlmRequest
@@ -394,6 +412,9 @@ function buildLlmRequestForTrace(
     // Create a clean config object, pruning responseSchema to reduce noise size
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {responseSchema, ...cleanConfig} = llmRequest.config;
+    if (cleanConfig.httpOptions) {
+      cleanConfig.httpOptions = redactHttpOptions(cleanConfig.httpOptions);
+    }
     result.config = cleanConfig;
   }
 

--- a/core/src/telemetry/tracing.ts
+++ b/core/src/telemetry/tracing.ts
@@ -15,7 +15,7 @@
  *    constructs of the framework that are not observable by the SDK.
  */
 
-import {Content} from '@google/genai';
+import {Content, HttpOptions} from '@google/genai';
 import {context, Context, trace} from '@opentelemetry/api';
 
 import {BaseAgent} from '../agents/base_agent.js';
@@ -373,6 +373,24 @@ export function traceSendData({
 }
 
 /**
+ * Returns a copy of the HTTP options without the caller-supplied fields that
+ * can carry credentials.
+ *
+ * `headers` commonly holds an Authorization bearer token and `extraBody` is a
+ * free-form request-body passthrough, so neither may reach an exported span
+ * attribute. The remaining fields are useful for debugging and stay.
+ *
+ * @param httpOptions The HTTP options taken from the request config.
+ * @returns A new HttpOptions object without `headers` and `extraBody`.
+ */
+function redactHttpOptions(httpOptions: HttpOptions): HttpOptions {
+  const redacted: HttpOptions = {...httpOptions};
+  delete redacted.headers;
+  delete redacted.extraBody;
+  return redacted;
+}
+
+/**
  * Builds a dictionary representation of the LLM request for tracing.
  *
  * This function prepares a dictionary representation of the LlmRequest
@@ -393,6 +411,9 @@ function buildLlmRequestForTrace(
   if (llmRequest.config) {
     // Create a clean config object, pruning responseSchema to reduce noise size
     const {responseSchema: _responseSchema, ...cleanConfig} = llmRequest.config;
+    if (cleanConfig.httpOptions) {
+      cleanConfig.httpOptions = redactHttpOptions(cleanConfig.httpOptions);
+    }
     result.config = cleanConfig;
   }
 

--- a/core/test/telemetry/tracing_test.ts
+++ b/core/test/telemetry/tracing_test.ts
@@ -288,5 +288,46 @@ describe('Telemetry Tracing Functions', () => {
         expect.anything(),
       );
     });
+
+    it('should not serialize credential-bearing httpOptions fields', () => {
+      // Arrange
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      const httpOptions = {
+        baseUrl: 'https://example.test',
+        headers: {Authorization: 'Bearer sentinel-secret-token'},
+        extraBody: {apiKey: 'sentinel-secret-token'},
+      };
+      const llmRequest = {
+        ...mockLlmRequest,
+        config: {temperature: 0.1, httpOptions},
+      };
+
+      // Act
+      traceCallLlm({
+        invocationContext: mockInvocationContext,
+        eventId: 'test-event-id',
+        llmRequest,
+        llmResponse: mockLlmResponse,
+      });
+
+      // Assert
+      const serialized: string =
+        mockSpan.setAttributes.mock.calls[0][0]['gcp.vertex.agent.llm_request'];
+      expect(serialized).not.toContain('sentinel-secret-token');
+      expect(serialized).not.toContain('Authorization');
+
+      const traced = JSON.parse(serialized);
+      expect(traced.config.httpOptions).toEqual({
+        baseUrl: 'https://example.test',
+      });
+      expect(traced.config.temperature).toBe(0.1);
+
+      // The config the SDK will actually send must be untouched.
+      expect(llmRequest.config.httpOptions).toBe(httpOptions);
+      expect(httpOptions.headers).toEqual({
+        Authorization: 'Bearer sentinel-secret-token',
+      });
+      expect(httpOptions.extraBody).toEqual({apiKey: 'sentinel-secret-token'});
+    });
   });
 });

--- a/core/test/telemetry/tracing_test.ts
+++ b/core/test/telemetry/tracing_test.ts
@@ -320,5 +320,46 @@ describe('Telemetry Tracing Functions', () => {
       expect(tracedRequest.config).not.toHaveProperty('responseSchema');
       expect(tracedRequest.config).toEqual({topP: 0.8, maxOutputTokens: 100});
     });
+
+    it('should not serialize credential-bearing httpOptions fields', () => {
+      // Arrange
+      vi.mocked(trace.getActiveSpan).mockReturnValue(mockSpan);
+      const httpOptions = {
+        baseUrl: 'https://example.test',
+        headers: {Authorization: 'Bearer sentinel-secret-token'},
+        extraBody: {apiKey: 'sentinel-secret-token'},
+      };
+      const llmRequest = {
+        ...mockLlmRequest,
+        config: {temperature: 0.1, httpOptions},
+      };
+
+      // Act
+      traceCallLlm({
+        invocationContext: mockInvocationContext,
+        eventId: 'test-event-id',
+        llmRequest,
+        llmResponse: mockLlmResponse,
+      });
+
+      // Assert
+      const serialized: string =
+        mockSpan.setAttributes.mock.calls[0][0]['gcp.vertex.agent.llm_request'];
+      expect(serialized).not.toContain('sentinel-secret-token');
+      expect(serialized).not.toContain('Authorization');
+
+      const traced = JSON.parse(serialized);
+      expect(traced.config.httpOptions).toEqual({
+        baseUrl: 'https://example.test',
+      });
+      expect(traced.config.temperature).toBe(0.1);
+
+      // The config the SDK will actually send must be untouched.
+      expect(llmRequest.config.httpOptions).toBe(httpOptions);
+      expect(httpOptions.headers).toEqual({
+        Authorization: 'Bearer sentinel-secret-token',
+      });
+      expect(httpOptions.extraBody).toEqual({apiKey: 'sentinel-secret-token'});
+    });
   });
 });


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**

`GenerateContentConfig.httpOptions` holds two caller-supplied passthrough
fields: `headers`, which is where an agent sets an `Authorization` header, and
`extraBody`, a free-form request-body passthrough. `BasicLlmRequestProcessor`
copies the agent's `generateContentConfig` onto the request, and
`buildLlmRequestForTrace` then serialized that config in full into the
`gcp.vertex.agent.llm_request` span attribute. Span content capture is on by
default, so whatever an agent had put in those two fields was written into
exported spans along with the rest of the request.

**Solution:**

`buildLlmRequestForTrace` now replaces `config.httpOptions` with a copy that
omits `headers` and `extraBody`. The remaining fields — `baseUrl`,
`baseUrlResourceScope`, `apiVersion`, `timeout`, `retryOptions` — are still
traced: they are useful when debugging a request and hold nothing the caller
supplied as a credential. This mirrors the exclusion `adk-python` applies in
`_build_llm_request_for_trace`.

The helper returns a new object instead of deleting keys in place.
`llmRequest.config.httpOptions` is the same object as the agent's own
`generateContentConfig.httpOptions`, so an in-place delete would also strip the
header from the real requests that follow. A test pins that the request object
is left untouched.

Parity note: `adk-python` additionally excludes `client_args`,
`async_client_args` and the live HTTP client fields. `HttpOptions` in
`@google/genai` has no equivalent members, so `{headers, extraBody}` is the
complete caller-supplied set for the TypeScript type.

Behaviour change: anything reading request headers back off the
`gcp.vertex.agent.llm_request` attribute will stop seeing them. That is the
intended effect of the change.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New test in `core/test/telemetry/tracing_test.ts`: `'should not serialize
credential-bearing httpOptions fields'`. It asserts that the sentinel value is
absent from the serialized attribute, that `baseUrl` survives the redaction, and
that the `llmRequest` object passed in is not mutated.

The test is load-bearing: with the two-line `if (cleanConfig.httpOptions)` hunk
removed, it fails on the sentinel while the six pre-existing tests in the file
still pass.

Commands run on this commit:

- `npx vitest run --project unit:core core/test/telemetry` → 20 passed
- `npm run ts:check` → clean
- `npx eslint core/src/telemetry/tracing.ts core/test/telemetry/tracing_test.ts` → clean
- `npx prettier --check` on both changed files → clean
- `npx secretlint` on both changed files → clean

Coverage of the new code: the helper and the redacting branch are covered by the
new test; the non-redacting branch is covered by the two existing `traceCallLlm`
tests.

**Manual End-to-End (E2E) Tests:**

To verify by hand: run any sample agent with
`generateContentConfig.httpOptions.headers = {Authorization: 'Bearer
manual-check'}` and an OpenTelemetry console exporter. The exported
`gcp.vertex.agent.llm_request` attribute should not contain `manual-check`, and
the request itself should still succeed — the header must still reach the model
call.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The change is confined to the tracing path. It does not alter what is sent to
the model, only what is recorded on the span.
