### PR TITLE
fix(build): make the web build loadable outside Node

### DIFF
--- a/core/build.js
+++ b/core/build.js
@@ -8,7 +8,13 @@ import {writeFile} from 'node:fs/promises';
 
 const platformBuildTargets = {
   'node': ['node10.4'],
-  'browser': ['chrome58', 'firefox57', 'safari11'],
+  // Safari 12, not 11: the library uses async generators throughout, and they
+  // are ES2018. Targeting Safari 11 asked esbuild to lower them, and its
+  // lowering of `yield* super.method()` emits `__yieldStar(super.method())` in
+  // a scope where `super` is a syntax error — so `models/apigee_llm.js` in the
+  // web build did not parse at all. Safari 11 was never really supported; the
+  // target only said it was.
+  'browser': ['chrome63', 'firefox57', 'safari12'],
 };
 
 const licenseHeaderText = `/**
@@ -75,7 +81,13 @@ function build({
     buildOptions.outdir = `./dist/${targetDir}`;
   }
 
-  if (format === 'esm') {
+  // Node ESM only. The shim exists so an ESM build can reach a CommonJS
+  // dependency, which is a Node concern — and adding it to the *browser* ESM
+  // build put `import {createRequire} from 'module'` at the top of every file
+  // in `dist/web`, so the browser build could only be loaded by Node. Bundlers
+  // targeting a browser, a worker or any edge runtime failed to resolve
+  // 'module' and stopped.
+  if (format === 'esm' && platform !== 'browser') {
     buildOptions.banner = {
       js:
         (buildOptions.banner?.js || '') +

--- a/core/test/web_build_is_platform_neutral_test.ts
+++ b/core/test/web_build_is_platform_neutral_test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Guards two regressions that made `dist/web` unloadable outside Node while
+ * every other test kept passing, because the rest of the suite imports `src`.
+ *
+ *  - **A Node builtin in the ESM banner.** `build.js` prepends a `createRequire`
+ *    shim to ESM output so an ESM build can reach a CommonJS dependency. That is
+ *    a Node concern, and it was applied to the browser build too — putting
+ *    `import {createRequire} from 'module'` at the top of *every* file in
+ *    `dist/web`, including leaf modules with no Node dependency at all. Any
+ *    bundler targeting a browser, a worker or an edge runtime then failed to
+ *    resolve `'module'`.
+ *
+ *  - **Output that does not parse.** The browser target included Safari 11,
+ *    which predates async generators, so esbuild lowered them — and its lowering
+ *    of `yield* super.method()` emits `__yieldStar(super.method())` in a scope
+ *    where `super` is a syntax error. `models/apigee_llm.js` did not parse.
+ *
+ * Deliberately *not* asserted: that nothing in `dist/web` imports a Node
+ * builtin. Several modules legitimately do — `artifacts/file_artifact_service`,
+ * `code_executors/unsafe_local_code_executor`, `environment/local_environment`,
+ * `skills/loader`, `a2a/*` — and they are only reached by importing them. The
+ * banner was different in kind: it was on everything.
+ *
+ * Skipped when `dist/web` has not been built, so `npm run test:unit` on a clean
+ * checkout does not fail for a missing artifact.
+ */
+
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
+import {dirname, extname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from 'vitest';
+
+const WEB_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'dist',
+  'web',
+);
+
+function jsFilesIn(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      found.push(...jsFilesIn(full));
+    } else if (extname(full) === '.js') {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+const built = existsSync(WEB_DIR);
+
+describe.skipIf(!built)('the web build is loadable outside Node', () => {
+  const files = built ? jsFilesIn(WEB_DIR) : [];
+  const relative = (file: string) => file.slice(WEB_DIR.length + 1);
+
+  it('produced output to check', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('carries no createRequire shim', () => {
+    const offenders = files
+      .filter((file) => readFileSync(file, 'utf8').includes('createRequire'))
+      .map(relative);
+
+    expect(
+      offenders,
+      `dist/web files with the Node createRequire shim:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('emits JavaScript that parses', async () => {
+    /**
+     * Parsed with the bundler the build itself uses, rather than by importing:
+     * these are ES modules with real dependencies, and the failure being
+     * guarded is purely syntactic — which is what `super` outside a method is.
+     */
+    const esbuild = await import('esbuild');
+    const unparseable: string[] = [];
+
+    for (const file of files) {
+      try {
+        esbuild.transformSync(readFileSync(file, 'utf8'), {
+          loader: 'js',
+          format: 'esm',
+        });
+      } catch {
+        unparseable.push(relative(file));
+      }
+    }
+
+    expect(
+      unparseable,
+      `dist/web files that do not parse:\n${unparseable.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
`dist/web` could only be loaded by Node, so `@google/adk` could not be bundled for a browser, a worker, or any edge runtime. Two independent causes, both in `core/build.js`.

**The createRequire banner was applied to the browser build.** The shim exists so an ESM build can reach a CommonJS dependency, which is a Node concern, but the condition was `format === 'esm'` — and the web build is browser + esm. Every one of the 256 files in `dist/web` therefore opened with `import {createRequire} from 'module'`, including leaf modules with no Node dependency at all. Bundlers targeting a browser resolve that as a missing package and stop.

**The browser target included Safari 11, which predates async generators.** esbuild lowered them, and its lowering of `yield* super.method()` emits `__yieldStar(super.method())` in a scope where `super` is a syntax error, so `models/apigee_llm.js` did not parse. Safari 11 was never really supported — the library uses async generators throughout, and they are ES2018. The target only claimed it.

Measured before and after with wrangler, since Cloudflare Workers is the case that fails hardest:

  before   ✘ [ERROR] Unexpected "super"
             dist/web/models/apigee_llm.js:142:25
  after    Total Upload: 4652.19 KiB / gzip: 795.49 KiB

And it runs, not merely builds: a Workflow with two FunctionNodes joining into a JoinNode, plus a RequestInput, constructed inside workerd and answering 200.

Adds a regression test. It asserts the two specific failures — no `createRequire` anywhere in `dist/web`, and every file parses — and deliberately does not assert that nothing imports a Node builtin, because several modules legitimately do (`file_artifact_service`, `unsafe_local_code_executor`, `local_environment`, `skills/loader`, `a2a/*`) and are only reached by importing them. The banner was different in kind: it was on everything. The test skips when `dist/web` has not been built, and it fails on the previous build and passes on this one.

The rest of the suite imports `src`, which is why neither of these was visible to it.

**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed npm test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
