### PR TITLE
fix(tools): reject an unusable OpenAPI HTTP credential instead of sending an unauthenticated request

### DIFF
--- a/core/src/tools/openapi_tool/auth/auth_helpers.ts
+++ b/core/src/tools/openapi_tool/auth/auth_helpers.ts
@@ -5,16 +5,24 @@
  */
 
 import {OpenAPIV3} from 'openapi-types';
-import {AuthCredential} from '../../../auth/auth_credential.js';
+import {
+  AuthCredential,
+  AuthCredentialTypes,
+} from '../../../auth/auth_credential.js';
 
 /**
  * Applies the given credential to the request headers and URL.
+ *
+ * An HTTP credential that carries no usable token throws, so the caller never
+ * sends an unauthenticated request in place of an authenticated one.
  *
  * @param url The target URL.
  * @param headers The request headers.
  * @param credential The auth credential.
  * @param authScheme The auth scheme from OpenAPI spec.
  * @returns The updated URL (if modified by query params).
+ * @throws {Error} If an HTTP credential holds basic credentials, or holds no
+ *   credentials at all.
  */
 export function applyCredential(
   url: string,
@@ -44,11 +52,21 @@ export function applyCredential(
       headers['Authorization'] = credential.apiKey;
     }
   } else if (
-    credential.http &&
-    credential.http.credentials &&
-    credential.http.credentials.token
+    credential.authType === AuthCredentialTypes.HTTP ||
+    credential.http
   ) {
-    headers['Authorization'] = `Bearer ${credential.http.credentials.token}`;
+    const httpCredentials = credential.http?.credentials;
+    if (httpCredentials?.token) {
+      // The 'Bearer' prefix is hardcoded, and http.scheme is ignored, to match
+      // adk-python's credential_to_param. Every exchanger in this repo mints
+      // scheme 'bearer', and any other scheme arrives without a token and
+      // throws below, so no mislabelled header reaches the wire.
+      headers['Authorization'] = `Bearer ${httpCredentials.token}`;
+    } else if (httpCredentials?.username || httpCredentials?.password) {
+      throw new Error('Basic Authentication is not supported.');
+    } else {
+      throw new Error('Invalid HTTP auth credentials');
+    }
   }
 
   return url;

--- a/core/test/tools/openapi_tool/auth_helpers_test.ts
+++ b/core/test/tools/openapi_tool/auth_helpers_test.ts
@@ -114,6 +114,145 @@ describe('auth_helpers', () => {
       expect(result).toBe(url);
       expect(headers['Authorization']).toBe('Bearer my_token');
     });
