### PR TITLE
fix(auth): redact credential secrets from the auth request event

### DIFF
--- a/core/src/auth/auth_handler.ts
+++ b/core/src/auth/auth_handler.ts
@@ -14,7 +14,7 @@ import {OAuth2CredentialExchanger} from './oauth2/oauth2_credential_exchanger.js
 // The auth request is sent to the client and stored in the session, so the
 // agent's own secrets must not travel in it. They are re-supplied from the
 // tool config when the credential is exchanged.
-function credentialWithoutSecrets(
+export function credentialWithoutSecrets(
   credential: AuthCredential | undefined,
 ): AuthCredential | undefined {
   if (!credential) {
@@ -34,6 +34,41 @@ function credentialWithoutSecrets(
     redacted.serviceAccount.serviceAccountCredential.privateKey = '';
   }
   return redacted;
+}
+
+/**
+ * Restores the configured OAuth2 client identity onto a credential.
+ *
+ * The credential comes back from the client, which must not get to choose
+ * which OAuth2 client the token is exchanged for, or where the secret that
+ * exchange posts is sent. `configured` is the credential the agent holds, and
+ * it wins on both fields. Only fills them in when the caller actually has a
+ * configured client, so the redacted config read back off the request event
+ * leaves the credential as it found it.
+ */
+export function withConfiguredClient(
+  credential: AuthCredential | undefined,
+  configured: AuthCredential | undefined,
+): AuthCredential | undefined {
+  if (!credential?.oauth2 || !configured?.oauth2) {
+    return credential;
+  }
+  const restored = structuredClone(credential);
+  restored.oauth2 = {
+    ...restored.oauth2,
+    clientId: configured.oauth2.clientId ?? restored.oauth2!.clientId,
+    clientSecret:
+      configured.oauth2.clientSecret ?? restored.oauth2!.clientSecret,
+  };
+  return restored;
+}
+
+/** Whether credential still needs, and is able to do, a token exchange. */
+function isExchangeable(credential: AuthCredential): boolean {
+  const oauth2 = credential.oauth2;
+  return Boolean(
+    oauth2 && !oauth2.accessToken && oauth2.clientId && oauth2.clientSecret,
+  );
 }
 
 function authConfigWithoutSecrets(config: AuthConfig): AuthConfig {
@@ -80,14 +115,37 @@ export class AuthHandler {
       return;
     }
 
-    if (this.authConfig.exchangedAuthCredential) {
-      const exchanger = new OAuth2CredentialExchanger();
-      const exchangedCredential = await exchanger.exchange({
-        authCredential: this.authConfig.exchangedAuthCredential,
-        authScheme: this.authConfig.authScheme,
-      });
-      state.set(credentialKey, exchangedCredential.credential);
+    const credential = withConfiguredClient(
+      this.authConfig.exchangedAuthCredential,
+      this.authConfig.rawAuthCredential,
+    );
+    if (!credential) {
+      return;
     }
+
+    // Without a client secret there is nothing to authenticate the token
+    // request with, so the exchange would fail rather than merely be
+    // unauthenticated. That is the normal case here: the request event is
+    // redacted, so the config read back off it carries no secret. Store the
+    // authorization code and let the tool, which still holds the configured
+    // credential, complete the exchange.
+    if (!isExchangeable(credential)) {
+      state.set(credentialKey, credential);
+
+      return;
+    }
+
+    const exchanger = new OAuth2CredentialExchanger();
+    const exchangedCredential = await exchanger.exchange({
+      authCredential: credential,
+      authScheme: this.authConfig.authScheme,
+    });
+    // The result goes into session state, which the client can read, so it
+    // keeps no secret either.
+    state.set(
+      credentialKey,
+      credentialWithoutSecrets(exchangedCredential.credential),
+    );
   }
 
   generateAuthRequest(): AuthConfig {

--- a/core/src/auth/auth_handler.ts
+++ b/core/src/auth/auth_handler.ts
@@ -11,6 +11,41 @@ import {AuthCredential} from './auth_credential.js';
 import {AuthConfig} from './auth_tool.js';
 import {OAuth2CredentialExchanger} from './oauth2/oauth2_credential_exchanger.js';
 
+// The auth request is sent to the client and stored in the session, so the
+// agent's own secrets must not travel in it. They are re-supplied from the
+// tool config when the credential is exchanged.
+function credentialWithoutSecrets(
+  credential: AuthCredential | undefined,
+): AuthCredential | undefined {
+  if (!credential) {
+    return credential;
+  }
+  const redacted = structuredClone(credential);
+  if (redacted.oauth2) {
+    redacted.oauth2.clientSecret = undefined;
+  }
+  if (redacted.apiKey !== undefined) {
+    redacted.apiKey = undefined;
+  }
+  if (redacted.http?.credentials) {
+    redacted.http.credentials.password = undefined;
+  }
+  if (redacted.serviceAccount?.serviceAccountCredential) {
+    redacted.serviceAccount.serviceAccountCredential.privateKey = '';
+  }
+  return redacted;
+}
+
+function authConfigWithoutSecrets(config: AuthConfig): AuthConfig {
+  return {
+    ...config,
+    rawAuthCredential: credentialWithoutSecrets(config.rawAuthCredential),
+    exchangedAuthCredential: credentialWithoutSecrets(
+      config.exchangedAuthCredential,
+    ),
+  };
+}
+
 /**
  * A handler that handles the auth flow in Agent Development Kit to help
  * orchestrates the credential request and response flow (e.g. OAuth flow)
@@ -56,6 +91,10 @@ export class AuthHandler {
   }
 
   generateAuthRequest(): AuthConfig {
+    return authConfigWithoutSecrets(this.buildAuthRequest());
+  }
+
+  private buildAuthRequest(): AuthConfig {
     const authSchemeType = this.authConfig.authScheme.type;
 
     if (!['oauth2', 'openIdConnect'].includes(authSchemeType)) {

--- a/core/src/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.ts
+++ b/core/src/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.ts
@@ -7,6 +7,10 @@
 import {OpenAPIV3} from 'openapi-types';
 import {Context} from '../../../agents/context.js';
 import {AuthCredential} from '../../../auth/auth_credential.js';
+import {
+  credentialWithoutSecrets,
+  withConfiguredClient,
+} from '../../../auth/auth_handler.js';
 import {AuthConfig} from '../../../auth/auth_tool.js';
 import {experimental} from '../../../utils/experimental.js';
 import {AutoAuthCredentialExchanger} from '../auth/credential_exchangers/auto_auth_credential_exchanger.js';
@@ -92,7 +96,14 @@ export class ToolAuthHandler {
     // need no user interaction, so requesting one would strand the tool in
     // `pending` forever.
     const authResponseCredential = this.context.getAuthResponse(authConfig);
-    const credential = authResponseCredential ?? this.authCredential;
+    // An auth response carries the outcome of the user's browser round trip,
+    // not the agent's own client identity: it travelled through the client, so
+    // the request it answers was redacted and the token endpoint would be
+    // given no secret to authenticate with. The configured credential supplies
+    // that half, and it is the only authority for it.
+    const credential = authResponseCredential
+      ? withConfiguredClient(authResponseCredential, this.authCredential)
+      : this.authCredential;
 
     if (!credential) {
       // No credential to work with, so ask the client for one.
@@ -114,7 +125,10 @@ export class ToolAuthHandler {
     // secret into the session store for nothing.
     if (authResponseCredential || result.wasExchanged) {
       const key = store.getCredentialKey(this.authScheme);
-      store.storeCredential(key, result.credential);
+      // This is written to session state, which the client can read, so the
+      // cached copy keeps the access token but not the client secret that
+      // was merged in to obtain it.
+      store.storeCredential(key, credentialWithoutSecrets(result.credential)!);
     }
 
     return {state: 'done', authCredential: result.credential};

--- a/core/test/auth/auth_handler_test.ts
+++ b/core/test/auth/auth_handler_test.ts
@@ -7,14 +7,23 @@
 import {AuthConfig, AuthCredentialTypes, AuthHandler, State} from '@google/adk';
 import {describe, expect, it, vi} from 'vitest';
 
+/** Credentials the mocked exchanger was asked to exchange, most recent last. */
+const exchangeCalls: Array<{clientId?: string; clientSecret?: string}> = [];
+
 vi.mock('../../src/auth/oauth2/oauth2_credential_exchanger.js', () => ({
   OAuth2CredentialExchanger: class {
-    exchange = vi.fn().mockResolvedValue({
-      credential: {
-        authType: 'oauth2',
-        oauth2: {accessToken: 'mockAccessToken'},
-      },
-      wasExchanged: true,
+    exchange = vi.fn().mockImplementation(({authCredential}) => {
+      exchangeCalls.push({
+        clientId: authCredential?.oauth2?.clientId,
+        clientSecret: authCredential?.oauth2?.clientSecret,
+      });
+      return Promise.resolve({
+        credential: {
+          authType: 'oauth2',
+          oauth2: {accessToken: 'mockAccessToken'},
+        },
+        wasExchanged: true,
+      });
     });
   },
 }));
@@ -102,7 +111,11 @@ describe('AuthHandler', () => {
         },
         exchangedAuthCredential: {
           authType: AuthCredentialTypes.OAUTH2,
-          oauth2: {authCode: '123'},
+          oauth2: {
+            authCode: '123',
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+          },
         },
       };
       const handler = new AuthHandler(authConfig);
@@ -180,6 +193,86 @@ describe('AuthHandler', () => {
         'credentialKey is empty.',
       );
       expect(state.hasDelta()).toBe(false);
+    });
+
+    it('stores the credential unexchanged for oauth2 when no client secret is available', async () => {
+      // The config read back off a redacted request event. There is nothing to
+      // authenticate a token request with, so the exchange waits for the tool
+      // rather than being attempted and failing.
+      const authConfig: AuthConfig = {
+        credentialKey: 'testKey',
+        authScheme: {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://auth.com',
+              tokenUrl: 'https://token.com',
+              scopes: {},
+            },
+          },
+        },
+        exchangedAuthCredential: {
+          authType: AuthCredentialTypes.OAUTH2,
+          oauth2: {authCode: '123', clientId: 'client-id'},
+        },
+      };
+      const handler = new AuthHandler(authConfig);
+      const state = new State();
+
+      await handler.parseAndStoreAuthResponse(state);
+
+      expect(state.get('temp:testKey')).toEqual({
+        authType: 'oauth2',
+        oauth2: {authCode: '123', clientId: 'client-id'},
+      });
+    });
+
+    it('restores the configured client identity before exchanging', async () => {
+      // The client identity is the agent's, so it comes from the raw
+      // credential the tool holds and never from the response.
+      const authConfig: AuthConfig = {
+        credentialKey: 'testKey',
+        authScheme: {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://auth.com',
+              tokenUrl: 'https://token.com',
+              scopes: {},
+            },
+          },
+        },
+        rawAuthCredential: {
+          authType: AuthCredentialTypes.OAUTH2,
+          oauth2: {
+            clientId: 'configured-id',
+            clientSecret: 'configured-secret',
+          },
+        },
+        exchangedAuthCredential: {
+          authType: AuthCredentialTypes.OAUTH2,
+          oauth2: {
+            authCode: '123',
+            clientId: 'response-id',
+            clientSecret: 'response-secret',
+          },
+        },
+      };
+      exchangeCalls.length = 0;
+      const handler = new AuthHandler(authConfig);
+      const state = new State();
+
+      await handler.parseAndStoreAuthResponse(state);
+
+      // The secret is posted to the token endpoint, so a response that could
+      // substitute its own would choose which client the code is redeemed as.
+      expect(exchangeCalls).toEqual([
+        {clientId: 'configured-id', clientSecret: 'configured-secret'},
+      ]);
+      expect(state.get('temp:testKey')).toEqual({
+        authType: 'oauth2',
+        oauth2: {accessToken: 'mockAccessToken'},
+      });
     });
   });
 

