### PR TITLE
fix(a2a): harden agent-card resolution against SSRF and a silent file read

### DIFF
--- a/core/src/a2a/agent_card.ts
+++ b/core/src/a2a/agent_card.ts
@@ -9,7 +9,6 @@ import {DefaultAgentCardResolver} from '@a2a-js/sdk/client';
 import * as fs from 'node:fs/promises';
 import {fileURLToPath} from 'node:url';
 import {BaseAgent} from '../agents/base_agent.js';
-
 import {
   InvocationContext,
   InvocationContextParams,
@@ -58,8 +57,9 @@ export async function resolveAgentCard(
 
   const url = parseCardUrl(agentCard);
   if (url && isHttpUrl(url)) {
+    await assertHostAllowed(url);
     const resolver = new DefaultAgentCardResolver({
-      fetchImpl: guardedAgentCardFetch,
+      fetchImpl: noRedirectFetch(agentCard),
     });
     return resolver.resolve(agentCard);
   }
@@ -103,26 +103,23 @@ async function readAgentCardFile(
 }
 
 /**
- * Fetches the agent card, refusing a link-local host and any redirect.
- *
- * The guard lives here rather than before {@link DefaultAgentCardResolver} runs
- * because this is the single point where the resolver reaches the network, and
- * the only place a URL the developer did not write can appear.
+ * Builds the `fetch` the card resolver uses, which refuses a redirect instead
+ * of following it. A redirect is the only way the card host, rather than the
+ * developer, picks where the request lands.
  */
-const guardedAgentCardFetch: typeof fetch = async (input, init) => {
-  // `Request` normalizes every form `fetch` accepts: a string, a URL, a Request.
-  const url = new URL(new Request(input).url);
-  await assertHostAllowed(url);
-  const response = await fetch(url, {...init, redirect: 'manual'});
-  if (isRedirect(response.status)) {
-    throw new Error(
-      `Refusing to follow a redirect while fetching the agent card from ${url} ` +
-        `(status ${response.status}, location ${response.headers.get('location')}). ` +
-        'Configure the final URL instead.',
-    );
-  }
-  return response;
-};
+function noRedirectFetch(source: string): typeof fetch {
+  return async (input, init) => {
+    const response = await fetch(input, {...init, redirect: 'manual'});
+    if (isRedirect(response.status)) {
+      throw new Error(
+        `Refusing to follow a redirect while fetching the agent card from ${source} ` +
+          `(status ${response.status}, location ${response.headers.get('location')}). ` +
+          'Configure the final URL instead.',
+      );
+    }
+    return response;
+  };
+}
 
 /**
  * Returns `true` for a redirect response, including the opaque one a `manual`
@@ -132,7 +129,13 @@ function isRedirect(status: number): boolean {
   return status === 0 || (status >= 300 && status < 400);
 }
 
-/** Throws when the URL's host is, or resolves to, a link-local address. */
+/**
+ * Throws when the URL's host is, or resolves to, a link-local address.
+ *
+ * Checking the configured URL covers the whole fetch: the resolver appends a
+ * relative well-known path, which cannot change the origin, and a redirect is
+ * refused rather than followed.
+ */
 async function assertHostAllowed(url: URL): Promise<void> {
   const host = normalizeHost(url.hostname);
   const addresses = await resolveHostAddresses(host);

--- a/core/src/a2a/agent_card.ts
+++ b/core/src/a2a/agent_card.ts
@@ -7,7 +7,9 @@
 import {AgentCard, AgentInterface, AgentSkill} from '@a2a-js/sdk';
 import {DefaultAgentCardResolver} from '@a2a-js/sdk/client';
 import * as fs from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
 import {BaseAgent} from '../agents/base_agent.js';
+
 import {
   InvocationContext,
   InvocationContextParams,
@@ -20,11 +22,32 @@ import {isSequentialAgent} from '../agents/sequential_agent.js';
 import {BaseTool, isBaseTool} from '../tools/base_tool.js';
 import {isBaseToolset} from '../tools/base_toolset.js';
 import {logger} from '../utils/logger.js';
+import {
+  isHttpUrl,
+  isLinkLocalAddress,
+  normalizeHost,
+  resolveHostAddresses,
+} from '../utils/ssrf_guard.js';
 import {RunnableRoot} from '../workflow/run_node_as_invocation.js';
 import {isWorkflow} from '../workflow/workflow.js';
 
 /**
+ * A single-letter URL protocol, which is a Windows drive letter rather than a
+ * scheme: `new URL('C:\\cards\\card.json')` parses with `protocol === 'c:'`.
+ */
+const WINDOWS_DRIVE_PROTOCOL = /^[a-z]:$/i;
+
+/**
  * Resolves the AgentCard from the provided source.
+ *
+ * A source is either an {@link AgentCard}, an `http(s)://` URL to fetch it
+ * from, a `file://` URL, or a filesystem path. Any other URL scheme throws: a
+ * source that looks like a URL is never read off the local filesystem.
+ *
+ * The card host must not be, or resolve to, a link-local address, and a
+ * redirect from the card endpoint is refused rather than followed. Loopback and
+ * private addresses stay allowed: they are where a locally served or
+ * VPC-internal peer agent lives.
  */
 export async function resolveAgentCard(
   agentCard: AgentCard | string,
@@ -33,18 +56,89 @@ export async function resolveAgentCard(
     return agentCard;
   }
 
-  const source = agentCard as string;
-  if (source.startsWith('http://') || source.startsWith('https://')) {
-    const resolver = new DefaultAgentCardResolver();
-    return await resolver.resolve(source);
+  const url = parseCardUrl(agentCard);
+  if (url && isHttpUrl(url)) {
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: guardedAgentCardFetch,
+    });
+    return resolver.resolve(agentCard);
   }
+  if (url && url.protocol !== 'file:') {
+    throw new Error(
+      `Unsupported agent card URL scheme "${url.protocol}": ${agentCard}. ` +
+        'Use http://, https:// or file://, or pass a filesystem path with no scheme.',
+    );
+  }
+  return readAgentCardFile(agentCard, url);
+}
 
+/**
+ * Parses an absolute URL out of a card source, or returns `null` when the
+ * source names a filesystem path.
+ */
+function parseCardUrl(source: string): URL | null {
+  let url: URL;
   try {
-    const content = await fs.readFile(source, 'utf-8');
+    url = new URL(source);
+  } catch {
+    return null;
+  }
+  return WINDOWS_DRIVE_PROTOCOL.test(url.protocol) ? null : url;
+}
+
+/** Reads and parses a card from `url` when it is a `file:` URL, else from `source`. */
+async function readAgentCardFile(
+  source: string,
+  url: URL | null,
+): Promise<AgentCard> {
+  try {
+    const path = url ? fileURLToPath(url) : source;
+    const content = await fs.readFile(path, 'utf-8');
     return JSON.parse(content) as AgentCard;
   } catch (err: unknown) {
     throw new Error(
       `Failed to read agent card from file ${source}: ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
+ * Fetches the agent card, refusing a link-local host and any redirect.
+ *
+ * The guard lives here rather than before {@link DefaultAgentCardResolver} runs
+ * because this is the single point where the resolver reaches the network, and
+ * the only place a URL the developer did not write can appear.
+ */
+const guardedAgentCardFetch: typeof fetch = async (input, init) => {
+  // `Request` normalizes every form `fetch` accepts: a string, a URL, a Request.
+  const url = new URL(new Request(input).url);
+  await assertHostAllowed(url);
+  const response = await fetch(url, {...init, redirect: 'manual'});
+  if (isRedirect(response.status)) {
+    throw new Error(
+      `Refusing to follow a redirect while fetching the agent card from ${url} ` +
+        `(status ${response.status}, location ${response.headers.get('location')}). ` +
+        'Configure the final URL instead.',
+    );
+  }
+  return response;
+};
+
+/**
+ * Returns `true` for a redirect response, including the opaque one a `manual`
+ * redirect produces on platforms that hide the status.
+ */
+function isRedirect(status: number): boolean {
+  return status === 0 || (status >= 300 && status < 400);
+}
+
+/** Throws when the URL's host is, or resolves to, a link-local address. */
+async function assertHostAllowed(url: URL): Promise<void> {
+  const host = normalizeHost(url.hostname);
+  const addresses = await resolveHostAddresses(host);
+  if (addresses.some(isLinkLocalAddress)) {
+    throw new Error(
+      `Refusing to fetch agent card from a link-local address: ${host}`,
     );
   }
 }

--- a/core/src/tools/load_web_page.ts
+++ b/core/src/tools/load_web_page.ts
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {lookup} from 'node:dns/promises';
-import {isIP} from 'node:net';
-
 import {z} from 'zod';
 
+import {
+  isHttpUrl,
+  isLocalhostHostname,
+  isNonGlobalAddress,
+  normalizeHost,
+  resolveHostAddresses,
+} from '../utils/ssrf_guard.js';
 import {FunctionTool} from './function_tool.js';
 
 /** Options for {@link loadWebPage}. */
@@ -17,201 +21,12 @@ export interface LoadWebPageOptions {
   timeoutMs?: number;
 }
 
-/** URL schemes that are allowed to be fetched (WHATWG `URL.protocol` form). */
-const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
-
 /** Default request timeout in milliseconds. */
 const DEFAULT_TIMEOUT_MS = 30_000;
-
-/**
- * IPv4 ranges that are not globally routable and therefore blocked to defeat
- * SSRF. Mirrors the non-global ranges rejected by Python's
- * `ipaddress.is_global`.
- */
-const BLOCKED_IPV4_CIDRS = [
-  '0.0.0.0/8', // "this host on this network"
-  '10.0.0.0/8', // private
-  '100.64.0.0/10', // shared address space / CGNAT
-  '127.0.0.0/8', // loopback
-  '169.254.0.0/16', // link-local (includes GCP metadata 169.254.169.254)
-  '172.16.0.0/12', // private
-  '192.0.0.0/24', // IETF protocol assignments
-  '192.0.2.0/24', // TEST-NET-1 (documentation)
-  '192.88.99.0/24', // 6to4 relay anycast (deprecated)
-  '192.168.0.0/16', // private
-  '198.18.0.0/15', // benchmarking
-  '198.51.100.0/24', // TEST-NET-2 (documentation)
-  '203.0.113.0/24', // TEST-NET-3 (documentation)
-  '224.0.0.0/4', // multicast
-  '240.0.0.0/4', // reserved / future use (includes 255.255.255.255)
-].map(parseIpv4Cidr);
-
-/**
- * IPv6 ranges that are not globally routable and therefore blocked. The
- * IPv4-mapped range `::ffff:0:0/96` is handled separately by extracting the
- * embedded IPv4 address and re-checking it with the IPv4 rules.
- */
-const BLOCKED_IPV6_CIDRS = [
-  '::/128', // unspecified
-  '::1/128', // loopback
-  '64:ff9b:1::/48', // local NAT64
-  '100::/64', // discard-only
-  '2001:db8::/32', // documentation
-  'fc00::/7', // unique-local (ULA, private)
-  'fe80::/10', // link-local
-  'ff00::/8', // multicast
-].map(parseIpv6Cidr);
 
 /** Builds the parity failure message for a URL. */
 function failedToFetchMessage(url: string): string {
   return `Failed to fetch url: ${url}`;
-}
-
-/**
- * Returns `true` for `localhost` and any `*.localhost` name (case-insensitive,
- * ignoring a trailing dot), matching the Python `_is_blocked_hostname` helper.
- */
-function isBlockedHostname(hostname: string): boolean {
-  const normalized = hostname.replace(/\.+$/, '').toLowerCase();
-  return normalized === 'localhost' || normalized.endsWith('.localhost');
-}
-
-/** Strips the surrounding brackets from an IPv6 URL hostname (`[::1]` → `::1`). */
-function normalizeHost(hostname: string): string {
-  return hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
-}
-
-/** Parses a dotted-quad IPv4 string into its four octets, or `null`. */
-function parseIpv4(address: string): number[] | null {
-  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(address);
-  if (!match) {
-    return null;
-  }
-  const octets = match.slice(1).map(Number);
-  if (octets.some((octet) => octet > 255)) {
-    return null;
-  }
-  return octets;
-}
-
-/** Expands a valid IPv6 address string into its eight 16-bit hextets, or `null`. */
-function parseIpv6(address: string): number[] | null {
-  if (isIP(address) !== 6) {
-    return null;
-  }
-  const [head, tail] = address.split('::');
-  const highGroups = head ? expandHextets(head) : [];
-  const lowGroups = tail ? expandHextets(tail) : [];
-  const compressed = address.includes('::')
-    ? new Array(8 - highGroups.length - lowGroups.length).fill(0)
-    : [];
-  return [...highGroups, ...compressed, ...lowGroups];
-}
-
-/**
- * Converts a colon-separated IPv6 fragment into hextets, expanding a trailing
- * embedded IPv4 group (e.g. the `1.2.3.4` in `::ffff:1.2.3.4`) into two hextets.
- */
-function expandHextets(fragment: string): number[] {
-  const hextets: number[] = [];
-  for (const group of fragment.split(':')) {
-    if (group.includes('.')) {
-      const octets = parseIpv4(group)!;
-      hextets.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
-    } else {
-      hextets.push(parseInt(group, 16));
-    }
-  }
-  return hextets;
-}
-
-/** Packs four IPv4 octets into an unsigned 32-bit integer. */
-function ipv4ToInt(octets: number[]): number {
-  return (
-    ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0
-  );
-}
-
-/** Packs eight IPv6 hextets into a 128-bit BigInt. */
-function hextetsToBigInt(hextets: number[]): bigint {
-  let value = 0n;
-  for (const hextet of hextets) {
-    value = (value << 16n) | BigInt(hextet);
-  }
-  return value;
-}
-
-/** Precomputes the network address and mask for an IPv4 CIDR string. */
-function parseIpv4Cidr(cidr: string): {base: number; mask: number} {
-  const [address, prefix] = cidr.split('/');
-  const mask = (0xffffffff << (32 - Number(prefix))) >>> 0;
-  return {base: (ipv4ToInt(parseIpv4(address)!) & mask) >>> 0, mask};
-}
-
-/** Precomputes the network address and prefix length for an IPv6 CIDR string. */
-function parseIpv6Cidr(cidr: string): {base: bigint; prefix: number} {
-  const [address, prefix] = cidr.split('/');
-  return {base: hextetsToBigInt(parseIpv6(address)!), prefix: Number(prefix)};
-}
-
-/** Returns `true` if the IPv4 octets fall within any blocked range. */
-function isBlockedIpv4(octets: number[]): boolean {
-  const value = ipv4ToInt(octets);
-  return BLOCKED_IPV4_CIDRS.some(
-    ({base, mask}) => (value & mask) >>> 0 === base,
-  );
-}
-
-/** Returns `true` if the IPv6 hextets fall within any blocked range. */
-function isBlockedIpv6(hextets: number[]): boolean {
-  const value = hextetsToBigInt(hextets);
-  // IPv4-mapped (::ffff:0:0/96): re-check the embedded IPv4 address.
-  if (value >> 32n === 0xffffn) {
-    return isBlockedIpv4([
-      Number((value >> 24n) & 0xffn),
-      Number((value >> 16n) & 0xffn),
-      Number((value >> 8n) & 0xffn),
-      Number(value & 0xffn),
-    ]);
-  }
-  return BLOCKED_IPV6_CIDRS.some(
-    ({base, prefix}) =>
-      value >> BigInt(128 - prefix) === base >> BigInt(128 - prefix),
-  );
-}
-
-/**
- * Returns `true` when `address` is not globally routable (private, loopback,
- * link-local, shared, reserved, multicast, ...). Unparseable input fails
- * closed (blocked).
- */
-function isBlockedAddress(address: string): boolean {
-  const octets = parseIpv4(address);
-  if (octets) {
-    return isBlockedIpv4(octets);
-  }
-  const hextets = parseIpv6(address);
-  if (hextets) {
-    return isBlockedIpv6(hextets);
-  }
-  return true;
-}
-
-/**
- * Resolves `hostname` to a de-duplicated list of IP addresses. IP literals are
- * returned as-is; hostnames are resolved via DNS. Throws when resolution
- * yields no address.
- */
-async function resolveHostAddresses(hostname: string): Promise<string[]> {
-  if (isIP(hostname) !== 0) {
-    return [hostname];
-  }
-  const records = await lookup(hostname, {all: true});
-  const addresses = [...new Set(records.map((record) => record.address))];
-  if (addresses.length === 0) {
-    throw new Error(`Unable to resolve host: ${hostname}`);
-  }
-  return addresses;
 }
 
 /**
@@ -220,10 +35,10 @@ async function resolveHostAddresses(hostname: string): Promise<string[]> {
  */
 function assertUrlAllowed(url: string): URL {
   const parsed = new URL(url);
-  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+  if (!isHttpUrl(parsed)) {
     throw new Error(`Unsupported url scheme: ${url}`);
   }
-  if (isBlockedHostname(parsed.hostname)) {
+  if (isLocalhostHostname(parsed.hostname)) {
     throw new Error(`Blocked host: ${parsed.hostname}`);
   }
   return parsed;
@@ -232,7 +47,7 @@ function assertUrlAllowed(url: string): URL {
 /** Resolves the host and throws if any resolved address is not globally routable. */
 async function validateResolvedAddresses(hostname: string): Promise<void> {
   const addresses = await resolveHostAddresses(hostname);
-  if (addresses.some(isBlockedAddress)) {
+  if (addresses.some(isNonGlobalAddress)) {
     throw new Error(`Blocked host: ${hostname}`);
   }
 }

--- a/core/src/utils/ssrf_guard.ts
+++ b/core/src/utils/ssrf_guard.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Address and scheme predicates shared by the outbound fetches that must not be
+ * pointed at an internal target.
+ *
+ * These are lexical and DNS-level checks, not a sandbox. Global `fetch`
+ * performs its own DNS resolution at connect time, so a residual
+ * time-of-check/time-of-use (DNS-rebinding) window exists between a caller's
+ * pre-flight lookup and fetch's own lookup. Closing it needs connection-level
+ * IP pinning (e.g. an `undici` Agent with a custom `lookup`).
+ */
+
+import {lookup} from 'node:dns/promises';
+import {isIP} from 'node:net';
+
+/** URL schemes that may be fetched (WHATWG `URL.protocol` form). */
+const HTTP_SCHEMES = new Set(['http:', 'https:']);
+
+/** An IPv4 network: its base address and mask, both unsigned 32-bit. */
+interface Ipv4Cidr {
+  base: number;
+  mask: number;
+}
+
+/** An IPv6 network: its base address and prefix length. */
+interface Ipv6Cidr {
+  base: bigint;
+  prefix: number;
+}
+
+/**
+ * IPv4 ranges that are not globally routable. Mirrors the non-global ranges
+ * rejected by Python's `ipaddress.is_global`.
+ */
+const NON_GLOBAL_IPV4_CIDRS = [
+  '0.0.0.0/8', // "this host on this network"
+  '10.0.0.0/8', // private
+  '100.64.0.0/10', // shared address space / CGNAT
+  '127.0.0.0/8', // loopback
+  '169.254.0.0/16', // link-local (includes GCP metadata 169.254.169.254)
+  '172.16.0.0/12', // private
+  '192.0.0.0/24', // IETF protocol assignments
+  '192.0.2.0/24', // TEST-NET-1 (documentation)
+  '192.88.99.0/24', // 6to4 relay anycast (deprecated)
+  '192.168.0.0/16', // private
+  '198.18.0.0/15', // benchmarking
+  '198.51.100.0/24', // TEST-NET-2 (documentation)
+  '203.0.113.0/24', // TEST-NET-3 (documentation)
+  '224.0.0.0/4', // multicast
+  '240.0.0.0/4', // reserved / future use (includes 255.255.255.255)
+].map(parseIpv4Cidr);
+
+/**
+ * IPv6 ranges that are not globally routable. Addresses that embed an IPv4
+ * target are handled separately by {@link embeddedIpv4}.
+ */
+const NON_GLOBAL_IPV6_CIDRS = [
+  '::/128', // unspecified
+  '::1/128', // loopback
+  '64:ff9b:1::/48', // local NAT64
+  '100::/64', // discard-only
+  '2001:db8::/32', // documentation
+  'fc00::/7', // unique-local (ULA, private)
+  'fe80::/10', // link-local
+  'ff00::/8', // multicast
+].map(parseIpv6Cidr);
+
+const LINK_LOCAL_IPV4_CIDR = parseIpv4Cidr('169.254.0.0/16');
+const LINK_LOCAL_IPV6_CIDR = parseIpv6Cidr('fe80::/10');
+const IPV4_MAPPED_CIDR = parseIpv6Cidr('::ffff:0:0/96');
+const NAT64_CIDR = parseIpv6Cidr('64:ff9b::/96');
+const SIX_TO_FOUR_CIDR = parseIpv6Cidr('2002::/16');
+const IPV4_COMPATIBLE_CIDR = parseIpv6Cidr('::/96');
+
+/** Returns `true` when `url` uses a scheme that may be fetched. */
+export function isHttpUrl(url: URL): boolean {
+  return HTTP_SCHEMES.has(url.protocol);
+}
+
+/**
+ * Returns `true` for `localhost` and any `*.localhost` name (case-insensitive,
+ * ignoring a trailing dot), matching Python's `_is_blocked_hostname` helper.
+ */
+export function isLocalhostHostname(hostname: string): boolean {
+  const normalized = hostname.replace(/\.+$/, '').toLowerCase();
+  return normalized === 'localhost' || normalized.endsWith('.localhost');
+}
+
+/** Strips the surrounding brackets from an IPv6 URL hostname (`[::1]` → `::1`). */
+export function normalizeHost(hostname: string): string {
+  return hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
+}
+
+/**
+ * Returns `true` when `address` is not globally routable (private, loopback,
+ * link-local, shared, reserved, multicast, ...). Unparseable input fails closed
+ * (blocked).
+ */
+export function isNonGlobalAddress(address: string): boolean {
+  return classifyAddress(address, isNonGlobalIpv4, isNonGlobalIpv6);
+}
+
+/**
+ * Returns `true` when `address` is link-local: IPv4 `169.254.0.0/16` (which
+ * holds the cloud metadata endpoint), IPv6 `fe80::/10`, or an IPv6 address that
+ * embeds a link-local IPv4. Unparseable input fails closed (blocked).
+ */
+export function isLinkLocalAddress(address: string): boolean {
+  return classifyAddress(address, isLinkLocalIpv4, isLinkLocalIpv6);
+}
+
+/**
+ * Resolves `hostname` to a de-duplicated list of IP addresses. IP literals are
+ * returned as-is; hostnames are resolved via DNS. Throws when resolution yields
+ * no address.
+ */
+export async function resolveHostAddresses(
+  hostname: string,
+): Promise<string[]> {
+  if (isIP(hostname) !== 0) {
+    return [hostname];
+  }
+  const records = await lookup(hostname, {all: true});
+  const addresses = [...new Set(records.map((record) => record.address))];
+  if (addresses.length === 0) {
+    throw new Error(`Unable to resolve host: ${hostname}`);
+  }
+  return addresses;
+}
+
+/**
+ * Applies the matching family predicate to `address`, failing closed when the
+ * address parses as neither IPv4 nor IPv6.
+ */
+function classifyAddress(
+  address: string,
+  matchesIpv4: (octets: number[]) => boolean,
+  matchesIpv6: (hextets: number[]) => boolean,
+): boolean {
+  const octets = parseIpv4(address);
+  if (octets) {
+    return matchesIpv4(octets);
+  }
+  const hextets = parseIpv6(address);
+  if (hextets) {
+    return matchesIpv6(hextets);
+  }
+  return true;
+}
+
+/** Parses a dotted-quad IPv4 string into its four octets, or `null`. */
+function parseIpv4(address: string): number[] | null {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(address);
+  if (!match) {
+    return null;
+  }
+  const octets = match.slice(1).map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    return null;
+  }
+  return octets;
+}
+
+/** Expands a valid IPv6 address string into its eight 16-bit hextets, or `null`. */
+function parseIpv6(address: string): number[] | null {
+  if (isIP(address) !== 6) {
+    return null;
+  }
+  const [head, tail] = address.split('::');
+  const highGroups = head ? expandHextets(head) : [];
+  const lowGroups = tail ? expandHextets(tail) : [];
+  const compressed = address.includes('::')
+    ? new Array(8 - highGroups.length - lowGroups.length).fill(0)
+    : [];
+  return [...highGroups, ...compressed, ...lowGroups];
+}
+
+/**
+ * Converts a colon-separated IPv6 fragment into hextets, expanding a trailing
+ * embedded IPv4 group (e.g. the `1.2.3.4` in `::ffff:1.2.3.4`) into two hextets.
+ */
+function expandHextets(fragment: string): number[] {
+  const hextets: number[] = [];
+  for (const group of fragment.split(':')) {
+    if (group.includes('.')) {
+      const octets = parseIpv4(group)!;
+      hextets.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
+    } else {
+      hextets.push(parseInt(group, 16));
+    }
+  }
+  return hextets;
+}
+
+/** Packs four IPv4 octets into an unsigned 32-bit integer. */
+function ipv4ToInt(octets: number[]): number {
+  return (
+    ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0
+  );
+}
+
+/** Packs eight IPv6 hextets into a 128-bit BigInt. */
+function hextetsToBigInt(hextets: number[]): bigint {
+  let value = 0n;
+  for (const hextet of hextets) {
+    value = (value << 16n) | BigInt(hextet);
+  }
+  return value;
+}
+
+/** Precomputes the network address and mask for an IPv4 CIDR string. */
+function parseIpv4Cidr(cidr: string): Ipv4Cidr {
+  const [address, prefix] = cidr.split('/');
+  const mask = (0xffffffff << (32 - Number(prefix))) >>> 0;
+  return {base: (ipv4ToInt(parseIpv4(address)!) & mask) >>> 0, mask};
+}
+
+/** Precomputes the network address and prefix length for an IPv6 CIDR string. */
+function parseIpv6Cidr(cidr: string): Ipv6Cidr {
+  const [address, prefix] = cidr.split('/');
+  return {base: hextetsToBigInt(parseIpv6(address)!), prefix: Number(prefix)};
+}
+
+/** Returns `true` when the IPv4 octets fall inside the network. */
+function matchesIpv4Cidr(octets: number[], {base, mask}: Ipv4Cidr): boolean {
+  return (ipv4ToInt(octets) & mask) >>> 0 === base;
+}
+
+/** Returns `true` when the IPv6 hextets fall inside the network. */
+function matchesIpv6Cidr(hextets: number[], {base, prefix}: Ipv6Cidr): boolean {
+  const shift = BigInt(128 - prefix);
+  return hextetsToBigInt(hextets) >> shift === base >> shift;
+}
+
+/**
+ * Returns the IPv4 address embedded in an IPv6 address as four octets, or
+ * `null` when it embeds none.
+ *
+ * An IPv6 range check alone does not reflect where such an address actually
+ * routes: `64:ff9b::169.254.169.254` is a global IPv6 address, but on a network
+ * with NAT64 it reaches the internal `169.254.169.254` metadata endpoint. The
+ * caller vets the embedded IPv4 instead. Mirrors Python's `_embedded_ipv4`.
+ */
+function embeddedIpv4(hextets: number[]): number[] | null {
+  if (matchesIpv6Cidr(hextets, SIX_TO_FOUR_CIDR)) {
+    return hextetsToOctets(hextets[1], hextets[2]);
+  }
+  if (
+    matchesIpv6Cidr(hextets, IPV4_MAPPED_CIDR) ||
+    matchesIpv6Cidr(hextets, NAT64_CIDR)
+  ) {
+    return hextetsToOctets(hextets[6], hextets[7]);
+  }
+  // IPv4-compatible `::a.b.c.d` (deprecated), excluding `::` and `::1`.
+  if (
+    matchesIpv6Cidr(hextets, IPV4_COMPATIBLE_CIDR) &&
+    (hextets[6] !== 0 || hextets[7] > 1)
+  ) {
+    return hextetsToOctets(hextets[6], hextets[7]);
+  }
+  return null;
+}
+
+/** Splits the two low hextets of an embedded IPv4 address into four octets. */
+function hextetsToOctets(high: number, low: number): number[] {
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff];
+}
+
+/** Returns `true` if the IPv4 octets fall within any non-global range. */
+function isNonGlobalIpv4(octets: number[]): boolean {
+  return NON_GLOBAL_IPV4_CIDRS.some((cidr) => matchesIpv4Cidr(octets, cidr));
+}
+
+/** Returns `true` if the IPv6 hextets fall within any non-global range. */
+function isNonGlobalIpv6(hextets: number[]): boolean {
+  const embedded = embeddedIpv4(hextets);
+  if (embedded) {
+    return isNonGlobalIpv4(embedded);
+  }
+  return NON_GLOBAL_IPV6_CIDRS.some((cidr) => matchesIpv6Cidr(hextets, cidr));
+}
+
+/** Returns `true` if the IPv4 octets are link-local. */
+function isLinkLocalIpv4(octets: number[]): boolean {
+  return matchesIpv4Cidr(octets, LINK_LOCAL_IPV4_CIDR);
+}
+
+/** Returns `true` if the IPv6 hextets are, or embed, a link-local address. */
+function isLinkLocalIpv6(hextets: number[]): boolean {
+  const embedded = embeddedIpv4(hextets);
+  if (embedded) {
+    return isLinkLocalIpv4(embedded);
+  }
+  return matchesIpv6Cidr(hextets, LINK_LOCAL_IPV6_CIDR);
+}

--- a/core/test/a2a/agent_card_test.ts
+++ b/core/test/a2a/agent_card_test.ts
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {describe, expect, it, vi} from 'vitest';
-import {buildAgentSkills} from '../../src/a2a/agent_card.js';
+import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {pathToFileURL} from 'node:url';
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {buildAgentSkills, resolveAgentCard} from '../../src/a2a/agent_card.js';
 import {node} from '../../src/workflow/node.js';
 import {Workflow} from '../../src/workflow/workflow.js';
 
@@ -20,6 +25,49 @@ import {
   ParallelAgent,
   SequentialAgent,
 } from '@google/adk';
+
+/**
+ * The `{all: true}` overload of `dns.lookup` the guard calls, declared here so
+ * the mock is typed without casting through the overloaded signature.
+ */
+type LookupAll = (
+  hostname: string,
+  options: {all: true},
+) => Promise<Array<{address: string; family: number}>>;
+
+const lookupMock = vi.hoisted(() => vi.fn<LookupAll>());
+
+vi.mock('node:dns/promises', () => ({lookup: lookupMock}));
+
+/** Resolves any hostname to the given IP list for the DNS `lookup` mock. */
+function resolveTo(...addresses: string[]): void {
+  lookupMock.mockResolvedValue(
+    addresses.map((address) => ({
+      address,
+      family: address.includes(':') ? 6 : 4,
+    })),
+  );
+}
+
+/** The card a stubbed agent-card endpoint or temp file serves. */
+const STUB_CARD = {
+  name: 'peer_agent',
+  description: 'A peer agent',
+  protocolVersion: '0.3.0',
+  version: '1.0.0',
+  url: 'http://localhost:8001/a2a/peer_agent/',
+  capabilities: {streaming: true},
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text'],
+  skills: [],
+};
+
+/** Builds the 200 response an agent-card endpoint returns. */
+function cardResponse(): Response {
+  return new Response(JSON.stringify(STUB_CARD), {
+    headers: {'content-type': 'application/json'},
+  });
+}
 
 // Minimal CustomAgent for testing BaseAgent path
 class CustomAgent extends BaseAgent {
@@ -234,6 +282,167 @@ describe('Agent Card', () => {
       const workflowSkill = skills.find((s) => s.name === 'workflow');
       expect(workflowSkill?.description).toBe('Runs a graph');
       expect(skills.find((s) => s.name === 'custom')).toBeUndefined();
+    });
+  });
+
+  describe('resolveAgentCard', () => {
+    let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+    let tempDir: string;
+    let cardPath: string;
+
+    beforeEach(async () => {
+      fetchMock = vi.fn<typeof fetch>();
+      vi.stubGlobal('fetch', fetchMock);
+      lookupMock.mockReset();
+      tempDir = await mkdtemp(join(tmpdir(), 'adk-agent-card-'));
+      cardPath = join(tempDir, 'card.json');
+      await writeFile(cardPath, JSON.stringify(STUB_CARD), 'utf-8');
+    });
+
+    afterEach(async () => {
+      vi.unstubAllGlobals();
+      await rm(tempDir, {recursive: true, force: true});
+    });
+
+    it('returns an AgentCard object without any I/O', async () => {
+      const card = await resolveAgentCard(STUB_CARD);
+
+      expect(card).toBe(STUB_CARD);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'http://169.254.169.254/',
+      'http://[fe80::1]/',
+      'http://[64:ff9b::a9fe:a9fe]/',
+    ])('refuses the link-local literal %s without fetching', async (source) => {
+      await expect(resolveAgentCard(source)).rejects.toThrow(
+        /Refusing to fetch agent card from a link-local address/,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refuses a hostname that resolves to a link-local address', async () => {
+      resolveTo('169.254.169.254');
+
+      await expect(
+        resolveAgentCard('http://cards.example.com/'),
+      ).rejects.toThrow(
+        'Refusing to fetch agent card from a link-local address: cards.example.com',
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refuses a hostname that resolves to both a global and a link-local address', async () => {
+      resolveTo('93.184.216.34', '169.254.169.254');
+
+      await expect(
+        resolveAgentCard('http://cards.example.com/'),
+      ).rejects.toThrow(
+        /Refusing to fetch agent card from a link-local address/,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refuses a redirect instead of following it', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: {location: 'http://169.254.169.254/'},
+        }),
+      );
+
+      await expect(
+        resolveAgentCard('http://cards.example.com/'),
+      ).rejects.toThrow(
+        /Refusing to follow a redirect .* \(status 302, location http:\/\/169\.254\.169\.254\/\)/,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(URL),
+        expect.objectContaining({redirect: 'manual'}),
+      );
+    });
+
+    it('refuses an opaque redirect response', async () => {
+      resolveTo('93.184.216.34');
+      fetchMock.mockResolvedValue(Response.error());
+
+      await expect(
+        resolveAgentCard('http://cards.example.com/'),
+      ).rejects.toThrow(/status 0, location null/);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(['http://localhost:8001/a2a/agent/', 'http://127.0.0.1:8001/'])(
+      'fetches the card from the loopback URL %s',
+      async (source) => {
+        resolveTo('127.0.0.1');
+        fetchMock.mockResolvedValue(cardResponse());
+
+        const card = await resolveAgentCard(source);
+
+        expect(card.name).toBe('peer_agent');
+        expect(fetchMock.mock.calls[0][0].toString()).toBe(
+          `${source}.well-known/agent-card.json`,
+        );
+      },
+    );
+
+    it('fetches the card from a private address', async () => {
+      fetchMock.mockResolvedValue(cardResponse());
+
+      const card = await resolveAgentCard('http://10.0.0.5/');
+
+      expect(card.name).toBe('peer_agent');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      'ftp://cards.example.com/card.json',
+      'gopher://cards.example.com/',
+      'htp://cards.example.com/card.json',
+      'data:application/json,{}',
+    ])('refuses the unsupported scheme in %s', async (source) => {
+      const rejection = resolveAgentCard(source);
+
+      await expect(rejection).rejects.toThrow(
+        /Unsupported agent card URL scheme/,
+      );
+      await expect(rejection).rejects.not.toThrow(
+        /Failed to read agent card from file/,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('reads the card from a filesystem path', async () => {
+      const card = await resolveAgentCard(cardPath);
+
+      expect(card.name).toBe('peer_agent');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('reads the card from a file:// URL', async () => {
+      const card = await resolveAgentCard(pathToFileURL(cardPath).href);
+
+      expect(card.name).toBe('peer_agent');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('treats a Windows drive letter as a path, not a scheme', async () => {
+      await expect(resolveAgentCard('C:\\cards\\card.json')).rejects.toThrow(
+        /^Failed to read agent card from file C:\\cards\\card\.json: /,
+      );
+    });
+
+    it('reports a missing card file with its source', async () => {
+      await expect(
+        resolveAgentCard('./no-such-agent-card.json'),
+      ).rejects.toThrow(
+        /^Failed to read agent card from file \.\/no-such-agent-card\.json: ENOENT/,
+      );
     });
   });
 });

--- a/core/test/utils/ssrf_guard_test.ts
+++ b/core/test/utils/ssrf_guard_test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, expect, it} from 'vitest';
+
+import {
+  isHttpUrl,
+  isLinkLocalAddress,
+  isNonGlobalAddress,
+} from '../../src/utils/ssrf_guard.js';
+
+describe('isHttpUrl', () => {
+  it.each(['http://example.com/', 'https://example.com/'])(
+    'accepts %s',
+    (url) => {
+      expect(isHttpUrl(new URL(url))).toBe(true);
+    },
+  );
+
+  it.each([
+    'file:///etc/passwd',
+    'ftp://example.com/card.json',
+    'gopher://example.com/',
+    'data:application/json,{}',
+  ])('rejects %s', (url) => {
+    expect(isHttpUrl(new URL(url))).toBe(false);
+  });
+});
+
+describe('isLinkLocalAddress', () => {
+  it.each([
+    '169.254.169.254',
+    '169.254.0.0',
+    '169.254.255.255',
+    'fe80::1',
+    'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+  ])('reports %s as link-local', (address) => {
+    expect(isLinkLocalAddress(address)).toBe(true);
+  });
+
+  it.each([
+    '::ffff:169.254.169.254', // IPv4-mapped
+    '64:ff9b::a9fe:a9fe', // NAT64 well-known prefix
+    '2002:a9fe:a9fe::', // 6to4
+    '::169.254.169.254', // IPv4-compatible
+  ])('reports %s as link-local through its embedded IPv4', (address) => {
+    expect(isLinkLocalAddress(address)).toBe(true);
+  });
+
+  it.each(['not-an-ip', '', '999.1.1.1', '169.254.1'])(
+    'fails closed on the unparseable address %s',
+    (address) => {
+      expect(isLinkLocalAddress(address)).toBe(true);
+    },
+  );
+
+  it.each([
+    '169.253.0.1',
+    '169.255.0.1',
+    '8.8.8.8',
+    '2606:4700:4700::1111',
+    'fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+    'fec0::1',
+    '::ffff:8.8.8.8',
+    '64:ff9b::8.8.8.8',
+    '2002:808:808::',
+  ])('reports %s as not link-local', (address) => {
+    expect(isLinkLocalAddress(address)).toBe(false);
+  });
+
+  it.each(['127.0.0.1', '::1', '::', '10.0.0.5', '192.168.1.1'])(
+    'allows %s, which this policy deliberately does not block',
+    (address) => {
+      expect(isLinkLocalAddress(address)).toBe(false);
+    },
+  );
+});
+
+describe('isNonGlobalAddress', () => {
+  it.each([
+    '64:ff9b::a9fe:a9fe', // NAT64 of the metadata endpoint
+    '64:ff9b::7f00:1', // NAT64 of loopback
+    '2002:7f00:1::', // 6to4 of loopback
+    '::7f00:1', // IPv4-compatible loopback
+    '::ffff:169.254.169.254', // IPv4-mapped
+  ])('blocks %s, which embeds a non-global IPv4', (address) => {
+    expect(isNonGlobalAddress(address)).toBe(true);
+  });
+
+  it.each([
+    '64:ff9b::8.8.8.8',
+    '2002:808:808::',
+    '::ffff:8.8.8.8',
+    '::fffe:7f00:1', // low 32 bits look like loopback, but this is not IPv4-compatible
+  ])('allows %s, which embeds a global IPv4', (address) => {
+    expect(isNonGlobalAddress(address)).toBe(false);
+  });
+
+  it.each([
+    '::',
+    '::1',
+    '64:ff9b:1::1', // local NAT64 prefix, not the well-known one
+    '127.0.0.1',
+    '169.254.169.254',
+    'fe80::1',
+    'not-an-ip',
+  ])('blocks %s', (address) => {
+    expect(isNonGlobalAddress(address)).toBe(true);
+  });
+});


### PR DESCRIPTION
Please ensure you have read the contribution guide before creating a pull request.

### Link to Issue or Description of Change

1. Link to an existing issue (if applicable): none; reported through a security review of the A2A client.
2. Description of the change:
   **Problem**: `resolveAgentCard` read any source that did not start with `http://` or `https://` off the local filesystem, so `file:///etc/passwd` or a typo like `htp://host/card.json` became an arbitrary file read. The fetch had no address check, so `http://169.254.169.254/` reached the cloud metadata endpoint. The fetch also followed redirects, so a card host could move the request to that endpoint itself.

**Solution**: A card source now resolves by scheme. `http(s)` fetches, `file://` and a bare filesystem path read, and any other scheme throws instead of falling through to `fs.readFile`. The fetch refuses a host that is or resolves to a link-local address, and refuses a redirect rather than following it. Loopback and private addresses stay allowed, because that is where a locally served or VPC-internal peer agent lives, and blocking them would break the shape `toA2a()` emits.

Four notes for the reviewer.

`file://` sources are newly supported, which is a small behavior addition rather than a fix. On `main` a `file://` source reached `fs.readFile('file:///...')` and always failed. Now that a URL-shaped source can no longer fall through to a file read, a developer who wants a local card needs a spelling the guard accepts, and this is it. A bare filesystem path keeps working unchanged.

The address checks already existed in `core/src/tools/load_web_page.ts`. They move to `core/src/utils/ssrf_guard.ts` rather than being duplicated, which is most of the line count. `loadWebPage`'s 44 existing tests pass unmodified.

The move tightens `loadWebPage` once, deliberately: an IPv6 address that embeds a non-global IPv4 through NAT64 (`64:ff9b::/96`), 6to4 (`2002::/16`) or the IPv4-compatible form is now blocked. `http://[64:ff9b::a9fe:a9fe]/` is `64:ff9b::169.254.169.254` and routes to the metadata endpoint on a NAT64 network. `adk-python`'s `_embedded_ipv4` already does this; the TypeScript port only un-embedded the IPv4-mapped form.

The design spec asked for the host check twice, once before `DefaultAgentCardResolver` runs and once inside the injected `fetchImpl`. One check is enough, and it runs on the configured URL. The resolver appends a relative well-known path, which cannot change the origin, and the injected `fetchImpl` refuses a redirect, so nothing else can pick where the request lands.

Related work in this repo: #829 pins a fetched card's RPC url(s) to the origin it was fetched from. That is the complement of this change — #829 guards where a card points us next, this one guards where we fetch the card from. The two are independent and can land in either order; whichever is second will need a trivial rebase, as both touch `core/src/a2a/agent_card.ts` and its test.

This change is not stacked on anything: it applies directly to `main`.

### Testing Plan

Please describe the tests that you ran to verify your changes. This is required for all PRs that are not small documentation or typo fixes.
Unit Tests:
[x] I have added or updated unit tests for my change.
[x] All unit tests pass locally.

```
npx vitest run --project unit:core core/test/a2a/agent_card_test.ts core/test/utils/ssrf_guard_test.ts core/test/tools/load_web_page_test.ts
  Test Files  3 passed (3)   Tests  121 passed (121)
npx vitest run --project unit:core core/test/a2a/
  Test Files 16 passed (16)  Tests  256 passed (256)
npx vitest run --project integration tests/integration/a2a/
  Test Files  3 passed (3)   Tests  6 passed (6)
npm run ts:check      # clean
npm run lint          # clean
npm run format:check  # clean
```

Line and branch coverage of the new code is 100% (`core/src/utils/ssrf_guard.ts` 100/100, `core/src/tools/load_web_page.ts` 100/100). `core/src/a2a/agent_card.ts` reports 88%; every uncovered line is pre-existing `buildAgentSkills` code, none is in this change.

Each new test was run against mutated source to prove it can fail:

| Mutation                                                            | Tests that failed | Failure message                                                                                                                         |
| ------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| Delete `await assertHostAllowed(url)`                               | 5                 | `expected [Function] to throw error matching /Refusing to fetch agent card from a l…/`                                                  |
| `redirect: 'manual'` back to the default                            | 1                 | `expected "spy" to be called with arguments: [ Any<URL>, ObjectContaining{…} ]`                                                         |
| Restore `startsWith('http://')` and the bare `fs.readFile` fallback | 4                 | `expected [Function] to throw error matching /Unsupported agent card URL scheme/ but got 'Failed to read agent card from file f…'`      |
| Drop the NAT64 arm of `embeddedIpv4`                                | 4                 | `expected false to be true`                                                                                                             |
| Block loopback and private too                                      | 3                 | `fetches the card from the loopback URL http://localhost:8001/a2a/agent/`                                                               |
| Drop the Windows drive-letter carve-out                             | 1                 | `expected [Function] to throw error matching /^Failed to read agent card from file …/ but got 'Unsupported agent card URL scheme "c:…'` |
| Drop the `status === 0` arm                                         | 1                 | `expected [Function] to throw error matching /status 0, location null/`                                                                 |

The loopback mutation is there on purpose: it pins the allowance as a decision, not an accident.

Manual End-to-End (E2E) Tests:
Please provide instructions on how to manually test your changes, including any necessary setup or configuration.

Run `npm run build`, then drive the built `resolveAgentCard` against a real local HTTP server with no mocks:

1. `resolveAgentCard('http://169.254.169.254/')` throws `Refusing to fetch agent card from a link-local address: 169.254.169.254`. The server's `connection` counter stays at 0, so no socket opens.
2. A card served over loopback resolves and returns the card.
3. A server answering `302 Location: http://169.254.169.254/computeMetadata/v1/` throws `Refusing to follow a redirect while fetching the agent card from … (status 302, location http://169.254.169.254/computeMetadata/v1/). Configure the final URL instead.`
4. `resolveAgentCard('ftp://cards.example.com/card.json')` throws `Unsupported agent card URL scheme "ftp:"` and reads no file.

All four behaved as listed. `tests/integration/a2a/**` also passes unmodified against a live local A2A server, which is the regression proof for local development.

### Checklist

[x] I have read the CONTRIBUTING.md document.
[x] I have performed a self-review of my own code.
[x] I have commented my code, particularly in hard-to-understand areas.
[x] I have added tests that prove my fix is effective or that my feature works.
[x] New and existing unit tests pass locally with my changes.