+
+    it('should throw for a basic credential', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
+        http: {
+          scheme: 'basic',
+          credentials: {username: 'user', password: 'password'},
+        },
+      };
+
+      expect(() => applyCredential(url, headers, credential)).toThrow(
+        'Basic Authentication is not supported.',
+      );
+      expect(headers).toEqual({});
+    });
+
+    it('should throw for a username-only credential', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
+        http: {scheme: 'basic', credentials: {username: 'user'}},
+      };
+
+      expect(() => applyCredential(url, headers, credential)).toThrow(
+        'Basic Authentication is not supported.',
+      );
+      expect(headers).toEqual({});
+    });
+
+    it('should throw for a password-only credential', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
+        http: {scheme: 'basic', credentials: {password: 'password'}},
+      };
+
+      expect(() => applyCredential(url, headers, credential)).toThrow(
+        'Basic Authentication is not supported.',
+      );
+      expect(headers).toEqual({});
+    });
+
+    it('should throw for an http credential with empty credentials', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
+        http: {scheme: 'bearer', credentials: {}},
+      };
+
+      expect(() => applyCredential(url, headers, credential)).toThrow(
+        'Invalid HTTP auth credentials',
+      );
+      expect(headers).toEqual({});
+    });
+
+    it('should throw for an HTTP credential with no http object', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
+      };
+
+      expect(() => applyCredential(url, headers, credential)).toThrow(
+        'Invalid HTTP auth credentials',
+      );
+      expect(headers).toEqual({});
+    });
+
+    it('should still send a bearer token when the scheme is not bearer', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
+        http: {scheme: 'basic', credentials: {token: 'my_token'}},
+      };
+
+      const result = applyCredential(url, headers, credential);
+
+      expect(result).toBe(url);
+      expect(headers['Authorization']).toBe('Bearer my_token');
+    });
+
+    it('should apply a bearer token carried under another auth type', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.OAUTH2,
+        http: {scheme: 'bearer', credentials: {token: 'my_token'}},
+      };
+
+      const result = applyCredential(url, headers, credential);
+
+      expect(result).toBe(url);
+      expect(headers['Authorization']).toBe('Bearer my_token');
+    });
+
+    it('should prefer the api key over an unsupported http credential', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.API_KEY,
+        apiKey: 'secret_key',
+        http: {
+          scheme: 'basic',
+          credentials: {username: 'user', password: 'password'},
+        },
+      };
+
+      const result = applyCredential(
+        url,
+        headers,
+        credential,
+        createApiKeyScheme('X-API-Key', 'header'),
+      );
+
+      expect(result).toBe(url);
+      expect(headers['X-API-Key']).toBe('secret_key');
+    });
+
+    it('should not name the credentials in the error message', () => {
+      const url = 'http://example.com';
+      const headers: Record<string, string> = {};
+      const credential: AuthCredential = {
+        authType: AuthCredentialTypes.HTTP,
+        http: {
+          scheme: 'basic',
+          credentials: {username: 'ripley', password: 'hunter2'},
+        },
+      };
+
+      expect(() => applyCredential(url, headers, credential)).toThrow(
+        /^Basic Authentication is not supported\.$/,
+      );
+    });
   });
 
   describe('createApiKeyScheme', () => {

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -10,7 +10,11 @@ import {
   AuthCredentialTypes,
   Context,
   createRestApiTool,
+  createSession,
+  InvocationContext,
+  LlmAgent,
   OpenApiSpecParser,
+  PluginManager,
   RestApiTool,
   ToolAuthHandler,
 } from '@google/adk';
@@ -542,34 +546,36 @@ describe('RestApiTool', () => {
       type: 'http',
       scheme: 'basic',
     };
+    const authCredential: AuthCredential = {
+      authType: AuthCredentialTypes.HTTP,
+      http: {
+        scheme: 'basic',
+        credentials: {username: 'user', password: 'password'},
+      },
+    };
     const tool = new RestApiTool(
       'test_tool',
       'description',
       endpoint,
       operation,
       authScheme,
+      authCredential,
     );
 
     globalThis.fetch = vi.fn();
 
-    const mockAuthHandler = {
-      prepareAuthCredentials: async () => ({
-        state: 'done',
-        authCredential: {
-          authType: AuthCredentialTypes.HTTP,
-          http: {
-            scheme: 'basic',
-            credentials: {username: 'user', password: 'password'},
-          },
-        },
-      }),
-    };
-    vi.spyOn(ToolAuthHandler, 'fromToolContext').mockReturnValue(
-      mockAuthHandler as unknown as ToolAuthHandler,
-    );
-
     await expect(
-      tool.runAsync({args: {}, toolContext: {} as unknown as Context}),
+      tool.runAsync({
+        args: {},
+        toolContext: new Context({
+          invocationContext: new InvocationContext({
+            invocationId: 'invocation-1',
+            agent: new LlmAgent({name: 'test_agent'}),
+            session: createSession({id: 'session-1', appName: 'test_app'}),
+            pluginManager: new PluginManager(),
+          }),
+        }),
+      }),
     ).rejects.toThrow('Basic Authentication is not supported.');
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });

--- a/core/test/tools/openapi_tool/rest_api_tool_test.ts
+++ b/core/test/tools/openapi_tool/rest_api_tool_test.ts
@@ -531,6 +531,49 @@ describe('RestApiTool', () => {
     );
   });
 
