### PR TITLE
feat(dev): serve a sample's README.md to the web UI

### DIFF
--- a/dev/src/server/adk_api_server.ts
+++ b/dev/src/server/adk_api_server.ts
@@ -30,6 +30,7 @@ import {trace, TracerProvider} from '@opentelemetry/api';
 import {SimpleSpanProcessor} from '@opentelemetry/sdk-trace-base';
 import cors from 'cors';
 import express, {Request, Response} from 'express';
+import * as fsPromises from 'node:fs/promises';
 import * as http from 'node:http';
 import * as path from 'node:path';
 import {version} from '../version.js';
@@ -133,6 +134,40 @@ export class AdkApiServer {
     tracerProvider: TracerProvider,
   ) => void;
   private server?: http.Server;
+  /**
+   * The sample's `README.md`, for the UI to render beside it.
+   *
+   * Resolved from the path the loader discovered the agent at, never from
+   * `appName`. `appName` arrives from the URL, so building a path out of it
+   * would be a traversal hole; adk-python defends that with an identifier
+   * check and a `is_relative_to` assertion on the resolved path. Asking the
+   * loader instead removes the class of bug rather than guarding it, because
+   * the only paths reachable are ones the loader already resolved itself.
+   *
+   * Note this is deliberately NOT `AgentFile.getFilePath()`, which returns the
+   * temporary bundle when one exists. The README sits beside the source.
+   *
+   * A missing README is the normal case and returns undefined. Any other read
+   * error is logged and also returns undefined: app info is what draws the
+   * graph, and failing the whole endpoint over a documentation file would take
+   * the UI down for a cosmetic reason.
+   */
+  private async readAppReadme(appName: string): Promise<string | undefined> {
+    try {
+      const agentFile = await this.agentLoader.getAgentFile(appName);
+      const readmePath = path.join(
+        path.dirname(agentFile.getSourceFilePath()),
+        'README.md',
+      );
+      return await fsPromises.readFile(readmePath, 'utf-8');
+    } catch (e) {
+      if ((e as {code?: string}).code !== 'ENOENT') {
+        this.logger.warn(`Could not read README.md for ${appName}: ${e}`);
+      }
+      return undefined;
+    }
+  }
+
   private readonly traceDict: Record<string, Record<string, unknown>> =
     Object.create(null);
   private readonly sessionTraceDict: Record<string, string[]> =
@@ -486,7 +521,13 @@ export class AdkApiServer {
             return res.status(404).json({error: `App not found: ${appName}`});
           }
 
