### PR TITLE
test(core): type the live session mock in gemini_llm_connection_test

### DIFF
--- a/core/test/models/gemini_llm_connection_test.ts
+++ b/core/test/models/gemini_llm_connection_test.ts
@@ -11,15 +11,15 @@ import {
   LiveServerGoAway,
   LiveServerMessage,
   LiveServerSessionResumptionUpdate,
+  Session,
 } from '@google/genai';
-import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {beforeEach, describe, expect, it, Mocked, vi} from 'vitest';
 import {GeminiLlmConnection} from '../../src/models/gemini_llm_connection.js';
 import {AsyncQueue} from '../../src/utils/async_queue.js';
 import {liveServerMessage} from '../utils/live_server_message_test_utils.js';
 
 describe('GeminiLlmConnection', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockSession: any;
+  let mockSession: Mocked<Session>;
   let messageQueue: AsyncQueue<LiveServerMessage>;
 
   beforeEach(() => {
@@ -28,7 +28,7 @@ describe('GeminiLlmConnection', () => {
       sendToolResponse: vi.fn(),
       sendRealtimeInput: vi.fn(),
       close: vi.fn(),
-    };
+    } as unknown as Mocked<Session>;
     messageQueue = new AsyncQueue<LiveServerMessage>();
   });
 


### PR DESCRIPTION
<!-- foundry:automerge -->
> ## This pull request will be merged automatically
>
> **Scheduled merge: 2026-09-04 21:11 UTC** (about 24h from opening).
>
> It was selected by [ADK Foundry] because the merge critic approved
> the change, it is small, it touches no sensitive path, and CI is
> green. No human has reviewed it.
>
> **To stop it:** close this pull request, add the `status/on-hold`
> label, or leave a review comment. Any of the three cancels the
> merge; pushing a commit restarts the clock. Nothing is merged while
> a question is open.
>
> **Approving does not stop it.** An approval, or a comment that says
> only `lgtm`, lets the merge run on schedule. Add any other text and
> the merge stops.
>
> Staged from fork PR #644.

**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**

`core/test/models/gemini_llm_connection_test.ts` types its live-session double as `any`. An inline `eslint-disable-next-line @typescript-eslint/no-explicit-any` comment hides the lint error that the `any` causes. The compiler therefore does not check the stubbed methods against the real `Session` type from `@google/genai`. A typo in a member name on the mock compiles silently.

**Solution:**

I type `mockSession` as `Mocked<Session>` and I delete the suppression. `@google/genai` declares `Session` as a class with private members, so one `as unknown as Mocked<Session>` cast at the assignment site is necessary. `Mocked<T>` intersects `T`, so the existing call sites and assertions need no further change. This is the shape already used in `core/test/a2a/agent_executor_test.ts`.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

I added no test. A type annotation and a type assertion are erased at emit, so the change adds no executable line. The 34 existing tests in the file pass unchanged:

```
$ npx vitest run --project unit:core core/test/models/gemini_llm_connection_test.ts
 Test Files  1 passed (1)
      Tests  34 passed (34)
```

`npx eslint` and `npx prettier --check` on the file both pass, and the file now contains no `any` and no `eslint-disable`.

**Manual End-to-End (E2E) Tests:**

Not applicable. The change touches one test file and no source file.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

None.
