### PR TITLE
docs(samples): add PostHog LLM observability example

### DIFF
--- a/samples/observability/README.md
+++ b/samples/observability/README.md
@@ -1,0 +1,87 @@
+# Observability samples
+
+Runnable TypeScript examples that route ADK's telemetry to a third-party
+observability backend.
+
+ADK instruments the framework with OpenTelemetry: every model call becomes a
+`gen_ai.*` span, and `maybeSetOtelProviders` lets you attach your own span
+processors without replacing ADK's tracing.
+These samples use that hook to forward spans to an external product.
+
+One directory per backend.
+
+## PostHog (`posthog/`)
+
+Sends ADK's `gen_ai.*` spans to [PostHog](https://posthog.com), which converts
+them into `$ai_generation` events server-side and surfaces them in its
+[LLM analytics](https://posthog.com/docs/ai-engineering/observability) product -
+model, token usage, latency, and, when span content capture is on, the prompt
+and response.
+
+### Wiring (recommended: the published `@posthog/ai/otel`)
+
+In your own project, install PostHog's AI SDK and hand its span processor to
+ADK. That is the whole integration:
+
+```bash
+npm install @posthog/ai
+```
+
+```ts
+import {maybeSetOtelProviders} from '@google/adk';
+import {PostHogSpanProcessor} from '@posthog/ai/otel';
+
+maybeSetOtelProviders([
+  {
+    spanProcessors: [
+      new PostHogSpanProcessor({
+        projectToken: process.env.POSTHOG_API_KEY!,
+        host: process.env.POSTHOG_HOST, // defaults to https://us.i.posthog.com
+      }),
+    ],
+  },
+]);
+```
+
+`PostHogSpanProcessor` keeps only AI spans, batches them, and exports them to
+PostHog's OTLP ingestion endpoint (`/i/v0/ai/otel`). It self-disables on a blank
+token, so leaving `POSTHOG_API_KEY` unset simply runs the agent without
+telemetry.
+
+The runnable sample in `posthog/agent.ts` inlines an equivalent processor
+instead of importing `@posthog/ai`, so this monorepo does not take on a new
+dependency (`@posthog/ai` optionally peer-depends on an older `@google/genai`
+than ADK uses). The inlined version uses only the OpenTelemetry packages ADK
+already depends on - the same OTLP path `@posthog/ai/otel` takes. In your own
+project, prefer the published class above.
+
+### Running the sample
+
+```bash
+npm run build            # builds @google/adk (and the CLI); needed once / after changes
+export GEMINI_API_KEY=...
+export POSTHOG_API_KEY=phc_...
+export POSTHOG_HOST=https://us.i.posthog.com   # optional; this is the default
+npm run sample -- samples/observability/posthog/agent.ts
+```
+
+Get the **project API key** (`phc_...`) from PostHog under
+_Settings -> Project -> API keys_, and use `https://us.i.posthog.com` (US cloud)
+or `https://eu.i.posthog.com` (EU cloud) as the host.
+
+`npm run sample -- <path>` is shorthand for
+`node dev/dist/esm/cli_entrypoint.js run <path>`. The CLI is interactive: type a
+message and press Enter; type `exit` to quit.
+
+### What shows up in PostHog
+
+Ask the agent a question, then open **LLM analytics** in PostHog. Within a few
+seconds the model call appears as an `$ai_generation` event carrying the model
+name (`gemini-flash-latest`), input/output token counts, latency, and the
+finish reason. Multiple turns in one session share a trace, so you can follow a
+conversation end to end.
+
+By default ADK also records prompt and response content on the spans. To keep
+message bodies out of your spans, set
+`ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS=false` before running; the events still
+carry model and usage metadata.

--- a/samples/observability/README.md
+++ b/samples/observability/README.md
@@ -18,6 +18,14 @@ them into `$ai_generation` events server-side and surfaces them in its
 model, token usage, latency, and, when span content capture is on, the prompt
 and response.
 
+> **Content capture is on by default.** ADK records the full request and full
+> response into the span attributes `gcp.vertex.agent.llm_request` and
+> `gcp.vertex.agent.llm_response` (both default to `true`). Because the sample
+> forwards these spans to PostHog, the entire conversation text leaves your
+> environment for a third party out of the box. To keep message bodies out of
+> the spans, set `ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS=false` before running;
+> the events still carry model and usage metadata.
+
 ### Wiring (recommended: the published `@posthog/ai/otel`)
 
 In your own project, install PostHog's AI SDK and hand its span processor to
@@ -72,6 +80,18 @@ or `https://eu.i.posthog.com` (EU cloud) as the host.
 `npm run sample -- <path>` is shorthand for
 `node dev/dist/esm/cli_entrypoint.js run <path>`. The CLI is interactive: type a
 message and press Enter; type `exit` to quit.
+
+This sample only wires up PostHog under `npm run sample`. Under `adk web` or
+`adk api_server`, ADK's `setupTelemetry()` registers the global tracer provider
+before any agent loads, so the sample's own registration is refused
+(`registerGlobal` returns `false` and logs "Attempted duplicate registration of
+API") and no spans reach PostHog.
+
+> **Note:** this sample sits outside the CI coverage guard. The
+> `tests/integration/docs_samples` "covers every sample on disk" check reads
+> only `samples/workflows` (its `SAMPLES_ROOT`), so nothing constructs
+> `posthog/agent.ts` in CI. An ADK API rename could leave it type-checking but
+> broken at load; run it manually after such changes.
 
 ### What shows up in PostHog
 

--- a/samples/observability/posthog/agent.ts
+++ b/samples/observability/posthog/agent.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Observability: PostHog LLM analytics
+ * https://posthog.com/docs/ai-engineering/observability
+ *
+ * ADK emits OpenTelemetry `gen_ai.*` spans for every model call. This sample
+ * routes those spans to PostHog, which converts them into `$ai_generation`
+ * events server-side, so a plain agent shows up in PostHog's LLM-observability
+ * product with model, token usage, latency and (optionally) prompt/response
+ * content.
+ *
+ * The wiring is one call: hand ADK a span processor through
+ * `maybeSetOtelProviders`. In your own project the processor is a one-line
+ * import from PostHog's published package:
+ *
+ *   import {PostHogSpanProcessor} from '@posthog/ai/otel';
+ *   new PostHogSpanProcessor({projectToken, host});
+ *
+ * This sample inlines the equivalent processor (see `createPostHogSpanProcessor`
+ * below) so it stays dependency-light and adds nothing to the ADK monorepo - it
+ * uses only the OpenTelemetry packages ADK already depends on, which is exactly
+ * the OTLP path `@posthog/ai/otel` takes. See this directory's README for the
+ * published-package version and setup.
+ *
+ * REQUIRES an API key (the agent calls a live model) and a PostHog project key
+ * (spans are dropped otherwise). Set the environment, then run:
+ *   export GEMINI_API_KEY=...
+ *   export POSTHOG_API_KEY=phc_...        # PostHog project API key
+ *   export POSTHOG_HOST=https://us.i.posthog.com   # or https://eu.i.posthog.com
+ *   npm run sample -- samples/observability/posthog/agent.ts
+ *
+ * Then ask the agent something and open PostHog -> LLM analytics; the model
+ * call appears as an `$ai_generation` event within a few seconds.
+ */
+
+import {LlmAgent, maybeSetOtelProviders} from '@google/adk';
+import {Context} from '@opentelemetry/api';
+import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-http';
+import {
+  BatchSpanProcessor,
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+// PostHog treats a span as AI-related when its name or any attribute key starts
+// with one of these prefixes. ADK's model-call spans carry `gen_ai.*`
+// attributes, so they match; everything else is dropped before export.
+const AI_SPAN_PREFIXES = ['gen_ai.', 'llm.', 'ai.', 'traceloop.'];
+
+function isAiSpan(span: ReadableSpan): boolean {
+  if (AI_SPAN_PREFIXES.some((prefix) => span.name.startsWith(prefix))) {
+    return true;
+  }
+  return Object.keys(span.attributes ?? {}).some((key) =>
+    AI_SPAN_PREFIXES.some((prefix) => key.startsWith(prefix)),
+  );
+}
+
+/**
+ * A span processor that batches AI spans and exports them to PostHog's OTLP
+ * ingestion endpoint. This mirrors `PostHogSpanProcessor` from
+ * `@posthog/ai/otel`; prefer that published class in a real project.
+ */
+function createPostHogSpanProcessor(options: {
+  projectToken: string;
+  host?: string;
+}): SpanProcessor {
+  const host = new URL(options.host || DEFAULT_POSTHOG_HOST).origin;
+  const inner = new BatchSpanProcessor(
+    new OTLPTraceExporter({
+      url: `${host}/i/v0/ai/otel`,
+      headers: {Authorization: `Bearer ${options.projectToken}`},
+    }),
+  );
+
+  return {
+    onStart(span: Span, parentContext: Context): void {
+      inner.onStart(span, parentContext);
+    },
+    // Filter on end, once the span's attributes are set.
+    onEnd(span: ReadableSpan): void {
+      if (isAiSpan(span)) inner.onEnd(span);
+    },
+    shutdown(): Promise<void> {
+      return inner.shutdown();
+    },
+    forceFlush(): Promise<void> {
+      return inner.forceFlush();
+    },
+  };
+}
+
+// Route ADK's `gen_ai.*` spans to PostHog. `maybeSetOtelProviders` registers a
+// global tracer provider only when it is given at least one span processor, so
+// guarding on the key keeps the sample a no-op until PostHog is configured.
+const projectToken = process.env.POSTHOG_API_KEY ?? '';
+if (projectToken) {
+  maybeSetOtelProviders([
+    {
+      spanProcessors: [
+        createPostHogSpanProcessor({
+          projectToken,
+          // Defaults to https://us.i.posthog.com when unset.
+          host: process.env.POSTHOG_HOST,
+        }),
+      ],
+    },
+  ]);
+} else {
+  console.warn(
+    'POSTHOG_API_KEY is not set; running without PostHog telemetry. ' +
+      'Set it to a phc_... project key to see $ai_generation events.',
+  );
+}
+
+export const rootAgent = new LlmAgent({
+  name: 'posthog_observability_agent',
+  model: 'gemini-flash-latest',
+  description: 'A minimal agent whose model calls are traced to PostHog.',
+  instruction:
+    'You are a concise assistant. Answer the user in a sentence or two.',
+});

--- a/samples/observability/posthog/agent.ts
+++ b/samples/observability/posthog/agent.ts
@@ -103,17 +103,16 @@ function createPostHogSpanProcessor(options: {
 // guarding on the key keeps the sample a no-op until PostHog is configured.
 const projectToken = process.env.POSTHOG_API_KEY ?? '';
 if (projectToken) {
-  maybeSetOtelProviders([
-    {
-      spanProcessors: [
-        createPostHogSpanProcessor({
-          projectToken,
-          // Defaults to https://us.i.posthog.com when unset.
-          host: process.env.POSTHOG_HOST,
-        }),
-      ],
-    },
-  ]);
+  const postHogProcessor = createPostHogSpanProcessor({
+    projectToken,
+    // Defaults to https://us.i.posthog.com when unset.
+    host: process.env.POSTHOG_HOST,
+  });
+  maybeSetOtelProviders([{spanProcessors: [postHogProcessor]}]);
+  // BatchSpanProcessor unref()s its flush timer, so it never holds the process
+  // open; without an explicit flush the last turn's spans never reach PostHog.
+  // shutdown() flushes the batch before the CLI exits.
+  process.on('beforeExit', () => void postHogProcessor.shutdown());
 } else {
   console.warn(
     'POSTHOG_API_KEY is not set; running without PostHog telemetry. ' +


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

ADK already instruments the framework with OpenTelemetry - every model call
becomes a `gen_ai.*` span - but there is no example showing how to get those
spans into a third-party LLM-observability product. Users who want per-call
model/token/latency analytics have to discover the `maybeSetOtelProviders`
hook and figure out the exporter wiring themselves.

**Solution:**

Add a runnable observability sample that routes ADK's `gen_ai.*` spans to
[PostHog](https://posthog.com), which converts them into `$ai_generation`
events server-side and surfaces them in its
[LLM analytics](https://posthog.com/docs/ai-engineering/observability) product
(model, token usage, latency, and optionally prompt/response content).

- `samples/observability/posthog/agent.ts` - a minimal `LlmAgent` whose model
  calls are traced to PostHog. The whole integration is one call:
  `maybeSetOtelProviders([{ spanProcessors: [postHogProcessor] }])`.
- `samples/observability/README.md` - setup (`POSTHOG_API_KEY`, host), how to
  run it, and what shows up in PostHog.

The recommended path for a real project is PostHog's published
[`@posthog/ai/otel`](https://www.npmjs.com/package/@posthog/ai) span processor,
which the README documents as a one-liner. The sample **inlines** an equivalent
processor rather than importing `@posthog/ai`, so this monorepo takes on no new
dependency (`@posthog/ai` optionally peer-depends on an older `@google/genai`
than ADK uses). The inlined processor is built only from the OpenTelemetry
packages ADK already depends on - the same OTLP path `@posthog/ai/otel` takes
internally (batch export to PostHog's `/i/v0/ai/otel` endpoint, filtered to AI
spans).

This mirrors the existing vendor-exporter pattern in
`core/src/telemetry/google_cloud.ts` and slots into the existing `samples/`
surface as a new `observability/` category (a sibling to `samples/workflows/`).

### Testing Plan

This is a docs/example change (a new sample plus its README); it adds no
library code and no new dependency.

**Static checks (all pass locally):**

- `npm run ts:check:samples` - the sample type-checks against the published
  `@google/adk` types like every other sample.
- `npm run lint` (ESLint), `npm run format:check` (Prettier) - clean.
- `secretlint` and `scripts/check_license.sh` - clean.

**Manual End-to-End (E2E) Tests:**

- Loaded the sample through the ADK CLI
  (`npm run sample -- samples/observability/posthog/agent.ts`): with no
  `POSTHOG_API_KEY` it logs the documented warning, constructs `rootAgent`, and
  runs the interactive loop.
- Verified the export wiring against a local mock OTLP server: a synthetic
  `gen_ai.*` span is POSTed to `/i/v0/ai/otel` with an `Authorization: Bearer`
  header, while a non-AI span is filtered out and dropped - matching PostHog's
  ingestion contract.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have manually tested my changes end-to-end.

### Additional context

`samples/observability/` is a new sibling to `samples/workflows/`. The
`docs_samples` integration test is scoped to `samples/workflows/`, so this
sample is covered by the static checks (type-check, lint, format, license)
rather than that runner, which needs a live model and a PostHog key to exercise.

