### PR TITLE
refactor(core): drop the redundant -1 limit when splitting an Apigee model string

### DIFF
--- a/core/src/models/apigee_llm.ts
+++ b/core/src/models/apigee_llm.ts
@@ -211,7 +211,7 @@ function validateModel(model: string): boolean {
   if (modelPart.length === 0) {
     return false;
   }
-  const components = modelPart.split('/', -1);
+  const components = modelPart.split('/');
   if (components[components.length - 1].length === 0) {
     return false;
   }


### PR DESCRIPTION
## What

`validateModel` in `core/src/models/apigee_llm.ts` split the model string with an explicit limit:

```ts
const components = modelPart.split('/', -1);
```

Drop the `-1`:

```ts
const components = modelPart.split('/');
```

## Why

The argument is a leftover from the Java original (`ApigeeLlm.java`), where `String.split(regex, -1)` is the idiomatic way to keep trailing empty strings — Java discards them otherwise. It was carried over verbatim when the class was ported in #125 (9e42b25).

JavaScript has nothing to opt out of here:

- `String.prototype.split` keeps trailing empty strings already — `'a/'.split('/')` is `['a', '']`.
- `limit` is coerced with `ToUint32`, so `-1` becomes `4294967295`, i.e. effectively no limit.

So the argument reads as a deliberate cap that does nothing, which misleads readers and trips up static analysis.

## Behavior

Unchanged. The trailing-slash case is still rejected by the empty last-component check on the following line.

## Testing

`core/test/models/apigee_llm_test.ts` — 43 tests pass.