### PR TITLE
feat(plugins): add MultimodalToolResultsPlugin with full Python parity

### DIFF
--- a/core/src/common.ts
+++ b/core/src/common.ts
@@ -230,6 +230,14 @@ export {
 export {BasePlugin, ContextCompactionTrigger} from './plugins/base_plugin.js';
 export {GlobalInstructionPlugin} from './plugins/global_instruction_plugin.js';
 export {LoggingPlugin} from './plugins/logging_plugin.js';
+export {
+  MultimodalToolResultsPlugin,
+  PARTS_RETURNED_BY_TOOLS_ID,
+  SESSION_PARTS_RETURNED_BY_TOOLS_ID,
+  isMultimodalToolResultsPlugin,
+  type MultimodalToolResultsPluginOptions,
+  type MultimodalToolResultsRetention,
+} from './plugins/multimodal_tool_results_plugin.js';
 export {PluginManager} from './plugins/plugin_manager.js';
 export {
   ADK_HANDLE_MODEL_ERROR_TOOL_NAME,

--- a/core/src/plugins/multimodal_tool_results_plugin.ts
+++ b/core/src/plugins/multimodal_tool_results_plugin.ts
@@ -1,0 +1,366 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {type Part} from '@google/genai';
+import {cloneDeep, isEqual} from 'lodash-es';
+
+import {type Context} from '../agents/context.js';
+import {type LlmRequest} from '../models/llm_request.js';
+import {type LlmResponse} from '../models/llm_response.js';
+import {State} from '../sessions/state.js';
+import {type BaseTool} from '../tools/base_tool.js';
+import {BasePlugin} from './base_plugin.js';
+
+/**
+ * Temporary state key for parts returned by tools in default (next_model_call) mode.
+ */
+export const PARTS_RETURNED_BY_TOOLS_ID = 'temp:PARTS_RETURNED_BY_TOOLS_ID';
+
+/**
+ * Session-scoped state key for parts returned by tools in session retention mode.
+ *
+ * Deliberately NOT "temp:"-prefixed: the session layer treats "temp:" state
+ * as invocation-scoped and strips it before persisting an event. Retention="session"
+ * needs the saved parts to survive into later conversational turns, so it is stored
+ * under this session-scoped key instead.
+ */
+export const SESSION_PARTS_RETURNED_BY_TOOLS_ID =
+  'multimodal_tool_results_plugin:PARTS_RETURNED_BY_TOOLS_ID';
+
+/**
+ * Temporary state key for current turn parts in session retention mode.
+ */
+export const _CURRENT_TURN_PARTS_ID =
+  'temp:multimodal_tool_results_plugin:current_turn_parts';
+
+/**
+ * Temporary flag indicating session parts were updated in the current invocation.
+ */
+export const _SESSION_UPDATED_KEY =
+  'temp:multimodal_tool_results_plugin:updated_in_invocation';
+
+/**
+ * Retention strategy for tool-returned multimodal parts.
+ */
+export type MultimodalToolResultsRetention = 'next_model_call' | 'session';
+
+/**
+ * Options for configuring {@link MultimodalToolResultsPlugin}.
+ */
+export interface MultimodalToolResultsPluginOptions {
+  /**
+   * The name of the plugin instance.
+   * Defaults to `'multimodal_tool_results_plugin'`.
+   */
+  name?: string;
+
+  /**
+   * How long tool-returned parts stay attached to model requests:
+   * - `'next_model_call'` (default): Attaches saved parts once to the immediate
+   *   next model request and then clears them.
+   * - `'session'`: Keeps re-attaching the latest saved parts to every subsequent
+   *   model request for the rest of the session. Inline data (images/audio bytes)
+   *   remains one-shot, while file data and text parts persist across turns.
+   */
+  retention?: MultimodalToolResultsRetention;
+}
+
+const MULTIMODAL_TOOL_RESULTS_PLUGIN_SYMBOL = Symbol.for(
+  'google.adk.multimodalToolResultsPlugin',
+);
+
+const PART_KEYS = new Set([
+  'text',
+  'inlineData',
+  'inline_data',
+  'fileData',
+  'file_data',
+  'functionCall',
+  'function_call',
+  'functionResponse',
+  'function_response',
+  'executableCode',
+  'executable_code',
+  'codeExecutionResult',
+  'code_execution_result',
+  'thought',
+  'thoughtSignature',
+  'thought_signature',
+  'videoMetadata',
+  'video_metadata',
+  'partMetadata',
+  'part_metadata',
+  'mediaResolution',
+  'media_resolution',
+]);
+
+/**
+ * Checks whether an object conforms to the Gemini {@link Part} structure.
+ *
+ * @param value The value to inspect.
+ * @returns True if the value is a Part object.
+ */
+export function isPart(value: unknown): value is Part {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 0) {
+    return false;
+  }
+  const hasPartDiscriminator =
+    'inlineData' in obj ||
+    'inline_data' in obj ||
+    'fileData' in obj ||
+    'file_data' in obj ||
+    'text' in obj ||
+    'functionCall' in obj ||
+    'function_call' in obj ||
+    'functionResponse' in obj ||
+    'function_response' in obj ||
+    'executableCode' in obj ||
+    'executable_code' in obj ||
+    'codeExecutionResult' in obj ||
+    'code_execution_result' in obj ||
+    'thought' in obj;
+
+  if (!hasPartDiscriminator) {
+    return false;
+  }
+
+  return keys.every((k) => PART_KEYS.has(k));
+}
+
+function hasInlineData(part: Part): boolean {
+  return (
+    part.inlineData != null ||
+    (part as Record<string, unknown>)['inline_data'] != null
+  );
+}
+
+function getStateValue<T>(
+  state: State | Record<string, unknown> | undefined,
+  key: string,
+): T | undefined {
+  if (state == null) {
+    return undefined;
+  }
+  if (typeof (state as State).get === 'function') {
+    return (state as State).get<T>(key);
+  }
+  return (state as Record<string, unknown>)[key] as T | undefined;
+}
+
+function setStateValue(
+  state: State | Record<string, unknown> | undefined,
+  key: string,
+  value: unknown,
+): void {
+  if (state == null) {
+    return;
+  }
+  if (typeof (state as State).set === 'function') {
+    (state as State).set(key, value);
+  } else {
+    (state as Record<string, unknown>)[key] = value;
+  }
+}
+
+function hasStateKey(
+  state: State | Record<string, unknown> | undefined,
+  key: string,
+): boolean {
+  if (state == null) {
+    return false;
+  }
+  if (typeof (state as State).has === 'function') {
+    return (state as State).has(key);
+  }
+  return key in (state as Record<string, unknown>);
+}
+
+/**
+ * Type guard for {@link MultimodalToolResultsPlugin}.
+ *
+ * @param plugin The plugin to check.
+ * @returns True if the plugin is an instance of MultimodalToolResultsPlugin.
+ */
+export function isMultimodalToolResultsPlugin(
+  plugin: unknown,
+): plugin is MultimodalToolResultsPlugin {
+  return (
+    plugin != null &&
+    typeof plugin === 'object' &&
+    (plugin as {[MULTIMODAL_TOOL_RESULTS_PLUGIN_SYMBOL]?: boolean})[
+      MULTIMODAL_TOOL_RESULTS_PLUGIN_SYMBOL
+    ] === true
+  );
+}
+
+/**
+ * Plugin that modifies function tool responses to support returning multimodal parts directly.
+ *
+ * Intercepts tool execution outputs returning `Part` or `Part[]` (such as images,
+ * audio, or PDF documents) and attaches them directly to the LLM's next request
+ * context so the model can inspect the multimodal content.
+ *
+ * @example
+ * ```typescript
+ * import {MultimodalToolResultsPlugin} from '@google/adk';
+ *
+ * // Create plugin with default next_model_call retention
+ * const plugin = new MultimodalToolResultsPlugin();
+ *
+ * // Or retain fileData across turns for the entire session
+ * const sessionPlugin = new MultimodalToolResultsPlugin({
+ *   retention: 'session',
+ * });
+ * ```
+ */
+export class MultimodalToolResultsPlugin extends BasePlugin {
+  readonly [MULTIMODAL_TOOL_RESULTS_PLUGIN_SYMBOL] = true;
+  readonly retention: MultimodalToolResultsRetention;
+
+  constructor(options?: MultimodalToolResultsPluginOptions) {
+    const name = options?.name ?? 'multimodal_tool_results_plugin';
+    const retention = options?.retention ?? 'next_model_call';
+    if (retention !== 'next_model_call' && retention !== 'session') {
+      throw new Error(
+        `retention must be 'next_model_call' or 'session', got ${retention}`,
+      );
+    }
+    super(name);
+    this.retention = retention;
+  }
+
+  /**
+   * Saves parts returned by the tool in context state.
+   *
+   * Later these are attached to the LLM request contents.
+   * No-op if the tool result is not a Part or Part[].
+   */
+  override async afterToolCallback(params: {
+    tool: BaseTool;
+    toolArgs: Record<string, unknown>;
+    toolContext: Context;
+    result: Record<string, unknown> | unknown;
+  }): Promise<Record<string, unknown> | undefined> {
+    const {toolContext, result} = params;
+
+    const isSinglePart = isPart(result);
+    const isPartsArray =
+      Array.isArray(result) && result.length > 0 && isPart(result[0]);
+
+    if (!isSinglePart && !isPartsArray) {
+      return result as Record<string, unknown>;
+    }
+
+    const parts: Part[] = isSinglePart
+      ? [cloneDeep(result as Part)]
+      : cloneDeep(result as Part[]);
+
+    if (this.retention === 'session') {
+      const sessionParts = parts.filter((p) => !hasInlineData(p));
+      const sessionKey = SESSION_PARTS_RETURNED_BY_TOOLS_ID;
+      const updatedKey = _SESSION_UPDATED_KEY;
+
+      if (sessionParts.length > 0) {
+        if (getStateValue(toolContext.state, updatedKey)) {
+          const existing =
+            getStateValue<Part[]>(toolContext.state, sessionKey) ?? [];
+          setStateValue(toolContext.state, sessionKey, [
+            ...existing,
+            ...sessionParts,
+          ]);
+        } else {
+          setStateValue(toolContext.state, updatedKey, true);
+          setStateValue(toolContext.state, sessionKey, [...sessionParts]);
+        }
+      }
+
+      const currentTurnKey = _CURRENT_TURN_PARTS_ID;
+      if (hasStateKey(toolContext.state, currentTurnKey)) {
+        const existing =
+          getStateValue<Part[]>(toolContext.state, currentTurnKey) ?? [];
+        setStateValue(toolContext.state, currentTurnKey, [
+          ...existing,
+          ...parts,
+        ]);
+      } else {
+        setStateValue(toolContext.state, currentTurnKey, [...parts]);
+      }
+    } else {
+      const tempKey = PARTS_RETURNED_BY_TOOLS_ID;
+      if (hasStateKey(toolContext.state, tempKey)) {
+        const existing =
+          getStateValue<Part[]>(toolContext.state, tempKey) ?? [];
+        setStateValue(toolContext.state, tempKey, [...existing, ...parts]);
+      } else {
+        setStateValue(toolContext.state, tempKey, [...parts]);
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Attaches saved parts returned by tools to the model request contents.
+   */
+  override async beforeModelCallback(params: {
+    callbackContext: Context;
+    llmRequest: LlmRequest;
+  }): Promise<LlmResponse | undefined> {
+    const {callbackContext, llmRequest} = params;
+
+    if (!llmRequest.contents || llmRequest.contents.length === 0) {
+      return undefined;
+    }
+
+    if (this.retention === 'session') {
+      const sessionKey = SESSION_PARTS_RETURNED_BY_TOOLS_ID;
+      const currentTurnKey = _CURRENT_TURN_PARTS_ID;
+
+      const savedSessionParts =
+        getStateValue<Part[]>(callbackContext.state, sessionKey) ?? [];
+      const currentParts =
+        getStateValue<Part[]>(callbackContext.state, currentTurnKey) ?? [];
+
+      const filteredSessionParts = savedSessionParts.filter(
+        (sp) => !currentParts.some((cp) => isEqual(sp, cp)),
+      );
+
+      const partsToAttach = [...filteredSessionParts, ...currentParts];
+
+      if (currentParts.length > 0) {
+        setStateValue(callbackContext.state, currentTurnKey, []);
+      }
+
+      if (partsToAttach.length > 0) {
+        const lastContent = llmRequest.contents[llmRequest.contents.length - 1];
+        if (!lastContent.parts) {
+          lastContent.parts = [];
+        }
+        lastContent.parts.push(...cloneDeep(partsToAttach));
+      }
+    } else {
+      const tempKey = PARTS_RETURNED_BY_TOOLS_ID;
+      const tempParts =
+        getStateValue<Part[]>(callbackContext.state, tempKey) ?? [];
+
+      if (tempParts.length > 0) {
+        const lastContent = llmRequest.contents[llmRequest.contents.length - 1];
+        if (!lastContent.parts) {
+          lastContent.parts = [];
+        }
+        lastContent.parts.push(...cloneDeep(tempParts));
+        setStateValue(callbackContext.state, tempKey, []);
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/core/src/plugins/multimodal_tool_results_plugin.ts
+++ b/core/src/plugins/multimodal_tool_results_plugin.ts
@@ -10,7 +10,6 @@ import {cloneDeep, isEqual} from 'lodash-es';
 import {type Context} from '../agents/context.js';
 import {type LlmRequest} from '../models/llm_request.js';
 import {type LlmResponse} from '../models/llm_response.js';
-import {State} from '../sessions/state.js';
 import {type BaseTool} from '../tools/base_tool.js';
 import {BasePlugin} from './base_plugin.js';
 
@@ -75,33 +74,28 @@ const MULTIMODAL_TOOL_RESULTS_PLUGIN_SYMBOL = Symbol.for(
 const PART_KEYS = new Set([
   'text',
   'inlineData',
-  'inline_data',
   'fileData',
-  'file_data',
   'functionCall',
-  'function_call',
   'functionResponse',
-  'function_response',
   'executableCode',
-  'executable_code',
   'codeExecutionResult',
-  'code_execution_result',
   'thought',
   'thoughtSignature',
-  'thought_signature',
   'videoMetadata',
-  'video_metadata',
   'partMetadata',
-  'part_metadata',
   'mediaResolution',
-  'media_resolution',
 ]);
 
 /**
- * Checks whether an object conforms to the Gemini {@link Part} structure.
+ * Checks whether an object conforms to the Gemini {@link Part} structure for
+ * multimodal content.
+ *
+ * Matches parts containing `inlineData` or `fileData`. Plain objects containing
+ * text or standard tool results are not treated as multimodal parts so their
+ * return values are not dropped.
  *
  * @param value The value to inspect.
- * @returns True if the value is a Part object.
+ * @returns True if the value is a multimodal Part object.
  */
 export function isPart(value: unknown): value is Part {
   if (value == null || typeof value !== 'object' || Array.isArray(value)) {
@@ -112,23 +106,8 @@ export function isPart(value: unknown): value is Part {
   if (keys.length === 0) {
     return false;
   }
-  const hasPartDiscriminator =
-    'inlineData' in obj ||
-    'inline_data' in obj ||
-    'fileData' in obj ||
-    'file_data' in obj ||
-    'text' in obj ||
-    'functionCall' in obj ||
-    'function_call' in obj ||
-    'functionResponse' in obj ||
-    'function_response' in obj ||
-    'executableCode' in obj ||
-    'executable_code' in obj ||
-    'codeExecutionResult' in obj ||
-    'code_execution_result' in obj ||
-    'thought' in obj;
-
-  if (!hasPartDiscriminator) {
+  const hasMultimodalPayload = 'inlineData' in obj || 'fileData' in obj;
+  if (!hasMultimodalPayload) {
     return false;
   }
 
@@ -136,51 +115,7 @@ export function isPart(value: unknown): value is Part {
 }
 
 function hasInlineData(part: Part): boolean {
-  return (
-    part.inlineData != null ||
-    (part as Record<string, unknown>)['inline_data'] != null
-  );
-}
-
-function getStateValue<T>(
-  state: State | Record<string, unknown> | undefined,
-  key: string,
-): T | undefined {
-  if (state == null) {
-    return undefined;
-  }
-  if (typeof (state as State).get === 'function') {
-    return (state as State).get<T>(key);
-  }
-  return (state as Record<string, unknown>)[key] as T | undefined;
-}
-
-function setStateValue(
-  state: State | Record<string, unknown> | undefined,
-  key: string,
-  value: unknown,
-): void {
-  if (state == null) {
-    return;
-  }
-  if (typeof (state as State).set === 'function') {
-    (state as State).set(key, value);
-  } else {
-    (state as Record<string, unknown>)[key] = value;
-  }
-}
-
-function hasStateKey(
-  state: State | Record<string, unknown> | undefined,
-  key: string,
-): boolean {
-  if (state == null) {
-    return false;
-  }
-  if (typeof (state as State).has === 'function') {
-    return (state as State).has(key);
-  }
-  return key in (state as Record<string, unknown>);
+  return part.inlineData != null;
 }
 
 /**
@@ -269,38 +204,29 @@ export class MultimodalToolResultsPlugin extends BasePlugin {
       const updatedKey = _SESSION_UPDATED_KEY;
 
       if (sessionParts.length > 0) {
-        if (getStateValue(toolContext.state, updatedKey)) {
-          const existing =
-            getStateValue<Part[]>(toolContext.state, sessionKey) ?? [];
-          setStateValue(toolContext.state, sessionKey, [
-            ...existing,
-            ...sessionParts,
-          ]);
+        if (toolContext.state.get(updatedKey)) {
+          const existing = toolContext.state.get<Part[]>(sessionKey) ?? [];
+          toolContext.state.set(sessionKey, [...existing, ...sessionParts]);
         } else {
-          setStateValue(toolContext.state, updatedKey, true);
-          setStateValue(toolContext.state, sessionKey, [...sessionParts]);
+          toolContext.state.set(updatedKey, true);
+          toolContext.state.set(sessionKey, [...sessionParts]);
         }
       }
 
       const currentTurnKey = _CURRENT_TURN_PARTS_ID;
-      if (hasStateKey(toolContext.state, currentTurnKey)) {
-        const existing =
-          getStateValue<Part[]>(toolContext.state, currentTurnKey) ?? [];
-        setStateValue(toolContext.state, currentTurnKey, [
-          ...existing,
-          ...parts,
-        ]);
+      if (toolContext.state.has(currentTurnKey)) {
+        const existing = toolContext.state.get<Part[]>(currentTurnKey) ?? [];
+        toolContext.state.set(currentTurnKey, [...existing, ...parts]);
       } else {
-        setStateValue(toolContext.state, currentTurnKey, [...parts]);
+        toolContext.state.set(currentTurnKey, [...parts]);
       }
     } else {
       const tempKey = PARTS_RETURNED_BY_TOOLS_ID;
-      if (hasStateKey(toolContext.state, tempKey)) {
-        const existing =
-          getStateValue<Part[]>(toolContext.state, tempKey) ?? [];
-        setStateValue(toolContext.state, tempKey, [...existing, ...parts]);
+      if (toolContext.state.has(tempKey)) {
+        const existing = toolContext.state.get<Part[]>(tempKey) ?? [];
+        toolContext.state.set(tempKey, [...existing, ...parts]);
       } else {
-        setStateValue(toolContext.state, tempKey, [...parts]);
+        toolContext.state.set(tempKey, [...parts]);
       }
     }
 
@@ -325,9 +251,9 @@ export class MultimodalToolResultsPlugin extends BasePlugin {
       const currentTurnKey = _CURRENT_TURN_PARTS_ID;
 
       const savedSessionParts =
-        getStateValue<Part[]>(callbackContext.state, sessionKey) ?? [];
+        callbackContext.state.get<Part[]>(sessionKey) ?? [];
       const currentParts =
-        getStateValue<Part[]>(callbackContext.state, currentTurnKey) ?? [];
+        callbackContext.state.get<Part[]>(currentTurnKey) ?? [];
 
       const filteredSessionParts = savedSessionParts.filter(
         (sp) => !currentParts.some((cp) => isEqual(sp, cp)),
@@ -336,7 +262,7 @@ export class MultimodalToolResultsPlugin extends BasePlugin {
       const partsToAttach = [...filteredSessionParts, ...currentParts];
 
       if (currentParts.length > 0) {
-        setStateValue(callbackContext.state, currentTurnKey, []);
+        callbackContext.state.set(currentTurnKey, []);
       }
 
       if (partsToAttach.length > 0) {
@@ -348,8 +274,7 @@ export class MultimodalToolResultsPlugin extends BasePlugin {
       }
     } else {
       const tempKey = PARTS_RETURNED_BY_TOOLS_ID;
-      const tempParts =
-        getStateValue<Part[]>(callbackContext.state, tempKey) ?? [];
+      const tempParts = callbackContext.state.get<Part[]>(tempKey) ?? [];
 
       if (tempParts.length > 0) {
         const lastContent = llmRequest.contents[llmRequest.contents.length - 1];
@@ -357,7 +282,7 @@ export class MultimodalToolResultsPlugin extends BasePlugin {
           lastContent.parts = [];
         }
         lastContent.parts.push(...cloneDeep(tempParts));
-        setStateValue(callbackContext.state, tempKey, []);
+        callbackContext.state.set(tempKey, []);
       }
     }
 

--- a/core/test/plugins/multimodal_tool_results_plugin_test.ts
+++ b/core/test/plugins/multimodal_tool_results_plugin_test.ts
@@ -39,22 +39,6 @@ function createMockContext(
   } as unknown as Context;
 }
 
-function createPlainMockContext(
-  initialState: Record<string, unknown> = {},
-): Context {
-  const store = {...initialState};
-  return {
-    invocationId: 'inv-test-456',
-    state: {
-      get: (key: string) => store[key],
-      set: (key: string, value: unknown) => {
-        store[key] = value;
-      },
-      has: (key: string) => key in store,
-    },
-  } as unknown as Context;
-}
-
 describe('MultimodalToolResultsPlugin', () => {
   describe('Initialization & Options', () => {
     it('should initialize with default options', () => {
@@ -92,8 +76,7 @@ describe('MultimodalToolResultsPlugin', () => {
   });
 
   describe('isPart helper', () => {
-    it('should identify valid Part objects', () => {
-      expect(isPart({text: 'hello world'})).toBe(true);
+    it('should identify valid multimodal Part objects', () => {
       expect(
         isPart({
           inlineData: {data: 'aGVsbG8=', mimeType: 'image/png'},
@@ -107,19 +90,9 @@ describe('MultimodalToolResultsPlugin', () => {
           },
         }),
       ).toBe(true);
-      expect(
-        isPart({
-          functionCall: {name: 'test_func', args: {}},
-        }),
-      ).toBe(true);
-      expect(
-        isPart({
-          functionResponse: {name: 'test_func', response: {output: 'ok'}},
-        }),
-      ).toBe(true);
     });
 
-    it('should reject non-Part objects', () => {
+    it('should reject non-Part objects and plain tool results', () => {
       expect(isPart(null)).toBe(false);
       expect(isPart(undefined)).toBe(false);
       expect(isPart('string')).toBe(false);
@@ -128,7 +101,23 @@ describe('MultimodalToolResultsPlugin', () => {
       expect(isPart({})).toBe(false);
       expect(isPart({some: 'data'})).toBe(false);
       expect(isPart({result: 'ok'})).toBe(false);
-      expect(isPart({text: 'hello', unexpectedExtraKey: 123})).toBe(false);
+      expect(isPart({text: 'hello world'})).toBe(false);
+      expect(
+        isPart({
+          functionResponse: {name: 'test_func', response: {output: 'ok'}},
+        }),
+      ).toBe(false);
+      expect(
+        isPart({
+          functionCall: {name: 'test_func', args: {}},
+        }),
+      ).toBe(false);
+      expect(
+        isPart({
+          inlineData: {data: 'aGVsbG8=', mimeType: 'image/png'},
+          unexpectedExtraKey: 123,
+        }),
+      ).toBe(false);
     });
   });
 
@@ -137,7 +126,17 @@ describe('MultimodalToolResultsPlugin', () => {
       const plugin = new MultimodalToolResultsPlugin();
       const mockTool = createMockTool();
       const context = createMockContext();
-      const parts: Part[] = [{text: 'part1'}, {text: 'part2'}];
+      const parts: Part[] = [
+        {
+          inlineData: {data: 'cGFydDE=', mimeType: 'image/png'},
+        },
+        {
+          fileData: {
+            fileUri: 'gs://bucket/file.pdf',
+            mimeType: 'application/pdf',
+          },
+        },
+      ];
 
       const afterResult = await plugin.afterToolCallback({
         tool: mockTool,
@@ -239,8 +238,12 @@ describe('MultimodalToolResultsPlugin', () => {
       const plugin = new MultimodalToolResultsPlugin();
       const mockTool = createMockTool();
       const context = createMockContext();
-      const parts1: Part[] = [{text: 'part1'}];
-      const parts2: Part[] = [{text: 'part2'}];
+      const parts1: Part[] = [
+        {fileData: {fileUri: 'gs://b/doc1.pdf', mimeType: 'application/pdf'}},
+      ];
+      const parts2: Part[] = [
+        {fileData: {fileUri: 'gs://b/doc2.pdf', mimeType: 'application/pdf'}},
+      ];
 
       await plugin.afterToolCallback({
         tool: mockTool,
@@ -257,8 +260,8 @@ describe('MultimodalToolResultsPlugin', () => {
       });
 
       expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual([
-        {text: 'part1'},
-        {text: 'part2'},
+        ...parts1,
+        ...parts2,
       ]);
 
       const llmRequest: LlmRequest = {
@@ -272,17 +275,21 @@ describe('MultimodalToolResultsPlugin', () => {
         llmRequest,
       });
 
-      expect(llmRequest.contents[0].parts).toEqual([
-        {text: 'part1'},
-        {text: 'part2'},
-      ]);
+      expect(llmRequest.contents[0].parts).toEqual([...parts1, ...parts2]);
     });
 
     it('should leave parts pending if llmRequest.contents is empty', async () => {
       const plugin = new MultimodalToolResultsPlugin();
       const mockTool = createMockTool();
       const context = createMockContext();
-      const parts: Part[] = [{text: 'pending_part'}];
+      const parts: Part[] = [
+        {
+          fileData: {
+            fileUri: 'gs://b/pending.pdf',
+            mimeType: 'application/pdf',
+          },
+        },
+      ];
 
       await plugin.afterToolCallback({
         tool: mockTool,
@@ -306,31 +313,32 @@ describe('MultimodalToolResultsPlugin', () => {
       expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual(parts);
     });
 
-    it('works seamlessly with plain object state stores', async () => {
+    it('should leave plain tool results with text or functionResponse fields completely unchanged', async () => {
       const plugin = new MultimodalToolResultsPlugin();
       const mockTool = createMockTool();
-      const context = createPlainMockContext();
-      const parts: Part[] = [{text: 'plain_part'}];
+      const context = createMockContext();
 
-      await plugin.afterToolCallback({
+      const textResult = {text: 'The weather is sunny in Paris.'};
+      const textAfter = await plugin.afterToolCallback({
         tool: mockTool,
         toolArgs: {},
         toolContext: context,
-        result: parts,
+        result: textResult,
       });
+      expect(textAfter).toEqual(textResult);
+      expect(context.state.has(PARTS_RETURNED_BY_TOOLS_ID)).toBe(false);
 
-      const llmRequest: LlmRequest = {
-        contents: [{parts: []} as Content],
-        toolsDict: {},
-        liveConnectConfig: {},
+      const funcResponseResult = {
+        functionResponse: {name: 'get_weather', response: {temp: 72}},
       };
-
-      await plugin.beforeModelCallback({
-        callbackContext: context,
-        llmRequest,
+      const funcAfter = await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: funcResponseResult,
       });
-
-      expect(llmRequest.contents[0].parts).toEqual(parts);
+      expect(funcAfter).toEqual(funcResponseResult);
+      expect(context.state.has(PARTS_RETURNED_BY_TOOLS_ID)).toBe(false);
     });
   });
 
@@ -339,7 +347,10 @@ describe('MultimodalToolResultsPlugin', () => {
       const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
       const mockTool = createMockTool();
       const context = createMockContext();
-      const parts: Part[] = [{text: 'part1'}, {text: 'part2'}];
+      const parts: Part[] = [
+        {fileData: {fileUri: 'gs://b/doc1.pdf', mimeType: 'application/pdf'}},
+        {fileData: {fileUri: 'gs://b/doc2.pdf', mimeType: 'application/pdf'}},
+      ];
 
       await plugin.afterToolCallback({
         tool: mockTool,
@@ -411,8 +422,12 @@ describe('MultimodalToolResultsPlugin', () => {
       const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
       const mockTool = createMockTool();
       const context = createMockContext();
-      const part1: Part = {text: 'part1'};
-      const part2: Part = {text: 'part2'};
+      const part1: Part = {
+        fileData: {fileUri: 'gs://b/part1.pdf', mimeType: 'application/pdf'},
+      };
+      const part2: Part = {
+        fileData: {fileUri: 'gs://b/part2.pdf', mimeType: 'application/pdf'},
+      };
 
       await plugin.afterToolCallback({
         tool: mockTool,
@@ -438,8 +453,12 @@ describe('MultimodalToolResultsPlugin', () => {
       const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
       const mockTool = createMockTool();
       const context = createMockContext();
-      const turn1Parts: Part[] = [{text: 'turn1_part'}];
-      const turn2Parts: Part[] = [{text: 'turn2_part'}];
+      const turn1Parts: Part[] = [
+        {fileData: {fileUri: 'gs://b/turn1.pdf', mimeType: 'application/pdf'}},
+      ];
+      const turn2Parts: Part[] = [
+        {fileData: {fileUri: 'gs://b/turn2.pdf', mimeType: 'application/pdf'}},
+      ];
 
       // Turn 1
       await plugin.afterToolCallback({
@@ -623,7 +642,9 @@ describe('MultimodalToolResultsPlugin', () => {
       const pluginManager = new PluginManager([plugin]);
       const mockTool = createMockTool();
       const context = createMockContext();
-      const parts: Part[] = [{text: 'plugin_manager_part'}];
+      const parts: Part[] = [
+        {inlineData: {data: 'cGx1Z2lu', mimeType: 'image/png'}},
+      ];
 
       await pluginManager.runAfterToolCallback({
         tool: mockTool,

--- a/core/test/plugins/multimodal_tool_results_plugin_test.ts
+++ b/core/test/plugins/multimodal_tool_results_plugin_test.ts
@@ -1,0 +1,649 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {type Content, type Part} from '@google/genai';
+import {describe, expect, it} from 'vitest';
+
+import {type Context} from '../../src/agents/context.js';
+import {type LlmRequest} from '../../src/models/llm_request.js';
+import {
+  _CURRENT_TURN_PARTS_ID,
+  _SESSION_UPDATED_KEY,
+  isMultimodalToolResultsPlugin,
+  isPart,
+  MultimodalToolResultsPlugin,
+  PARTS_RETURNED_BY_TOOLS_ID,
+  SESSION_PARTS_RETURNED_BY_TOOLS_ID,
+} from '../../src/plugins/multimodal_tool_results_plugin.js';
+import {PluginManager} from '../../src/plugins/plugin_manager.js';
+import {State} from '../../src/sessions/state.js';
+import {type BaseTool} from '../../src/tools/base_tool.js';
+
+function createMockTool(name = 'mock_multimodal_tool'): BaseTool {
+  return {
+    name,
+    description: 'Mock multimodal tool for testing',
+  } as unknown as BaseTool;
+}
+
+function createMockContext(
+  initialState: Record<string, unknown> = {},
+): Context {
+  const state = new State(initialState);
+  return {
+    invocationId: 'inv-test-123',
+    state,
+  } as unknown as Context;
+}
+
+function createPlainMockContext(
+  initialState: Record<string, unknown> = {},
+): Context {
+  const store = {...initialState};
+  return {
+    invocationId: 'inv-test-456',
+    state: {
+      get: (key: string) => store[key],
+      set: (key: string, value: unknown) => {
+        store[key] = value;
+      },
+      has: (key: string) => key in store,
+    },
+  } as unknown as Context;
+}
+
+describe('MultimodalToolResultsPlugin', () => {
+  describe('Initialization & Options', () => {
+    it('should initialize with default options', () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      expect(plugin.name).toBe('multimodal_tool_results_plugin');
+      expect(plugin.retention).toBe('next_model_call');
+      expect(isMultimodalToolResultsPlugin(plugin)).toBe(true);
+    });
+
+    it('should accept custom name and retention', () => {
+      const plugin = new MultimodalToolResultsPlugin({
+        name: 'custom_multimodal_plugin',
+        retention: 'session',
+      });
+      expect(plugin.name).toBe('custom_multimodal_plugin');
+      expect(plugin.retention).toBe('session');
+    });
+
+    it('should throw an error for invalid retention option', () => {
+      expect(() => {
+        new MultimodalToolResultsPlugin({
+          // @ts-expect-error Testing runtime validation for invalid input
+          retention: 'invalid_mode',
+        });
+      }).toThrowError(/retention must be 'next_model_call' or 'session'/);
+    });
+
+    it('should correctly identify plugin with isMultimodalToolResultsPlugin', () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      expect(isMultimodalToolResultsPlugin(plugin)).toBe(true);
+      expect(isMultimodalToolResultsPlugin(null)).toBe(false);
+      expect(isMultimodalToolResultsPlugin({})).toBe(false);
+      expect(isMultimodalToolResultsPlugin({name: 'fake'})).toBe(false);
+    });
+  });
+
+  describe('isPart helper', () => {
+    it('should identify valid Part objects', () => {
+      expect(isPart({text: 'hello world'})).toBe(true);
+      expect(
+        isPart({
+          inlineData: {data: 'aGVsbG8=', mimeType: 'image/png'},
+        }),
+      ).toBe(true);
+      expect(
+        isPart({
+          fileData: {
+            fileUri: 'gs://bucket/file.pdf',
+            mimeType: 'application/pdf',
+          },
+        }),
+      ).toBe(true);
+      expect(
+        isPart({
+          functionCall: {name: 'test_func', args: {}},
+        }),
+      ).toBe(true);
+      expect(
+        isPart({
+          functionResponse: {name: 'test_func', response: {output: 'ok'}},
+        }),
+      ).toBe(true);
+    });
+
+    it('should reject non-Part objects', () => {
+      expect(isPart(null)).toBe(false);
+      expect(isPart(undefined)).toBe(false);
+      expect(isPart('string')).toBe(false);
+      expect(isPart(123)).toBe(false);
+      expect(isPart([])).toBe(false);
+      expect(isPart({})).toBe(false);
+      expect(isPart({some: 'data'})).toBe(false);
+      expect(isPart({result: 'ok'})).toBe(false);
+      expect(isPart({text: 'hello', unexpectedExtraKey: 123})).toBe(false);
+    });
+  });
+
+  describe('next_model_call retention (default mode)', () => {
+    it('should save parts returned by a tool to state and return undefined', async () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const parts: Part[] = [{text: 'part1'}, {text: 'part2'}];
+
+      const afterResult = await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts,
+      });
+
+      expect(afterResult).toBeUndefined();
+      expect(context.state.has(PARTS_RETURNED_BY_TOOLS_ID)).toBe(true);
+      expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual(parts);
+
+      // Verify beforeModelCallback attaches the parts to llmRequest
+      const llmRequest: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      expect(llmRequest.contents[0].parts).toEqual(parts);
+      // State should be cleared after attaching
+      expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual([]);
+    });
+
+    it('should handle single Part instance returned by tool', async () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const singlePart: Part = {
+        inlineData: {data: 'aW1hZ2VkYXRh', mimeType: 'image/jpeg'},
+      };
+
+      const afterResult = await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: singlePart,
+      });
+
+      expect(afterResult).toBeUndefined();
+      expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual([
+        singlePart,
+      ]);
+
+      const llmRequest: LlmRequest = {
+        contents: [{parts: [{text: 'User prompt'}]} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      expect(llmRequest.contents[0].parts).toEqual([
+        {text: 'User prompt'},
+        singlePart,
+      ]);
+      expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual([]);
+    });
+
+    it('should leave non-part tool results completely unchanged', async () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const originalResult = {temperature: 72, unit: 'Fahrenheit'};
+
+      const afterResult = await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: originalResult,
+      });
+
+      expect(afterResult).toEqual(originalResult);
+      expect(context.state.has(PARTS_RETURNED_BY_TOOLS_ID)).toBe(false);
+
+      const llmRequest: LlmRequest = {
+        contents: [{parts: [{text: 'Original'}]} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      expect(llmRequest.contents[0].parts).toEqual([{text: 'Original'}]);
+    });
+
+    it('should accumulate parts from multiple tools in order', async () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const parts1: Part[] = [{text: 'part1'}];
+      const parts2: Part[] = [{text: 'part2'}];
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts1,
+      });
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts2,
+      });
+
+      expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual([
+        {text: 'part1'},
+        {text: 'part2'},
+      ]);
+
+      const llmRequest: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      expect(llmRequest.contents[0].parts).toEqual([
+        {text: 'part1'},
+        {text: 'part2'},
+      ]);
+    });
+
+    it('should leave parts pending if llmRequest.contents is empty', async () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const parts: Part[] = [{text: 'pending_part'}];
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts,
+      });
+
+      const llmRequest: LlmRequest = {
+        contents: [],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      expect(llmRequest.contents).toEqual([]);
+      expect(context.state.get(PARTS_RETURNED_BY_TOOLS_ID)).toEqual(parts);
+    });
+
+    it('works seamlessly with plain object state stores', async () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      const mockTool = createMockTool();
+      const context = createPlainMockContext();
+      const parts: Part[] = [{text: 'plain_part'}];
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts,
+      });
+
+      const llmRequest: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      expect(llmRequest.contents[0].parts).toEqual(parts);
+    });
+  });
+
+  describe('session retention mode', () => {
+    it('should serialize and retain non-binary parts in session state', async () => {
+      const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const parts: Part[] = [{text: 'part1'}, {text: 'part2'}];
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts,
+      });
+
+      expect(context.state.has(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toBe(true);
+      expect(context.state.get(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toEqual(
+        parts,
+      );
+    });
+
+    it('should separate inline binary parts from session parts', async () => {
+      const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const filePart: Part = {
+        fileData: {fileUri: 'gs://bucket/doc.pdf', mimeType: 'application/pdf'},
+      };
+      const binaryPart: Part = {
+        inlineData: {data: 'YmluYXJ5', mimeType: 'image/png'},
+      };
+      const parts = [filePart, binaryPart];
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts,
+      });
+
+      // Session state should only contain filePart (inlineData is excluded)
+      const sessionParts = context.state.get<Part[]>(
+        SESSION_PARTS_RETURNED_BY_TOOLS_ID,
+      );
+      expect(sessionParts).toEqual([filePart]);
+
+      // All parts should be in current turn temp state (preserving order)
+      const currentTurnParts = context.state.get<Part[]>(
+        _CURRENT_TURN_PARTS_ID,
+      );
+      expect(currentTurnParts).toEqual([filePart, binaryPart]);
+
+      // Verify beforeModelCallback
+      const llmRequest: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      // Model request receives both in order without duplicate filePart
+      expect(llmRequest.contents[0].parts).toEqual([filePart, binaryPart]);
+
+      // Temp state is cleared, session state remains for subsequent turns
+      expect(context.state.get(_CURRENT_TURN_PARTS_ID)).toEqual([]);
+      expect(context.state.get(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toEqual([
+        filePart,
+      ]);
+    });
+
+    it('should accumulate session parts across multiple tools in the same turn', async () => {
+      const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const part1: Part = {text: 'part1'};
+      const part2: Part = {text: 'part2'};
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: [part1],
+      });
+
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: [part2],
+      });
+
+      expect(context.state.get(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toEqual([
+        part1,
+        part2,
+      ]);
+    });
+
+    it('should replace session parts on a new invocation turn', async () => {
+      const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const turn1Parts: Part[] = [{text: 'turn1_part'}];
+      const turn2Parts: Part[] = [{text: 'turn2_part'}];
+
+      // Turn 1
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: turn1Parts,
+      });
+
+      expect(context.state.get(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toEqual(
+        turn1Parts,
+      );
+
+      // Simulate turn boundary: temp keys stripped at end of turn
+      context.state.set(_SESSION_UPDATED_KEY, undefined);
+      context.state.set(_CURRENT_TURN_PARTS_ID, undefined);
+
+      // Turn 2
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: turn2Parts,
+      });
+
+      // Session parts from turn 1 should be replaced by turn 2 parts
+      expect(context.state.get(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toEqual(
+        turn2Parts,
+      );
+    });
+
+    it('should not erase previous session parts if an intermediate turn only returns binary parts', async () => {
+      const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const filePart: Part = {
+        fileData: {fileUri: 'gs://bucket/doc.pdf', mimeType: 'application/pdf'},
+      };
+      const binaryPart: Part = {
+        inlineData: {data: 'aW1hZ2U=', mimeType: 'image/jpeg'},
+      };
+
+      // Turn 1: returns file part
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: [filePart],
+      });
+
+      expect(context.state.get(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toEqual([
+        filePart,
+      ]);
+
+      // Simulate turn boundary
+      context.state.set(_SESSION_UPDATED_KEY, undefined);
+      context.state.set(_CURRENT_TURN_PARTS_ID, undefined);
+
+      // Turn 2: returns binary part only
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: [binaryPart],
+      });
+
+      // Previous session part still preserved!
+      expect(context.state.get(SESSION_PARTS_RETURNED_BY_TOOLS_ID)).toEqual([
+        filePart,
+      ]);
+      expect(context.state.get(_CURRENT_TURN_PARTS_ID)).toEqual([binaryPart]);
+    });
+
+    it('should retain session parts across subsequent model calls in the same turn', async () => {
+      const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const filePart: Part = {
+        fileData: {fileUri: 'gs://bucket/doc.pdf', mimeType: 'application/pdf'},
+      };
+
+      // Tool 1: returns filePart
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: [filePart],
+      });
+
+      // Model call 1: attaches filePart
+      const llmRequest1: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest: llmRequest1,
+      });
+      expect(llmRequest1.contents[0].parts).toEqual([filePart]);
+
+      // Tool 2 in same turn: returns non-part response
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: {status: 'success'},
+      });
+
+      // Model call 2 in same turn: still has filePart attached
+      const llmRequest2: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+      await plugin.beforeModelCallback({
+        callbackContext: context,
+        llmRequest: llmRequest2,
+      });
+      expect(llmRequest2.contents[0].parts).toEqual([filePart]);
+    });
+
+    it('survives real turn boundary with temp keys stripped from session state', async () => {
+      const plugin = new MultimodalToolResultsPlugin({retention: 'session'});
+      const mockTool = createMockTool();
+      const sessionState: Record<string, unknown> = {};
+      const context1 = {
+        state: new State(sessionState),
+      } as unknown as Context;
+
+      const filePart: Part = {
+        fileData: {
+          fileUri: 'gs://bucket/contract.pdf',
+          mimeType: 'application/pdf',
+        },
+      };
+
+      // Turn 1 tool returns filePart
+      await plugin.afterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context1,
+        result: [filePart],
+      });
+
+      // At end of turn, the session service strips temp: keys from session state
+      for (const key of Object.keys(sessionState)) {
+        if (key.startsWith(State.TEMP_PREFIX)) {
+          delete sessionState[key];
+        }
+      }
+
+      expect(sessionState[SESSION_PARTS_RETURNED_BY_TOOLS_ID]).toEqual([
+        filePart,
+      ]);
+      expect(sessionState[_SESSION_UPDATED_KEY]).toBeUndefined();
+      expect(sessionState[_CURRENT_TURN_PARTS_ID]).toBeUndefined();
+
+      // Turn 2 starts with the persisted session state
+      const context2 = {
+        state: new State(sessionState),
+      } as unknown as Context;
+
+      const llmRequest: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await plugin.beforeModelCallback({
+        callbackContext: context2,
+        llmRequest,
+      });
+
+      // Turn 1 file part successfully reattached in Turn 2
+      expect(llmRequest.contents[0].parts).toEqual([filePart]);
+    });
+
+    it('integrates cleanly with PluginManager', async () => {
+      const plugin = new MultimodalToolResultsPlugin();
+      const pluginManager = new PluginManager([plugin]);
+      const mockTool = createMockTool();
+      const context = createMockContext();
+      const parts: Part[] = [{text: 'plugin_manager_part'}];
+
+      await pluginManager.runAfterToolCallback({
+        tool: mockTool,
+        toolArgs: {},
+        toolContext: context,
+        result: parts as unknown as Record<string, unknown>,
+      });
+
+      const llmRequest: LlmRequest = {
+        contents: [{parts: []} as Content],
+        toolsDict: {},
+        liveConnectConfig: {},
+      };
+
+      await pluginManager.runBeforeModelCallback({
+        callbackContext: context,
+        llmRequest,
+      });
+
+      expect(llmRequest.contents[0].parts).toEqual(parts);
+    });
+  });
+});


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://google.github.io/adk-docs/contributing-guide/) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: N/A
- Related: N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
In Python ADK, we have `MultimodalToolResultsPlugin`, but `adk-js` doesn't have it yet. 

Right now in `adk-js`, tools can only return text or JSON. If a tool produces an image, chart, or PDF (as a Gemini `Part` object), those parts get dropped or converted to text, so the model never actually sees the image or document.

**Solution:**
This PR ports `MultimodalToolResultsPlugin` from Python ADK to TypeScript.

- When a tool returns a `Part` or `Part[]`, the plugin catches it in `afterToolCallback` and saves it to state.
- In `beforeModelCallback`, right before the prompt goes to the model, it attaches those parts to `llmRequest.contents` so Gemini can inspect them.
- Supports both retention modes from Python:
  - `next_model_call` (default): sends parts to the next model call and clears them so they aren't resent.
  - `session`: keeps document/image URIs (`fileData`) across turns for follow-up questions, while keeping raw base64 binary (`inlineData`) one-shot to avoid blowing up session storage.
- Tools returning normal text/JSON are ignored and untouched.
- Exported in `common.ts` without any Node-specific imports, so it works in browser builds too. Uses symbol branding (`isMultimodalToolResultsPlugin`) instead of `instanceof` to be safe across bundles.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added 20 unit tests in `core/test/plugins/multimodal_tool_results_plugin_test.ts`:
- Tested default and custom retention settings.
- Tested `isPart` helper with valid parts (inlineData, fileData, text) and non-parts (plain objects, primitives).
- Tested `next_model_call` saving parts and cleaning them up after model call.
- Tested `session` retention across multiple turns and checked that raw inlineData is not leaked into subsequent turns.
- Tested standard tool results pass through unchanged.
- Tested registration and callback handling with `PluginManager`.

All 20 tests pass with Vitest (`npm test -- core/test/plugins/multimodal_tool_results_plugin_test.ts`).
Also ran `npm run docs:check`, `npx eslint`, and `npm run build` in `core` with 0 errors.

**Manual End-to-End (E2E) Tests:**

I wrote a standalone test script that runs a mock tool returning a PNG image `Part`, triggers `afterToolCallback`, and then calls `beforeModelCallback`. Confirmed that the image is added to the model request contents next to the tool response, and verified that temporary state is cleared afterwards.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-js/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Brings `adk-js` to parity with `google.adk.plugins.multimodal_tool_results_plugin` in Python ADK.
