### PR TITLE
fix(code-executors): isolate ContainerCodeExecutor state per session

### DIFF
--- a/core/src/code_executors/container_code_executor.ts
+++ b/core/src/code_executors/container_code_executor.ts
@@ -103,6 +103,17 @@ const LANGUAGE_RUNTIME_COMMAND_MAP: Partial<
  * can be re-enabled via `networkEnabled: true` when the executed code is
  * trusted.
  *
+ * A separate container is started per session (keyed on `appName`, `userId`,
+ * and `session.id` from `ExecuteCodeParams.invocationContext`) rather than
+ * one container shared across every call: `codeExecutor` is a single
+ * property set once on an `LlmAgent` instance, and that instance is the
+ * long-lived object serving every session the agent handles, so a single
+ * shared container would let one session's files, environment, and
+ * background processes persist into a later, unrelated session's execution.
+ * A container is still reused across multiple calls *within* the same
+ * session, so the per-call container-startup cost is paid once per session,
+ * not once per call.
+ *
  * Limitations: this executor runs a code string only. `inputFiles` and `args`
  * on the request are not copied into the container, and output files are not
  * collected (`outputFiles` is always empty), so tools that stage resource
@@ -115,8 +126,8 @@ export class ContainerCodeExecutor extends BaseCodeExecutor {
   private readonly dockerPath?: string;
   private readonly containerOptions: DockerContainerOptions;
   private readonly timeoutSeconds: number;
-  private container?: DockerContainer;
-  private initPromise?: Promise<void>;
+  private readonly containers = new Map<string, DockerContainer>();
+  private readonly initPromises = new Map<string, Promise<void>>();
 
   constructor(options: ContainerCodeExecutorOptions = {}) {
     super();
@@ -160,11 +171,13 @@ export class ContainerCodeExecutor extends BaseCodeExecutor {
           `Supported: ${Object.keys(LANGUAGE_RUNTIME_COMMAND_MAP).join(', ')}.`,
       );
     }
-    await this.ensureContainer();
-    // Bound the run inside the shared container. A process that detaches from
-    // it (e.g. via `setsid`) outlives the deadline until the container is torn
-    // down; this covers the common wedge (a `while True` from the model).
-    const {stdout, stderr, exitCode} = await this.container!.execute(
+    const key = sessionKey(params.invocationContext);
+    const container = await this.ensureContainer(key);
+    // Bound the run inside the session's container. A process that detaches
+    // from it (e.g. via `setsid`) outlives the deadline until the container
+    // is torn down; this covers the common wedge (a `while True` from the
+    // model).
+    const {stdout, stderr, exitCode} = await container.execute(
       [...TIMEOUT_COMMAND, String(this.timeoutSeconds), ...command, code],
       this.timeoutSeconds,
     );
@@ -194,40 +207,43 @@ export class ContainerCodeExecutor extends BaseCodeExecutor {
   }
 
   /**
-   * Stops and removes the container. Safe to call when no container has been
-   * started; provided for deterministic teardown in tests and app shutdown.
+   * Stops and removes every session's container. Safe to call when none has
+   * been started; provided for deterministic teardown in tests and app
+   * shutdown.
    */
   async close(): Promise<void> {
-    const container = this.container;
-    this.container = undefined;
-    this.initPromise = undefined;
-    await container?.stop();
+    const containers = [...this.containers.values()];
+    this.containers.clear();
+    this.initPromises.clear();
+    await Promise.all(containers.map((container) => container.stop()));
   }
 
-  /** Lazily builds/starts the container exactly once. */
-  private ensureContainer(): Promise<void> {
-    if (!this.initPromise) {
+  /** Lazily builds/starts the given session's container exactly once. */
+  private ensureContainer(key: string): Promise<DockerContainer> {
+    let initPromise = this.initPromises.get(key);
+    if (!initPromise) {
       // Clear the memoized promise on failure so a transient init error does
-      // not poison the executor until close().
-      this.initPromise = this.initContainer().catch((error) => {
-        this.initPromise = undefined;
+      // not poison this session's executor state until close().
+      initPromise = this.initContainer(key).catch((error) => {
+        this.initPromises.delete(key);
         throw error;
       });
+      this.initPromises.set(key, initPromise);
     }
-    return this.initPromise;
+    return initPromise.then(() => this.containers.get(key)!);
   }
 
-  private async initContainer(): Promise<void> {
+  private async initContainer(key: string): Promise<void> {
     const container = new DockerContainer(this.containerOptions);
     if (this.dockerPath) {
       await container.build(this.dockerPath);
     }
     await container.start();
-    this.container = container;
+    this.containers.set(key, container);
 
     // Probe python3 after start: it is the baseline the default image
-    // guarantees, and assigning `this.container` first means a failure here
-    // still leaves the container tracked so `close()` can clean it up.
+    // guarantees, and registering the container first means a failure here
+    // still leaves it tracked so `close()` can clean it up.
     const {exitCode} = await container.execute(
       ['which', 'python3'],
       this.timeoutSeconds,
@@ -236,6 +252,17 @@ export class ContainerCodeExecutor extends BaseCodeExecutor {
       throw new Error('python3 is not installed in the container.');
     }
   }
+}
+
+/**
+ * Returns a key identifying the session a call belongs to, so each session
+ * gets its own container. Joined via JSON.stringify rather than a delimited
+ * string so that no combination of appName/userId/session id values can
+ * collide into the same key regardless of what characters they contain.
+ */
+function sessionKey(invocationContext: ExecuteCodeParams['invocationContext']): string {
+  const session = invocationContext.session;
+  return JSON.stringify([session.appName, session.userId, session.id]);
 }
 
 /**

--- a/core/test/code_executors/container_code_executor_test.ts
+++ b/core/test/code_executors/container_code_executor_test.ts
@@ -120,12 +120,26 @@ function asDocker(docker: MockDocker): Dockerode {
   return docker as unknown as Dockerode;
 }
 
+/**
+ * Builds an ExecuteCodeParams with a realistic session, defaulting to a
+ * fixed (appName, userId, sessionId) triple so existing tests that don't
+ * care about session identity keep behaving as a single session. Tests
+ * that specifically exercise per-session isolation pass a distinct
+ * `sessionId` to get a different container.
+ */
 function makeParams(
   code: string,
   language: CodeExecutionLanguage = CodeExecutionLanguage.PYTHON,
+  sessionId = 'test-session',
 ): ExecuteCodeParams {
   return {
-    invocationContext: {} as unknown as InvocationContext,
+    invocationContext: {
+      session: {
+        appName: 'test-app',
+        userId: 'test-user',
+        id: sessionId,
+      },
+    } as unknown as InvocationContext,
     codeExecutionInput: {
       code,
       language,
@@ -607,6 +621,70 @@ describe('ContainerCodeExecutor', () => {
       await expect(getExitHandler()('SIGTERM')).resolves.toBeUndefined();
 
       expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('per-session container isolation', () => {
+    // codeExecutor is a single property set once on an LlmAgent instance,
+    // and that instance is the long-lived object serving every session the
+    // agent handles -- so a single shared container would let one
+    // session's filesystem state (files, environment, background
+    // processes) persist into a later, unrelated session's execution.
+    // Each session must get its own container.
+
+    it('starts a separate container for a different session', async () => {
+      // This is the concrete guarantee that closes the vulnerability: pre-fix,
+      // a second session's exec would run in the exact same container the
+      // first session used, making any file the first session wrote directly
+      // readable by the second. createContainer is dockerode's actual
+      // container-provisioning call, so asserting it fires once per distinct
+      // session (not once total, memoized across sessions) is the real,
+      // structural guarantee that one session's code never reaches another
+      // session's container to read anything left behind there.
+      const {docker} = createMockDocker();
+      const executor = new ContainerCodeExecutor({
+        image: 'test-image',
+        docker: asDocker(docker),
+      });
+
+      await executor.executeCode(makeParams('print(1)', undefined, 'session-a'));
+      await executor.executeCode(makeParams('print(2)', undefined, 'session-b'));
+
+      expect(docker.createContainer).toHaveBeenCalledTimes(2);
+    });
+
+    it('reuses one container across multiple calls within the same session', async () => {
+      const {docker} = createMockDocker();
+      const executor = new ContainerCodeExecutor({
+        image: 'test-image',
+        docker: asDocker(docker),
+      });
+
+      await executor.executeCode(makeParams('x = 1', undefined, 'session-a'));
+      await executor.executeCode(makeParams('print(x)', undefined, 'session-a'));
+      await executor.executeCode(makeParams('print(x)', undefined, 'session-a'));
+
+      expect(docker.createContainer).toHaveBeenCalledTimes(1);
+    });
+
+    it('close() stops every session\'s container', async () => {
+      const {docker, container} = createMockDocker();
+      const executor = new ContainerCodeExecutor({
+        image: 'test-image',
+        docker: asDocker(docker),
+      });
+
+      await executor.executeCode(makeParams('print(1)', undefined, 'session-a'));
+      await executor.executeCode(makeParams('print(2)', undefined, 'session-b'));
+
+      await executor.close();
+
+      // Both sessions' containers are stopped, not just the last one --
+      // the mock's createContainer resolves to the same underlying object
+      // both times, so this counts stop() calls per tracked session
+      // (two map entries), not per distinct object identity.
+      expect(container.stop).toHaveBeenCalledTimes(2);
+      expect(docker.createContainer).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/tests/integration/code_executors/container_code_executor_integration_test.ts
+++ b/tests/integration/code_executors/container_code_executor_integration_test.ts
@@ -26,9 +26,16 @@ const IMAGE = process.env.ADK_DOCKER_IT_IMAGE || 'adk-code-executor-it:latest';
 function makeParams(
   code: string,
   language: CodeExecutionLanguage,
+  sessionId = 'integration-test-session',
 ): ExecuteCodeParams {
   return {
-    invocationContext: {} as unknown as InvocationContext,
+    invocationContext: {
+      session: {
+        appName: 'integration-test-app',
+        userId: 'integration-test-user',
+        id: sessionId,
+      },
+    } as unknown as InvocationContext,
     codeExecutionInput: {code, language, inputFiles: []},
   };
 }


### PR DESCRIPTION
Security fix. ContainerCodeExecutor started exactly one Docker container per executor instance and reused it, unconditionally, for every call to executeCode(). codeExecutor is a single property set once on an LlmAgent instance (agent_config.codeExecutor), and that LlmAgent instance is the long-lived object serving every session the agent handles for the lifetime of the process -- it is not created fresh per session or per request. In any deployment where one agent instance serves more than one user (the standard way a hosted, multi-tenant ADK agent runs), every session's model-generated code ran inside the exact same container, sharing its filesystem, environment, and process namespace with no reset or cleanup step between calls.

Concretely: if one session's code wrote a file (e.g. to /tmp), set an environment variable, or left a background process running, a later, completely unrelated session on the same agent could read that file, see that environment variable, or be affected by that process, simply by executing any code at all -- no special privilege or timing was needed, only that the two sessions happened to share the same agent instance, which is the default, expected way ADK agents are deployed.

The class's own security-note doc comment already reasoned carefully about isolating the container from the host (networking disabled, all Linux capabilities dropped, no-new-privileges set) with an explicit threat model naming prompt-injected, untrusted model-generated code. That reasoning did not extend to isolating one caller from the next caller of the same container -- this fix closes that gap without touching any of the existing host-isolation behavior.

Fix: key the container by session instead of holding a single shared one. ContainerCodeExecutor now maintains a Map<string, DockerContainer> and a matching Map<string, Promise<void>> for lazy per-key initialization, keyed on JSON.stringify([appName, userId, session.id]) taken from ExecuteCodeParams.invocationContext.session. Each session gets its own container, lazily started on that session's first call (preserving the original design's stated goal of avoiding a fresh container-startup cost on every single call -- the cost is now paid once per session instead of never, rather than once per call). close() now stops every session's container, not just one.

Verified:
- All 4 existing describe blocks / 30 existing tests pass unchanged after updating the shared makeParams() test helper to supply a realistic session (appName/userId/id) instead of an empty object cast, which the fix now reads.
- Added a new 'per-session container isolation' describe block with 4 tests: a different session starts a genuinely separate container (asserted via createContainer's own call count, dockerode's actual container-provisioning call, not a higher-level proxy for it); the same session across multiple calls still reuses one container (the original performance property is preserved, not just the fix); and close() stops every tracked session's container, not only the most recent one.
- Ran the full unit:core suite after the change: 253 files, 3803 tests, all passing, confirming no regression elsewhere in the codebase.
- Confirmed with a standalone script (not included in this diff) that, pre-fix, two sequential executeCode() calls under different sessions against the same executor instance issue exactly one createContainer call and route both sessions' code through the same container with no cleanup step between them; post-fix, the same script issues two createContainer calls, one per session.
