### PR TITLE
fix(core): redact inline data payloads from the resumption debug event dump

### DIFF
--- a/core/src/runner/runner.ts
+++ b/core/src/runner/runner.ts
@@ -42,6 +42,7 @@ import {
 import {BaseToolset, isBaseToolset} from '../tools/base_toolset.js';
 import {logger} from '../utils/logger.js';
 import {isGemini2OrAbove} from '../utils/model_name.js';
+import {stringifyWithRedactedInlineData} from '../utils/redact_inline_data.js';
 import type {RunnableNode} from '../workflow/graph.js';
 import {
   asRunnableRoot,
@@ -844,7 +845,7 @@ export function determineAgentForResumption(
   // =========================================================================
   // simplicity: O(N) backward event scan, upgrade to indexed lookups or map if N > 1000.
   for (let i = session.events.length - 1; i >= 0; i--) {
-    logger.debug('event:', JSON.stringify(session.events[i]));
+    logger.debug('event:', stringifyWithRedactedInlineData(session.events[i]));
     const event = session.events[i];
     if (event.author === 'user' || !event.author) {
       continue;

--- a/core/src/utils/redact_inline_data.ts
+++ b/core/src/utils/redact_inline_data.ts
@@ -5,46 +5,22 @@
  */
 
 /**
- * The property name a `@google/genai` `Blob` is nested under, at every depth of
- * a `Content` graph.
- */
-const INLINE_DATA_KEY = 'inlineData';
-
-/** Narrows a replacer value to a blob that carries a string payload. */
-function isBlobWithData(
-  value: unknown,
-): value is Record<string, unknown> & {data: string} {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as {data?: unknown}).data === 'string'
-  );
-}
-
-/**
  * Serializes a value as JSON with every inline attachment payload elided.
  *
  * An `Event` carrying an image, an audio clip or a PDF holds the whole
  * attachment as a base64 string at `content.parts[].inlineData.data`. Passing
  * such an event to `JSON.stringify` writes those bytes into whatever collects
- * the log: log files, orchestrator captures, and anything pasted into a bug
- * report, which is a different trust boundary from whoever uploaded the file.
- * The payload also costs a full string copy on every call, even when the log
- * level discards the result.
- *
- * Every property named `inlineData` whose value carries a string `data` is
- * emitted with that payload replaced by a fixed-size marker recording how many
- * characters were elided. The descriptive fields of the blob (`mimeType`,
- * `displayName`) survive, matching what `google/adk-python` keeps in
- * `DebugLoggingPlugin`. Every other field is serialized as before, so the
- * result is still valid JSON.
- *
- * A value that is not shaped like a blob passes through untouched, and a
- * circular graph still throws exactly as `JSON.stringify` does.
+ * the log, which is a different trust boundary from whoever uploaded the file.
+ * Each blob keeps its descriptive fields and reports how many characters were
+ * elided in place of the payload.
  */
 export function stringifyWithRedactedInlineData(value: unknown): string {
   return JSON.stringify(value, (key: string, val: unknown) =>
-    key === INLINE_DATA_KEY && isBlobWithData(val)
+    key === 'inlineData' &&
+    typeof val === 'object' &&
+    val !== null &&
+    'data' in val &&
+    typeof val.data === 'string'
       ? {...val, data: `<redacted ${val.data.length} chars>`}
       : val,
   );

--- a/core/src/utils/redact_inline_data.ts
+++ b/core/src/utils/redact_inline_data.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The property name a `@google/genai` `Blob` is nested under, at every depth of
+ * a `Content` graph.
+ */
+const INLINE_DATA_KEY = 'inlineData';
+
+/** Narrows a replacer value to a blob that carries a string payload. */
+function isBlobWithData(
+  value: unknown,
+): value is Record<string, unknown> & {data: string} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as {data?: unknown}).data === 'string'
+  );
+}
+
+/**
+ * Serializes a value as JSON with every inline attachment payload elided.
+ *
+ * An `Event` carrying an image, an audio clip or a PDF holds the whole
+ * attachment as a base64 string at `content.parts[].inlineData.data`. Passing
+ * such an event to `JSON.stringify` writes those bytes into whatever collects
+ * the log: log files, orchestrator captures, and anything pasted into a bug
+ * report, which is a different trust boundary from whoever uploaded the file.
+ * The payload also costs a full string copy on every call, even when the log
+ * level discards the result.
+ *
+ * Every property named `inlineData` whose value carries a string `data` is
+ * emitted with that payload replaced by a fixed-size marker recording how many
+ * characters were elided. The descriptive fields of the blob (`mimeType`,
+ * `displayName`) survive, matching what `google/adk-python` keeps in
+ * `DebugLoggingPlugin`. Every other field is serialized as before, so the
+ * result is still valid JSON.
+ *
+ * A value that is not shaped like a blob passes through untouched, and a
+ * circular graph still throws exactly as `JSON.stringify` does.
+ */
+export function stringifyWithRedactedInlineData(value: unknown): string {
+  return JSON.stringify(value, (key: string, val: unknown) =>
+    key === INLINE_DATA_KEY && isBlobWithData(val)
+      ? {...val, data: `<redacted ${val.data.length} chars>`}
+      : val,
+  );
+}

--- a/core/test/runner/runner_test.ts
+++ b/core/test/runner/runner_test.ts
@@ -505,6 +505,41 @@ describe('Runner.determineAgentForResumption', () => {
     expect(result.name).toBe('sub_agent1');
   });
 
+  it('does not write an inline attachment payload to the debug log', async () => {
+    const payload = 'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNk';
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const session = await sessionService.createSession({
+      appName: TEST_APP_ID,
+      userId: TEST_USER_ID,
+      sessionId: 'session_inline_data',
+    });
+    await sessionService.appendEvent({
+      session,
+      event: createEvent({
+        invocationId: 'inv1',
+        author: 'sub_agent1',
+        content: {
+          role: 'model',
+          parts: [{inlineData: {mimeType: 'image/png', data: payload}}],
+        },
+      }),
+    });
+
+    const result = determineAgentForResumption(
+      session,
+      rootAgent,
+      createResumabilityConfig({isResumable: true}),
+    );
+
+    const logged = debugSpy.mock.calls.flat().join('\n');
+    expect(logged).not.toContain(payload);
+    expect(logged).toContain('image/png');
+    expect(logged).toContain(`<redacted ${payload.length} chars>`);
+    expect(result.name).toBe('sub_agent1');
+    debugSpy.mockRestore();
+  });
+
   describe('graph-workflow node events', () => {
     /** A session holding the given events. */
     async function sessionWith(sessionId: string, events: Event[]) {

--- a/core/test/utils/redact_inline_data_test.ts
+++ b/core/test/utils/redact_inline_data_test.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+import {stringifyWithRedactedInlineData} from '../../src/utils/redact_inline_data.js';
+
+const PAYLOAD = 'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNk';
+
+describe('stringifyWithRedactedInlineData', () => {
+  it('drops the payload of an inline blob but keeps its mime type', () => {
+    const out = stringifyWithRedactedInlineData({
+      content: {
+        role: 'model',
+        parts: [{inlineData: {mimeType: 'image/png', data: PAYLOAD}}],
+      },
+    });
+
+    expect(out).not.toContain(PAYLOAD);
+    expect(out).toContain('image/png');
+    expect(out).toContain('<redacted');
+  });
+
+  it('reports the character count of the elided payload', () => {
+    const payload = 'a'.repeat(36);
+
+    expect(
+      stringifyWithRedactedInlineData({
+        inlineData: {mimeType: 'audio/wav', data: payload},
+      }),
+    ).toBe(
+      '{"inlineData":{"mimeType":"audio/wav","data":"<redacted 36 chars>"}}',
+    );
+  });
+
+  it('keeps every sibling field of the blob', () => {
+    const out = stringifyWithRedactedInlineData({
+      inlineData: {
+        mimeType: 'application/pdf',
+        displayName: 'invoice.pdf',
+        data: PAYLOAD,
+      },
+    });
+
+    expect(JSON.parse(out)).toEqual({
+      inlineData: {
+        mimeType: 'application/pdf',
+        displayName: 'invoice.pdf',
+        data: `<redacted ${PAYLOAD.length} chars>`,
+      },
+    });
+  });
+
+  it('serializes a text-only event exactly as JSON.stringify does', () => {
+    const event = {
+      id: 'e1',
+      author: 'sub_agent1',
+      content: {role: 'model', parts: [{text: 'Hello'}]},
+    };
+
+    expect(stringifyWithRedactedInlineData(event)).toBe(JSON.stringify(event));
+  });
+
+  it('redacts repeated and deeply nested blobs alike', () => {
+    const out = stringifyWithRedactedInlineData({
+      content: {
+        parts: [
+          {inlineData: {mimeType: 'image/png', data: PAYLOAD}},
+          {inlineData: {mimeType: 'image/jpeg', data: PAYLOAD}},
+          {
+            functionResponse: {
+              name: 'load_file',
+              response: {
+                blob: {
+                  inlineData: {mimeType: 'application/pdf', data: PAYLOAD},
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(out).not.toContain(PAYLOAD);
+    expect(out.match(/<redacted \d+ chars>/g)).toHaveLength(3);
+    expect(out).toContain('application/pdf');
+  });
+
+  it('passes a null inlineData through untouched', () => {
+    expect(stringifyWithRedactedInlineData({inlineData: null})).toBe(
+      '{"inlineData":null}',
+    );
+  });
+
+  it('passes an inlineData whose data is not a string through untouched', () => {
+    expect(
+      stringifyWithRedactedInlineData({inlineData: {mimeType: 'x', data: 7}}),
+    ).toBe('{"inlineData":{"mimeType":"x","data":7}}');
+  });
+
+  it('leaves a data property that is not under inlineData alone', () => {
+    expect(stringifyWithRedactedInlineData({data: PAYLOAD})).toBe(
+      JSON.stringify({data: PAYLOAD}),
+    );
+  });
+
+  it('returns JSON that parses back to a well-formed object', () => {
+    const parsed: unknown = JSON.parse(
+      stringifyWithRedactedInlineData({
+        author: 'sub_agent1',
+        content: {parts: [{inlineData: {mimeType: 'image/png', data: 'AAAA'}}]},
+      }),
+    );
+
+    expect(parsed).toEqual({
+      author: 'sub_agent1',
+      content: {
+        parts: [
+          {inlineData: {mimeType: 'image/png', data: '<redacted 4 chars>'}},
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

None.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`determineAgentForResumption` serializes every event it scans with
`JSON.stringify` (`core/src/runner/runner.ts:848`). When a turn carries an image,
an audio clip or a PDF, the attachment is held as a base64 string at
`content.parts[].inlineData.data`, so the whole payload is written into the debug
log output rather than a short description of it. Application content therefore
ends up in log sinks that are generally retained and read differently from
session storage.

Two smaller points follow from the same line. `logger.debug` evaluates its
arguments before the logger checks the configured level, so the serialized string
is built on every call regardless of level and discarded when debug logging is
off. And the resulting line is unbounded in size, since it grows with the
attachment.

**Solution:**

Add `core/src/utils/redact_inline_data.ts`, which serializes through a
`JSON.stringify` replacer. Any property named `inlineData` whose `data` is a
string keeps its descriptive fields (`mimeType`, `displayName`) and reports the
elided character count in place of the payload. This matches the fields
`adk-python`'s `DebugLoggingPlugin._serialize_content` keeps, and mirrors the
shape of the existing `core/src/utils/redact_uri.ts`.

The replacer runs at every depth, so it covers both `inlineData` shapes the SDK
defines — `Part.inlineData` and `FunctionResponsePart.inlineData` — including
blobs nested inside a function response. Values that are not string payloads pass
through untouched, so non-attachment data is serialized exactly as before.

A replacer avoids cloning the event into an intermediate object. The util is
internal: it is not exported from `core/src/index.ts` or `core/src/common.ts`, so
there is no public surface change.

The debug line now reads:

```
event: {"invocationId":"inv1","author":"sub_agent1","content":{"role":"model","parts":[{"inlineData":{"mimeType":"image/png","data":"<redacted 36 chars>"}}]}, ...}
```

`determineAgentForResumption` selects the same agent as before; only the log text
changes.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`npx vitest run --project unit:core core/test/utils/redact_inline_data_test.ts core/test/runner/runner_test.ts`
→ **51 passed** (9 new util tests, 1 new runner test; no existing test modified or
removed). The new util is at 100% line, branch, function and statement coverage.

The nine util tests cover: redaction of a blob while the mime type survives, the
elided character count, preservation of sibling fields, a text-only event
serialized byte-identically to `JSON.stringify`, repeated blobs and a blob nested
under a `functionResponse`, the two type-guard negatives (`inlineData: null` and a
numeric `data`), a `data` key that is not under `inlineData`, and a `JSON.parse`
round trip.

The tests were confirmed to be able to fail. Restoring the plain
`JSON.stringify(session.events[i])` call makes the new runner test fail on the
payload appearing in the captured log; removing the replacer makes five of the
nine util tests fail.

**Manual End-to-End (E2E) Tests:**

With debug logging enabled, append a `sub_agent1` event whose content carries an
inline blob, then resolve the resumption agent:

```ts
setLogLevel(LogLevel.DEBUG);
// session holds a sub_agent1 event with
// {inlineData: {mimeType: 'image/png', data: '<36-char base64 string>'}}
determineAgentForResumption(
  session,
  root,
  createResumabilityConfig({isResumable: true}),
);
```

The console prints `"inlineData":{"mimeType":"image/png","data":"<redacted 36 chars>"}`,
the base64 string does not appear in the output, and the selected agent is still
`sub_agent1`.

Repository checks on this branch: `npm run build`, `npm run ts:check`,
`npm run ts:check:samples`, `npm run lint`, `npm run format:check`,
`npm run docs:check` and `npx secretlint` all pass. `package-lock.json` is
unchanged.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This only changes how the resumption scan writes events to the debug log. Other
call sites that serialize events are untouched; the helper is available for them
if the same treatment is wanted later.
