### PR TITLE
feat(plugins): add ContextFilterPlugin for context windowing and filtering

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -228,6 +228,16 @@ export {
   type ToolFailureResponse,
 } from './plugins/_reflect_retry_utils.js';
 export {BasePlugin, ContextCompactionTrigger} from './plugins/base_plugin.js';
+export {
+  ContextFilterPlugin,
+  adjustSplitIndexToAvoidOrphanedFunctionResponses,
+  getInvocationStartIndices,
+  isContextFilterPlugin,
+  isFunctionResponseContent,
+  isHumanUserContent,
+  type ContextFilterPluginOptions,
+  type CustomFilterFunction,
+} from './plugins/context_filter_plugin.js';
 export {GlobalInstructionPlugin} from './plugins/global_instruction_plugin.js';
 export {LoggingPlugin} from './plugins/logging_plugin.js';
 export {PluginManager} from './plugins/plugin_manager.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -230,7 +230,6 @@ export {
 export {BasePlugin, ContextCompactionTrigger} from './plugins/base_plugin.js';
 export {
   ContextFilterPlugin,
-  isContextFilterPlugin,
   type ContextFilterPluginOptions,
   type CustomFilterFunction,
 } from './plugins/context_filter_plugin.js';

--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -230,11 +230,7 @@ export {
 export {BasePlugin, ContextCompactionTrigger} from './plugins/base_plugin.js';
 export {
   ContextFilterPlugin,
-  adjustSplitIndexToAvoidOrphanedFunctionResponses,
-  getInvocationStartIndices,
   isContextFilterPlugin,
-  isFunctionResponseContent,
-  isHumanUserContent,
   type ContextFilterPluginOptions,
   type CustomFilterFunction,
 } from './plugins/context_filter_plugin.js';

--- a/core/src/plugins/context_filter_plugin.ts
+++ b/core/src/plugins/context_filter_plugin.ts
@@ -12,6 +12,13 @@ import {logger} from '../utils/logger.js';
 import {BasePlugin} from './base_plugin.js';
 
 /**
+ * A unique symbol to identify ADK ContextFilterPlugin instances.
+ */
+const CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL = Symbol.for(
+  'google.adk.contextFilterPlugin',
+);
+
+/**
  * Moves `splitIndex` left until function calls and responses stay paired.
  *
  * When truncating context, we must avoid keeping a `functionResponse` while
@@ -21,7 +28,7 @@ import {BasePlugin} from './base_plugin.js';
  * @param splitIndex Candidate split index (keep `contents.slice(splitIndex)`).
  * @returns A (possibly smaller) split index that preserves call/response pairs.
  */
-export function adjustSplitIndexToAvoidOrphanedFunctionResponses(
+function _adjustSplitIndexToAvoidOrphanedFunctionResponses(
   contents: Content[],
   splitIndex: number,
 ): number {
@@ -31,10 +38,10 @@ export function adjustSplitIndexToAvoidOrphanedFunctionResponses(
     if (parts) {
       for (let j = parts.length - 1; j >= 0; j--) {
         const part = parts[j];
-        if (part.functionResponse && part.functionResponse.id) {
+        if (part.functionResponse?.id) {
           neededCallIds.add(part.functionResponse.id);
         }
-        if (part.functionCall && part.functionCall.id) {
+        if (part.functionCall?.id) {
           neededCallIds.delete(part.functionCall.id);
         }
       }
@@ -54,17 +61,8 @@ export function adjustSplitIndexToAvoidOrphanedFunctionResponses(
  * @param content The Content to inspect.
  * @returns True if any part in the content has a functionResponse.
  */
-export function isFunctionResponseContent(content: Content): boolean {
-  const parts = content.parts;
-  return (
-    parts !== undefined &&
-    parts !== null &&
-    Array.isArray(parts) &&
-    parts.some(
-      (part) =>
-        part.functionResponse !== undefined && part.functionResponse !== null,
-    )
-  );
+function _isFunctionResponseContent(content: Content): boolean {
+  return content.parts?.some((part) => part.functionResponse != null) ?? false;
 }
 
 /**
@@ -73,8 +71,8 @@ export function isFunctionResponseContent(content: Content): boolean {
  * @param content The Content to inspect.
  * @returns True if role is 'user' and content is not a function response.
  */
-export function isHumanUserContent(content: Content): boolean {
-  return content.role === 'user' && !isFunctionResponseContent(content);
+function _isHumanUserContent(content: Content): boolean {
+  return content.role === 'user' && !_isFunctionResponseContent(content);
 }
 
 /**
@@ -86,11 +84,11 @@ export function isHumanUserContent(content: Content): boolean {
  * @param contents Full conversation contents in chronological order.
  * @returns A list of indices where each index marks the beginning of an invocation.
  */
-export function getInvocationStartIndices(contents: Content[]): number[] {
+function _getInvocationStartIndices(contents: Content[]): number[] {
   const invocationStartIndices: number[] = [];
   let previousWasHumanUser = false;
   for (let i = 0; i < contents.length; i++) {
-    const isHumanUser = isHumanUserContent(contents[i]);
+    const isHumanUser = _isHumanUserContent(contents[i]);
     if (isHumanUser && !previousWasHumanUser) {
       invocationStartIndices.push(i);
     }
@@ -145,6 +143,9 @@ export interface ContextFilterPluginOptions {
  * - Safe error handling: catches errors during filtering and preserves original context.
  */
 export class ContextFilterPlugin extends BasePlugin {
+  /** A unique symbol to identify ADK ContextFilterPlugin instances. */
+  readonly [CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL] = true;
+
   readonly numInvocationsToKeep?: number;
   readonly customFilter?: CustomFilterFunction;
   readonly removeAmount: number;
@@ -163,20 +164,24 @@ export class ContextFilterPlugin extends BasePlugin {
     name = 'context_filter_plugin',
     removeAmount = 1,
   ) {
+    const pluginName =
+      typeof options === 'object' && options !== null
+        ? (options.name ?? 'context_filter_plugin')
+        : name;
+    super(pluginName);
+
     if (typeof options === 'object' && options !== null) {
-      super(options.name ?? 'context_filter_plugin');
       this.numInvocationsToKeep = options.numInvocationsToKeep;
       this.customFilter = options.customFilter;
       this.removeAmount = options.removeAmount ?? 1;
     } else {
-      super(name);
       this.numInvocationsToKeep = options;
       this.customFilter = customFilter;
       this.removeAmount = removeAmount;
     }
 
     if (this.removeAmount < 1) {
-      throw new Error('remove_amount must be at least 1');
+      throw new Error('removeAmount must be at least 1');
     }
   }
 
@@ -196,7 +201,7 @@ export class ContextFilterPlugin extends BasePlugin {
         this.numInvocationsToKeep !== null &&
         this.numInvocationsToKeep > 0
       ) {
-        const invocationStartIndices = getInvocationStartIndices(contents);
+        const invocationStartIndices = _getInvocationStartIndices(contents);
         if (
           invocationStartIndices.length >=
           this.numInvocationsToKeep + this.removeAmount
@@ -206,7 +211,7 @@ export class ContextFilterPlugin extends BasePlugin {
               invocationStartIndices.length - this.numInvocationsToKeep
             ];
 
-          splitIndex = adjustSplitIndexToAvoidOrphanedFunctionResponses(
+          splitIndex = _adjustSplitIndexToAvoidOrphanedFunctionResponses(
             contents,
             splitIndex,
           );
@@ -231,10 +236,18 @@ export class ContextFilterPlugin extends BasePlugin {
 }
 
 /**
- * Type guard for {@link ContextFilterPlugin}.
+ * Type guard to check if an object is an instance of ContextFilterPlugin.
+ *
+ * @param obj The object to check.
+ * @returns True if the object is an instance of ContextFilterPlugin, false otherwise.
  */
 export function isContextFilterPlugin(
-  plugin: unknown,
-): plugin is ContextFilterPlugin {
-  return plugin instanceof ContextFilterPlugin;
+  obj: unknown,
+): obj is ContextFilterPlugin {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL in obj &&
+    obj[CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL] === true
+  );
 }

--- a/core/src/plugins/context_filter_plugin.ts
+++ b/core/src/plugins/context_filter_plugin.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Content} from '@google/genai';
+import {Context} from '../agents/context.js';
+import {LlmRequest} from '../models/llm_request.js';
+import {LlmResponse} from '../models/llm_response.js';
+import {logger} from '../utils/logger.js';
+import {BasePlugin} from './base_plugin.js';
+
+/**
+ * Moves `splitIndex` left until function calls and responses stay paired.
+ *
+ * When truncating context, we must avoid keeping a `functionResponse` while
+ * dropping its matching preceding `functionCall`.
+ *
+ * @param contents Full conversation contents in chronological order.
+ * @param splitIndex Candidate split index (keep `contents.slice(splitIndex)`).
+ * @returns A (possibly smaller) split index that preserves call/response pairs.
+ */
+export function adjustSplitIndexToAvoidOrphanedFunctionResponses(
+  contents: Content[],
+  splitIndex: number,
+): number {
+  const neededCallIds = new Set<string>();
+  for (let i = contents.length - 1; i >= 0; i--) {
+    const parts = contents[i].parts;
+    if (parts) {
+      for (let j = parts.length - 1; j >= 0; j--) {
+        const part = parts[j];
+        if (part.functionResponse && part.functionResponse.id) {
+          neededCallIds.add(part.functionResponse.id);
+        }
+        if (part.functionCall && part.functionCall.id) {
+          neededCallIds.delete(part.functionCall.id);
+        }
+      }
+    }
+
+    if (i <= splitIndex && neededCallIds.size === 0) {
+      return i;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Returns whether a Content object contains function responses.
+ *
+ * @param content The Content to inspect.
+ * @returns True if any part in the content has a functionResponse.
+ */
+export function isFunctionResponseContent(content: Content): boolean {
+  const parts = content.parts;
+  return (
+    parts !== undefined &&
+    parts !== null &&
+    Array.isArray(parts) &&
+    parts.some(
+      (part) =>
+        part.functionResponse !== undefined && part.functionResponse !== null,
+    )
+  );
+}
+
+/**
+ * Returns whether a Content object represents human user input (not tool output).
+ *
+ * @param content The Content to inspect.
+ * @returns True if role is 'user' and content is not a function response.
+ */
+export function isHumanUserContent(content: Content): boolean {
+  return content.role === 'user' && !isFunctionResponseContent(content);
+}
+
+/**
+ * Returns indices that begin a user-started invocation.
+ *
+ * An invocation begins with one or more consecutive user messages. Tool outputs
+ * (function responses) have role="user" but are not considered invocation starts.
+ *
+ * @param contents Full conversation contents in chronological order.
+ * @returns A list of indices where each index marks the beginning of an invocation.
+ */
+export function getInvocationStartIndices(contents: Content[]): number[] {
+  const invocationStartIndices: number[] = [];
+  let previousWasHumanUser = false;
+  for (let i = 0; i < contents.length; i++) {
+    const isHumanUser = isHumanUserContent(contents[i]);
+    if (isHumanUser && !previousWasHumanUser) {
+      invocationStartIndices.push(i);
+    }
+    previousWasHumanUser = isHumanUser;
+  }
+  return invocationStartIndices;
+}
+
+/**
+ * Custom filter function for manipulating or transforming Content items.
+ */
+export type CustomFilterFunction = (
+  contents: Content[],
+) => Content[] | Promise<Content[]>;
+
+/**
+ * Options for configuring {@link ContextFilterPlugin}.
+ */
+export interface ContextFilterPluginOptions {
+  /**
+   * The number of last invocations to keep. An invocation starts with one or
+   * more consecutive user messages and can contain multiple model turns (e.g. tool
+   * calls) until the next user message starts a new invocation.
+   */
+  numInvocationsToKeep?: number;
+
+  /**
+   * A function to filter or transform the context before sending to the model.
+   */
+  customFilter?: CustomFilterFunction;
+
+  /**
+   * The name of the plugin instance. Defaults to 'context_filter_plugin'.
+   */
+  name?: string;
+
+  /**
+   * The number of invocations to remove when the context exceeds the limit.
+   * Must be at least 1. Defaults to 1.
+   */
+  removeAmount?: number;
+}
+
+/**
+ * A plugin that filters the LLM context to reduce its size and sanitize sensitive data.
+ *
+ * Provides:
+ * - Invocation windowing: retains only the most recent N invocations.
+ * - Call/response pair safety: moves the split point backwards if necessary to prevent
+ *   orphaned functionResponse parts.
+ * - Custom filtering: hooks a custom filter function (e.g. for PII redaction or content filtering).
+ * - Safe error handling: catches errors during filtering and preserves original context.
+ */
+export class ContextFilterPlugin extends BasePlugin {
+  readonly numInvocationsToKeep?: number;
+  readonly customFilter?: CustomFilterFunction;
+  readonly removeAmount: number;
+
+  /**
+   * Initializes the ContextFilterPlugin.
+   *
+   * @param options Configuration options, or the number of invocations to keep.
+   * @param customFilter Optional custom filter function (when using positional args).
+   * @param name Optional plugin name (when using positional args).
+   * @param removeAmount Optional remove amount (when using positional args).
+   */
+  constructor(
+    options?: ContextFilterPluginOptions | number,
+    customFilter?: CustomFilterFunction,
+    name = 'context_filter_plugin',
+    removeAmount = 1,
+  ) {
+    if (typeof options === 'object' && options !== null) {
+      super(options.name ?? 'context_filter_plugin');
+      this.numInvocationsToKeep = options.numInvocationsToKeep;
+      this.customFilter = options.customFilter;
+      this.removeAmount = options.removeAmount ?? 1;
+    } else {
+      super(name);
+      this.numInvocationsToKeep = options;
+      this.customFilter = customFilter;
+      this.removeAmount = removeAmount;
+    }
+
+    if (this.removeAmount < 1) {
+      throw new Error('remove_amount must be at least 1');
+    }
+  }
+
+  override async beforeModelCallback(params: {
+    callbackContext: Context;
+    llmRequest: LlmRequest;
+  }): Promise<LlmResponse | undefined> {
+    try {
+      if (!params.llmRequest.contents) {
+        return;
+      }
+
+      let contents = params.llmRequest.contents;
+
+      if (
+        this.numInvocationsToKeep !== undefined &&
+        this.numInvocationsToKeep !== null &&
+        this.numInvocationsToKeep > 0
+      ) {
+        const invocationStartIndices = getInvocationStartIndices(contents);
+        if (
+          invocationStartIndices.length >=
+          this.numInvocationsToKeep + this.removeAmount
+        ) {
+          let splitIndex =
+            invocationStartIndices[
+              invocationStartIndices.length - this.numInvocationsToKeep
+            ];
+
+          splitIndex = adjustSplitIndexToAvoidOrphanedFunctionResponses(
+            contents,
+            splitIndex,
+          );
+          contents = contents.slice(splitIndex);
+        }
+      }
+
+      if (this.customFilter) {
+        contents = await this.customFilter(contents);
+      }
+
+      params.llmRequest.contents = contents;
+    } catch (error) {
+      logger.error(
+        `[${this.name}] Failed to reduce context for request:`,
+        error,
+      );
+    }
+
+    return;
+  }
+}
+
+/**
+ * Type guard for {@link ContextFilterPlugin}.
+ */
+export function isContextFilterPlugin(
+  plugin: unknown,
+): plugin is ContextFilterPlugin {
+  return plugin instanceof ContextFilterPlugin;
+}

--- a/core/src/plugins/context_filter_plugin.ts
+++ b/core/src/plugins/context_filter_plugin.ts
@@ -12,13 +12,6 @@ import {logger} from '../utils/logger.js';
 import {BasePlugin} from './base_plugin.js';
 
 /**
- * A unique symbol to identify ADK ContextFilterPlugin instances.
- */
-const CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL = Symbol.for(
-  'google.adk.contextFilterPlugin',
-);
-
-/**
  * Moves `splitIndex` left until function calls and responses stay paired.
  *
  * When truncating context, we must avoid keeping a `functionResponse` while
@@ -143,9 +136,6 @@ export interface ContextFilterPluginOptions {
  * - Safe error handling: catches errors during filtering and preserves original context.
  */
 export class ContextFilterPlugin extends BasePlugin {
-  /** A unique symbol to identify ADK ContextFilterPlugin instances. */
-  readonly [CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL] = true;
-
   readonly numInvocationsToKeep?: number;
   readonly customFilter?: CustomFilterFunction;
   readonly removeAmount: number;
@@ -153,32 +143,13 @@ export class ContextFilterPlugin extends BasePlugin {
   /**
    * Initializes the ContextFilterPlugin.
    *
-   * @param options Configuration options, or the number of invocations to keep.
-   * @param customFilter Optional custom filter function (when using positional args).
-   * @param name Optional plugin name (when using positional args).
-   * @param removeAmount Optional remove amount (when using positional args).
+   * @param options Configuration options.
    */
-  constructor(
-    options?: ContextFilterPluginOptions | number,
-    customFilter?: CustomFilterFunction,
-    name = 'context_filter_plugin',
-    removeAmount = 1,
-  ) {
-    const pluginName =
-      typeof options === 'object' && options !== null
-        ? (options.name ?? 'context_filter_plugin')
-        : name;
-    super(pluginName);
-
-    if (typeof options === 'object' && options !== null) {
-      this.numInvocationsToKeep = options.numInvocationsToKeep;
-      this.customFilter = options.customFilter;
-      this.removeAmount = options.removeAmount ?? 1;
-    } else {
-      this.numInvocationsToKeep = options;
-      this.customFilter = customFilter;
-      this.removeAmount = removeAmount;
-    }
+  constructor(options: ContextFilterPluginOptions = {}) {
+    super(options.name ?? 'context_filter_plugin');
+    this.numInvocationsToKeep = options.numInvocationsToKeep;
+    this.customFilter = options.customFilter;
+    this.removeAmount = options.removeAmount ?? 1;
 
     if (this.removeAmount < 1) {
       throw new Error('removeAmount must be at least 1');
@@ -233,21 +204,4 @@ export class ContextFilterPlugin extends BasePlugin {
 
     return;
   }
-}
-
-/**
- * Type guard to check if an object is an instance of ContextFilterPlugin.
- *
- * @param obj The object to check.
- * @returns True if the object is an instance of ContextFilterPlugin, false otherwise.
- */
-export function isContextFilterPlugin(
-  obj: unknown,
-): obj is ContextFilterPlugin {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL in obj &&
-    obj[CONTEXT_FILTER_PLUGIN_SIGNATURE_SYMBOL] === true
-  );
 }

--- a/core/src/plugins/context_filter_plugin.ts
+++ b/core/src/plugins/context_filter_plugin.ts
@@ -169,7 +169,6 @@ export class ContextFilterPlugin extends BasePlugin {
 
       if (
         this.numInvocationsToKeep !== undefined &&
-        this.numInvocationsToKeep !== null &&
         this.numInvocationsToKeep > 0
       ) {
         const invocationStartIndices = _getInvocationStartIndices(contents);

--- a/core/test/plugins/context_filter_plugin_test.ts
+++ b/core/test/plugins/context_filter_plugin_test.ts
@@ -12,10 +12,7 @@ import {BaseLlm} from '../../src/models/base_llm.js';
 import {BaseLlmConnection} from '../../src/models/base_llm_connection.js';
 import {LlmRequest} from '../../src/models/llm_request.js';
 import {LlmResponse} from '../../src/models/llm_response.js';
-import {
-  ContextFilterPlugin,
-  isContextFilterPlugin,
-} from '../../src/plugins/context_filter_plugin.js';
+import {ContextFilterPlugin} from '../../src/plugins/context_filter_plugin.js';
 import {PluginManager} from '../../src/plugins/plugin_manager.js';
 import {InMemoryRunner} from '../../src/runner/in_memory_runner.js';
 
@@ -453,53 +450,6 @@ describe('ContextFilterPlugin', () => {
     expect(() => {
       new ContextFilterPlugin({numInvocationsToKeep: 1, removeAmount: -1});
     }).toThrow('removeAmount must be at least 1');
-  });
-
-  it('should support positional constructor parameters', async () => {
-    const plugin = new ContextFilterPlugin(
-      1,
-      (contents) => contents.filter((c) => c.role === 'model'),
-      'custom_named_filter',
-      1,
-    );
-
-    expect(plugin.name).toBe('custom_named_filter');
-    expect(plugin.numInvocationsToKeep).toBe(1);
-    expect(plugin.removeAmount).toBe(1);
-
-    const contents = [
-      createContent('user', 'user_prompt_1'),
-      createContent('model', 'model_response_1'),
-      createContent('user', 'user_prompt_2'),
-      createContent('model', 'model_response_2'),
-    ];
-    const llmRequest = createMockLlmRequest(contents);
-
-    await plugin.beforeModelCallback({
-      callbackContext: createMockContext(),
-      llmRequest,
-    });
-
-    expect(llmRequest.contents.length).toBe(1);
-    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('model_response_2');
-  });
-
-  it('should support isContextFilterPlugin brand-symbol guard', () => {
-    const plugin = new ContextFilterPlugin();
-    expect(isContextFilterPlugin(plugin)).toBe(true);
-    expect(isContextFilterPlugin({})).toBe(false);
-    expect(isContextFilterPlugin(null)).toBe(false);
-    expect(isContextFilterPlugin(undefined)).toBe(false);
-    expect(
-      isContextFilterPlugin({
-        [Symbol.for('google.adk.contextFilterPlugin')]: true,
-      }),
-    ).toBe(true);
-    expect(
-      isContextFilterPlugin({
-        [Symbol.for('google.adk.contextFilterPlugin')]: false,
-      }),
-    ).toBe(false);
   });
 
   it('should work seamlessly when registered in PluginManager', async () => {

--- a/core/test/plugins/context_filter_plugin_test.ts
+++ b/core/test/plugins/context_filter_plugin_test.ts
@@ -14,11 +14,7 @@ import {LlmRequest} from '../../src/models/llm_request.js';
 import {LlmResponse} from '../../src/models/llm_response.js';
 import {
   ContextFilterPlugin,
-  adjustSplitIndexToAvoidOrphanedFunctionResponses,
-  getInvocationStartIndices,
   isContextFilterPlugin,
-  isFunctionResponseContent,
-  isHumanUserContent,
 } from '../../src/plugins/context_filter_plugin.js';
 import {PluginManager} from '../../src/plugins/plugin_manager.js';
 import {InMemoryRunner} from '../../src/runner/in_memory_runner.js';
@@ -452,11 +448,11 @@ describe('ContextFilterPlugin', () => {
   it('should throw an error when removeAmount is less than 1', () => {
     expect(() => {
       new ContextFilterPlugin({numInvocationsToKeep: 1, removeAmount: 0});
-    }).toThrow('remove_amount must be at least 1');
+    }).toThrow('removeAmount must be at least 1');
 
     expect(() => {
       new ContextFilterPlugin({numInvocationsToKeep: 1, removeAmount: -1});
-    }).toThrow('remove_amount must be at least 1');
+    }).toThrow('removeAmount must be at least 1');
   });
 
   it('should support positional constructor parameters', async () => {
@@ -488,43 +484,22 @@ describe('ContextFilterPlugin', () => {
     expect(llmRequest.contents[0].parts?.[0]?.text).toBe('model_response_2');
   });
 
-  it('should correctly evaluate helper functions', () => {
-    const userContent = createContent('user', 'Hello');
-    const modelContent = createContent('model', 'Hi');
-    const funcResponseContent = createFunctionResponseContent('tool', 'id-1');
-    const funcCallContent = createFunctionCallContent('tool', 'id-1');
-
-    expect(isFunctionResponseContent(funcResponseContent)).toBe(true);
-    expect(isFunctionResponseContent(userContent)).toBe(false);
-    expect(isFunctionResponseContent(modelContent)).toBe(false);
-
-    expect(isHumanUserContent(userContent)).toBe(true);
-    expect(isHumanUserContent(funcResponseContent)).toBe(false);
-    expect(isHumanUserContent(modelContent)).toBe(false);
-
-    const contents = [
-      userContent,
-      modelContent,
-      funcCallContent,
-      funcResponseContent,
-    ];
-    const startIndices = getInvocationStartIndices(contents);
-    expect(startIndices).toEqual([0]);
-
-    // Test adjustSplitIndexToAvoidOrphanedFunctionResponses
-    const adjustedIndex = adjustSplitIndexToAvoidOrphanedFunctionResponses(
-      contents,
-      3,
-    );
-    expect(adjustedIndex).toBe(2); // Goes back to include funcCallContent at index 2
-  });
-
-  it('should support isContextFilterPlugin type guard', () => {
+  it('should support isContextFilterPlugin brand-symbol guard', () => {
     const plugin = new ContextFilterPlugin();
     expect(isContextFilterPlugin(plugin)).toBe(true);
     expect(isContextFilterPlugin({})).toBe(false);
     expect(isContextFilterPlugin(null)).toBe(false);
     expect(isContextFilterPlugin(undefined)).toBe(false);
+    expect(
+      isContextFilterPlugin({
+        [Symbol.for('google.adk.contextFilterPlugin')]: true,
+      }),
+    ).toBe(true);
+    expect(
+      isContextFilterPlugin({
+        [Symbol.for('google.adk.contextFilterPlugin')]: false,
+      }),
+    ).toBe(false);
   });
 
   it('should work seamlessly when registered in PluginManager', async () => {

--- a/core/test/plugins/context_filter_plugin_test.ts
+++ b/core/test/plugins/context_filter_plugin_test.ts
@@ -1,0 +1,642 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Content} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+import {Context} from '../../src/agents/context.js';
+import {LlmAgent} from '../../src/agents/llm_agent.js';
+import {BaseLlm} from '../../src/models/base_llm.js';
+import {BaseLlmConnection} from '../../src/models/base_llm_connection.js';
+import {LlmRequest} from '../../src/models/llm_request.js';
+import {LlmResponse} from '../../src/models/llm_response.js';
+import {
+  ContextFilterPlugin,
+  adjustSplitIndexToAvoidOrphanedFunctionResponses,
+  getInvocationStartIndices,
+  isContextFilterPlugin,
+  isFunctionResponseContent,
+  isHumanUserContent,
+} from '../../src/plugins/context_filter_plugin.js';
+import {PluginManager} from '../../src/plugins/plugin_manager.js';
+import {InMemoryRunner} from '../../src/runner/in_memory_runner.js';
+
+class MockLlm extends BaseLlm {
+  lastRequest?: LlmRequest;
+
+  constructor() {
+    super({model: 'mock-llm'});
+  }
+
+  override async *generateContentAsync(
+    request: LlmRequest,
+  ): AsyncGenerator<LlmResponse, void, void> {
+    this.lastRequest = request;
+    yield {
+      content: {role: 'model', parts: [{text: 'Hello from mock LLM'}]},
+    };
+  }
+
+  override async connect(_llmRequest: LlmRequest): Promise<BaseLlmConnection> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+function createContent(role: string, text: string): Content {
+  return {
+    role,
+    parts: [{text}],
+  };
+}
+
+function createFunctionCallContent(name: string, callId: string): Content {
+  return {
+    role: 'model',
+    parts: [
+      {
+        functionCall: {
+          id: callId,
+          name,
+          args: {},
+        },
+      },
+    ],
+  };
+}
+
+function createFunctionResponseContent(name: string, callId: string): Content {
+  return {
+    role: 'user',
+    parts: [
+      {
+        functionResponse: {
+          id: callId,
+          name,
+          response: {result: 'ok'},
+        },
+      },
+    ],
+  };
+}
+
+function createMockContext(): Context {
+  return {
+    invocationId: 'inv-test',
+    agentName: 'test_agent',
+    state: {
+      get: () => undefined,
+      set: () => {},
+    },
+  } as unknown as Context;
+}
+
+function createMockLlmRequest(contents: Content[]): LlmRequest {
+  return {
+    contents,
+    toolsDict: {},
+    liveConnectConfig: {},
+  };
+}
+
+describe('ContextFilterPlugin', () => {
+  it('should not perform filtering when no options are provided', async () => {
+    const plugin = new ContextFilterPlugin();
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents).toEqual(contents);
+    expect(llmRequest.contents.length).toBe(2);
+  });
+
+  it('should truncate context to the last N invocations', async () => {
+    const plugin = new ContextFilterPlugin({numInvocationsToKeep: 1});
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents.length).toBe(2);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('user_prompt_2');
+    expect(llmRequest.contents[1].parts?.[0]?.text).toBe('model_response_2');
+  });
+
+  it('should apply a custom synchronous filter function', async () => {
+    const removeModelResponses = (items: Content[]) =>
+      items.filter((c) => c.role !== 'model');
+
+    const plugin = new ContextFilterPlugin({
+      customFilter: removeModelResponses,
+    });
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents.length).toBe(2);
+    expect(llmRequest.contents.every((c) => c.role === 'user')).toBe(true);
+  });
+
+  it('should apply an asynchronous custom filter function', async () => {
+    const asyncFilter = async (items: Content[]) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return items.filter((c) => c.parts?.[0]?.text?.includes('2'));
+    };
+
+    const plugin = new ContextFilterPlugin({customFilter: asyncFilter});
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents.length).toBe(2);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('user_prompt_2');
+    expect(llmRequest.contents[1].parts?.[0]?.text).toBe('model_response_2');
+  });
+
+  it('should apply both custom filter and last N invocations filtering', async () => {
+    const removeFirstItem = (items: Content[]) => items.slice(1);
+
+    const plugin = new ContextFilterPlugin({
+      numInvocationsToKeep: 1,
+      customFilter: removeFirstItem,
+    });
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+      createContent('user', 'user_prompt_3'),
+      createContent('model', 'model_response_3'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    // Keeping last 1 invocation leaves prompt_3 and response_3 (2 items),
+    // and customFilter removes the first item, leaving 1 item (response_3).
+    expect(llmRequest.contents.length).toBe(1);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('model_response_3');
+  });
+
+  it('should handle invocations with multiple consecutive user turns', async () => {
+    const plugin = new ContextFilterPlugin({numInvocationsToKeep: 1});
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2a'),
+      createContent('user', 'user_prompt_2b'),
+      createContent('model', 'model_response_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents.length).toBe(3);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('user_prompt_2a');
+    expect(llmRequest.contents[1].parts?.[0]?.text).toBe('user_prompt_2b');
+    expect(llmRequest.contents[2].parts?.[0]?.text).toBe('model_response_2');
+  });
+
+  it('should not filter when total invocations are below keep + remove threshold', async () => {
+    const plugin = new ContextFilterPlugin({numInvocationsToKeep: 3});
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+    const originalContents = [...llmRequest.contents];
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents).toEqual(originalContents);
+  });
+
+  it('should gracefully handle exceptions in custom filter without altering context', async () => {
+    const faultyFilter = () => {
+      throw new Error('Custom filter boom');
+    };
+
+    const plugin = new ContextFilterPlugin({customFilter: faultyFilter});
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+    const originalContents = [...llmRequest.contents];
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents).toEqual(originalContents);
+  });
+
+  it('should preserve function_call and function_response pairs to avoid orphaned responses', async () => {
+    const plugin = new ContextFilterPlugin({numInvocationsToKeep: 2});
+
+    const contents = [
+      createContent('user', 'Hello'),
+      createContent('model', 'Hi there!'),
+      createContent('user', 'I want to know about X'),
+      createFunctionCallContent('knowledge_base', 'call_1'),
+      createFunctionResponseContent('knowledge_base', 'call_1'),
+      createContent('model', 'I found some information...'),
+      createContent('user', 'can you explain more about Y'),
+      createFunctionCallContent('knowledge_base', 'call_2'),
+      createFunctionResponseContent('knowledge_base', 'call_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    const callIdsPresent = new Set<string>();
+    const responseIdsPresent = new Set<string>();
+
+    for (const content of llmRequest.contents) {
+      if (content.parts) {
+        for (const part of content.parts) {
+          if (part.functionCall?.id) {
+            callIdsPresent.add(part.functionCall.id);
+          }
+          if (part.functionResponse?.id) {
+            responseIdsPresent.add(part.functionResponse.id);
+          }
+        }
+      }
+    }
+
+    // Every function response MUST have a matching function call present in the contents
+    for (const responseId of responseIdsPresent) {
+      expect(callIdsPresent.has(responseId)).toBe(true);
+    }
+  });
+
+  it('should handle nested and multiple tool calls without orphaned responses', async () => {
+    const plugin = new ContextFilterPlugin({numInvocationsToKeep: 1});
+
+    const contents = [
+      createContent('user', 'Hello'),
+      createContent('model', 'Hi!'),
+      createContent('user', 'Do task'),
+      createFunctionCallContent('tool_a', 'call_a'),
+      createFunctionResponseContent('tool_a', 'call_a'),
+      createFunctionCallContent('tool_b', 'call_b'),
+      createFunctionResponseContent('tool_b', 'call_b'),
+      createContent('model', 'Done with tasks'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    const callIds = new Set<string>();
+    const responseIds = new Set<string>();
+    const texts: string[] = [];
+
+    for (const content of llmRequest.contents) {
+      if (content.parts) {
+        for (const part of content.parts) {
+          if (part.functionCall?.id) callIds.add(part.functionCall.id);
+          if (part.functionResponse?.id)
+            responseIds.add(part.functionResponse.id);
+          if (part.text) texts.push(part.text);
+        }
+      }
+    }
+
+    expect(texts).toContain('Do task');
+    expect(texts).toContain('Done with tasks');
+    expect(texts).not.toContain('Hello');
+    expect(texts).not.toContain('Hi!');
+
+    for (const responseId of responseIds) {
+      expect(callIds.has(responseId)).toBe(true);
+    }
+  });
+
+  it('should keep initial user prompt in multi-turn tool invocation', async () => {
+    const plugin = new ContextFilterPlugin({numInvocationsToKeep: 1});
+
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createFunctionCallContent('get_weather', 'call_1'),
+      createFunctionResponseContent('get_weather', 'call_1'),
+      createContent('model', 'final_answer_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    const texts = llmRequest.contents.flatMap(
+      (c) =>
+        c.parts?.map((p) => p.text).filter((t): t is string => Boolean(t)) ??
+        [],
+    );
+
+    expect(texts).toContain('user_prompt_2');
+    expect(texts).toContain('final_answer_2');
+    expect(texts).not.toContain('user_prompt_1');
+  });
+
+  it('should support removeAmount correctly', async () => {
+    const plugin = new ContextFilterPlugin({
+      numInvocationsToKeep: 2,
+      removeAmount: 1,
+    });
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+      createContent('user', 'user_prompt_3'),
+      createContent('model', 'model_response_3'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents.length).toBe(4);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('user_prompt_2');
+    expect(llmRequest.contents[3].parts?.[0]?.text).toBe('model_response_3');
+  });
+
+  it('should support higher removeAmount', async () => {
+    const plugin = new ContextFilterPlugin({
+      numInvocationsToKeep: 3,
+      removeAmount: 2,
+    });
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+      createContent('user', 'user_prompt_3'),
+      createContent('model', 'model_response_3'),
+      createContent('user', 'user_prompt_4'),
+      createContent('model', 'model_response_4'),
+      createContent('user', 'user_prompt_5'),
+      createContent('model', 'model_response_5'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    // Keeps last 3 invocations
+    expect(llmRequest.contents.length).toBe(6);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('user_prompt_3');
+    expect(llmRequest.contents[5].parts?.[0]?.text).toBe('model_response_5');
+  });
+
+  it('should throw an error when removeAmount is less than 1', () => {
+    expect(() => {
+      new ContextFilterPlugin({numInvocationsToKeep: 1, removeAmount: 0});
+    }).toThrow('remove_amount must be at least 1');
+
+    expect(() => {
+      new ContextFilterPlugin({numInvocationsToKeep: 1, removeAmount: -1});
+    }).toThrow('remove_amount must be at least 1');
+  });
+
+  it('should support positional constructor parameters', async () => {
+    const plugin = new ContextFilterPlugin(
+      1,
+      (contents) => contents.filter((c) => c.role === 'model'),
+      'custom_named_filter',
+      1,
+    );
+
+    expect(plugin.name).toBe('custom_named_filter');
+    expect(plugin.numInvocationsToKeep).toBe(1);
+    expect(plugin.removeAmount).toBe(1);
+
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await plugin.beforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents.length).toBe(1);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('model_response_2');
+  });
+
+  it('should correctly evaluate helper functions', () => {
+    const userContent = createContent('user', 'Hello');
+    const modelContent = createContent('model', 'Hi');
+    const funcResponseContent = createFunctionResponseContent('tool', 'id-1');
+    const funcCallContent = createFunctionCallContent('tool', 'id-1');
+
+    expect(isFunctionResponseContent(funcResponseContent)).toBe(true);
+    expect(isFunctionResponseContent(userContent)).toBe(false);
+    expect(isFunctionResponseContent(modelContent)).toBe(false);
+
+    expect(isHumanUserContent(userContent)).toBe(true);
+    expect(isHumanUserContent(funcResponseContent)).toBe(false);
+    expect(isHumanUserContent(modelContent)).toBe(false);
+
+    const contents = [
+      userContent,
+      modelContent,
+      funcCallContent,
+      funcResponseContent,
+    ];
+    const startIndices = getInvocationStartIndices(contents);
+    expect(startIndices).toEqual([0]);
+
+    // Test adjustSplitIndexToAvoidOrphanedFunctionResponses
+    const adjustedIndex = adjustSplitIndexToAvoidOrphanedFunctionResponses(
+      contents,
+      3,
+    );
+    expect(adjustedIndex).toBe(2); // Goes back to include funcCallContent at index 2
+  });
+
+  it('should support isContextFilterPlugin type guard', () => {
+    const plugin = new ContextFilterPlugin();
+    expect(isContextFilterPlugin(plugin)).toBe(true);
+    expect(isContextFilterPlugin({})).toBe(false);
+    expect(isContextFilterPlugin(null)).toBe(false);
+    expect(isContextFilterPlugin(undefined)).toBe(false);
+  });
+
+  it('should work seamlessly when registered in PluginManager', async () => {
+    const pluginManager = new PluginManager();
+    const filterPlugin = new ContextFilterPlugin({numInvocationsToKeep: 1});
+    pluginManager.registerPlugin(filterPlugin);
+
+    const contents = [
+      createContent('user', 'user_prompt_1'),
+      createContent('model', 'model_response_1'),
+      createContent('user', 'user_prompt_2'),
+      createContent('model', 'model_response_2'),
+    ];
+    const llmRequest = createMockLlmRequest(contents);
+
+    await pluginManager.runBeforeModelCallback({
+      callbackContext: createMockContext(),
+      llmRequest,
+    });
+
+    expect(llmRequest.contents.length).toBe(2);
+    expect(llmRequest.contents[0].parts?.[0]?.text).toBe('user_prompt_2');
+    expect(llmRequest.contents[1].parts?.[0]?.text).toBe('model_response_2');
+  });
+
+  it('should filter context in an end-to-end InMemoryRunner simulation across multiple turns', async () => {
+    const mockLlm = new MockLlm();
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: mockLlm,
+      instruction: 'Test agent',
+    });
+    const filterPlugin = new ContextFilterPlugin({numInvocationsToKeep: 1});
+    const runner = new InMemoryRunner({
+      agent,
+      plugins: [filterPlugin],
+    });
+
+    const session = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: 'user-1',
+    });
+
+    // Turn 1
+    for await (const _ of runner.runAsync({
+      userId: 'user-1',
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'Message 1'}]},
+    })) {
+      // consume generator
+    }
+
+    // Turn 2
+    for await (const _ of runner.runAsync({
+      userId: 'user-1',
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'Message 2'}]},
+    })) {
+      // consume generator
+    }
+
+    // In Turn 2, with numInvocationsToKeep = 1, only Message 2 should be sent to the model (Message 1 trimmed)
+    expect(mockLlm.lastRequest).toBeDefined();
+    const texts = mockLlm.lastRequest?.contents.flatMap(
+      (c) =>
+        c.parts?.map((p) => p.text).filter((t): t is string => Boolean(t)) ??
+        [],
+    );
+    expect(texts).toContain('Message 2');
+    expect(texts).not.toContain('Message 1');
+  });
+
+  it('should sanitize PII with customFilter in an end-to-end InMemoryRunner simulation', async () => {
+    const mockLlm = new MockLlm();
+    const agent = new LlmAgent({
+      name: 'test_agent',
+      model: mockLlm,
+      instruction: 'Test agent',
+    });
+    const piiRedactorPlugin = new ContextFilterPlugin({
+      customFilter: (contents) =>
+        contents.map((c) => ({
+          ...c,
+          parts: c.parts?.map((p) => ({
+            ...p,
+            text: p.text
+              ? p.text.replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED_SSN]')
+              : p.text,
+          })),
+        })),
+    });
+    const runner = new InMemoryRunner({
+      agent,
+      plugins: [piiRedactorPlugin],
+    });
+
+    const session = await runner.sessionService.createSession({
+      appName: runner.appName,
+      userId: 'user-1',
+    });
+
+    for await (const _ of runner.runAsync({
+      userId: 'user-1',
+      sessionId: session.id,
+      newMessage: {role: 'user', parts: [{text: 'My SSN is 123-45-6789'}]},
+    })) {
+      // consume generator
+    }
+
+    expect(mockLlm.lastRequest).toBeDefined();
+    const promptText = mockLlm.lastRequest?.contents[0]?.parts?.[0]?.text;
+    expect(promptText).toBe('My SSN is [REDACTED_SSN]');
+    expect(promptText).not.toContain('123-45-6789');
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: N/A
- Related: N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
In multi-turn conversations, the chat history sent to the LLM grows with every turn. This causes three issues:
1. High token usage, higher costs, slower responses, and hitting model context limits.
2. If developers manually trim messages, they risk keeping a tool response while cutting off its preceding tool call. When this happens, Gemini fails immediately with an orphaned function response error.
3. Private user data (like emails or personal info) is sent to the model without any automatic sanitization hook.

ADK-Python already has `ContextFilterPlugin` to handle this, but ADK-JS was missing this feature.

**Solution:**
We port `ContextFilterPlugin` to ADK-JS:
1. **Invocation Windowing**: Automatically keeps only the last N user interactions and removes older turns once a threshold is reached.
2. **Orphan Protection**: Scans backwards when trimming so that tool calls and their matching tool responses always stay paired, preventing Gemini API crashes.
3. **Custom Filtering**: Allows developers to attach sync or async filter functions to redact private data or modify messages before sending them to the model.
4. **Safe Error Handling**: Catches any errors during filtering and preserves original messages so the agent never crashes.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of results:
- Added 20 new unit and integration tests in `context_filter_plugin_test.ts` covering windowing, consecutive user turns, threshold bypass, sync/async custom filters, PII masking, orphan response protection, error resilience, and multi-turn runner integration.
- All 20 new tests passed.
- All 119 existing plugin tests passed with zero regressions.

**Manual End-to-End (E2E) Tests:**

- Created a standalone test script outside ADK-JS verifying 28 test cases across exports, windowing, tool pair safety, custom filtering, and multi-turn runner simulation. All 28 checks passed.
- Ran all repository checks: `npm run ts:check`, `npm run lint`, `npm run format:check`, `npm run docs:check`, `npm run build`, and `bash scripts/check_license.sh`. All passed with zero errors or warnings.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is a non-breaking, opt-in feature that ports `ContextFilterPlugin` from Python ADK to achieve parity in ADK-JS. Existing agents and runners that do not use the plugin remain completely unaffected.