-          return res.json(serializeAppInfo(appName, rootAgent));
+          return res.json(
+            serializeAppInfo(
+              appName,
+              rootAgent,
+              await this.readAppReadme(appName),
+            ),
+          );
         } catch (e) {
           const error = `Failed to get app info: ${e}`;
 

--- a/dev/src/utils/agent_loader.ts
+++ b/dev/src/utils/agent_loader.ts
@@ -346,6 +346,21 @@ export class AgentFile {
     return this.cleanupFilePath || this.filePath;
   }
 
+  /**
+   * The path the agent was discovered at, before any bundling.
+   *
+   * Distinct from {@link getFilePath}, which returns the temporary bundle when
+   * one exists. A caller looking for files that sit *beside* the agent — its
+   * README, its fixtures — needs the original directory, and the bundle lives
+   * somewhere else entirely.
+   *
+   * Available before the agent loads, because it is only ever the path the
+   * loader already resolved.
+   */
+  getSourceFilePath(): string {
+    return this.filePath;
+  }
+
   async [Symbol.asyncDispose](): Promise<void> {
     return this.dispose();
   }

--- a/dev/test/server/adk_api_server_test.ts
+++ b/dev/test/server/adk_api_server_test.ts
@@ -24,7 +24,10 @@ import {
   Workflow,
 } from '@google/adk';
 import {ReadableSpan} from '@opentelemetry/sdk-trace-base';
+import * as fsPromises from 'node:fs/promises';
 import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 
@@ -1232,10 +1235,14 @@ describe('AdkWebServer', () => {
 
   describe('Structure graph', () => {
     /** Points the loader at `agent` for the rest of the test. */
-    function loadInstead(agent: unknown) {
+    function loadInstead(
+      agent: unknown,
+      sourceFilePath = '/nonexistent/agent.ts',
+    ) {
       agentLoader.getAgentFile = (() =>
         Promise.resolve({
           load: () => Promise.resolve(agent),
+          getSourceFilePath: () => sourceFilePath,
           async [Symbol.asyncDispose](): Promise<void> {
             return;
           },
@@ -1292,6 +1299,42 @@ describe('AdkWebServer', () => {
         expect(response.data?.root_agent.sub_agents).toEqual([
           expect.objectContaining({name: 'child', description: 'a child'}),
         ]);
+      });
+
+      it('returns the README.md sitting beside the agent', async () => {
+        const dir = await fsPromises.mkdtemp(
+          path.join(os.tmpdir(), 'adk-readme-'),
+        );
+        await fsPromises.writeFile(
+          path.join(dir, 'README.md'),
+          '# Sample\n\nWhat it shows.\n',
+          'utf-8',
+        );
+        loadInstead(
+          new LlmAgent({name: 'documented'}),
+          path.join(dir, 'agent.ts'),
+        );
+
+        const response = await client.get<{readme?: string}>(
+          '/dev/apps/testApp/build_graph',
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.readme).toBe('# Sample\n\nWhat it shows.\n');
+      });
+
+      it('omits readme when the agent has no README.md', async () => {
+        // The common case today: none of the samples carries one yet, so a
+        // missing file must be silent rather than a 500 or a logged error.
+        loadInstead(new LlmAgent({name: 'undocumented'}));
+
+        const response = await client.get<{name: string; readme?: string}>(
+          '/dev/apps/testApp/build_graph',
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.name).toBe('testApp');
+        expect(response.data?.readme).toBeUndefined();
       });
 
       // A workflow keeps its structure in its edges, so a serializer that only


### PR DESCRIPTION
## Problem

`AppInfo` has carried an optional `readme` field since it was added, and nothing
ever filled it. The `build_graph` handler calls
`serializeAppInfo(appName, rootAgent)` with two arguments, so the field is always
absent and the UI renders no description when a sample is selected.

adk-python does this already: `cli/dev_server.py` reads `README.md` from the
agent directory and passes it to `serialize_app_info`.

## Solution

Read `README.md` from the directory the agent was loaded from, and pass it
through.

The path comes from the loader, never from `appName`. `appName` arrives from the
URL, so joining it onto the agents directory would be a traversal hole —
adk-python defends that with an identifier check on every path segment plus an
`is_relative_to` assertion on the resolved path. Asking the loader for the file
it already resolved removes the class of bug rather than guarding it, because
the only reachable paths are ones the loader discovered itself.

That needs a new `AgentFile.getSourceFilePath()`. The existing `getFilePath()`
returns the temporary bundle when one exists, and the README sits beside the
source, not beside the bundle.

A missing README is the normal case and yields `undefined` silently — no sample
in this repository carries one yet. Any other read error is logged and also
yields `undefined`: app info is what draws the graph, and failing the whole
endpoint over a documentation file would take the UI down for a cosmetic reason.

## Testing

Two tests added to `dev/test/server/adk_api_server_test.ts`: one asserting the
README is returned, one asserting a sample without one still serves app info
with `readme` absent.

The file's `loadInstead` stub gained `getSourceFilePath`, or every existing test
in it would have logged a warning through the new path.

`npx vitest run dev/test/server/adk_api_server_test.ts` — 74 passed.
`tsc --noEmit -p dev` — 0 errors. eslint and prettier clean.