### PR TITLE
feat(auth): emit a PKCE S256 code challenge on the OAuth2 authorization URI

### DIFF
--- a/core/src/auth/auth_credential.ts
+++ b/core/src/auth/auth_credential.ts
@@ -48,6 +48,11 @@ export interface OAuth2Auth {
   state?: string;
   codeVerifier?: string;
   /**
+   * The PKCE code challenge method. Only 'S256' is supported; any other value
+   * is rejected when the authorization URI is generated.
+   */
+  codeChallengeMethod?: string;
+  /**
    * tool or adk can decide the redirect_uri if they don't want client to decide
    */
   redirectUri?: string;

--- a/core/src/auth/auth_handler.ts
+++ b/core/src/auth/auth_handler.ts
@@ -10,6 +10,13 @@ import {randomUUID} from '../utils/env_aware_utils.js';
 import {AuthCredential} from './auth_credential.js';
 import {AuthConfig} from './auth_tool.js';
 import {OAuth2CredentialExchanger} from './oauth2/oauth2_credential_exchanger.js';
+import {
+  createS256CodeChallenge,
+  generateCodeVerifier,
+} from './oauth2/oauth2_utils.js';
+
+/** The only PKCE code challenge method this handler supports. */
+const S256_CODE_CHALLENGE_METHOD = 'S256';
 
 /**
  * A handler that handles the auth flow in Agent Development Kit to help
@@ -95,9 +102,14 @@ export class AuthHandler {
   /**
    * Generates an response containing the auth uri for user to sign in.
    *
+   * When the credential requests PKCE, the URI also carries the S256 code
+   * challenge derived from the credential's code verifier, and the returned
+   * credential carries the verifier the later token exchange must send.
+   *
    * @return An AuthCredential object containing the auth URI and state.
    * @throws Error: If the authorization endpoint is not configured in the
-   *     auth scheme.
+   *     auth scheme, or the credential requests a code challenge method other
+   *     than 'S256'.
    */
   generateAuthUri(): AuthCredential | undefined {
     const authScheme = this.authConfig.authScheme;
@@ -105,6 +117,17 @@ export class AuthHandler {
 
     if (!authCredential || !authCredential.oauth2) {
       return authCredential;
+    }
+
+    const oauth2 = authCredential.oauth2;
+    const codeChallengeMethod = oauth2.codeChallengeMethod;
+    if (
+      codeChallengeMethod &&
+      codeChallengeMethod !== S256_CODE_CHALLENGE_METHOD
+    ) {
+      throw new Error(
+        `Unsupported codeChallengeMethod: ${codeChallengeMethod}. Only '${S256_CODE_CHALLENGE_METHOD}' is supported.`,
+      );
     }
 
     let authorizationEndpoint = '';
@@ -140,23 +163,40 @@ export class AuthHandler {
 
     const state = randomUUID();
     const url = new URL(authorizationEndpoint);
-    url.searchParams.set('client_id', authCredential.oauth2.clientId || '');
-    url.searchParams.set(
-      'redirect_uri',
-      authCredential.oauth2.redirectUri || '',
-    );
+    url.searchParams.set('client_id', oauth2.clientId || '');
+    url.searchParams.set('redirect_uri', oauth2.redirectUri || '');
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('scope', scopes.join(' '));
     url.searchParams.set('state', state);
     url.searchParams.set('access_type', 'offline');
     url.searchParams.set('prompt', 'consent');
 
+    if (oauth2.audience) {
+      url.searchParams.set('audience', oauth2.audience);
+    }
+    if (oauth2.nonce) {
+      url.searchParams.set('nonce', oauth2.nonce);
+    }
+
+    // A verifier without a requested method stays off the URI: the provider
+    // has no challenge to bind it to, so advertising one would be a lie.
+    let codeVerifier = oauth2.codeVerifier;
+    if (codeChallengeMethod) {
+      codeVerifier ??= generateCodeVerifier();
+      url.searchParams.set(
+        'code_challenge',
+        createS256CodeChallenge(codeVerifier),
+      );
+      url.searchParams.set('code_challenge_method', codeChallengeMethod);
+    }
+
     const exchangedAuthCredential: AuthCredential = {
       ...authCredential,
       oauth2: {
-        ...authCredential.oauth2,
+        ...oauth2,
         authUri: url.toString(),
         state,
+        codeVerifier,
       },
     };
 

--- a/core/src/auth/oauth2/oauth2_utils.ts
+++ b/core/src/auth/oauth2/oauth2_utils.ts
@@ -4,12 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {createHash, randomBytes} from 'node:crypto';
+
 import {logger} from '../../utils/logger.js';
 import {redactUriPassword} from '../../utils/redact_uri.js';
 import {OAuth2Auth} from '../auth_credential.js';
 
 import {AuthScheme, OpenIdConnectWithConfig} from '../auth_schemes.js';
 import {validateDiscoveryUrl} from './oauth2_discovery.js';
+
+/**
+ * Bytes of entropy behind a generated PKCE code verifier. 36 bytes is a whole
+ * number of base64 groups, so it encodes to exactly 48 unreserved characters,
+ * inside the 43-128 range RFC 7636 requires, with no modulo bias.
+ */
+const CODE_VERIFIER_BYTES = 36;
+
+/**
+ * Generates a cryptographically secure PKCE code verifier (RFC 7636).
+ */
+export function generateCodeVerifier(): string {
+  return randomBytes(CODE_VERIFIER_BYTES).toString('base64url');
+}
+
+/**
+ * Derives the S256 PKCE code challenge for a code verifier (RFC 7636): the
+ * unpadded base64url encoding of the verifier's SHA-256 digest.
+ */
+export function createS256CodeChallenge(codeVerifier: string): string {
+  return createHash('sha256').update(codeVerifier).digest('base64url');
+}
 
 /**
  * Returns the token endpoint for the given auth scheme.

--- a/core/src/utils/crypto_shim.ts
+++ b/core/src/utils/crypto_shim.ts
@@ -21,3 +21,31 @@ export function randomUUID(): string {
       'present in this environment.',
   );
 }
+
+/**
+ * Stand-in for `createHash`, reached from the PKCE helpers in
+ * `auth/oauth2/oauth2_utils.ts`.
+ *
+ * A PKCE code challenge needs a synchronous SHA-256, and the Web Crypto API
+ * offers none: `crypto.subtle.digest` is asynchronous, while `generateAuthUri`
+ * is called from synchronous public API. PKCE is therefore unavailable in the
+ * bundled web build, and this throws rather than emit an authorization request
+ * with a missing or forged challenge.
+ */
+export function createHash(_algorithm: string): never {
+  throw new Error(
+    'createHash: PKCE code challenges require a synchronous SHA-256, which ' +
+      'the Web Crypto API does not provide (crypto.subtle.digest is async).',
+  );
+}
+
+/**
+ * Stand-in for `randomBytes`, reached when the PKCE helpers in
+ * `auth/oauth2/oauth2_utils.ts` generate a code verifier.
+ */
+export function randomBytes(_size: number): never {
+  throw new Error(
+    'randomBytes: no cryptographically secure source of randomness is ' +
+      'available in this environment.',
+  );
+}

--- a/core/test/auth/auth_handler_test.ts
+++ b/core/test/auth/auth_handler_test.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {AuthConfig, AuthCredentialTypes, AuthHandler, State} from '@google/adk';
+import {
+  AuthConfig,
+  AuthCredential,
+  AuthCredentialTypes,
+  AuthHandler,
+  OAuth2Auth,
+  State,
+} from '@google/adk';
+import {createHash} from 'node:crypto';
 import {describe, expect, it, vi} from 'vitest';
 
 vi.mock('../../src/auth/oauth2/oauth2_credential_exchanger.js', () => ({
@@ -18,6 +26,44 @@ vi.mock('../../src/auth/oauth2/oauth2_credential_exchanger.js', () => ({
     });
   },
 }));
+
+/** Builds an authorization-code config whose oauth2 block the test controls. */
+function authConfigWithOAuth2(oauth2: OAuth2Auth): AuthConfig {
+  return {
+    credentialKey: 'testKey',
+    authScheme: {
+      type: 'oauth2',
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://auth.com',
+          tokenUrl: 'https://token.com',
+          scopes: {scope1: 'desc'},
+        },
+      },
+    },
+    rawAuthCredential: {
+      authType: AuthCredentialTypes.OAUTH2,
+      oauth2: {
+        clientId: 'id',
+        clientSecret: 'secret',
+        redirectUri: 'https://redirect.com',
+        ...oauth2,
+      },
+    },
+  };
+}
+
+/** Reads the query parameters off a generated authorization URI. */
+function authUriParams(
+  credential: AuthCredential | undefined,
+): URLSearchParams {
+  const authUri = credential?.oauth2?.authUri;
+  if (!authUri) {
+    expect.fail('expected the generated credential to carry an auth URI');
+  }
+
+  return new URL(authUri).searchParams;
+}
 
 describe('AuthHandler', () => {
   describe('getAuthResponse', () => {
@@ -402,6 +448,168 @@ describe('AuthHandler', () => {
 
       expect(uri).toBeDefined();
       expect(uri?.oauth2?.authUri).toContain('https://token.com');
+    });
+
+    it('emits the S256 code challenge and its method when PKCE is requested', () => {
+      const handler = new AuthHandler(
+        authConfigWithOAuth2({codeChallengeMethod: 'S256'}),
+      );
+
+      const params = authUriParams(handler.generateAuthUri());
+
+      expect(params.get('code_challenge_method')).toBe('S256');
+      expect(params.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    });
+
+    it('emits a code challenge that is the SHA-256 of the returned verifier', () => {
+      const handler = new AuthHandler(
+        authConfigWithOAuth2({codeChallengeMethod: 'S256'}),
+      );
+
+      const uri = handler.generateAuthUri();
+      const verifier = uri?.oauth2?.codeVerifier;
+      if (!verifier) {
+        expect.fail('expected the generated credential to carry a verifier');
+      }
+
+      expect(authUriParams(uri).get('code_challenge')).toBe(
+        createHash('sha256').update(verifier).digest('base64url'),
+      );
+    });
+
+    it('generates a 48-character verifier when the credential supplies none', () => {
+      const handler = new AuthHandler(
+        authConfigWithOAuth2({codeChallengeMethod: 'S256'}),
+      );
+
+      const uri = handler.generateAuthUri();
+
+      expect(uri?.oauth2?.codeVerifier).toHaveLength(48);
+      expect(uri?.oauth2?.codeVerifier).toMatch(/^[A-Za-z0-9\-._~]+$/);
+    });
+
+    it('does not repeat a generated verifier across calls', () => {
+      const first = new AuthHandler(
+        authConfigWithOAuth2({codeChallengeMethod: 'S256'}),
+      ).generateAuthUri();
+      const second = new AuthHandler(
+        authConfigWithOAuth2({codeChallengeMethod: 'S256'}),
+      ).generateAuthUri();
+
+      expect(first?.oauth2?.codeVerifier).not.toBe(
+        second?.oauth2?.codeVerifier,
+      );
+    });
+
+    it('reuses a supplied codeVerifier instead of generating one', () => {
+      const handler = new AuthHandler(
+        authConfigWithOAuth2({
+          codeChallengeMethod: 'S256',
+          codeVerifier: 'supplied-verifier',
+        }),
+      );
+
+      const uri = handler.generateAuthUri();
+
+      expect(uri?.oauth2?.codeVerifier).toBe('supplied-verifier');
+      expect(authUriParams(uri).get('code_challenge')).toBe(
+        createHash('sha256').update('supplied-verifier').digest('base64url'),
+      );
+    });
+
+    it('throws for a code challenge method other than S256', () => {
+      const handler = new AuthHandler(
+        authConfigWithOAuth2({codeChallengeMethod: 'plain'}),
+      );
+
+      expect(() => handler.generateAuthUri()).toThrow(
+        /Unsupported codeChallengeMethod: plain/,
+      );
+    });
+
+    it('throws for an unsupported method even when the endpoint is missing', () => {
+      const handler = new AuthHandler({
+        credentialKey: 'testKey',
+        authScheme: {
+          type: 'oauth2',
+          flows: {clientCredentials: {tokenUrl: '', scopes: {}}},
+        },
+        rawAuthCredential: {
+          authType: AuthCredentialTypes.OAUTH2,
+          oauth2: {clientId: 'id', codeChallengeMethod: 'plain'},
+        },
+      });
+
+      expect(() => handler.generateAuthUri()).toThrow(
+        /Unsupported codeChallengeMethod: plain/,
+      );
+    });
+
+    it('omits the PKCE params when no method is requested', () => {
+      const handler = new AuthHandler(authConfigWithOAuth2({}));
+
+      const params = authUriParams(handler.generateAuthUri());
+
+      expect(params.get('code_challenge')).toBeNull();
+      expect(params.get('code_challenge_method')).toBeNull();
+    });
+
+    it('omits the PKCE params for a verifier without a method', () => {
+      const handler = new AuthHandler(
+        authConfigWithOAuth2({codeVerifier: 'supplied-verifier'}),
+      );
+
+      const uri = handler.generateAuthUri();
+      const params = authUriParams(uri);
+
+      expect(params.get('code_challenge')).toBeNull();
+      expect(params.get('code_challenge_method')).toBeNull();
+      expect(uri?.oauth2?.codeVerifier).toBe('supplied-verifier');
+    });
+
+    it('forwards the audience when the credential sets one', () => {
+      const handler = new AuthHandler(
+        authConfigWithOAuth2({audience: 'https://api.example.com'}),
+      );
+
+      const params = authUriParams(handler.generateAuthUri());
+
+      expect(params.get('audience')).toBe('https://api.example.com');
+    });
+
+    it('omits the audience when the credential sets none', () => {
+      const handler = new AuthHandler(authConfigWithOAuth2({}));
+
+      expect(
+        authUriParams(handler.generateAuthUri()).get('audience'),
+      ).toBeNull();
+    });
+
+    it('forwards the nonce when the credential sets one', () => {
+      const handler = new AuthHandler(authConfigWithOAuth2({nonce: 'n-0S6'}));
+
+      const params = authUriParams(handler.generateAuthUri());
+
+      expect(params.get('nonce')).toBe('n-0S6');
+    });
+
+    it('omits the nonce when the credential sets none', () => {
+      const handler = new AuthHandler(authConfigWithOAuth2({}));
+
+      expect(authUriParams(handler.generateAuthUri()).get('nonce')).toBeNull();
+    });
+
+    it('does not write the generated verifier back onto the raw credential', () => {
+      const authConfig = authConfigWithOAuth2({codeChallengeMethod: 'S256'});
+      const handler = new AuthHandler(authConfig);
+
+      const uri = handler.generateAuthUri();
+
+      expect(uri?.oauth2?.codeVerifier).toBeDefined();
+      expect(
+        authConfig.rawAuthCredential?.oauth2?.codeVerifier,
+      ).toBeUndefined();
+      expect(authConfig.rawAuthCredential?.oauth2?.authUri).toBeUndefined();
     });
   });
 });

--- a/core/test/auth/oauth2/oauth2_utils_test.ts
+++ b/core/test/auth/oauth2/oauth2_utils_test.ts
@@ -10,12 +10,18 @@ import {
   AuthorizationCodeParams,
   ClientCredentialsParams,
   createOAuth2TokenRequestBody,
+  createS256CodeChallenge,
   fetchOAuth2Tokens,
+  generateCodeVerifier,
   getTokenEndpoint,
   isTokenExpired,
   parseAuthorizationCode,
   RefreshTokenParams,
 } from '../../../src/auth/oauth2/oauth2_utils.js';
+import {
+  createHash as shimCreateHash,
+  randomBytes as shimRandomBytes,
+} from '../../../src/utils/crypto_shim.js';
 
 describe('oauth2_utils', () => {
   describe('getTokenEndpoint', () => {
@@ -280,6 +286,61 @@ describe('oauth2_utils', () => {
       // With 60s leeway, 30s should be considered expired
       expect(isTokenExpired({expiresAt: nearFutureTimeMs} as OAuth2Auth)).toBe(
         true,
+      );
+    });
+  });
+
+  describe('createS256CodeChallenge', () => {
+    it('matches the published SHA-256 vector for "abc"', () => {
+      expect(createS256CodeChallenge('abc')).toBe(
+        'ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0',
+      );
+    });
+
+    it('encodes base64url, so no "+", "/" or "=" survives', () => {
+      // The standard base64 digest of 'v2' is
+      // '+wTctpcOTD0Yc95R/VpQ17tGszgxE2AmZcNQ7EC1+ZA=', which carries all
+      // three characters RFC 7636 forbids in a code challenge.
+      const challenge = createS256CodeChallenge('v2');
+
+      expect(challenge).toBe('-wTctpcOTD0Yc95R_VpQ17tGszgxE2AmZcNQ7EC1-ZA');
+      expect(challenge).not.toMatch(/[+/=]/);
+    });
+
+    it('returns the 43 characters a SHA-256 digest encodes to', () => {
+      expect(createS256CodeChallenge(generateCodeVerifier())).toHaveLength(43);
+    });
+  });
+
+  describe('generateCodeVerifier', () => {
+    it('returns 48 unreserved characters', () => {
+      const verifier = generateCodeVerifier();
+
+      expect(verifier).toHaveLength(48);
+      expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/);
+    });
+
+    it('does not repeat itself across calls', () => {
+      const verifiers = new Set(
+        Array.from({length: 1000}, () => generateCodeVerifier()),
+      );
+
+      expect(verifiers.size).toBe(1000);
+    });
+  });
+
+  // The web build aliases node:crypto to this shim, so it stands in for the
+  // PKCE helpers above in a browser, where no synchronous SHA-256 exists.
+  describe('crypto_shim', () => {
+    it('throws instead of degrading when hashing a code verifier', () => {
+      expect(() => shimCreateHash('sha256')).toThrow(
+        /require a synchronous SHA-256/,
+      );
+    });
+
+    it('throws instead of degrading when generating a code verifier', () => {
+      expect(() => shimRandomBytes(36)).toThrow(
+        /no cryptographically secure source of randomness/,
       );
     });
   });

--- a/core/test/auth/pkce_round_trip_test.ts
+++ b/core/test/auth/pkce_round_trip_test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {AuthConfig, AuthCredentialTypes, AuthHandler} from '@google/adk';
+import {createHash} from 'node:crypto';
+import {describe, expect, it} from 'vitest';
+import {createOAuth2TokenRequestBody} from '../../src/auth/oauth2/oauth2_utils.js';
+
+/**
+ * Drives the whole PKCE exchange with no mocks: the handler builds the
+ * authorization URI, and the verifier it returns travels into the token
+ * request body the exchanger sends. A provider accepts the exchange only when
+ * the challenge on the URI is the SHA-256 of that body's `code_verifier`, so
+ * this test performs the check the provider would.
+ */
+describe('PKCE round trip', () => {
+  const authConfig: AuthConfig = {
+    credentialKey: 'pkce-round-trip',
+    authScheme: {
+      type: 'oauth2',
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/oauth2/authorize',
+          tokenUrl: 'https://example.com/oauth2/token',
+          scopes: {read: 'read access'},
+        },
+      },
+    },
+    rawAuthCredential: {
+      authType: AuthCredentialTypes.OAUTH2,
+      oauth2: {
+        clientId: 'id',
+        clientSecret: 'secret',
+        redirectUri: 'https://example.com/callback',
+        codeChallengeMethod: 'S256',
+      },
+    },
+  };
+
+  it('sends a code_verifier that the URI challenge verifies', () => {
+    const requested = new AuthHandler(authConfig).generateAuthRequest();
+    const oauth2 = requested.exchangedAuthCredential?.oauth2;
+    if (!oauth2?.authUri || !oauth2.codeVerifier) {
+      expect.fail('expected an auth URI and a code verifier');
+    }
+
+    const body = createOAuth2TokenRequestBody({
+      grantType: 'authorization_code',
+      clientId: 'id',
+      clientSecret: 'secret',
+      code: 'authorization-code-from-the-provider',
+      redirectUri: 'https://example.com/callback',
+      codeVerifier: oauth2.codeVerifier,
+    });
+
+    const params = new URL(oauth2.authUri).searchParams;
+    const sentVerifier = body.get('code_verifier');
+    expect(sentVerifier).toBe(oauth2.codeVerifier);
+    expect(params.get('code_challenge_method')).toBe('S256');
+    expect(params.get('code_challenge')).toBe(
+      createHash('sha256')
+        .update(sentVerifier ?? '')
+        .digest('base64url'),
+    );
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**

`adk-js` implements only half of PKCE (RFC 7636). The token exchange already
sends `code_verifier` (`core/src/auth/oauth2/oauth2_utils.ts`), but
`AuthHandler.generateAuthUri()` puts no `code_challenge` on the authorization
URI. A provider therefore has nothing to bind the verifier to, and the
`code_verifier` sent at exchange time is a value the provider cannot check.
The credential's `audience` and `nonce` are dropped from the URI as well.
`adk-python`'s `AuthHandler.generate_auth_uri` emits all three.

**Solution:**

`generateAuthUri()` now derives the S256 challenge from the credential's code
verifier, generates a verifier with `node:crypto`'s CSPRNG when the caller
supplies none, and returns that verifier on the exchanged credential so the
later token exchange can send it. It rejects any code challenge method other
than `S256`, and forwards `audience` and `nonce` when set. The two PKCE helpers
live in `auth/oauth2/oauth2_utils.ts`, next to the `code_verifier` half of the
flow.

Behaviour is unchanged unless the credential sets `codeChallengeMethod`: a
credential that requests no method produces the same authorization URI as
before. Only the challenge and the method reach the URI; the verifier itself is
never placed on it and is never logged.

Notes for the reviewer:

- **The hash is synchronous on purpose.** `generateAuthUri()` is reached from
  the synchronous public `CallbackContext.requestCredential()`, so
  `crypto.subtle.digest` is unusable. It uses `node:crypto`, which the web
  bundle aliases to `core/src/utils/crypto_shim.ts`. The two new shim stubs
  throw, following the file's existing `randomUUID` contract, so PKCE is
  unavailable in the bundled web build. That is a documented limitation rather
  than a regression — PKCE works in no build today — and the alternative is an
  async public API. The shim throws rather than emit an authorization request
  with a missing or forged challenge. `npm run build:bundle` succeeds and the
  bundle contains no `node:crypto` reference.
- **Parity vs. local convention.** Wire-visible strings match Python exactly
  (`code_challenge`, `code_challenge_method`, `S256`, `audience`, `nonce`). The
  error message uses the JS field name `codeChallengeMethod` and throws
  `Error`, like every other guard in the file.
- **A verifier without a method emits no challenge.** This reproduces authlib's
  behaviour, which Python relies on.
- The generated verifier is 36 CSPRNG bytes encoded as base64url: 48
  unreserved characters, inside the 43–128 range RFC 7636 requires, with no
  modulo bias.
- No suppressions, no `any`, no new dependency.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
npx vitest run --project unit:core core/test/auth/   # 14 files, 217 tests, all pass
npm run build && npm run ts:check && npm run ts:check:samples
npm run lint && npm run format:check                 # all clean
```

17 new cases in `core/test/auth/auth_handler_test.ts`, 7 in
`core/test/auth/oauth2/oauth2_utils_test.ts`, and a no-mocks round trip in
`core/test/auth/pkce_round_trip_test.ts`. The four existing `generateAuthUri`
tests are unmodified; no existing test was weakened or removed.

New source lines are at 100% line and branch coverage.

**Proof the tests can fail.** Each mutation was applied to the source and
reverted:

| Mutation                                                   | Result                                                                               |
| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| Delete `searchParams.set('code_challenge', ...)`           | 3 failed — `expected null to be 'HocX9xaevoNbL5le-QirVOjee…'`                        |
| Send the raw verifier as the challenge (plain, not S256)   | 3 failed — `expected '6w2bQx644JZ1dFssOF_3J3Wu0Uor…' to match /^[A-Za-z0-9_-]{43}$/` |
| Delete the `nonce` forwarding                              | 1 failed — `expected null to be 'n-0S6'`                                             |
| Delete the unsupported-method guard                        | 2 failed — `expected [Function] to throw an error`                                   |
| Delete the `audience` forwarding                           | 1 failed — `expected null to be 'https://api.example.com'`                           |
| `digest('base64')` instead of `digest('base64url')`        | 6 failed — `expected '…OD9+DWVAoUkuWkK0CITuX…' to match /^[A-Za-z0-9_-]{43}$/`       |
| Delete `code_challenge` (round trip only)                  | 1 failed — `expected null to be 'HgM2b6EgtYh0tVg2vOZhBrKbi…'`                        |
| Return the raw verifier field instead of the generated one | 1 failed — `expected an auth URI and a code verifier`                                |

**Manual End-to-End (E2E) Tests:**

A live provider is not needed. `core/test/auth/pkce_round_trip_test.ts` runs the
real flow with no mocks: it builds the authorization URI through
`AuthHandler.generateAuthRequest()`, feeds the returned verifier into
`createOAuth2TokenRequestBody()`, and performs the check the provider performs —
that the URI's `code_challenge` is the SHA-256 of the body's `code_verifier`.

To verify by hand: build an OAuth2 credential with `codeChallengeMethod: 'S256'`,
call `generateAuthUri()`, and confirm against any RFC 7636 checker that
`base64url(sha256(codeVerifier))` equals the URI's `code_challenge`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

PKCE stays opt-in: it activates only for credentials that set
`codeChallengeMethod: 'S256'`. Callers that want the protection have to request
it; nothing in this change turns it on for an existing credential.