--- a/core/test/auth/auth_handler_test.ts
+++ b/core/test/auth/auth_handler_test.ts
@@ -193,7 +193,49 @@ describe('AuthHandler', () => {
 
       const request = handler.generateAuthRequest();
 
-      expect(request).toBe(authConfig);
+      expect(request).toEqual(authConfig);
+    });
+
+    it('strips a non-oauth api key from the request', () => {
+      const authConfig: AuthConfig = {
+        credentialKey: 'testKey',
+        authScheme: {type: 'apiKey', name: 'testKey', in: 'header'},
+        rawAuthCredential: {
+          authType: AuthCredentialTypes.API_KEY,
+          apiKey: 'super-secret-api-key',
+        },
+      };
+      const handler = new AuthHandler(authConfig);
+
+      const request = handler.generateAuthRequest();
+
+      expect(request.rawAuthCredential?.apiKey).toBeUndefined();
+    });
+
+    it('strips the oauth2 client secret from the request', () => {
+      const authConfig: AuthConfig = {
+        credentialKey: 'testKey',
+        authScheme: {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://auth.com',
+              tokenUrl: 'https://token.com',
+              scopes: {},
+            },
+          },
+        },
+        rawAuthCredential: {
+          authType: AuthCredentialTypes.OAUTH2,
+          oauth2: {clientId: 'cid', clientSecret: 'super-secret'},
+        },
+      };
+      const handler = new AuthHandler(authConfig);
+
+      const request = handler.generateAuthRequest();
+
+      expect(request.rawAuthCredential?.oauth2?.clientSecret).toBeUndefined();
+      expect(request.rawAuthCredential?.oauth2?.clientId).toBe('cid');
     });
 
     it('returns original config if exchangedAuthCredential.oauth2.authUri is present', () => {
@@ -218,7 +260,7 @@ describe('AuthHandler', () => {
 
       const request = handler.generateAuthRequest();
 
-      expect(request).toBe(authConfig);
+      expect(request).toEqual(authConfig);
     });
 
     it('throws if rawAuthCredential is missing for oauth2', () => {
@@ -289,7 +331,7 @@ describe('AuthHandler', () => {
 
       const request = handler.generateAuthRequest();
 
-      expect(request.exchangedAuthCredential).toBe(
+      expect(request.exchangedAuthCredential).toEqual(
         authConfig.rawAuthCredential,
       );
     });

--- a/core/test/auth/oauth2_round_trip_test.ts
+++ b/core/test/auth/oauth2_round_trip_test.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {AuthConfig, AuthHandler, State} from '@google/adk';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {bindCredentialResponse} from '../../src/auth/credential_response_binding.js';
+
+/**
+ * The full authorization-code round trip, from the request the agent raises to
+ * the token the tool ends up with.
+ *
+ * Redacting the request event removes the client secret from everything the
+ * client can see, which is the point, but the token endpoint still has to be
+ * given one. These tests drive the real path end to end so that a redaction
+ * that also breaks the exchange fails here rather than in someone's browser.
+ */
+
+const TOKEN_URL = 'https://oauth.example.com/token';
+const CLIENT_ID = 'the-client-id';
+const CLIENT_SECRET = 'the-client-secret';
+
+/** The config as the tool holds it, secret included. */
+function toolAuthConfig(): AuthConfig {
+  return {
+    credentialKey: 'test_key',
+    authScheme: {
+      type: 'oauth2',
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://oauth.example.com/auth',
+          tokenUrl: TOKEN_URL,
+          scopes: {profile: 'profile scope'},
+        },
+      },
+    },
+    rawAuthCredential: {
+      authType: 'oauth2',
+      oauth2: {
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+        redirectUri: 'https://app.example.com/callback',
+      },
+    },
+  } as AuthConfig;
+}
+
+describe('oauth2 authorization-code round trip', () => {
+  let tokenRequests: URLSearchParams[];
+
+  beforeEach(() => {
+    tokenRequests = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: unknown, init?: {body?: unknown}) => {
+        const params = new URLSearchParams(String(init?.body ?? ''));
+        tokenRequests.push(params);
+        // An authorization server rejects a token request that does not
+        // authenticate the client, so model that rather than assuming success.
+        if (params.get('client_secret') !== CLIENT_SECRET) {
+          return new Response(JSON.stringify({error: 'invalid_client'}), {
+            status: 401,
+            headers: {'content-type': 'application/json'},
+          });
+        }
+        return new Response(
+          JSON.stringify({access_token: 'the-access-token', expires_in: 3600}),
+          {status: 200, headers: {'content-type': 'application/json'}},
+        );
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the client secret out of the request the client receives', () => {
+    const request = new AuthHandler(toolAuthConfig()).generateAuthRequest();
+
+    expect(
+      request.exchangedAuthCredential?.oauth2?.clientSecret,
+    ).toBeUndefined();
+    expect(request.rawAuthCredential?.oauth2?.clientSecret).toBeUndefined();
+    // The client still gets what it needs to run the flow.
+    expect(request.exchangedAuthCredential?.oauth2?.authUri).toContain(
+      `client_id=${CLIENT_ID}`,
+    );
+  });
+
+  it('exchanges the code for a token using the configured client secret', async () => {
+    // Step 1: the agent raises the request. This is what reaches the client.
+    const request = new AuthHandler(toolAuthConfig()).generateAuthRequest();
+    const issuedState = request.exchangedAuthCredential?.oauth2?.state;
+
+    // Step 2: the client answers with the redirect it landed on. The
+    // preprocessor reconciles that against the request as read back off the
+    // event, which is the redacted copy.
+    const response = bindCredentialResponse(request, {
+      exchangedAuthCredential: {
+        oauth2: {
+          authResponseUri: `https://app.example.com/callback?code=the-code&state=${issuedState}`,
+        },
+      },
+    });
+    expect(response).toBeDefined();
+
+    const state = new State({});
+    // The tool's own config is the authority for the client identity, so the
+    // handler is given it the same way the tool holds it.
+    await new AuthHandler({
+      ...response!,
+      rawAuthCredential: toolAuthConfig().rawAuthCredential,
+    }).parseAndStoreAuthResponse(state);
+
+    expect(tokenRequests).toHaveLength(1);
+    expect(tokenRequests[0].get('client_id')).toBe(CLIENT_ID);
+    expect(tokenRequests[0].get('client_secret')).toBe(CLIENT_SECRET);
+    expect(tokenRequests[0].get('code')).toBe('the-code');
+
+    const stored = state.get('temp:test_key') as
+      | {oauth2?: {accessToken?: string; clientSecret?: string}}
+      | undefined;
+    expect(stored?.oauth2?.accessToken).toBe('the-access-token');
+    // The stored copy lives in session state, so it keeps no secret either.
+    expect(stored?.oauth2?.clientSecret).toBeUndefined();
+  });
+
+  it('defers the exchange when the config it was handed carries no secret', async () => {
+    // The preprocessor path: the config comes back off the request event, so
+    // it has been redacted and there is no secret to authenticate a token
+    // request with. Attempting the exchange anyway is what broke the login.
+    const request = new AuthHandler(toolAuthConfig()).generateAuthRequest();
+    const response = bindCredentialResponse(request, {
+      exchangedAuthCredential: {
+        oauth2: {
+          authResponseUri: `https://app.example.com/callback?code=the-code&state=${request.exchangedAuthCredential?.oauth2?.state}`,
+        },
+      },
+    });
+
+    const state = new State({});
+    await new AuthHandler(response!).parseAndStoreAuthResponse(state);
+
+    // No token request went out, and nothing threw.
+    expect(tokenRequests).toHaveLength(0);
+
+    // The authorization code is kept, so the tool can finish the exchange with
+    // the credential it holds.
+    const stored = state.get('temp:test_key') as
+      | {oauth2?: {authResponseUri?: string; clientSecret?: string}}
+      | undefined;
+    expect(stored?.oauth2?.authResponseUri).toContain('code=the-code');
+    expect(stored?.oauth2?.clientSecret).toBeUndefined();
+  });
+});

--- a/core/test/tools/openapi_tool/tool_auth_handler_test.ts
+++ b/core/test/tools/openapi_tool/tool_auth_handler_test.ts
@@ -14,18 +14,24 @@ import {describe, expect, it, vi} from 'vitest';
 import {State} from '../../../src/sessions/state.js';
 import {AutoAuthCredentialExchanger} from '../../../src/tools/openapi_tool/auth/credential_exchangers/auto_auth_credential_exchanger.js';
 
+/** Credentials the mocked exchanger was handed, most recent last. */
+const exchangedCredentials: AuthCredential[] = [];
+
 // Mock AutoAuthCredentialExchanger
 vi.mock(
   '../../../src/tools/openapi_tool/auth/credential_exchangers/auto_auth_credential_exchanger.js',
   () => {
     return {
       AutoAuthCredentialExchanger: vi.fn().mockImplementation(() => ({
-        exchange: vi.fn().mockResolvedValue({
-          credential: {
-            authType: AuthCredentialTypes.HTTP,
-            http: {scheme: 'bearer', credentials: {token: 'exchanged-token'}},
-          },
-          wasExchanged: true,
+        exchange: vi.fn().mockImplementation(({authCredential}) => {
+          exchangedCredentials.push(authCredential);
+          return Promise.resolve({
+            credential: {
+              authType: AuthCredentialTypes.HTTP,
+              http: {scheme: 'bearer', credentials: {token: 'exchanged-token'}},
+            },
+            wasExchanged: true,
+          });
         }),
       })),
     };
@@ -262,5 +268,105 @@ describe('ToolAuthHandler', () => {
       'oauth2_existing_exchanged_credential',
     );
     expect(stored?.http?.credentials.token).toBe('exchanged-token');
+  });
+
+  it('exchanges an auth response using the configured client secret', async () => {
+    // The auth response travelled through the client, so the request it
+    // answers was redacted and it carries no secret. The token endpoint still
+    // needs one, and the tool's own configured credential is where it comes
+    // from.
+    exchangedCredentials.length = 0;
+    const state = new State();
+    const mockContext = {
+      state,
+      getAuthResponse: vi.fn().mockReturnValue({
+        authType: AuthCredentialTypes.OAUTH2,
+        oauth2: {authCode: 'the-code', clientId: 'response-id'},
+      }),
+      requestCredential: vi.fn(),
+    } as unknown as Context;
+
+    const result = await new ToolAuthHandler(
+      mockContext,
+      {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://example.com/auth',
+            tokenUrl: 'https://example.com/token',
+            scopes: {},
+          },
+        },
+      },
+      {
+        authType: AuthCredentialTypes.OAUTH2,
+        oauth2: {clientId: 'configured-id', clientSecret: 'configured-secret'},
+      },
+    ).prepareAuthCredentials();
+
+    expect(result.state).toBe('done');
+    expect(exchangedCredentials).toHaveLength(1);
+    const handed = exchangedCredentials[0].oauth2;
+    // The code answers the request; the client identity is the agent's.
+    expect(handed?.authCode).toBe('the-code');
+    expect(handed?.clientSecret).toBe('configured-secret');
+    expect(handed?.clientId).toBe('configured-id');
+  });
+
+  it('caches the exchanged credential without the client secret', async () => {
+    exchangedCredentials.length = 0;
+    const state = new State();
+    const mockContext = {
+      state,
+      getAuthResponse: vi.fn().mockReturnValue({
+        authType: AuthCredentialTypes.OAUTH2,
+        oauth2: {authCode: 'the-code'},
+      }),
+      requestCredential: vi.fn(),
+    } as unknown as Context;
+
+    // A real OAuth2 exchange returns an oauth2 credential, and the client
+    // fields ride along on it, so the redaction has something to remove.
+    vi.mocked(AutoAuthCredentialExchanger).mockImplementationOnce(
+      () =>
+        ({
+          exchange: vi.fn().mockResolvedValue({
+            credential: {
+              authType: AuthCredentialTypes.OAUTH2,
+              oauth2: {
+                accessToken: 'the-access-token',
+                clientId: 'configured-id',
+                clientSecret: 'configured-secret',
+              },
+            },
+            wasExchanged: true,
+          }),
+        }) as unknown as AutoAuthCredentialExchanger,
+    );
+
+    await new ToolAuthHandler(
+      mockContext,
+      {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://example.com/auth',
+            tokenUrl: 'https://example.com/token',
+            scopes: {},
+          },
+        },
+      },
+      {
+        authType: AuthCredentialTypes.OAUTH2,
+        oauth2: {clientId: 'configured-id', clientSecret: 'configured-secret'},
+      },
+    ).prepareAuthCredentials();
+
+    // The cache lives in session state, which the client can read.
+    const stored = state.get<AuthCredential>(
+      'oauth2_existing_exchanged_credential',
+    );
+    expect(stored?.oauth2?.accessToken).toBe('the-access-token');
+    expect(stored?.oauth2?.clientSecret).toBeUndefined();
   });
 });


