### PR TITLE
docs(workflow): point the dynamic scheduler at Workflow.startNodeTask

### DIFF
--- a/core/src/workflow/dynamic_node_scheduler.ts
+++ b/core/src/workflow/dynamic_node_scheduler.ts
@@ -111,7 +111,7 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
       if (prior && isFastForwardable(prior)) {
         // Completed in a prior turn -> return cached output, do not re-execute.
         // `rerunOnResume` is deliberately not consulted, as in the static twin
-        // (`Workflow.scheduleNode`): it says what to do with an interrupt the
+        // (`Workflow.startNodeTask`): it says what to do with an interrupt the
         // node is still waiting on, and `isFastForwardable` has already ruled
         // a waiting node out. Consulted here it would replay the whole run.
         return this.completeWithoutRunning(
@@ -124,7 +124,7 @@ export class DynamicNodeScheduler implements ScheduleDynamicNode {
       // (raised interrupts, produced no output) does NOT re-run its body. It
       // completes with the resolved resume value(s) as its output, which
       // `ctx.runNode()` hands back to the caller. Mirrors the static-graph
-      // handoff in `Workflow.scheduleNode`; without it such a child re-runs,
+      // handoff in `Workflow.startNodeTask`; without it such a child re-runs,
       // raises a brand-new interrupt, and the workflow can never resume.
       const handoff = this.resumeHandoff(ctx, node, prior);
       if (handoff) {


### PR DESCRIPTION
Two comments in DynamicNodeScheduler cite `Workflow.scheduleNode` as the static twin of the resume paths they guard, but no such method exists. The static graph runner schedules through `Workflow.startNodeTask`, which is where both cited behaviors actually live: the `isFastForwardable` fast-forward that skips `rerunOnResume`, and the handoff that completes a node interrupted last turn with its resolved resume value.

A reader following the reference found nothing and had no way to check that the dynamic path still matches the static one.

**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed npm test results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
