### PR TITLE
refactor(a2a): collapse the duplicate input-required event builders

### DIFF
--- a/core/src/a2a/a2a_event.ts
+++ b/core/src/a2a/a2a_event.ts
@@ -330,7 +330,13 @@ export function createTaskFailedEvent({
 }
 
 /**
- * Creates an input required event.
+ * Creates an input-required status update.
+ *
+ * A2A has one `input-required` state, so every reason an agent can pause for a
+ * human produces the same status update: a long-running tool asking for input,
+ * and a client message that left an earlier request unanswered. What separates
+ * them travels in `parts` — a validation failure carries a text part marked
+ * `validation_error` — not in the shape of the event, so both go through here.
  */
 export function createTaskInputRequiredEvent({
   taskId,
@@ -341,41 +347,6 @@ export function createTaskInputRequiredEvent({
   taskId: string;
   contextId: string;
   parts: A2APart[];
-  metadata?: Record<string, unknown>;
-}): TaskStatusUpdateEvent {
-  return {
-    kind: 'status-update',
-    taskId,
-    contextId,
-    final: true,
-    status: {
-      state: TaskState.INPUT_REQUIRED,
-      message: {
-        kind: 'message',
-        messageId: randomUUID(),
-        role: 'agent',
-        taskId,
-        contextId,
-        parts,
-      },
-      timestamp: new Date().toISOString(),
-    },
-    metadata,
-  };
-}
-
-/**
- * Creates an error message for missing input for a function call.
- */
-export function createInputMissingErrorEvent({
-  taskId,
-  contextId,
-  parts,
-  metadata,
-}: {
-  parts: A2APart[];
-  taskId: string;
-  contextId: string;
   metadata?: Record<string, unknown>;
 }): TaskStatusUpdateEvent {
   return {

--- a/core/src/a2a/event_processor_utils.ts
+++ b/core/src/a2a/event_processor_utils.ts
@@ -13,7 +13,6 @@ import {
 import {Event as AdkEvent} from '../events/event.js';
 import {createEventActions} from '../events/event_actions.js';
 import {
-  createInputMissingErrorEvent,
   createTaskCompletedEvent,
   createTaskFailedEvent,
   createTaskInputRequiredEvent,
@@ -191,7 +190,7 @@ export function getUnansweredRequestEvent(options: {
     return undefined;
   }
 
-  return createInputMissingErrorEvent({
+  return createTaskInputRequiredEvent({
     taskId: task?.id ?? taskId,
     contextId: task?.contextId ?? contextId,
     parts: [

--- a/core/test/a2a/a2a_event_test.ts
+++ b/core/test/a2a/a2a_event_test.ts
@@ -12,7 +12,6 @@ import {
 } from '@a2a-js/sdk';
 import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 import {
-  createInputMissingErrorEvent,
   createTask,
   createTaskArtifactUpdateEvent,
   createTaskCompletedEvent,
@@ -486,9 +485,9 @@ describe('a2a_event', () => {
       });
     });
 
-    it('createInputMissingErrorEvent', () => {
+    it('createTaskInputRequiredEvent carries validation-error parts through', () => {
       expect(
-        createInputMissingErrorEvent({
+        createTaskInputRequiredEvent({
           parts: [
             {kind: 'text', text: 'valid input'},
             {


### PR DESCRIPTION
### Link to Issue or Description of Change

No existing issue — describing the change below.

**Problem:**

`createInputMissingErrorEvent` and `createTaskInputRequiredEvent` in
`core/src/a2a/a2a_event.ts` had byte-for-byte identical bodies. Both returned the
same `TaskStatusUpdateEvent` with `state: TaskState.INPUT_REQUIRED`, `final: true`
and the same message payload; only the parameter destructuring order differed.

Two names for one output invite a reader to hunt for a difference that is not
there. The name `createInputMissingErrorEvent` also misdescribed what it built:
an `input-required` state is a pause waiting on a human, not an error, and it was
never a distinct state on the wire.

Introduced in #178 (43618ab) and carried forward in #186 (c52e77f).

**Solution:**

Deleted `createInputMissingErrorEvent` and pointed its single caller,
`getUnansweredRequestEvent` in `core/src/a2a/event_processor_utils.ts`, at
`createTaskInputRequiredEvent`.

Consolidating rather than extracting a shared helper behind both names: two thin
wrappers over one identical output would preserve exactly the confusion this
fixes.

A2A has a single `input-required` state, so both reasons an agent pauses for a
human — a long-running tool asking for input, and a message that left an earlier
request unanswered — must produce the same event. What distinguishes them already
travels in `parts`: the unanswered-request path appends a text part marked
`validation_error: true`. The callers keep saying which case they are in without a
second builder to say it for them. The surviving builder's doc comment now records
this, so the next reader does not re-derive it.

Checked against `adk-python` for parity: it has no equivalent builder pair, so
nothing upstream motivated two names.

**No public API change.** `core/src/a2a/index.ts` exports a curated list that never
included either builder, so both were internal to `core`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

The existing `createInputMissingErrorEvent` case in `core/test/a2a/a2a_event_test.ts`
was retargeted at `createTaskInputRequiredEvent` rather than deleted — it is the only
case covering metadata-bearing parts passing through on an event with no event-level
`metadata`, so dropping it would have lost real coverage.

Full `npm run test:coverage` under CI conditions (`CI=true`), matching
`.github/workflows/validation.yaml`:

```
Test Files  336 passed | 20 skipped (356)
     Tests  4089 passed | 44 skipped (4133)
```

The two directly relevant suites:

```
✓ core/test/a2a/a2a_event_test.ts (30 tests)
✓ core/test/a2a/event_processor_utils_test.ts (19 tests)
```

Every other validation step run locally and passing: `secretlint`, `npm run build`,
`ts:check`, `ts:check:samples`, `lint`, `format:check`, `docs:check`.

**Manual End-to-End (E2E) Tests:**

Not applicable. This is an internal refactor with no behavior change — the emitted
`TaskStatusUpdateEvent` is byte-for-byte what the deleted builder produced, since the
two builders were already identical. Verified by the unit suites above rather than by
hand.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. — n/a, see above.
- [x] Any dependent changes have been merged and published in downstream modules. — none.

### Additional context

Diff is 3 files, +10 / −41.
