### PR TITLE
fix(tests): delete the unreachable duplicate generateContentAsync in the js build_setup fixtures

### DIFF
--- a/tests/integration/build_setup/js_commonjs/agent.js
+++ b/tests/integration/build_setup/js_commonjs/agent.js
@@ -18,10 +18,6 @@ setLogLevel(LogLevel.DEBUG);
 class MockLll extends BaseLlm {
   static supportedModels = ['test-llm-model'];
 
-  async generateContentAsync(prompt) {
-    return `Mock response to: ${prompt}`;
-  }
-
   async *generateContentAsync() {
     const generateContentResponse = new GenerateContentResponse();
 

--- a/tests/integration/build_setup/js_esm/agent.js
+++ b/tests/integration/build_setup/js_esm/agent.js
@@ -18,10 +18,6 @@ setLogLevel(LogLevel.DEBUG);
 class MockLll extends BaseLlm {
   static supportedModels = ['test-llm-model'];
 
-  async generateContentAsync(prompt) {
-    return `Mock response to: ${prompt}`;
-  }
-
   async *generateContentAsync() {
     const generateContentResponse = new GenerateContentResponse();
 


### PR DESCRIPTION
<!-- foundry:automerge -->
> ## This pull request will be merged automatically
>
> **Scheduled merge: 2026-09-04 21:18 UTC** (about 24h from opening).
>
> It was selected by [ADK Foundry] because the merge critic approved
> the change, it is small, it touches no sensitive path, and CI is
> green. No human has reviewed it.
>
> **To stop it:** close this pull request, add the `status/on-hold`
> label, or leave a review comment. Any of the three cancels the
> merge; pushing a commit restarts the clock. Nothing is merged while
> a question is open.
>
> **Approving does not stop it.** An approval, or a comment that says
> only `lgtm`, lets the merge run on schedule. Add any other text and
> the merge stops.
>
> Staged from fork PR #786.

**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**

The `js_commonjs` and `js_esm` build_setup fixtures declare `generateContentAsync` twice on `MockLll`. JavaScript assigns class members in source order, so the async generator overwrites the plain method and the first copy never runs. The dead copy takes a `prompt` and returns a string, which does not match the abstract `BaseLlm.generateContentAsync` contract in `core/src/models/base_llm.ts`. It reads as a fallback that the fixture does not have.

**Solution:**

I deleted the unreachable method from both fixtures. Each fixture now has one `async *generateContentAsync()` member, like its four `ts_*` siblings. Runtime behaviour does not change.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

The deleted code was unreachable, so there is no new path to cover. `npm run lint` and `npm run format:check` exit 0.

**Manual End-to-End (E2E) Tests:**

1. Confirm the duplicate is gone. The current config does not enable `no-dupe-class-members` for `.js` files, so enable it on the command line:

```
npx eslint --rule '{"no-dupe-class-members":"error"}' \
  tests/integration/build_setup/js_commonjs/agent.js \
  tests/integration/build_setup/js_esm/agent.js
```

The output is empty and the exit code is 0.

2. Confirm the check can fail. I restored the duplicates and ran the same command. It reported `Duplicate name 'generateContentAsync'` in both files and exited 1.

3. Confirm the behaviour does not change. The existing integration test is the guard, and I did not edit it:

```
npx vitest run --project integration tests/integration/build_setup/build_setup_test.ts
```

Result: 20 passed, 4 skipped. The `js_commonjs` and `js_esm` cases still assert that the response contains `test-llm-model-response`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
