### PR TITLE
chore(agents): add the unit-guide and sample-creator authoring skills

### DIFF
--- a/.agents/skills/adk-sample-creator/SKILL.md
+++ b/.agents/skills/adk-sample-creator/SKILL.md
@@ -6,8 +6,9 @@ description: >-
   `README.md` — following the conventions the samples use. Use when the user
   wants to add a sample or example demonstrating a feature or agent pattern
   (a dynamic orchestrator, fan-out/fan-in, a standalone tool-using agent), asks
-  where a new sample belongs under `samples/`, or wants an existing sample's
-  header comment or README row brought up to the standard structure. Don't use
+  where a new sample belongs under `samples/`, wants to backfill a `README.md`
+  for a sample that has none, or wants an existing sample's header comment or
+  README brought up to the standard structure. Don't use
   for building a real working agent for the user's own project, or for writing
   usage documentation for a class (use `adk-unit-guide`).
 ---
@@ -81,17 +82,31 @@ A sample directory holds two files:
 `samples/{category}/{name}/README.md` follows
 [the per-sample section of readme-template.md](references/readme-template.md#per-sample-readme).
 
-This diverges from what is on disk. None of the 26 samples that predate this
-skill has a README: each carries a header comment in `agent.ts` and a row in
-its category table and nothing else. New samples set the convention rather than
-follow it, so there is no neighbouring directory to copy — the template is the
-reference. Adding a sample does not oblige you to retrofit the existing 26.
+The README is not only for people reading the repository. **`adk web` renders
+it in the UI when a sample is selected**, so it is the description a developer
+reads while deciding whether to run the sample, without leaving the browser.
+That is why every sample needs one and why the file is required rather than
+encouraged.
+
+Two notes on the state of that in adk-js, because both affect what you should
+expect:
+
+- None of the 26 samples that predate this skill has a README yet. They are
+  being backfilled. Until that finishes there is no neighbouring directory to
+  copy, so the template is the reference.
+- adk-js declares the field but does not fill it. `AppInfo` in
+  `dev/src/server/app_info.ts` carries an optional `readme`, and
+  `adk_api_server.ts` calls `serializeAppInfo(appName, rootAgent)` without it,
+  so nothing reads the file from disk. adk-python does:
+  `cli/dev_server.py` opens `README.md` in the agent directory and returns its
+  contents. Closing that gap is a change to the dev server, not to a sample.
+  Write the README as though it were already rendered, because it will be.
 
 The README and the header comment overlap, and both stay. The header is what a
 reader sees having already opened the code, so it keeps carrying the run
 command and the behaviour that is easy to get wrong. The README is what a
-reader sees when they arrive at the directory from GitHub or from a guide,
-before they have opened anything, and it is the only one of the two with room
+reader sees before they open anything — in the `adk web` UI, or arriving at the
+directory from GitHub or a guide — and it is the only one of the two with room
 for the prompts to try, the topology diagram, and the links out to the guides.
 
 ### The header

--- a/.agents/skills/adk-sample-creator/SKILL.md
+++ b/.agents/skills/adk-sample-creator/SKILL.md
@@ -2,8 +2,8 @@
 name: adk-sample-creator
 description: >-
   Creates a new sample agent in the ADK TypeScript repository — the sample
-  directory, its `agent.ts`, and its row in the category `README.md` —
-  following the conventions the existing samples already use. Use when the user
+  directory, its `agent.ts`, its `README.md`, and its row in the category
+  `README.md` — following the conventions the samples use. Use when the user
   wants to add a sample or example demonstrating a feature or agent pattern
   (a dynamic orchestrator, fan-out/fan-in, a standalone tool-using agent), asks
   where a new sample belongs under `samples/`, or wants an existing sample's
@@ -50,10 +50,13 @@ every sample is an agent, and the category is already in the path.
 
 A new category is four things, and skipping any of them is the usual mistake:
 
-1.  `samples/{category}/` holding the sample directories.
-2.  `samples/{category}/README.md`, following
-    [readme-template.md](references/readme-template.md). Nothing generates it
-    and no other README links it, so a category without one is undiscoverable.
+1.  `samples/{category}/` holding the sample directories, each with its own
+    `README.md`.
+2.  `samples/{category}/README.md` — the category's own README, which is a
+    different document from the per-sample ones and follows
+    [the category section of readme-template.md](references/readme-template.md#category-readme).
+    Nothing generates it and no other README links it, so a category without
+    one is undiscoverable.
 3.  A link from the top-level `README.md` or from the guide the samples
     support, so a reader arrives at the new README from somewhere.
 4.  A decision about execution coverage, recorded in the category README.
@@ -64,20 +67,30 @@ A new category is four things, and skipping any of them is the usual mistake:
     construction or execution coverage until someone widens that test. Say
     which of the two the category has.
 
-## 2. Write `agent.ts`
+## 2. Write the sample directory
 
-A sample directory holds one file:
+A sample directory holds two files:
 
-| File       | Required | Purpose                                               |
-| ---------- | -------- | ----------------------------------------------------- |
-| `agent.ts` | yes      | The agent or workflow. Must `export const rootAgent`. |
+| File        | Required | Purpose                                                            |
+| ----------- | -------- | ------------------------------------------------------------------ |
+| `agent.ts`  | yes      | The agent or workflow. Must `export const rootAgent`.              |
+| `README.md` | yes      | What the sample shows, prompts to drive it, and what to read next. |
 
-There is no per-sample `README.md`, unlike adk-python. All 26 existing samples
-have a header comment in `agent.ts` and a row in their category README, and
-nothing else; a lone sample carrying its own README would be the odd one out,
-and the two places would drift. Everything the Python per-sample README held
-lives in one of those two places — see
-[readme-template.md](references/readme-template.md) for which goes where.
+`samples/{category}/{name}/README.md` follows
+[the per-sample section of readme-template.md](references/readme-template.md#per-sample-readme).
+
+This diverges from what is on disk. None of the 26 samples that predate this
+skill has a README: each carries a header comment in `agent.ts` and a row in
+its category table and nothing else. New samples set the convention rather than
+follow it, so there is no neighbouring directory to copy — the template is the
+reference. Adding a sample does not oblige you to retrofit the existing 26.
+
+The README and the header comment overlap, and both stay. The header is what a
+reader sees having already opened the code, so it keeps carrying the run
+command and the behaviour that is easy to get wrong. The README is what a
+reader sees when they arrive at the directory from GitHub or from a guide,
+before they have opened anything, and it is the only one of the two with room
+for the prompts to try, the topology diagram, and the links out to the guides.
 
 ### The header
 
@@ -194,7 +207,10 @@ export const rootAgent = new LlmAgent({
 ## 3. Register the sample
 
 Add a row to the category `README.md`, following
-[readme-template.md](references/readme-template.md).
+[the category section of readme-template.md](references/readme-template.md#category-readme).
+That row is in addition to the sample's own `README.md`, not instead of it: the
+row is how a reader browsing the category finds the sample, and the README is
+what they get when they follow it.
 
 For a sample under `samples/workflows/`, also add it to
 `tests/integration/docs_samples/docs_samples_test.ts` — to `OFFLINE` with the
@@ -211,6 +227,10 @@ npm run lint
 npm run format:check
 bash scripts/check_license.sh
 ```
+
+Then resolve every relative link the new `README.md` adds and confirm the target
+exists. Nothing in CI reads a Markdown link, so a wrong number of `../` ships
+silently.
 
 For a `samples/workflows/` sample, also run the integration test, which
 constructs every sample and runs the offline ones against a stubbed model:
@@ -252,9 +272,6 @@ agent with a tool.
   file, and no sample directory carries a recorded eval set. The record and
   replay fixtures live with the integration tests under
   `tests/integration/workflows/`, not with the samples.
-- **The Mermaid topology diagram.** No adk-js sample has one, because the
-  per-sample README that held it does not exist here. A graph small enough to
-  draw is already legible in the `edges` array.
 - **"Read the `adk-style` skill first".** adk-js has no `adk-style` skill;
   `eslint.config.js`, `.prettierrc.js`, and the root `tsconfig.json` are the
   style authority, and CI enforces all three.

--- a/.agents/skills/adk-sample-creator/SKILL.md
+++ b/.agents/skills/adk-sample-creator/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: adk-sample-creator
+description: >-
+  Creates a new sample agent in the ADK TypeScript repository — the sample
+  directory, its `agent.ts`, and its row in the category `README.md` —
+  following the conventions the existing samples already use. Use when the user
+  wants to add a sample or example demonstrating a feature or agent pattern
+  (a dynamic orchestrator, fan-out/fan-in, a standalone tool-using agent), asks
+  where a new sample belongs under `samples/`, or wants an existing sample's
+  header comment or README row brought up to the standard structure. Don't use
+  for building a real working agent for the user's own project, or for writing
+  usage documentation for a class (use `adk-unit-guide`).
+---
+
+# ADK Sample Creator
+
+Creates samples under `samples/`. These are deliberately minimal agents that
+each exercise one or two features — distinct from the `adk-samples` repository,
+which hosts full end-to-end applications.
+
+Every sample is a consumer of the published package: it imports from
+`@google/adk`, never from `core/src/…`, and `samples/tsconfig.json` resets
+`paths` so that the type check resolves it through `node_modules` the way a
+user's project does. Run `npm run build` before `npm run ts:check:samples`,
+because the samples type-check against `core/dist/types/`, so a symbol added to
+`core/src/` this session does not exist for them until the build emits it.
+
+## 1. Pick the category directory
+
+Every sample lives at `samples/{category}/…/{sample_name}/agent.ts`. List the
+categories and confirm with the user which one the sample belongs in before
+creating anything.
+
+```bash
+ls samples/
+```
+
+Today there is exactly one category, `workflows`, and it nests one level
+further into groups that mirror the adk.dev page each sample ports:
+`samples/workflows/{group}/{sample_name}/`. A category with no such page to
+mirror is flat: `samples/{category}/{sample_name}/`.
+
+Name the sample directory in `snake_case` after the feature it demonstrates:
+`fan_out_join`, `custom_run_ids`, `retrieval`.
+
+Do not add an `_agent` suffix, and do not repeat the category as a prefix —
+every sample is an agent, and the category is already in the path.
+
+### Adding a new category
+
+A new category is four things, and skipping any of them is the usual mistake:
+
+1.  `samples/{category}/` holding the sample directories.
+2.  `samples/{category}/README.md`, following
+    [readme-template.md](references/readme-template.md). Nothing generates it
+    and no other README links it, so a category without one is undiscoverable.
+3.  A link from the top-level `README.md` or from the guide the samples
+    support, so a reader arrives at the new README from somewhere.
+4.  A decision about execution coverage, recorded in the category README.
+    `tests/integration/docs_samples/docs_samples_test.ts` resolves
+    `SAMPLES_ROOT` to `samples/workflows` specifically, so it neither runs nor
+    guards a sample in any other category. A new category gets lint, Prettier,
+    the license check, and `ts:check:samples` for free, and gets no
+    construction or execution coverage until someone widens that test. Say
+    which of the two the category has.
+
+## 2. Write `agent.ts`
+
+A sample directory holds one file:
+
+| File       | Required | Purpose                                               |
+| ---------- | -------- | ----------------------------------------------------- |
+| `agent.ts` | yes      | The agent or workflow. Must `export const rootAgent`. |
+
+There is no per-sample `README.md`, unlike adk-python. All 26 existing samples
+have a header comment in `agent.ts` and a row in their category README, and
+nothing else; a lone sample carrying its own README would be the odd one out,
+and the two places would drift. Everything the Python per-sample README held
+lives in one of those two places — see
+[readme-template.md](references/readme-template.md) for which goes where.
+
+### The header
+
+Two block comments, in this order, before the imports. Both are required: the
+license header is enforced by `scripts/check_license.sh` in CI, which matches
+the four lines exactly.
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Parallel tasks: fan out and join paths
+ * https://adk.dev/graphs/routes/#parallel-tasks-fan-out-and-join-paths
+ *
+ * A `JoinNode` is a fan-in barrier: it waits for EVERY predecessor to finish
+ * and then hands the next node an object keyed by predecessor node name.
+ *
+ * Run (offline, no API key):
+ *   npm run sample -- samples/workflows/routes/fan_out_join/agent.ts
+ */
+```
+
+The second block is a title line, then the adk.dev section the sample ports,
+then what the sample demonstrates and the behaviour that is easy to get wrong,
+then how to run it. Link an adk.dev URL only when the sample really does port a
+section of it. Every link in the repository today is under
+`https://adk.dev/graphs/`, because every sample so far is a graph-docs port; a
+sample with no page behind it links its unit guide under `docs/guides/` by
+relative path instead of inventing a URL.
+
+The last stanza states the cost of running the sample, and readers scan for it,
+so keep the existing wording rather than a paraphrase:
+
+- `Run (offline, no API key):` — the sample calls no model.
+- `REQUIRES an API key. Set GEMINI_API_KEY, then:` — a node or agent calls a
+  live model.
+- Anything else the sample needs, such as an optional npm package or a
+  directory of documents, is named in the same stanza. A reader who has to
+  discover a missing peer dependency from a runtime error has been misled by
+  the header.
+
+Follow it with the run command on its own indented line. The command is always
+`npm run sample -- <path from the repository root>`, which is shorthand for
+`node dev/dist/esm/cli_entrypoint.js run <path>` and needs `npm run build`
+first.
+
+### Code style
+
+Import from `@google/adk`. Relative imports inside a sample carry a `.js`
+extension under `nodenext` resolution, but a sample rarely has one.
+
+Set `model: 'gemini-flash-latest'` on every `LlmAgent`. adk-js has no
+system-configured default: `LlmAgent.canonicalModel` walks up to the parent
+agent and throws `No model found for {name}` when nothing sets one, so an
+agent without a model fails at run time rather than inheriting a default. The
+floating `-latest` alias is what every model-using sample sets, in all 12 places, and it answers
+the concern a pinned `gemini-2.5-flash` would raise, because the alias moves
+when the model behind it is retired.
+
+Identifiers are `camelCase` and types are `PascalCase`, while the `name:`
+string on an agent, a node, or a workflow is `snake_case` — that string is what
+the model sees and what the CLI prints as `[<node_name>]:`.
+
+Then pick one of the two shapes.
+
+### Pattern A — Workflow, for multi-step graphs
+
+Use when the sample needs multiple nodes, routing, or parallel execution.
+
+```ts
+import {JoinNode, node, NodeContext, Workflow} from '@google/adk';
+```
+
+```ts
+const parallelTaskA = node(
+  (_ctx: NodeContext, text: string) => text.toUpperCase(),
+  {name: 'parallel_task_A'},
+);
+
+export const rootAgent = new Workflow({
+  name: 'fan_out_workflow',
+  edges: [['START', parallelTaskA, new JoinNode({name: 'my_join_node'})]],
+});
+```
+
+A handler always takes `(ctx, input)` and reads state through `ctx.state`;
+nothing is injected by parameter name. `node(fn, options)` is the factory form,
+and the explicit `new FunctionNode(name, fn, config)` constructor is also
+public — reach for it only when the sample is about that constructor.
+
+### Pattern B — Standalone agent, for single-agent or simple tool use
+
+Use when there is no graph and the agent drives its own loop.
+
+```ts
+import {LlmAgent} from '@google/adk';
+
+export const rootAgent = new LlmAgent({
+  name: 'standalone_assistant',
+  model: 'gemini-flash-latest',
+  description: 'An assistant that can help with queries.',
+  instruction: 'You are a helpful assistant.',
+  tools: [someTool],
+});
+```
+
+`tools` accepts a `ToolUnion`, which is a `BaseTool`, a `BaseToolset`, or a
+`BaseNode`, so a tool instance, a toolset, and a node all go in the same array.
+
+## 3. Register the sample
+
+Add a row to the category `README.md`, following
+[readme-template.md](references/readme-template.md).
+
+For a sample under `samples/workflows/`, also add it to
+`tests/integration/docs_samples/docs_samples_test.ts` — to `OFFLINE` with the
+turns that drive it, or to `MODEL_BACKED` if it calls a live model. That test
+asserts the two lists equal the directories on disk, so an unregistered sample
+fails `covers every sample on disk` rather than silently gaining no coverage.
+
+## 4. Verify
+
+```bash
+npm run build
+npm run ts:check:samples
+npm run lint
+npm run format:check
+bash scripts/check_license.sh
+```
+
+For a `samples/workflows/` sample, also run the integration test, which
+constructs every sample and runs the offline ones against a stubbed model:
+
+```bash
+npx vitest run --project integration tests/integration/docs_samples
+```
+
+## Worked examples
+
+Read these before writing a new sample — one static graph, one standalone
+agent with a tool.
+
+- `samples/workflows/routes/fan_out_join/agent.ts` — three functions run in
+  parallel from `START`, collected by a `JoinNode`, then aggregated. One edge
+  row per parallel path.
+
+  ```ts
+  edges: [
+    ['START', parallelTaskA, myJoinNode],
+    ['START', parallelTaskB, myJoinNode],
+    [myJoinNode, finalTaskD],
+  ],
+  ```
+
+- `samples/workflows/data_handling/schemas/agent.ts` — a `FunctionTool` built
+  from a Zod schema, given to an `LlmAgent` that a node wraps. Shows the rule
+  that trips people up: the schema that validates a node's input belongs on
+  the node, because `LlmAgent.inputSchema` is only consulted when the agent
+  is exposed as a tool.
+
+  ```ts
+  node(flightSearcher, {inputSchema: flightSearchInputSchema}),
+  ```
+
+## Dropped from the adk-python skill
+
+- **`__init__.py` and `tests/*.json`.** TypeScript has no package-marker
+  file, and no sample directory carries a recorded eval set. The record and
+  replay fixtures live with the integration tests under
+  `tests/integration/workflows/`, not with the samples.
+- **The Mermaid topology diagram.** No adk-js sample has one, because the
+  per-sample README that held it does not exist here. A graph small enough to
+  draw is already legible in the `edges` array.
+- **"Read the `adk-style` skill first".** adk-js has no `adk-style` skill;
+  `eslint.config.js`, `.prettierrc.js`, and the root `tsconfig.json` are the
+  style authority, and CI enforces all three.

--- a/.agents/skills/adk-sample-creator/SKILL.md
+++ b/.agents/skills/adk-sample-creator/SKILL.md
@@ -58,7 +58,9 @@ A new category is four things, and skipping any of them is the usual mistake:
     Nothing generates it and no other README links it, so a category without
     one is undiscoverable.
 3.  A link from the top-level `README.md` or from the guide the samples
-    support, so a reader arrives at the new README from somewhere.
+    support, so a reader arrives at the new category README from somewhere.
+    The per-sample READMEs are reached from that category README's table, not
+    linked from outside.
 4.  A decision about execution coverage, recorded in the category README.
     `tests/integration/docs_samples/docs_samples_test.ts` resolves
     `SAMPLES_ROOT` to `samples/workflows` specifically, so it neither runs nor

--- a/.agents/skills/adk-sample-creator/references/readme-template.md
+++ b/.agents/skills/adk-sample-creator/references/readme-template.md
@@ -1,0 +1,150 @@
+# Sample category README structure
+
+adk-js has no per-sample `README.md`. Each category directory has one
+`README.md` covering every sample in it, and each sample contributes a row to
+its table. The content adk-python put in a per-sample README is split between
+two places here:
+
+| adk-python per-sample README | adk-js home                                                                 |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| Overview                     | The `Shows` column of the category table, plus the sample's header comment. |
+| Sample Inputs                | The header comment, as a `Try "…"` line, when the sample parses its input.  |
+| Graph                        | Dropped. The `edges` array is the diagram.                                  |
+| How To                       | The header comment.                                                         |
+| Related Guides               | The category README's own links, so one list serves every sample.           |
+
+## Sections
+
+Write the category README in this order. `samples/workflows/README.md` is the
+worked example for all of it.
+
+### Title and scope
+
+One heading and a paragraph: what the category holds, and what a directory in
+it corresponds to. State the mapping rule, because it is what tells a
+contributor where a new sample goes:
+
+> Runnable TypeScript workflows for each section of the ADK
+> [Graph Workflows docs](https://adk.dev/graphs/). One directory per section,
+> grouped by the page it belongs to, so a sample directory maps 1:1 to a
+> section anchor on adk.dev.
+
+Say what every directory exports, which is `rootAgent`, and how a sample fills
+in the helpers the docs leave undefined.
+
+### Running
+
+The build-once, run-by-path pair, and what `npm run sample` expands to:
+
+````markdown
+```bash
+npm run build            # builds @google/adk (and the CLI); needed once / after changes
+npm run sample -- samples/{category}/{sample_name}/agent.ts
+```
+````
+
+Then the type-check command, `npm run ts:check:samples`, and why `samples/` is
+checked separately: it is not an npm workspace, so `npm run build` does not
+compile it, and it resolves `@google/adk` through `node_modules` rather than
+through the root `paths` aliases.
+
+### Coverage
+
+State plainly whether CI executes the samples in this category.
+`tests/integration/docs_samples/docs_samples_test.ts` resolves `SAMPLES_ROOT`
+to `samples/workflows`, so only that category is constructed and run. For any
+other category, say that lint, Prettier, the license check, and
+`ts:check:samples` are the coverage, and that nothing runs the sample. A reader
+deciding whether to trust a sample needs to know which of the two it is.
+
+### Requirements
+
+What a sample in this category needs beyond the repository: an API key, an
+optional npm package, a corpus, a local service. Name the environment variables
+and the exact install command. The per-sample header repeats the ones that
+sample needs, and this section is where the reader finds the whole set.
+
+### Samples
+
+One table per group, or a single table for a flat category. Columns:
+
+| Column         | Contents                                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| `Sample`       | The directory name in backticks.                                                         |
+| `Docs section` | A link to the adk.dev section, for a category that ports one. Omit the column otherwise. |
+| `Shows`        | One line naming the one or two features the sample exists to demonstrate.                |
+| `Key`          | `✅` when it calls a live model, `—` when it runs offline.                               |
+
+Add a column when the category has a cost the `Key` column does not cover, such
+as an optional package, rather than hiding it in prose.
+
+### Worth knowing
+
+Behaviour in this category that is easy to get wrong, each item also called out
+in the affected sample's header comment. Write it as a bolded claim followed by
+the reason, so a reader skimming the bold text still learns something:
+
+> - **A second `output` event overwrites the first, silently.** A node may emit
+>   any number of events carrying `output`; nothing throws, the last one wins,
+>   and the successor never sees the rest.
+
+Omit the section when the category has nothing surprising in it.
+
+### See also
+
+The guides under `docs/guides/` that explain the classes the category
+exercises, and any larger set of examples elsewhere in the repository. Link by
+relative path. From `samples/{category}/README.md` the repository root is two
+levels up:
+
+```markdown
+- [Retrieval tools](../../docs/guides/tools/retrieval/index.md) - Choosing between client-side retrieval and Vertex AI RAG.
+```
+
+## Template
+
+````markdown
+# {Category} samples
+
+What this category holds, and what one directory in it corresponds to. Each
+directory exports a `rootAgent` that runs with the ADK CLI.
+
+## Running
+
+```bash
+npm run build            # builds @google/adk (and the CLI); needed once / after changes
+npm run sample -- samples/{category}/{sample_name}/agent.ts
+```
+
+`npm run sample -- <path>` is shorthand for
+`node dev/dist/esm/cli_entrypoint.js run <path>`.
+
+`samples/` is not an npm workspace, so `npm run build` does not compile it. It
+has its own `samples/tsconfig.json` and is type-checked separately:
+
+```bash
+npm run ts:check:samples
+```
+
+## Coverage
+
+Which CI checks reach these samples, and whether anything executes them.
+
+## Requirements
+
+What these samples need beyond the repository, with the exact commands.
+
+## Samples
+
+| Sample   | Shows                         | Key |
+| -------- | ----------------------------- | --- |
+| `{name}` | One line on what it exercises | —   |
+
+## Worth knowing
+
+- **A claim worth remembering.** Why it is true and what goes wrong without it.
+
+## See also
+
+- [Guide Title](../../docs/guides/path/to/index.md) - Brief description of what the guide covers.
+````

--- a/.agents/skills/adk-sample-creator/references/readme-template.md
+++ b/.agents/skills/adk-sample-creator/references/readme-template.md
@@ -1,22 +1,129 @@
-# Sample category README structure
+# Sample README structure
 
-adk-js has no per-sample `README.md`. Each category directory has one
-`README.md` covering every sample in it, and each sample contributes a row to
-its table. The content adk-python put in a per-sample README is split between
-two places here:
+Two kinds of README, with different readers. Every sample directory has one, and
+every category directory has one.
 
-| adk-python per-sample README | adk-js home                                                                 |
-| ---------------------------- | --------------------------------------------------------------------------- |
-| Overview                     | The `Shows` column of the category table, plus the sample's header comment. |
-| Sample Inputs                | The header comment, as a `Try "…"` line, when the sample parses its input.  |
-| Graph                        | Dropped. The `edges` array is the diagram.                                  |
-| How To                       | The header comment.                                                         |
-| Related Guides               | The category README's own links, so one list serves every sample.           |
+| README                                | Reader                                                                           |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| `samples/{category}/{name}/README.md` | Someone who has landed on this one sample and wants to run it and understand it. |
+| `samples/{category}/README.md`        | Someone browsing the category, deciding which sample to open.                    |
 
-## Sections
+The per-sample README is new. None of the 26 samples that predate this skill has
+one, so this file is the reference and the neighbouring directories are not. The
+category README already exists for `samples/workflows/`, which is the worked
+example for the second half of this file.
 
-Write the category README in this order. `samples/workflows/README.md` is the
-worked example for all of it.
+## Per-sample README
+
+Sections in this order. Omit one only when the sample gives you nothing to put
+in it.
+
+### Overview
+
+What the sample does and which feature or pattern it exists to demonstrate. Two
+or three sentences. This repeats the first stanza of the `agent.ts` header
+comment on purpose, because a reader who arrived at the directory has not opened
+the code yet.
+
+### Sample Inputs
+
+Prompts a reader can paste in to exercise the sample. Wrap each prompt in
+backticks. If a prompt needs an explanation, leave a blank line between the
+prompt and the explanation and indent the explanation by two spaces — without
+the blank line Markdown folds them into one list item.
+
+Pick prompts that reach the feature the sample is about. A prompt the agent
+answers without calling the tool teaches the reader nothing about the tool.
+
+### Graph
+
+A Mermaid diagram of the structure, not of the request and response flow.
+
+- For a `Workflow` root agent, draw the nodes and the edges.
+- For an agent that orchestrates tools or sub-agents, draw the topology of the
+  agent and what hangs off it.
+
+Include the diagram when the topology is not already obvious from the code. A
+`Workflow` whose `edges` array reads as the picture does not need one — the
+array is the diagram, and a second copy of it drifts. An `LlmAgent` with tools
+or sub-agents has no `edges` array at all, so its topology is written down
+nowhere else, and the diagram is the only place a reader sees it whole.
+
+Keep it to a few nodes and edges. A `user -> agent -> API -> tool -> user`
+sequence diagram is noise: it says nothing the topology does not.
+
+### How To
+
+The key techniques the sample uses, with the few lines of code that show each
+one. This is the section that answers "what do I copy into my own project", so
+name the technique, then show it in the sample's own code rather than in a
+paraphrase of it.
+
+### Related Guides
+
+Links to the guides under `docs/guides/` that explain the classes the sample
+uses, each with a one-line summary. Link by relative path, and count the `../`
+from the sample's own directory: from `samples/{category}/{name}/README.md` the
+repository root is three levels up, and from a sample in a nested category such
+as `samples/workflows/{group}/{name}/README.md` it is four.
+
+```markdown
+- [FilesRetrieval](../../../docs/guides/tools/retrieval/files_retrieval/index.md) - Indexing a local directory of documents into a retrieval tool.
+```
+
+Confirm each file exists before linking it.
+
+### Template
+
+````markdown
+# {Sample name}
+
+## Overview
+
+What the sample does and the feature it exists to demonstrate.
+
+## Sample Inputs
+
+- `A prompt that exercises the feature`
+
+- `A prompt that needs a note`
+
+  _What the agent does with it, or what to watch for in the output._
+
+## Graph
+
+For a `Workflow` root agent:
+
+```mermaid
+graph TD
+    START --> my_node
+    my_node --> END
+```
+
+For an agent orchestrating tools or sub-agents:
+
+```mermaid
+graph TD
+    MyAgent[my_agent] -->|calls| MyTool(my_tool)
+```
+
+## How To
+
+**The technique.** Why the sample does it this way.
+
+```ts
+const example = someCall();
+```
+
+## Related Guides
+
+- [Guide Title](../../../docs/guides/path/to/index.md) - What the guide covers.
+````
+
+## Category README
+
+One README per category directory, covering every sample in it, with a row per
+sample in its table.
 
 ### Title and scope
 
@@ -61,8 +168,8 @@ deciding whether to trust a sample needs to know which of the two it is.
 
 What a sample in this category needs beyond the repository: an API key, an
 optional npm package, a corpus, a local service. Name the environment variables
-and the exact install command. The per-sample header repeats the ones that
-sample needs, and this section is where the reader finds the whole set.
+and the exact install command. The per-sample header and README repeat the ones
+that sample needs, and this section is where the reader finds the whole set.
 
 ### Samples
 
@@ -70,7 +177,7 @@ One table per group, or a single table for a flat category. Columns:
 
 | Column         | Contents                                                                                 |
 | -------------- | ---------------------------------------------------------------------------------------- |
-| `Sample`       | The directory name in backticks.                                                         |
+| `Sample`       | The directory name in backticks, linked to that sample's own `README.md`.                |
 | `Docs section` | A link to the adk.dev section, for a category that ports one. Omit the column otherwise. |
 | `Shows`        | One line naming the one or two features the sample exists to demonstrate.                |
 | `Key`          | `✅` when it calls a live model, `—` when it runs offline.                               |
@@ -98,10 +205,10 @@ relative path. From `samples/{category}/README.md` the repository root is two
 levels up:
 
 ```markdown
-- [Retrieval tools](../../docs/guides/tools/retrieval/index.md) - Choosing between client-side retrieval and Vertex AI RAG.
+- [BaseRetrievalTool](../../docs/guides/tools/retrieval/base_retrieval_tool/index.md) - Choosing between client-side retrieval and Vertex AI RAG.
 ```
 
-## Template
+### Template
 
 ````markdown
 # {Category} samples
@@ -136,9 +243,9 @@ What these samples need beyond the repository, with the exact commands.
 
 ## Samples
 
-| Sample   | Shows                         | Key |
-| -------- | ----------------------------- | --- |
-| `{name}` | One line on what it exercises | —   |
+| Sample                       | Shows                         | Key |
+| ---------------------------- | ----------------------------- | --- |
+| [`{name}`]({name}/README.md) | One line on what it exercises | —   |
 
 ## Worth knowing
 

--- a/.agents/skills/adk-sample-creator/references/readme-template.md
+++ b/.agents/skills/adk-sample-creator/references/readme-template.md
@@ -3,14 +3,23 @@
 Two kinds of README, with different readers. Every sample directory has one, and
 every category directory has one.
 
-| README                                | Reader                                                                           |
-| ------------------------------------- | -------------------------------------------------------------------------------- |
-| `samples/{category}/{name}/README.md` | Someone who has landed on this one sample and wants to run it and understand it. |
-| `samples/{category}/README.md`        | Someone browsing the category, deciding which sample to open.                    |
+| README                                | Reader                                                                                          |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `samples/{category}/{name}/README.md` | Someone who selected this sample in `adk web`, or landed on the directory, and wants to run it. |
+| `samples/{category}/README.md`        | Someone browsing the category, deciding which sample to open.                                   |
 
-The per-sample README is new. None of the 26 samples that predate this skill has
-one, so this file is the reference and the neighbouring directories are not. The
-category README already exists for `samples/workflows/`, which is the worked
+`adk web` renders the per-sample README in the UI when a sample is selected, so
+it is read in a browser far more often than in the repository. Write it for
+someone deciding whether to run the sample, who cannot see the code yet.
+
+Two notes on the current state. None of the 26 samples that predate this skill
+has a README yet — they are being backfilled, so this file is the reference and
+the neighbouring directories are not. And adk-js does not yet populate the field
+it declares: `AppInfo.readme` exists in `dev/src/server/app_info.ts`, and
+`adk_api_server.ts` never passes it, where adk-python's `cli/dev_server.py`
+reads `README.md` from the agent directory. Write for the rendered case anyway.
+
+The category README already exists for `samples/workflows/`, which is the worked
 example for the second half of this file.
 
 ## Per-sample README

--- a/.agents/skills/adk-unit-guide/SKILL.md
+++ b/.agents/skills/adk-unit-guide/SKILL.md
@@ -109,25 +109,22 @@ you an example to adapt and they pin the behavior the guide is allowed to claim.
 ## Where the guide goes
 
 Mirror the source path under `docs/guides/`, dropping the `core/src/` prefix and
-the `.ts` extension, one directory per unit, guide named `index.md`:
+the `.ts` extension. One source file is one unit, one unit is one directory, and
+the guide is that directory's `index.md`:
 
-| Source                                          | Guide                                                    |
-| :---------------------------------------------- | :------------------------------------------------------- |
-| `core/src/tools/mcp/mcp_toolset.ts`             | `docs/guides/tools/mcp_toolset/index.md`                 |
-| `core/src/plugins/reflect_retry_tool_plugin.ts` | `docs/guides/plugins/reflect_retry_tool_plugin/index.md` |
+| Source                                              | Guide                                                        |
+| :-------------------------------------------------- | :----------------------------------------------------------- |
+| `core/src/tools/mcp/mcp_toolset.ts`                 | `docs/guides/tools/mcp/mcp_toolset/index.md`                 |
+| `core/src/plugins/reflect_retry_tool_plugin.ts`     | `docs/guides/plugins/reflect_retry_tool_plugin/index.md`     |
+| `core/src/tools/retrieval/base_retrieval_tool.ts`   | `docs/guides/tools/retrieval/base_retrieval_tool/index.md`   |
+| `core/src/tools/retrieval/llama_index_retrieval.ts` | `docs/guides/tools/retrieval/llama_index_retrieval/index.md` |
+| `core/src/tools/retrieval/files_retrieval.ts`       | `docs/guides/tools/retrieval/files_retrieval/index.md`       |
 
-adk-js splits a module that adk-python keeps in one file, so a "unit" is
-sometimes a source directory rather than a source file. When a directory holds
-one base class and the implementations that only exist to subclass it, write one
-guide for the directory at that directory's `index.md`:
-
-| Source                      | Guide                                  |
-| :-------------------------- | :------------------------------------- |
-| `core/src/tools/retrieval/` | `docs/guides/tools/retrieval/index.md` |
-
-Splitting those three files into three guides would produce three pages that
-each say "see the other two", and a reader choosing between the implementations
-has to see them side by side to choose.
+The rule does not bend for a directory that holds a base class and the
+implementations that subclass it, which is the last three rows. Each file is
+still a unit and still gets its own guide. A reader looking up `FilesRetrieval`
+has a page named after the class they are holding, and the guide for a class
+they are not using does not grow to cover them.
 
 Use named files instead of `index.md` only when one source file has genuinely
 separate usage modes.
@@ -138,6 +135,29 @@ code has not changed, so the diff shows only what the change actually altered.
 Then add the guide to `docs/guides/README.md` under the right category heading,
 as `* [Title](path/index.md) - one-line summary.` That index is the only table
 of contents; a guide missing from it is unreachable.
+
+### Guides for a set of siblings
+
+Splitting a base class and its implementations across guides costs the reader
+something real, and the split does not pay for itself unless you buy it back. A
+reader arrives at one page from search, not at the set, so they need to be able
+to tell from the first paragraph whether they are on the right page — and if
+they are not, which sibling is. Two things carry the set:
+
+- **Each guide opens by naming its siblings**, one line each, giving the reason
+  to pick that one rather than a description of what it is. Put this before the
+  guide explains its own class, because it is what tells the reader to keep
+  reading or to leave. Link siblings by relative path from one guide directory
+  to the next: `[FilesRetrieval](../files_retrieval/index.md)`.
+- **`docs/guides/README.md` lists the set under one shared heading**, with a
+  sentence above the list saying what the set is for. A reader scanning the
+  index sees a family and its entry point, rather than three entries that look
+  unrelated because they sort apart.
+
+Put a comparison that decides between the siblings, or between the family and
+something outside it, in the guide for the class where that decision is made —
+usually the base class, since that is where a reader lands before they have
+chosen an implementation. The other guides link to it rather than repeat it.
 
 ## Code examples
 
@@ -176,10 +196,13 @@ of contents; a guide missing from it is unreachable.
 
 ## Link related samples
 
-Link samples by repo-relative path from the guide, not by GitHub URL. From
-`docs/guides/{topic}/{unit}/index.md` the repository root is four levels up:
-`[Retrieval tools](../../../../samples/tools/retrieval/agent.ts)`. Confirm the
-file exists before linking it.
+Link samples by repo-relative path from the guide, not by GitHub URL. Count the
+`../` from the guide's own directory rather than reusing a depth from another
+guide, because a guide that mirrors a nested source directory sits deeper. From
+`docs/guides/{topic}/{unit}/index.md` the repository root is four levels up, and
+from `docs/guides/tools/retrieval/files_retrieval/index.md` it is five:
+`[Retrieval tools](../../../../../samples/tools/retrieval/agent.ts)`. Confirm
+the file exists before linking it.
 
 ## Structure
 

--- a/.agents/skills/adk-unit-guide/SKILL.md
+++ b/.agents/skills/adk-unit-guide/SKILL.md
@@ -199,10 +199,11 @@ chosen an implementation. The other guides link to it rather than repeat it.
 Link samples by repo-relative path from the guide, not by GitHub URL. Count the
 `../` from the guide's own directory rather than reusing a depth from another
 guide, because a guide that mirrors a nested source directory sits deeper. From
-`docs/guides/{topic}/{unit}/index.md` the repository root is four levels up, and
-from `docs/guides/tools/retrieval/files_retrieval/index.md` it is five:
-`[Retrieval tools](../../../../../samples/tools/retrieval/agent.ts)`. Confirm
-the file exists before linking it.
+`docs/guides/{topic}/{unit}/index.md` the repository root is four levels up:
+`[Fan-out and join](../../../../samples/workflows/routes/fan_out_join/agent.ts)`.
+From `docs/guides/tools/retrieval/files_retrieval/index.md` it is five. Confirm
+the file exists before linking it. Every sample on disk today sits under
+`samples/workflows/`, so a path under any other category is one you invented.
 
 ## Structure
 

--- a/.agents/skills/adk-unit-guide/SKILL.md
+++ b/.agents/skills/adk-unit-guide/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: adk-unit-guide
+description: >-
+  Writes a hands-on developer guide for one ADK TypeScript code unit — a minimal
+  runnable example, how it works, a configuration-option table, advanced uses,
+  limitations, and links to related samples — to
+  `docs/guides/{topic}/{unit}/index.md`, then lists it in the index at
+  `docs/guides/README.md`. Its reader is a developer calling the unit from their
+  own application, at more depth than the published adk.dev documentation
+  carries. Use when asked to "write a unit guide for {class}", "document how to
+  use {feature}", "add a guide for {file}", or after shipping a user-facing
+  class, node, tool, or plugin. Don't use for internals documentation aimed at
+  someone changing or extending the unit. Don't use to write a runnable sample
+  under `samples/` (use `adk-sample-creator`).
+---
+
+# ADK code unit guide
+
+A unit guide is granular usage documentation for one code unit, deeper than what
+ships on adk.dev — so detail that would bloat the published documentation has
+somewhere to live. The reader wants to call the unit from an application, so
+lead with working code.
+
+Unit guides focus on public APIs and caller-visible behavior. Do not
+discuss internal implementation details (such as private methods, internal state
+mechanisms, or unexported helpers).
+
+`docs/guides/` is new in adk-js. Until it fills out, expect to create the
+category heading in the index as well as the guide.
+
+## Voice
+
+Write to help the reader understand, not to instruct them from above.
+
+- **Give the reason, not only the rule.** Whenever the guide states a
+  constraint, a default, or a recommendation, say why it is that way. A reader
+  who knows the reason can handle the case the guide did not anticipate.
+- **Do not decide for the reader.** Phrasings such as "most applications never
+  need this" or "you will rarely" tell people what they want. State the
+  trade-off and let them choose.
+- **Explain at the caller's level.** Explaining what happens is required;
+  explaining the machinery that makes it happen is not. If an explanation needs
+  a private symbol to make sense, it is pitched at the wrong layer.
+- **Length follows understanding.** Brevity is not the goal. Where a reader
+  would have a follow-up question, answer it. Where the sentence already lands,
+  leave it.
+- **Problem before syntax.** Say what the reader is trying to do, then show the
+  code.
+- Every heading has at least one sentence under it before the next heading, and
+  every code block has a sentence introducing what it does.
+
+Sentence-level rules, following the Google developer documentation style guide:
+present tense, no contractions, no parentheticals (use commas), no bare "This"
+as a subject, no `e.g.` or `etc.`, no superlatives, sentence case in headings,
+and no heading deeper than H3.
+
+### What the difference looks like
+
+Both pairs below are quoted from adk-python guides, because adk-js has no older
+guide to quote. The failure each one shows is language-independent.
+
+From the `BaseNode` guide. Before:
+
+> Most applications never subclass `BaseNode`, so the sections that follow cover
+> the settings first.
+
+That decides for the reader and gives them nothing to check their own case
+against. After:
+
+> You usually configure a node rather than subclass one, because the settings
+> below cover what most graphs need. Subclassing earns its keep when you want
+> behavior the settings cannot express, and that case is at the end.
+
+Same length, same facts. The second one names the reason, so a reader can tell
+which of the two situations is theirs.
+
+A second pair, from the `JoinNode` guide. Before:
+
+> Here three tasks run in parallel on the same input, and a `JoinNode` collects
+> their results.
+
+That opens in speech rather than documentation, and it drops the name of the
+pattern the reader would search for. After:
+
+> This example builds a fan-out/fan-in workflow. Three tasks run in parallel on
+> the same input, and a `JoinNode` aggregates their results so that a final node
+> can present all three together.
+
+## Inputs
+
+Require the source file, or a class, function, or interface named inside it.
+Also read its unit tests under `core/test/` when they exist, because they give
+you an example to adapt and they pin the behavior the guide is allowed to claim.
+
+## Analyse before writing
+
+- Purpose and intended use of the unit.
+- Which classes depend on it, and which it depends on.
+- Configuration options the unit itself introduces, ignoring inherited ones.
+  In adk-js an option is usually a field on the unit's `…Params` or `…Config`
+  interface, so read that interface rather than the constructor body.
+- Whether the unit is exported from `core/src/index.ts` or `core/src/common.ts`.
+  A unit the reader cannot import from `@google/adk` is not ready for a guide;
+  say so instead of documenting a deep import path.
+- Known limitations.
+- Exclude internal implementation details such as private fields, unexported
+  helper functions, and internal data structures.
+
+## Where the guide goes
+
+Mirror the source path under `docs/guides/`, dropping the `core/src/` prefix and
+the `.ts` extension, one directory per unit, guide named `index.md`:
+
+| Source                                          | Guide                                                    |
+| :---------------------------------------------- | :------------------------------------------------------- |
+| `core/src/tools/mcp/mcp_toolset.ts`             | `docs/guides/tools/mcp_toolset/index.md`                 |
+| `core/src/plugins/reflect_retry_tool_plugin.ts` | `docs/guides/plugins/reflect_retry_tool_plugin/index.md` |
+
+adk-js splits a module that adk-python keeps in one file, so a "unit" is
+sometimes a source directory rather than a source file. When a directory holds
+one base class and the implementations that only exist to subclass it, write one
+guide for the directory at that directory's `index.md`:
+
+| Source                      | Guide                                  |
+| :-------------------------- | :------------------------------------- |
+| `core/src/tools/retrieval/` | `docs/guides/tools/retrieval/index.md` |
+
+Splitting those three files into three guides would produce three pages that
+each say "see the other two", and a reader choosing between the implementations
+has to see them side by side to choose.
+
+Use named files instead of `index.md` only when one source file has genuinely
+separate usage modes.
+
+Update an existing guide in place, keeping the existing wording wherever the
+code has not changed, so the diff shows only what the change actually altered.
+
+Then add the guide to `docs/guides/README.md` under the right category heading,
+as `* [Title](path/index.md) - one-line summary.` That index is the only table
+of contents; a guide missing from it is unreachable.
+
+## Code examples
+
+- One minimal example under "Get started", with enough of the surrounding
+  classes to show where the call belongs. Start from a unit test if one exists.
+- Keep the `import {…} from '@google/adk'` line, because the import is the
+  single most error-prone thing a reader copies, and the reader imports from the
+  package, never from `core/src/…`. Omit unrelated Node built-in imports and
+  runner boilerplate, which add nothing about the unit.
+- Guide code is a consumer of the published package. Relative imports inside
+  the repository carry a `.js` extension under `nodenext` resolution; a guide
+  example rarely has one, and it must not put `.js` on `@google/adk`.
+- Show what a developer would actually write. An example that only demonstrates
+  the shape of an interface, or that drives a service the reader would normally
+  reach through `Runner`, does not belong in a guide.
+- Set `model: 'gemini-flash-latest'` on an `LlmAgent`. There is no
+  system-configured default in adk-js — `canonicalModel` throws
+  `No model found for {name}` when neither the agent nor an ancestor sets one —
+  so a model-free example does not run. The floating `-latest` alias is what
+  every sample in the repository uses, and it answers the same concern a pinned
+  `gemini-2.5-flash` would raise, because the alias moves when the model behind
+  it is retired.
+- Names follow the repository split: `camelCase` for variables, functions, and
+  interface fields; `PascalCase` for classes and types; `snake_case` only inside
+  the string passed as an agent's or a node's `name`, which is the identifier
+  the model and the CLI see.
+- For workflow nodes, show the logic as a plain function passed to
+  `node(fn, {name})` rather than a `BaseNode` subclass, unless the use case
+  genuinely requires the subclass. Reach for `new FunctionNode(...)` only when
+  demonstrating `FunctionNode` configuration itself.
+- Verify every example against the real signatures before shipping it. Type the
+  snippet into a scratch file under `samples/` and run
+  `npm run ts:check:samples`, or copy it into a test file and run
+  `npm run ts:check`. A guide example that does not compile is worse than no
+  example, because the reader assumes the mistake is theirs.
+
+## Link related samples
+
+Link samples by repo-relative path from the guide, not by GitHub URL. From
+`docs/guides/{topic}/{unit}/index.md` the repository root is four levels up:
+`[Retrieval tools](../../../../samples/tools/retrieval/agent.ts)`. Confirm the
+file exists before linking it.
+
+## Structure
+
+Follow [references/guide-template.md](references/guide-template.md) section by
+section.
+
+## Dropped from the adk-python skill
+
+adk-python pairs each guide with a design document at
+`docs/design/{topic}/{unit}/index.md` and lists it as an input. adk-js has no
+`docs/design/` tree and no design-document skill, so that input is dropped
+rather than replaced with an invented location.

--- a/.agents/skills/adk-unit-guide/references/guide-template.md
+++ b/.agents/skills/adk-unit-guide/references/guide-template.md
@@ -8,6 +8,14 @@ instructions for what to write in each section, not text to keep.
 
 Two-sentence summary of the code unit.
 
+When the unit is one of a set of siblings, follow the summary with the set: a
+sentence naming what the siblings have in common, then one line per sibling
+giving the reason to pick it, linked by relative path. This comes before the
+introduction, because it is what a reader who arrived from search uses to decide
+whether to keep reading.
+
+- [{sibling}](../{sibling}/index.md) - The case it is the right answer for.
+
 ## Introduction
 
 Prose covering the purpose and application of the unit, the key classes that
@@ -58,8 +66,16 @@ signatures.
 ## Related samples
 
 Links to samples under `samples/` that exercise the unit, each with a one-line
-description. Paths are relative, and the repository root is four levels up
-from the guide.
+description. Paths are relative, and the repository root is one `../` per
+segment of the guide's own path: four levels up from
+`docs/guides/{topic}/{unit}/index.md`, five from a guide one directory deeper.
+
+## Related guides
+
+Other guides a reader of this one needs, each with a one-line description. The
+siblings named at the top of the page repeat here so that the list at the end of
+the guide is complete, and the guide that carries a shared comparison is linked
+from every guide that defers to it.
 ````
 
 Omit a section outright when the code gives you nothing to put in it.

--- a/.agents/skills/adk-unit-guide/references/guide-template.md
+++ b/.agents/skills/adk-unit-guide/references/guide-template.md
@@ -1,0 +1,65 @@
+# Unit guide template
+
+Copy this structure into `docs/guides/{topic}/{unit}/index.md`. The bullets are
+instructions for what to write in each section, not text to keep.
+
+````markdown
+# {unit_name}
+
+Two-sentence summary of the code unit.
+
+## Introduction
+
+Prose covering the purpose and application of the unit, the key classes that
+depend on it, and the developer problems it solves.
+
+## Get started
+
+A single minimal implementation demonstrating the unit, with enough of the
+surrounding classes to show where the call belongs. Keep the `@google/adk`
+import line and omit runner boilerplate to keep the code snippet focused.
+
+```ts
+import {SomeUnit} from '@google/adk';
+```
+
+## How it works
+
+How the unit accomplishes its purpose from a caller's perspective, the classes
+it depends on, the classes that depend on it, and the cross-class interactions a
+caller will notice. Do not discuss internal implementation details (such as
+private fields, internal data structures, or unexported helpers).
+
+## Configuration options
+
+A table of the options the unit itself introduces, which in adk-js is usually
+the unit's `…Params` or `…Config` interface:
+
+| Option     | Type     | Default     | Description       |
+| :--------- | :------- | :---------- | :---------------- |
+| `{option}` | `{type}` | `{default}` | What it controls. |
+
+Follow the table with a paragraph per option covering real behaviour and usage
+patterns, not a restatement of the type. Omit options inherited from a base
+class, never include private fields, and do not enumerate every field and
+method — exhaustive API reference belongs in the generated TypeDoc reference.
+
+## Advanced applications
+
+Use cases beyond the minimum: the problem each solves and the implementation
+for that circumstance. Omit the section when there are none.
+
+## Limitations
+
+Known limits of the unit. An optional peer dependency the unit needs at
+runtime belongs here, because a reader cannot discover it from the type
+signatures.
+
+## Related samples
+
+Links to samples under `samples/` that exercise the unit, each with a one-line
+description. Paths are relative, and the repository root is four levels up
+from the guide.
+````
+
+Omit a section outright when the code gives you nothing to put in it.


### PR DESCRIPTION
Migrates adk-python's two authoring skills to adk-js conventions, so unit guides
and samples have a written standard here as they do there.

**4 files, +859, −0.** No source code is touched.

- `.agents/skills/adk-unit-guide/` — writes a developer guide for one code unit
  into `docs/guides/{topic}/{unit}/index.md`
- `.agents/skills/adk-sample-creator/` — creates a sample under
  `samples/{category}/{name}/`

Split out of #854 so that PR stays retrieval-only; they share no files and
either can merge first. #854 contains the first output of both.

## What migration changed

Voice, structure and reasoning are kept verbatim where they still apply.
Everything Python-specific was rewritten against adk-js as it actually is,
checked in the repository rather than assumed.

**One rule inverts.** adk-python says never set `model=` on a sample, because
samples inherit a system-configured default. adk-js has no such default:
`LlmAgent.canonicalModel` walks to the parent and throws
`No model found for {name}` (`core/src/agents/llm_agent.ts:646`). Both skills
therefore *require* a model and specify `gemini-flash-latest`, the floating
alias all 12 model-using call sites under `samples/` already use. That serves
the same purpose the Python rule exists for — not pinning a model that gets
retired.

**Every sample gets a `README.md`.** `adk web` renders it when a sample is
selected, so it is read in a browser more often than in the repository, by
someone deciding whether to run the sample before they can see any code. Note
the field is declared but not yet populated in adk-js — #853 wires that up.

**Paths.** `samples/{category}/{name}/agent.ts`, not `contributing/samples/`.
The header format is documented exactly as the existing samples write it,
including the licence block matched literally by `scripts/check_license.sh`.

**Adding a sample category** is spelled out, including the non-obvious part:
`tests/integration/docs_samples/docs_samples_test.ts` resolves its root to
`samples/workflows` specifically, so a new category gets lint, Prettier, licence
and `ts:check:samples` — and nothing that runs it.

## Dropped, each with the reason stated in the skill

- The `docs/design/{topic}/{unit}/index.md` pairing. adk-js has no design-doc
  tree and no `adk-unit-design` skill; no location was invented for one.
- `__init__.py` and eval-set fixtures. No counterpart here.
- "Read the `adk-style` skill first." No such skill; eslint, Prettier and
  tsconfig are the authority.

## Verification

`lint`, `format:check` and `check_license.sh` pass. Both `SKILL.md` files carry
valid frontmatter with `name` and `description`.

These are documentation for authors; they change no runtime behaviour.