### PR TITLE
fix(deploy): pass shell:true to spawn on win32 to fix ENOENT for .cmd…

### DIFF
--- a/dev/src/cli/deploy/deploy_utils.ts
+++ b/dev/src/cli/deploy/deploy_utils.ts
@@ -21,7 +21,10 @@ export const spawnAsync = (
   options: SpawnOptions,
 ) => {
   return new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, options);
+    const child = spawn(command, args, {
+      ...options,
+      shell: process.platform === 'win32',
+    });
     child.on('close', (code: number) => {
       if (code === 0) {
         resolve();

--- a/dev/test/cli/deploy_utils_test.ts
+++ b/dev/test/cli/deploy_utils_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {spawnAsync} from '../../src/cli/deploy/deploy_utils.js';
+
+const spawnMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+  spawn: (command: string, args: string[], options: unknown) =>
+    spawnMock(command, args, options),
+}));
+
+function mockChildProcess() {
+  return {
+    on: vi.fn((name: string, cb: (code: number) => void) => {
+      if (name === 'close') {
+        process.nextTick(() => cb(0));
+      }
+    }),
+  };
+}
+
+function setPlatform(platform: typeof process.platform) {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+}
+
+describe('spawnAsync', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.clearAllMocks();
+  });
+
+  it('runs the command through a shell on Windows so .cmd shims like gcloud resolve', async () => {
+    setPlatform('win32');
+    spawnMock.mockReturnValue(mockChildProcess());
+
+    await spawnAsync('gcloud', ['version'], {stdio: 'inherit'});
+
+    expect(spawnMock).toHaveBeenCalledWith('gcloud', ['version'], {
+      stdio: 'inherit',
+      shell: true,
+    });
+  });
+
+  it('does not use a shell on non-Windows platforms', async () => {
+    setPlatform('linux');
+    spawnMock.mockReturnValue(mockChildProcess());
+
+    await spawnAsync('gcloud', ['version'], {stdio: 'inherit'});
+
+    expect(spawnMock).toHaveBeenCalledWith('gcloud', ['version'], {
+      stdio: 'inherit',
+      shell: false,
+    });
+  });
+});


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**
On Windows, `adk deploy agent_engine` fails with `spawn gcloud ENOENT` right after the container build/push step starts. `spawnAsync` in `deploy_utils.ts` calls `child_process.spawn(command, args, options)` without `shell: true`. On Windows, `gcloud` (like `npm`/`npx`) is a `.cmd` shim, and `child_process.spawn` cannot execute `.cmd`/`.bat` files unless `shell: true` is passed. As a result, deployment fails even though `gcloud` is correctly installed and on `PATH`.

**Solution:**
Pass `shell: process.platform === "win32"` to the `spawn()` call in `spawnAsync`, so Windows resolves `.cmd`/`.bat` executables correctly while leaving behavior unchanged on macOS/Linux (where `shell` stays `false`/unset).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**

Tested on Windows 11 (10.0.26200), Node.js v24.16.0, npm 11.13.0, with `@google/adk`/`@google/adk-devtools` `~2.0.0`, running:

```
npx adk deploy agent_engine agent.ts --project=<project> --region=europe-west1 --repository=<repository> --display_name="RAG ADK Agent"
```

Before the fix:
```
Building and pushing container image to <region>-docker.pkg.dev/<project>/<repository>/agent-engine-agent:latest using Cloud Builds...
Failed to deploy to Agent Engine: spawn gcloud ENOENT
[ADK CLI] Error deploying agent: spawn gcloud ENOENT
```

After applying the fix (validated locally via a `patch-package` patch before submitting this PR), the same command completes the build/push/deploy flow successfully.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
