### PR TITLE
fix(dev): let --bundle false actually load an agent

### DIFF
--- a/dev/src/cli/cli.ts
+++ b/dev/src/cli/cli.ts
@@ -134,7 +134,7 @@ const COMPILE_AGENT_FILE = new Option(
 ).default(true);
 const BUNDLE_AGENT_FILE = new Option(
   '--bundle [boolean]',
-  'Optional. Whether to compile ts agent file to js before execution',
+  'Optional. Whether to bundle the agent file and its imports into a single output before execution. When false, imports stay as runtime requires resolved from the project node_modules. Default: true',
 ).default(true);
 const A2A_OPTION = new Option(
   '--a2a [boolean]',

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -201,26 +201,33 @@ export class AgentFile {
         bundle: this.options.bundle,
         minify: this.options.bundle,
         plugins: [replaceDirnamePlugin(filePath, originalDir), shimPlugin()],
-        // See http://mikro-orm.io/docs/deployment#deploy-a-bundle-of-entities-and-dependencies-with-esbuild for more details
-        external: [
-          'sqlite3',
-          'better-sqlite3',
-          'mysql',
-          'mysql2',
-          // Native addons must remain external so Node can resolve their
-          // platform-specific assets at runtime.
-          'onnxruntime-node',
-          'oracledb',
-          'pg-native',
-          'pg-query-stream',
-          'tedious',
-          'libsql',
-          // Optional peer dependencies of vite and eslint that are not
-          // installed and MUST NOT be bundled.
-          'lightningcss',
-          'jiti',
-          'jiti/package.json',
-        ],
+        // esbuild rejects `external` when `bundle` is false, and it is also
+        // unnecessary: unbundled output already keeps every import as a
+        // runtime require, resolved from the linked project node_modules.
+        ...(this.options.bundle
+          ? {
+              // See http://mikro-orm.io/docs/deployment#deploy-a-bundle-of-entities-and-dependencies-with-esbuild for more details
+              external: [
+                'sqlite3',
+                'better-sqlite3',
+                'mysql',
+                'mysql2',
+                // Native addons must remain external so Node can resolve their
+                // platform-specific assets at runtime.
+                'onnxruntime-node',
+                'oracledb',
+                'pg-native',
+                'pg-query-stream',
+                'tedious',
+                'libsql',
+                // Optional peer dependencies of vite and eslint that are not
+                // installed and MUST NOT be bundled.
+                'lightningcss',
+                'jiti',
+                'jiti/package.json',
+              ],
+            }
+          : {}),
       });
 
       this.cleanupDirPath = outputDir;

--- a/dev/test/utils/agent_loader_test.ts
+++ b/dev/test/utils/agent_loader_test.ts
@@ -318,6 +318,35 @@ describe('AgentLoader', () => {
       await expect(fs.access(compiledAgentPath)).rejects.toThrow();
     });
 
+    it('omits external when bundling is disabled', async () => {
+      const agentPath = path.join(tempAgentsDir, 'agent2.ts');
+      await fs.writeFile(agentPath, agent2TsContent);
+
+      const compiledAgentPath = compiledPath('agent2.cjs');
+      (esbuild.build as Mock).mockImplementation(async () => {
+        await fs.writeFile(compiledAgentPath, agent2CjsContentMocked);
+        return Promise.resolve();
+      });
+
+      const agentFile = new AgentFile(agentPath, {
+        compile: true,
+        bundle: false,
+      });
+      const agent = await agentFile.load();
+
+      expect(agent.name).toEqual('agent2');
+      // esbuild rejects `external` when `bundle` is false, so the loader must
+      // not pass it for unbundled builds.
+      expect((esbuild.build as Mock).mock.calls[0][0]).toMatchObject({
+        bundle: false,
+        minify: false,
+      });
+      expect((esbuild.build as Mock).mock.calls[0][0].external).toBeUndefined();
+
+      await agentFile.dispose();
+      await expect(fs.access(compiledAgentPath)).rejects.toThrow();
+    });
+
     it('compiles into a private temp dir without allowing overwrite', async () => {
       const agentPath = path.join(tempAgentsDir, 'agent1.js');
       await fs.writeFile(agentPath, agent1JsContent);


### PR DESCRIPTION
## What

Fixes #714. `--bundle false` could never succeed on any agent because `dev/src/utils/agent_loader.ts` passed an `external` list to esbuild unconditionally while `bundle: this.options.bundle` came from the CLI flag. esbuild rejects `external` when `bundle` is false:

```
✘ [ERROR] Cannot use "external" without "bundle"
```

## Change

- Only pass the `external` list when bundling is enabled. An unbundled build already keeps every import as a runtime `require`, resolved from the project `node_modules` that the loader links into the temp output dir.
- Fix `--bundle`'s help text in `cli.ts`, which was a verbatim copy of `--compile`'s and did not describe bundling.
- Add a unit test asserting esbuild is invoked without `external` when `bundle: false`.

## Verification

- Reproduced the original esbuild failure with `bundle: false` + `external` and confirmed the success path with the fix applied.
- `npx vitest run --project unit:dev dev/test/utils/agent_loader_test.ts` (39 tests) passes, including the new `omits external when bundling is disabled` case.
- `adk run agent.ts --bundle false` now reaches the REPL on a Workflow root (exit code 0); the default `--bundle true` path is unchanged.
- `tsc --noEmit -p dev/tsconfig.json`, prettier, and eslint all pass on the changed files.