+  it('should send no request for a basic auth credential', async () => {
+    const endpoint = {
+      baseUrl: 'http://api.example.com',
+      path: '/test',
+      method: 'GET',
+    };
+    const operation: OpenAPIV3.OperationObject = {responses: {}};
+    const authScheme: OpenAPIV3.SecuritySchemeObject = {
+      type: 'http',
+      scheme: 'basic',
+    };
+    const tool = new RestApiTool(
+      'test_tool',
+      'description',
+      endpoint,
+      operation,
+      authScheme,
+    );
+
+    globalThis.fetch = vi.fn();
+
+    const mockAuthHandler = {
+      prepareAuthCredentials: async () => ({
+        state: 'done',
+        authCredential: {
+          authType: AuthCredentialTypes.HTTP,
+          http: {
+            scheme: 'basic',
+            credentials: {username: 'user', password: 'password'},
+          },
+        },
+      }),
+    };
+    vi.spyOn(ToolAuthHandler, 'fromToolContext').mockReturnValue(
+      mockAuthHandler as unknown as ToolAuthHandler,
+    );
+
+    await expect(
+      tool.runAsync({args: {}, toolContext: {} as unknown as Context}),
+    ).rejects.toThrow('Basic Authentication is not supported.');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('should fallback to JSON if no requestBody in spec', async () => {
     const endpoint = {
       baseUrl: 'http://api.example.com',


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**

`applyCredential()` in `core/src/tools/openapi_tool/auth/auth_helpers.ts` only
matched an HTTP credential that carries a token:

```ts
} else if (
  credential.http &&
  credential.http.credentials &&
  credential.http.credentials.token
) {
  headers['Authorization'] = `Bearer ${credential.http.credentials.token}`;
}
```

Any other HTTP credential shape matched no branch and fell through, so
`RestApiTool` went on to `globalThis.fetch` with no `Authorization` header. A
credential the caller configured was silently dropped and the request went out
unauthenticated instead of failing. Three shapes took that path:

- `http.credentials` holding `username`/`password` (a `basic` scheme),
- `http.credentials` present but empty,
- `authType: HTTP` with no `http` object at all.

The observable result was an opaque `401` from the remote API with nothing
pointing back at ADK, which is a confusing way to learn that the credential was
never applied. Sending the request without authentication is also the wrong
default: refusing is the safer outcome when a configured credential cannot be
honoured.

**Solution:**

`applyCredential()` now throws for an HTTP credential it cannot apply, before
any header is written and before `globalThis.fetch` is reached, so no
unauthenticated request goes out in place of an authenticated one. The API-key
branch is untouched, and a token-bearing HTTP credential still produces the same
`Authorization: Bearer <token>` header as before.

The messages match `adk-python`'s `credential_to_param`:
`Basic Authentication is not supported.` for username/password, and
`Invalid HTTP auth credentials` for an HTTP credential that carries nothing
usable. This brings the two SDKs to the same behaviour for the same input.

**Behaviour change:** the three shapes listed above previously returned quietly
and now throw. Each of them already failed to authenticate, so nothing that
worked before stops working — the failure just becomes visible at the call site
instead of arriving later as a remote `401`. No source or test in this
repository constructs those shapes; the only in-repo producer of an HTTP
credential is `service_account_exchanger.ts`, which always sets a token.

**On `http.scheme`:** the `Bearer` prefix stays hardcoded and `http.scheme` is
still ignored, matching `adk-python`. Interpolating the scheme would put
`Authorization: basic <opaque-token>` on the wire, which is not RFC 7617 and
would be rejected by the peer — a new silent failure in place of the old one.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

No existing test was modified or removed. Nine cases were added to the existing
`describe('applyCredential')` in `auth_helpers_test.ts`, covering each rejected
shape, each error message, and the unchanged API-key and bearer-token paths.
One case in `rest_api_tool_test.ts` covers the end-to-end symptom: it builds a
real `Context`, `InvocationContext` and `Session`, runs the real
`ToolAuthHandler` and credential exchanger with only `fetch` stubbed, and
asserts that `runAsync` rejects and that `fetch` is never called.

Commands run on this commit, rebased onto `main`:

```
npx vitest run --project unit:core core/test/tools/openapi_tool/
  # 8 files, 118 tests passed

npm run build          # clean
npm run ts:check       # clean
npm run ts:check:samples  # clean
npm run lint           # clean
npm run format:check   # clean
```

Line and branch coverage of
`core/src/tools/openapi_tool/auth/auth_helpers.ts` from `auth_helpers_test.ts`
is 100%.

Each new test was also checked against deliberately mutated source and failed
as expected:

1. Restoring the original two-branch chain — six unit cases fail with
   `expected [Function] to throw an error`, and the `rest_api_tool_test.ts`
   case fails with `promise resolved "{ error: 'Failed to execute API call…' }"
   instead of rejecting`, i.e. the request reaches `fetch`.
2. Replacing `` `Bearer ${token}` `` with `` `${credential.http?.scheme} ${token}` `` —
   three cases fail, including `expected 'basic my_token' to be 'Bearer my_token'`
   and the pre-existing `should apply bearer token`.
3. Swapping the two error messages — six cases fail.

**Manual End-to-End (E2E) Tests:**

No live endpoint is required; the added `rest_api_tool_test.ts` case exercises
the same path through the real auth handler. Configuring an `OpenAPIToolset`
with an `http`/`basic` security scheme and a username/password credential
previously produced a request with no `Authorization` header; it now throws
`Basic Authentication is not supported.` before the request is built.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

`applyCredential()` has one production caller, `RestApiTool.call()` at
`core/src/tools/openapi_tool/rest_api_tool.ts`. The throw is raised before the
`try` block that wraps `fetch`, so it propagates to the caller rather than being
folded into the `{error: 'Failed to execute API call: …'}` return value — the
failure is reported as a rejection, not as a tool result that looks like a
remote error.
