### PR TITLE
fix(context): respect isolation scopes during compaction

### DIFF
--- a/core/src/agents/processors/content_processor_utils.ts
+++ b/core/src/agents/processors/content_processor_utils.ts
@@ -18,6 +18,7 @@ import {
 } from '../../events/event.js';
 import {isSegmentPrefix} from '../../utils/branch_trie.js';
 
+import {isEventVisibleInIsolationScope} from '../../context/compaction_utils.js';
 import {
   AF_FUNCTION_CALL_ID_PREFIX,
   REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
@@ -62,6 +63,9 @@ export function getContents(
   const filteredEvents: Event[] = [];
 
   for (const event of events) {
+    if (!isEventVisibleInIsolationScope(event, currentIsolationScope)) {
+      continue;
+    }
     if (isCompactedEvent(event)) {
       filteredEvents.push(convertCompactedEvent(event));
       continue;
@@ -117,7 +121,7 @@ function shouldIncludeEventInContext(
   ) {
     return false;
   }
-  if (isOutsideIsolationScope(event, currentIsolationScope)) {
+  if (!isEventVisibleInIsolationScope(event, currentIsolationScope)) {
     return false;
   }
   return (
@@ -236,16 +240,6 @@ function turnStart(events: Event[], anchor: number): number {
  * shared history and visible everywhere. So an isolated node sees the ambient
  * conversation plus its own turns, while its peers never see those turns.
  */
-function isOutsideIsolationScope(
-  event: Event,
-  currentIsolationScope?: string,
-): boolean {
-  return (
-    event.isolationScope !== undefined &&
-    event.isolationScope !== currentIsolationScope
-  );
-}
-
 /**
  * Whether the event is an auth event.
  *

--- a/core/src/agents/processors/content_request_processor.ts
+++ b/core/src/agents/processors/content_request_processor.ts
@@ -42,7 +42,10 @@ export class ContentRequestProcessor implements BaseLlmRequestProcessor {
       return;
     }
 
-    const events = getActiveEvents(invocationContext.session.events);
+    const events = getActiveEvents(
+      invocationContext.session.events,
+      invocationContext.isolationScope,
+    );
 
     if (agent.includeContents === 'default') {
       // Include full conversation history

--- a/core/src/context/agent_controlled_context_compactor.ts
+++ b/core/src/context/agent_controlled_context_compactor.ts
@@ -29,7 +29,10 @@ export class AgentControlledContextCompactor implements BaseContextCompactor {
 
   async compact(invocationContext: InvocationContext): Promise<void> {
     const events = invocationContext.session.events;
-    const activeEvents = getActiveEvents(events);
+    const activeEvents = getActiveEvents(
+      events,
+      invocationContext.isolationScope,
+    );
 
     // Find the consolidate_context tool call.
     const consolidateToolCallIndex = activeEvents.reduce(
@@ -75,6 +78,7 @@ export class AgentControlledContextCompactor implements BaseContextCompactor {
 
     try {
       const compactedEvent = await this.summarizer.summarize(eventsToCompact);
+      compactedEvent.isolationScope ??= invocationContext.isolationScope;
       invocationContext.session.events.push(compactedEvent);
     } catch (error) {
       // If the summarizer fails, log the error, clear the flags, and proceed without compaction.

--- a/core/src/context/anchored_context_compactor.ts
+++ b/core/src/context/anchored_context_compactor.ts
@@ -8,7 +8,10 @@ import {InvocationContext} from '../agents/invocation_context.js';
 import {CompactedEvent, isScratchpadEvent} from '../events/compacted_event.js';
 import {Event, getEventTokens} from '../events/event.js';
 import {BaseContextCompactor} from './base_context_compactor.js';
-import {calculateRetainStartIndex} from './compaction_utils.js';
+import {
+  calculateRetainStartIndex,
+  isEventVisibleInIsolationScope,
+} from './compaction_utils.js';
 import {BaseSummarizer} from './summarizers/base_summarizer.js';
 
 export interface AnchoredContextCompactorOptions {
@@ -41,11 +44,17 @@ export class AnchoredContextCompactor implements BaseContextCompactor {
     this.summarizer = options.summarizer;
   }
 
-  private getActiveEvents(events: Event[]): Event[] {
+  private getActiveEvents(
+    events: Event[],
+    currentIsolationScope?: string,
+  ): Event[] {
+    const visibleEvents = events.filter((event) =>
+      isEventVisibleInIsolationScope(event, currentIsolationScope),
+    );
     let latestScratchpad: CompactedEvent | undefined = undefined;
 
-    for (let i = events.length - 1; i >= 0; i--) {
-      const e = events[i];
+    for (let i = visibleEvents.length - 1; i >= 0; i--) {
+      const e = visibleEvents[i];
       if (isScratchpadEvent(e)) {
         latestScratchpad = e;
         break;
@@ -53,10 +62,10 @@ export class AnchoredContextCompactor implements BaseContextCompactor {
     }
 
     if (!latestScratchpad) {
-      return events;
+      return visibleEvents;
     }
 
-    const activeRawEvents = events.filter(
+    const activeRawEvents = visibleEvents.filter(
       (e) => e.timestamp > latestScratchpad!.endTime && !isScratchpadEvent(e),
     );
 
@@ -67,7 +76,10 @@ export class AnchoredContextCompactor implements BaseContextCompactor {
     invocationContext: InvocationContext,
   ): boolean | Promise<boolean> {
     const events = invocationContext.session.events;
-    const activeEvents = this.getActiveEvents(events);
+    const activeEvents = this.getActiveEvents(
+      events,
+      invocationContext.isolationScope,
+    );
     const hasScratchpad =
       activeEvents.length > 0 && isScratchpadEvent(activeEvents[0]);
     const rawEvents = hasScratchpad ? activeEvents.slice(1) : activeEvents;
@@ -94,7 +106,10 @@ export class AnchoredContextCompactor implements BaseContextCompactor {
 
   async compact(invocationContext: InvocationContext): Promise<void> {
     const events = invocationContext.session.events;
-    const activeEvents = this.getActiveEvents(events);
+    const activeEvents = this.getActiveEvents(
+      events,
+      invocationContext.isolationScope,
+    );
     const hasScratchpad =
       activeEvents.length > 0 && isScratchpadEvent(activeEvents[0]);
     const rawEvents = hasScratchpad ? activeEvents.slice(1) : activeEvents;
@@ -116,11 +131,19 @@ export class AnchoredContextCompactor implements BaseContextCompactor {
     const rawEventsToCompact = rawEvents.slice(0, retainStartIndex);
 
     let scratchpadEvent: CompactedEvent;
+    const existingScratchpad = hasScratchpad
+      ? (activeEvents[0] as CompactedEvent)
+      : undefined;
+    const reusableScratchpad =
+      existingScratchpad &&
+      (existingScratchpad.isolationScope === undefined ||
+        existingScratchpad.isolationScope === invocationContext.isolationScope)
+        ? existingScratchpad
+        : undefined;
 
-    if (hasScratchpad) {
-      const existingScratchpad = activeEvents[0] as CompactedEvent;
+    if (reusableScratchpad) {
       scratchpadEvent = await this.summarizer.summarize([
-        existingScratchpad,
+        reusableScratchpad,
         ...rawEventsToCompact,
       ]);
     } else {
@@ -132,17 +155,31 @@ export class AnchoredContextCompactor implements BaseContextCompactor {
       ...scratchpadEvent,
       isScratchpad: true,
       author: 'system',
+      ...(invocationContext.isolationScope === undefined
+        ? {}
+        : {isolationScope: invocationContext.isolationScope}),
     } as CompactedEvent;
 
-    // Reconstruct the events list: inactive events + new scratchpad + active retained events
-    const inactiveEvents = events.slice(0, events.indexOf(activeEvents[0]));
-    const retainedRawEvents = rawEvents.slice(retainStartIndex);
-
-    const newEventsList = [
-      ...inactiveEvents,
-      updatedScratchpad,
-      ...retainedRawEvents,
-    ];
+    // Replace only the current scope's compacted events. Peer-scope events and
+    // shared history must remain in the session for their own readers.
+    const replacedEvents = new Set<Event>([
+      ...(reusableScratchpad ? [reusableScratchpad] : []),
+      ...rawEventsToCompact,
+    ]);
+    const firstReplacedIndex = events.findIndex((event) =>
+      replacedEvents.has(event),
+    );
+    const newEventsList: Event[] = [];
+    let insertedScratchpad = false;
+    for (let index = 0; index < events.length; index++) {
+      const event = events[index];
+      if (index === firstReplacedIndex) {
+        newEventsList.push(updatedScratchpad);
+        insertedScratchpad = true;
+      }
+      if (!replacedEvents.has(event)) newEventsList.push(event);
+    }
+    if (!insertedScratchpad) newEventsList.push(updatedScratchpad);
 
     // Mutate the original session events array.
     events.length = 0;

--- a/core/src/context/anchored_context_compactor.ts
+++ b/core/src/context/anchored_context_compactor.ts
@@ -160,11 +160,17 @@ export class AnchoredContextCompactor implements BaseContextCompactor {
         : {isolationScope: invocationContext.isolationScope}),
     } as CompactedEvent;
 
-    // Replace only the current scope's compacted events. Peer-scope events and
-    // shared history must remain in the session for their own readers.
+    // Replace only events owned by the current scope. Shared history may be
+    // included in the summary, but it must remain in the session for peer and
+    // unscoped readers.
+    const shouldReplaceEvent = (event: Event): boolean =>
+      invocationContext.isolationScope === undefined ||
+      event.isolationScope === invocationContext.isolationScope;
     const replacedEvents = new Set<Event>([
-      ...(reusableScratchpad ? [reusableScratchpad] : []),
-      ...rawEventsToCompact,
+      ...(reusableScratchpad && shouldReplaceEvent(reusableScratchpad)
+        ? [reusableScratchpad]
+        : []),
+      ...rawEventsToCompact.filter(shouldReplaceEvent),
     ]);
     const firstReplacedIndex = events.findIndex((event) =>
       replacedEvents.has(event),

--- a/core/src/context/compaction_utils.ts
+++ b/core/src/context/compaction_utils.ts
@@ -18,16 +18,27 @@ import {
  * @param events The full history of events.
  * @returns The active events, starting with the latest CompactedEvent if present.
  */
-export function getActiveEvents(events: Event[]): Event[] {
-  const latest = events.filter(isCompactedEvent).pop();
+export function getActiveEvents(
+  events: Event[],
+  currentIsolationScope?: string,
+): Event[] {
+  const visibleEvents =
+    currentIsolationScope !== undefined
+      ? events.filter(
+          (event) =>
+            event.isolationScope === undefined ||
+            event.isolationScope === currentIsolationScope,
+        )
+      : events;
+  const latest = visibleEvents.filter(isCompactedEvent).pop();
   return latest
     ? [
         latest,
-        ...events.filter(
+        ...visibleEvents.filter(
           (e) => !isCompactedEvent(e) && e.timestamp > latest.endTime,
         ),
       ]
-    : events;
+    : visibleEvents;
 }
 
 /**

--- a/core/src/context/compaction_utils.ts
+++ b/core/src/context/compaction_utils.ts
@@ -16,20 +16,17 @@ import {
  * If no compaction has occurred, returns all events.
  *
  * @param events The full history of events.
+ * @param currentIsolationScope The scope of the caller. Events tagged with a
+ *   different scope are withheld.
  * @returns The active events, starting with the latest CompactedEvent if present.
  */
 export function getActiveEvents(
   events: Event[],
   currentIsolationScope?: string,
 ): Event[] {
-  const visibleEvents =
-    currentIsolationScope !== undefined
-      ? events.filter(
-          (event) =>
-            event.isolationScope === undefined ||
-            event.isolationScope === currentIsolationScope,
-        )
-      : events;
+  const visibleEvents = events.filter((event) =>
+    isEventVisibleInIsolationScope(event, currentIsolationScope),
+  );
   const latest = visibleEvents.filter(isCompactedEvent).pop();
   return latest
     ? [
@@ -39,6 +36,21 @@ export function getActiveEvents(
         ),
       ]
     : visibleEvents;
+}
+
+/**
+ * Whether an event is visible to a caller's isolation scope.
+ * Untagged events are shared history; tagged events are visible only to their
+ * own scope. An unscoped caller therefore sees only shared history.
+ */
+export function isEventVisibleInIsolationScope(
+  event: Event,
+  currentIsolationScope?: string,
+): boolean {
+  return (
+    event.isolationScope === undefined ||
+    event.isolationScope === currentIsolationScope
+  );
 }
 
 /**

--- a/core/src/context/token_based_context_compactor.ts
+++ b/core/src/context/token_based_context_compactor.ts
@@ -55,7 +55,10 @@ export class TokenBasedContextCompactor implements BaseContextCompactor {
     invocationContext: InvocationContext,
   ): boolean | Promise<boolean> {
     const events = invocationContext.session.events;
-    const activeEvents = getActiveEvents(events);
+    const activeEvents = getActiveEvents(
+      events,
+      invocationContext.isolationScope,
+    );
     const rawEvents = activeEvents.filter((e) => !isCompactedEvent(e));
 
     if (rawEvents.length <= this.eventRetentionSize) {
@@ -83,7 +86,10 @@ export class TokenBasedContextCompactor implements BaseContextCompactor {
 
   async compact(invocationContext: InvocationContext): Promise<void> {
     const events = invocationContext.session.events;
-    const activeEvents = getActiveEvents(events);
+    const activeEvents = getActiveEvents(
+      events,
+      invocationContext.isolationScope,
+    );
     const rawEvents = activeEvents.filter((e) => !isCompactedEvent(e));
 
     if (rawEvents.length <= this.eventRetentionSize) {

--- a/core/src/context/token_based_context_compactor.ts
+++ b/core/src/context/token_based_context_compactor.ts
@@ -125,6 +125,7 @@ export class TokenBasedContextCompactor implements BaseContextCompactor {
       };
     }
 
+    compactedEvent.isolationScope ??= invocationContext.isolationScope;
     invocationContext.session.events.push(compactedEvent);
   }
 }

--- a/core/src/context/trajectory_thought_pruning_compactor.ts
+++ b/core/src/context/trajectory_thought_pruning_compactor.ts
@@ -7,6 +7,7 @@
 import {InvocationContext} from '../agents/invocation_context.js';
 import {hasThoughts, pruneThoughts} from '../events/event.js';
 import {BaseContextCompactor} from './base_context_compactor.js';
+import {isEventVisibleInIsolationScope} from './compaction_utils.js';
 
 /**
  * Options for TrajectoryThoughtPruningCompactor.
@@ -37,28 +38,40 @@ export class TrajectoryThoughtPruningCompactor implements BaseContextCompactor {
     invocationContext: InvocationContext,
   ): boolean | Promise<boolean> {
     const events = invocationContext.session.events;
-    if (events.length <= this.eventRetentionSize) {
+    const visibleIndices = events.flatMap((event, index) =>
+      isEventVisibleInIsolationScope(event, invocationContext.isolationScope)
+        ? [index]
+        : [],
+    );
+    if (visibleIndices.length <= this.eventRetentionSize) {
       return false;
     }
 
-    const olderEvents = events.slice(
-      0,
-      events.length - this.eventRetentionSize,
-    );
+    const olderEvents = visibleIndices
+      .slice(0, visibleIndices.length - this.eventRetentionSize)
+      .map((index) => events[index]);
     return olderEvents.some((event) => hasThoughts(event));
   }
 
   compact(invocationContext: InvocationContext): void | Promise<void> {
     const events = invocationContext.session.events;
-    if (events.length <= this.eventRetentionSize) {
+    const visibleIndices = events.flatMap((event, index) =>
+      isEventVisibleInIsolationScope(event, invocationContext.isolationScope)
+        ? [index]
+        : [],
+    );
+    if (visibleIndices.length <= this.eventRetentionSize) {
       return;
     }
 
-    const pruneLimit = events.length - this.eventRetentionSize;
-    for (let i = 0; i < pruneLimit; i++) {
-      const event = events[i];
+    const pruneIndices = visibleIndices.slice(
+      0,
+      visibleIndices.length - this.eventRetentionSize,
+    );
+    for (const index of pruneIndices) {
+      const event = events[index];
       if (hasThoughts(event)) {
-        events[i] = pruneThoughts(event);
+        events[index] = pruneThoughts(event);
       }
     }
   }

--- a/core/src/context/truncating_context_compactor.ts
+++ b/core/src/context/truncating_context_compactor.ts
@@ -6,6 +6,7 @@
 
 import {InvocationContext} from '../agents/invocation_context.js';
 import {BaseContextCompactor} from './base_context_compactor.js';
+import {isEventVisibleInIsolationScope} from './compaction_utils.js';
 
 export interface TruncatingContextCompactorOptions {
   /** The maximum number of events to retain in the session history. */
@@ -28,24 +29,40 @@ export class TruncatingContextCompactor implements BaseContextCompactor {
   }
 
   shouldCompact(invocationContext: InvocationContext): boolean {
-    const eventsLength = invocationContext.session.events.length;
+    const visibleEventsLength = invocationContext.session.events.filter(
+      (event) =>
+        isEventVisibleInIsolationScope(event, invocationContext.isolationScope),
+    ).length;
     return (
-      eventsLength > this.threshold + Math.max(0, this.preserveLeadingEvents)
+      visibleEventsLength >
+      this.threshold + Math.max(0, this.preserveLeadingEvents)
     );
   }
 
   compact(invocationContext: InvocationContext): void {
     const events = invocationContext.session.events;
+    const visibleIndices = events.flatMap((event, index) =>
+      isEventVisibleInIsolationScope(event, invocationContext.isolationScope)
+        ? [index]
+        : [],
+    );
 
     // We only compact if we exceed the threshold considering the preserved events prefix.
     const excess =
-      events.length - this.threshold - Math.max(0, this.preserveLeadingEvents);
+      visibleIndices.length -
+      this.threshold -
+      Math.max(0, this.preserveLeadingEvents);
     if (excess <= 0) {
       return;
     }
 
-    const startIndexToRemove = Math.max(0, this.preserveLeadingEvents);
-
-    events.splice(startIndexToRemove, excess);
+    const preserveCount = Math.max(0, this.preserveLeadingEvents);
+    const indicesToRemove = visibleIndices.slice(
+      preserveCount,
+      preserveCount + excess,
+    );
+    for (const index of indicesToRemove.reverse()) {
+      events.splice(index, 1);
+    }
   }
 }

--- a/core/src/workflow/run_llm_agent_as_node.ts
+++ b/core/src/workflow/run_llm_agent_as_node.ts
@@ -91,7 +91,7 @@ async function appendNodeInputAsUserTurn(
     branch: ctx.branch,
     content: toUserContent(nodeInput),
   });
-  if (ctx.isolationScope) {
+  if (ctx.isolationScope !== undefined) {
     userEvent.isolationScope = ctx.isolationScope;
   }
   const sessionService = ctx.invocationContext.sessionService;

--- a/core/test/agents/processors/content_processor_utils_test.ts
+++ b/core/test/agents/processors/content_processor_utils_test.ts
@@ -488,6 +488,38 @@ describe('getContents', () => {
     );
   });
 
+  it('should filter compacted events by isolation scope', () => {
+    const peerSummary = {
+      isCompacted: true,
+      isolationScope: 'peer',
+      author: 'system',
+      compactedContent: 'peer summary',
+      timestamp: 12345,
+      invocationId: 'peer-invocation',
+      branch: 'main',
+    } as unknown as CompactedEvent;
+    const currentSummary = {
+      isCompacted: true,
+      isolationScope: 'current',
+      author: 'system',
+      compactedContent: 'current summary',
+      timestamp: 12346,
+      invocationId: 'current-invocation',
+      branch: 'main',
+    } as unknown as CompactedEvent;
+
+    const contents = getContents(
+      [peerSummary, currentSummary],
+      'my_agent',
+      undefined,
+      'current',
+    );
+
+    expect(contents).toHaveLength(1);
+    expect(contents[0].parts?.[0].text).toContain('current summary');
+    expect(contents[0].parts?.[0].text).not.toContain('peer summary');
+  });
+
   it('should skip rearranging when the second latest event contains the corresponding function calls', () => {
     const e0 = createEvent({
       author: 'user',

--- a/core/test/context/anchored_context_compactor_test.ts
+++ b/core/test/context/anchored_context_compactor_test.ts
@@ -211,6 +211,60 @@ describe('AnchoredContextCompactor', () => {
     expect(context.session.events[2].id).toBe('4');
   });
 
+  it('should preserve shared history during scoped compaction', async () => {
+    const compactor = new AnchoredContextCompactor({
+      tokenThreshold: 0,
+      eventRetentionSize: 1,
+      summarizer: new MockSummarizer(),
+    });
+
+    const sharedScratchpad = createMockScratchpadEvent(
+      'shared-scratchpad',
+      5,
+      'shared summary',
+    );
+    sharedScratchpad.timestamp = 1;
+    sharedScratchpad.startTime = 0;
+    sharedScratchpad.endTime = 1;
+
+    const sharedEvent = createMockEvent('shared', 5);
+    sharedEvent.timestamp = 2;
+
+    const currentEvent = createMockEvent('current', 5);
+    currentEvent.timestamp = 3;
+    currentEvent.isolationScope = 'current';
+
+    const retainedCurrentEvent = createMockEvent('current-retained', 5);
+    retainedCurrentEvent.timestamp = 4;
+    retainedCurrentEvent.isolationScope = 'current';
+
+    const peerEvent = createMockEvent('peer', 5);
+    peerEvent.timestamp = 5;
+    peerEvent.isolationScope = 'peer';
+
+    const context = createMockInvocationContext([
+      sharedScratchpad,
+      sharedEvent,
+      currentEvent,
+      retainedCurrentEvent,
+      peerEvent,
+    ]);
+    context.isolationScope = 'current';
+
+    await compactor.compact(context);
+
+    expect(context.session.events).toContain(sharedScratchpad);
+    expect(context.session.events).toContain(sharedEvent);
+    expect(context.session.events).not.toContain(currentEvent);
+    expect(context.session.events).toContain(retainedCurrentEvent);
+    expect(context.session.events).toContain(peerEvent);
+
+    const scopedScratchpad = context.session.events.find(
+      (event) => event.id === 'mock-id',
+    );
+    expect(scopedScratchpad?.isolationScope).toBe('current');
+  });
+
   it('should not split tool call and responses', async () => {
     const compactor = new AnchoredContextCompactor({
       tokenThreshold: 10,

--- a/core/test/context/token_based_context_compactor_test.ts
+++ b/core/test/context/token_based_context_compactor_test.ts
@@ -87,6 +87,55 @@ function createMockInvocationContext(events: Event[]): InvocationContext {
 }
 
 describe('TokenBasedContextCompactor', () => {
+  it('does not summarize events from another isolation scope', async () => {
+    const summarized: Event[][] = [];
+    const summarizer: BaseSummarizer = {
+      async summarize(events) {
+        summarized.push(events);
+        return {
+          id: 'summary',
+          invocationId: '',
+          author: 'system',
+          timestamp: Date.now(),
+          isCompacted: true,
+          startTime: events[0].timestamp,
+          endTime: events[events.length - 1].timestamp,
+          compactedContent: 'summary',
+          content: {role: 'model', parts: [{text: 'summary'}]},
+        } as CompactedEvent;
+      },
+    };
+    const current = createMockEvent(
+      'current',
+      undefined,
+      false,
+      false,
+      'current',
+    );
+    current.isolationScope = 'current';
+    const current2 = createMockEvent(
+      'current2',
+      undefined,
+      false,
+      false,
+      'current2',
+    );
+    current2.isolationScope = 'current';
+    const peer = createMockEvent('peer', undefined, false, false, 'peer');
+    peer.isolationScope = 'peer';
+    const context = createMockInvocationContext([current, current2, peer]);
+    context.isolationScope = 'current';
+    const compactor = new TokenBasedContextCompactor({
+      tokenThreshold: 0,
+      eventRetentionSize: 1,
+      summarizer,
+    });
+
+    await compactor.compact(context);
+
+    expect(summarized).toHaveLength(1);
+    expect(summarized[0]).toEqual([current]);
+  });
   it('should not compact if event count is within retention size', async () => {
     const compactor = new TokenBasedContextCompactor({
       tokenThreshold: 10,

--- a/core/test/context/token_based_context_compactor_test.ts
+++ b/core/test/context/token_based_context_compactor_test.ts
@@ -123,7 +123,7 @@ describe('TokenBasedContextCompactor', () => {
     current2.isolationScope = 'current';
     const peer = createMockEvent('peer', undefined, false, false, 'peer');
     peer.isolationScope = 'peer';
-    const context = createMockInvocationContext([current, current2, peer]);
+    const context = createMockInvocationContext([current, peer, current2]);
     context.isolationScope = 'current';
     const compactor = new TokenBasedContextCompactor({
       tokenThreshold: 0,
@@ -135,6 +135,7 @@ describe('TokenBasedContextCompactor', () => {
 
     expect(summarized).toHaveLength(1);
     expect(summarized[0]).toEqual([current]);
+    expect(context.session.events.at(-1)?.isolationScope).toBe('current');
   });
   it('should not compact if event count is within retention size', async () => {
     const compactor = new TokenBasedContextCompactor({


### PR DESCRIPTION
Closes #824

## Problem

`TokenBasedContextCompactor` selected events from the entire session before applying workflow isolation. This allowed a peer node's event to reach the summarizer and then the current node's model after compaction.

## Changes

- Filter active events by the invocation's `isolationScope` before token counting and compaction.
- Preserve the existing behavior for unscoped invocations.
- Add a regression test that verifies peer-scope events are excluded from the summarizer input.

## Tests

- `npx vitest run --project unit:core core/test/context/token_based_context_compactor_test.ts` (8 passed)
- `npm run ts:check` (passed)
- `npx eslint core/src/context/compaction_utils.ts core/src/context/token_based_context_compactor.ts core/test/context/token_based_context_compactor_test.ts` (passed)
- `npx prettier core/src/context/compaction_utils.ts core/src/context/token_based_context_compactor.ts core/test/context/token_based_context_compactor_test.ts --check` (passed)
- `git diff --check` (passed)

## Compatibility / Known limitations

Unscoped compaction remains unchanged. This PR does not add a live-model or end-to-end test; the regression is covered with deterministic unit-test fixtures and requires no credentials or external services.