### PR DESCRIPTION
`generateAuthRequest` returned the auth config with the credential left intact, so the `adk_request_credential` function call that is streamed to the client and stored in the session carried the OAuth2 client secret, and for non-oauth schemes an `apiKey`, an HTTP Basic `password`, or a service account `privateKey`. These belong to the agent, not to the end user.

The first commit strips those fields from `rawAuthCredential` and `exchangedAuthCredential` before the config is returned. The client still receives the scheme, `clientId`, and generated `authUri` it needs to complete the flow.

Because the secret is now removed from the request event, it can no longer be read back at exchange time, so the second commit re-supplies the configured client secret from the tool config when the token exchange runs (the deferred exchange). Without it the OAuth2 flow that this change redacts would have no secret to authenticate with and would break.

The third commit fixes a bug the second one exposed. The exchanged credential is cached into session state, and that write ran the same full redaction over it. For apiKey and http the secret is the credential itself, so caching a redacted copy left the second invocation reading it back with no key or password and making an unauthenticated request. The cache write now drops only the OAuth2 client secret and keeps every other secret, which is what the next invocation authenticates with. Two-invocation tests for apiKey and http cover it.

On parity: this matches the shape of the redaction adk-python applies on its direct-to-client and workflow paths, but not byte for byte. At the adk-python revision this repo pins (`1d89e0f`) the redaction there is repr-only rather than a structural strip of the credential fields, so the two are not identical today. The A2A relay path here (`scrub credential material before forwarding to a remote A2A peer`, #767) already dropped the whole credential part; this closes the direct-to-client path.
