### PR TITLE
fix(auth): reject an empty credentialKey before storing the auth credential

### DIFF
--- a/core/src/auth/auth_handler.ts
+++ b/core/src/auth/auth_handler.ts
@@ -25,7 +25,17 @@ export class AuthHandler {
     return state.get<AuthCredential>(credentialKey);
   }
 
+  /**
+   * Stores the exchanged credential in the session state.
+   *
+   * @param state The session state to store the credential in.
+   * @throws Error: If the auth config has no credentialKey.
+   */
   async parseAndStoreAuthResponse(state: State): Promise<void> {
+    if (!this.authConfig.credentialKey) {
+      throw new Error('credentialKey is empty.');
+    }
+
     const credentialKey = 'temp:' + this.authConfig.credentialKey;
 
     const authSchemeType = this.authConfig.authScheme.type;

--- a/core/test/auth/auth_handler_test.ts
+++ b/core/test/auth/auth_handler_test.ts
@@ -115,6 +115,72 @@ describe('AuthHandler', () => {
         oauth2: {accessToken: 'mockAccessToken'},
       });
     });
+
+    it('throws when credentialKey is an empty string', async () => {
+      const authConfig: AuthConfig = {
+        credentialKey: '',
+        authScheme: {type: 'apiKey', name: 'testKey', in: 'header'},
+        exchangedAuthCredential: {
+          authType: AuthCredentialTypes.API_KEY,
+          apiKey: 'testToken',
+        },
+      };
+      const handler = new AuthHandler(authConfig);
+      const state = new State();
+
+      await expect(handler.parseAndStoreAuthResponse(state)).rejects.toThrow(
+        'credentialKey is empty.',
+      );
+      expect(state.get('temp:')).toBeUndefined();
+      expect(state.hasDelta()).toBe(false);
+    });
+
+    it('throws when an untyped config omits credentialKey', async () => {
+      // Mirrors the unchecked cast of client-supplied args in
+      // auth_preprocessor.
+      const authConfig = {
+        authScheme: {type: 'apiKey', name: 'testKey', in: 'header'},
+        exchangedAuthCredential: {
+          authType: AuthCredentialTypes.API_KEY,
+          apiKey: 'testToken',
+        },
+      } as AuthConfig;
+      const handler = new AuthHandler(authConfig);
+      const state = new State();
+
+      await expect(handler.parseAndStoreAuthResponse(state)).rejects.toThrow(
+        'credentialKey is empty.',
+      );
+      expect(state.get('temp:undefined')).toBeUndefined();
+      expect(state.hasDelta()).toBe(false);
+    });
+
+    it('throws before exchanging an oauth2 credential', async () => {
+      const authConfig: AuthConfig = {
+        credentialKey: '',
+        authScheme: {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://auth.com',
+              tokenUrl: 'https://token.com',
+              scopes: {},
+            },
+          },
+        },
+        exchangedAuthCredential: {
+          authType: AuthCredentialTypes.OAUTH2,
+          oauth2: {authCode: '123'},
+        },
+      };
+      const handler = new AuthHandler(authConfig);
+      const state = new State();
+
+      await expect(handler.parseAndStoreAuthResponse(state)).rejects.toThrow(
+        'credentialKey is empty.',
+      );
+      expect(state.hasDelta()).toBe(false);
+    });
   });
 
   describe('generateAuthRequest', () => {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No existing issue.

**2. Or, if no issue exists, describe the change:**

**Problem:**

`AuthHandler.parseAndStoreAuthResponse` builds its session-state key by
concatenation:

```ts
const credentialKey = 'temp:' + this.authConfig.credentialKey;
```

The key is never checked first, so a falsy `credentialKey` still produces a
usable string and the credential is written to the literal slot `temp:`, or to
`temp:undefined`. Any two auth configs that reach this method without a key
therefore address the same slot instead of two distinct ones, and the second
write replaces the first.

`AuthConfig.credentialKey` is a required `string`, so the in-repo callers cannot
construct one without it. The value can still arrive absent, because the config
is read back out of a function call's `args` and cast rather than validated.

Most of that surface is already covered on `main`: `bindCredentialResponse`
returns `undefined` when the request carries no `credentialKey`, which stops
`AuthPreprocessor` before it stores anything. The path that is not covered is
`processAuthResume` in `hitl_utils`: when the resume payload is a plain value
rather than a full config, it takes the `else` branch, spreads the incoming
`authConfig` as-is and calls the handler without going through that check.

**Solution:**

Reject the empty key in the handler itself, as its first statement:

```ts
if (!this.authConfig.credentialKey) {
  throw new Error('credentialKey is empty.');
}
```

Placing it there means the check runs before any `state.set`, and before an
`OAuth2CredentialExchanger` is constructed for the oauth2 path, so no partial
work happens on the way to the error. It also holds for callers added later,
rather than relying on each one validating first.

This matches `google/adk-python`, whose `AuthHandler.parse_and_store_auth_response`
raises on `if not credential_key`. The guard is a plain falsy check with no
trimming or format rules, so the accepted set of keys is unchanged for every
caller that already supplies one.

Scope notes:

- `AuthConfig.credentialKey` stays a required `string`. Widening it to optional
  would push nullability onto every caller for a value that only arrives absent
  through a cast.
- The two callers now propagate the error. `adk-python` does the same and adds
  no `try`.
- The read path, `getAuthResponse`, is left alone here to keep the change small.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Three cases were appended to the existing `describe('parseAndStoreAuthResponse')`
block in `core/test/auth/auth_handler_test.ts`: an empty-string key, an untyped
config that omits the key entirely, and an oauth2 scheme that must be rejected
before the exchange. Each asserts the rejection, that the junk slot is empty,
and that `state.hasDelta()` is `false` — that is, that nothing was written. The
existing tests in that block are unmodified.

```
npx vitest run --project unit:core core/test/auth/auth_handler_test.ts
  Test Files  1 passed (1)
       Tests  20 passed (20)        # 17 existing + 3 new

npx vitest run --project unit:core core/test/auth/auth_preprocessor_test.ts \
    core/test/workflow/hitl_test.ts core/test/workflow/auth_gate_test.ts
  Test Files  3 passed (3)
       Tests  50 passed (50)        # the two call sites and the auth gate

npx eslint   core/src/auth/auth_handler.ts core/test/auth/auth_handler_test.ts   # clean
npx prettier --check core/src/auth/auth_handler.ts core/test/auth/auth_handler_test.ts
  All matched files use Prettier code style!
```

The new tests were confirmed to be load-bearing by deleting the guard and
re-running the file: all three failed with `promise resolved "undefined"
instead of rejecting`, and the 17 existing tests still passed.

**Manual End-to-End (E2E) Tests:**

No manual test applies. The type checker prevents an in-repo caller from
building an `AuthConfig` without a key, so this state is only reachable from a
malformed auth payload. The second unit test reproduces that payload using the
same cast the production path uses, which is a more faithful reproduction than
a manual run.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (Not applicable — see above.)
- [x] Any dependent changes have been merged and published in downstream modules. (None.)

### Additional context

The change is 10 added lines in `core/src/auth/auth_handler.ts` (the guard plus
a doc comment) and 66 added lines of tests. No other file is touched, and
`package-lock.json` is unchanged.
